### PR TITLE
Final merge of missing AtB elements to fix Briefing and Contract issues

### DIFF
--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -546,7 +546,20 @@ public class MekHQ implements GameListener {
         client.getGame().addGameListener(this);
         currentScenario = scenario;
 
-        gameThread = new GameThread(playerName, password, client, this, meks, scenario);
+        // Start the game thread - also refactor this into a factory
+        if (getCampaign().getCampaignOptions().isUseStratCon() && (scenario instanceof AtBScenario atBScenario)) {
+            gameThread = new AtBGameThread(playerName,
+                  password,
+                  client,
+                  this,
+                  meks,
+                  atBScenario,
+                  autoResolveBehaviorSettings,
+                  useExperimentalPacarGui,
+                  true);
+        } else {
+            gameThread = new GameThread(playerName, password, client, this, meks, scenario);
+        }
         gameThread.start();
     }
 

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -9446,6 +9446,90 @@ public class Campaign implements ITechManager {
         getRetirementDefectionTracker().setLastRetirementRoll(getLocalDate());
     }
 
+    public void initAtB(boolean newCampaign) {
+        if (!newCampaign) {
+            /*
+             * Switch all contracts to AtBContract's
+             */
+            for (Entry<Integer, Mission> me : missions.entrySet()) {
+                Mission m = me.getValue();
+                if (m instanceof Contract && !(m instanceof AtBContract)) {
+                    me.setValue(new AtBContract((Contract) m, this));
+                }
+            }
+
+            /*
+             * Go through all the personnel records and assume the earliest date is the date
+             * the unit was founded.
+             */
+            LocalDate founding = null;
+            for (Person person : getPersonnel()) {
+                for (LogEntry logEntry : person.getPersonalLog()) {
+                    if ((founding == null) || logEntry.getDate().isBefore(founding)) {
+                        founding = logEntry.getDate();
+                    }
+                }
+            }
+            /*
+             * Go through the personnel records again and assume that any person who joined the unit on the founding
+             * date is one of the founding members. Also assume that MWs assigned to a non-Assault `Mek on the date
+             * they joined came with that `Mek (which is a less certain assumption)
+             */
+            for (Person person : getPersonnel()) {
+                LocalDate join = person.getPersonalLog()
+                                       .stream()
+                                       .filter(e -> e.getDesc().startsWith("Joined "))
+                                       .findFirst()
+                                       .map(LogEntry::getDate)
+                                       .orElse(null);
+                if ((join != null) && join.equals(founding)) {
+                    person.setFounder(true);
+                }
+                if (person.getPrimaryRole().isMekWarrior() ||
+                          (person.getPrimaryRole().isAerospacePilot() &&
+                                 getCampaignOptions().isAeroRecruitsHaveUnits()) ||
+                          person.getPrimaryRole().isProtoMekPilot()) {
+                    for (LogEntry logEntry : person.getPersonalLog()) {
+                        if (logEntry.getDate().equals(join) && logEntry.getDesc().startsWith("Assigned to ")) {
+                            String mek = logEntry.getDesc().substring(12);
+                            MekSummary ms = MekSummaryCache.getInstance().getMek(mek);
+                            if (null != ms &&
+                                      (person.isFounder() || ms.getWeightClass() < EntityWeightClass.WEIGHT_ASSAULT)) {
+                                person.setOriginalUnitWeight(ms.getWeightClass());
+                                if (ms.isClan()) {
+                                    person.setOriginalUnitTech(Person.TECH_CLAN);
+                                } else if (ms.getYear() > 3050) {
+                                    // TODO : Fix this so we aren't using a hack that just assumes IS2
+                                    person.setOriginalUnitTech(Person.TECH_IS2);
+                                }
+                                if ((null != person.getUnit()) &&
+                                          ms.getName().equals(person.getUnit().getEntity().getShortNameRaw())) {
+                                    person.setOriginalUnitId(person.getUnit().getId());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            addAllCombatTeams(this.formations);
+
+            // Determine whether there is an active contract
+            setHasActiveContract();
+        }
+
+        setAtBConfig(AtBConfiguration.loadFromXml());
+        RandomFactionGenerator.getInstance().startup(this);
+        getContractMarket().generateContractOffers(this, newCampaign); // TODO : AbstractContractMarket : Remove
+    }
+
+    /**
+     * Stop processing AtB events and release memory.
+     */
+    public void shutdownAtB() {
+        RandomFactionGenerator.getInstance().dispose();
+    }
+
     /**
      * Checks if an employee turnover prompt should be displayed based on campaign options, current date, and other
      * conditions (like transit status and campaign start date).

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -1734,25 +1734,6 @@ public class CampaignNewDayManager {
               failedWillpowerCheck);
     }
 
-    @Deprecated(since = "0.50.10", forRemoval = true)
-    void processShipSearch() {
-        StringBuilder report = new StringBuilder();
-        if (finances.debit(TransactionType.UNIT_PURCHASE,
-              today,
-              campaign.getAtBConfig().shipSearchCostPerWeek(),
-              "Ship Search")) {
-            report.append(campaign.getAtBConfig().shipSearchCostPerWeek().toAmountAndSymbolString())
-                  .append(" deducted for ship search.");
-        } else {
-            campaign.addReport(FINANCES, "<font color=" +
-                                               ReportingUtilities.getNegativeColor() +
-                                               ">Insufficient funds for ship search.</font>");
-            return;
-        }
-
-        campaign.addReport(ACQUISITIONS, report.toString());
-    }
-
     /**
      * Processes the resupply operation for a given contract.
      *

--- a/MekHQ/src/mekhq/campaign/force/CombatTeam.java
+++ b/MekHQ/src/mekhq/campaign/force/CombatTeam.java
@@ -767,7 +767,7 @@ public class CombatTeam {
                 boolean isClan = campaign.isClanCampaign();
 
                 CampaignOptions campaignOptions = campaign.getCampaignOptions();
-                if (campaignOptions.isUseStratCon() && !campaignOptions.isUseStratCon()) {
+                if (!campaignOptions.isUseStratCon()) {
                     if (entityType == ETYPE_TANK) {
                         if (isClan) {
                             weight += entity.getWeight() * 0.5;

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -743,7 +743,7 @@ public class AtBContract extends Contract {
                 yield false;
             }
             case 3 -> { // Resupply
-                if (campaignOptions.isUseStratCon() && !campaignOptions.isUseStratCon()) {
+                if (!campaignOptions.isUseStratCon()) {
                     campaign.addReport(GENERAL, "Bonus: Ronin");
                     new RoninOffer(campaign, stratconCampaignState, requiredCombatTeams);
                     yield false;

--- a/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/RecoveryTimeData.java
+++ b/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/RecoveryTimeData.java
@@ -107,6 +107,35 @@ public record RecoveryTimeData(
      * @since 0.50.10
      */
     public String getRecoveryTimeBreakdownString(boolean includeHTMLTags) {
+        StringBuilder breakdown = new StringBuilder(includeHTMLTags ? "<html>" : "");
+
+        breakdown.append(getFormattedTextAt(RESOURCE_BUNDLE,
+              "RecoveryTimeData.recoveryTimeBreakdown.baseRecoveryTime",
+              baseRecoveryTime));
+
+        breakdown.append(getFormattedTextAt(RESOURCE_BUNDLE,
+              "RecoveryTimeData.recoveryTimeBreakdown.weatherMultiplier",
+              weatherMultiplier));
+
+        breakdown.append(getFormattedTextAt(RESOURCE_BUNDLE,
+              "RecoveryTimeData.recoveryTimeBreakdown.windMultiplier",
+              windMultiplier));
+
+        breakdown.append(getFormattedTextAt(RESOURCE_BUNDLE,
+              "RecoveryTimeData.recoveryTimeBreakdown.temperatureMultiplier",
+              temperatureMultiplier));
+
+        breakdown.append(getFormattedTextAt(RESOURCE_BUNDLE,
+              "RecoveryTimeData.recoveryTimeBreakdown.gravityMultiplier",
+              gravityMultiplier));
+
+        breakdown.append(getFormattedTextAt(RESOURCE_BUNDLE,
+              "RecoveryTimeData.recoveryTimeBreakdown.atmosphereMultiplier",
+              atmosphereMultiplier));
+
+        breakdown.append(getFormattedTextAt(RESOURCE_BUNDLE,
+              "RecoveryTimeData.recoveryTimeBreakdown.lightMultiplier",
+              lightMultiplier));
 
         double totalMultiplier = BASE_MULTIPLIER +
                                        weatherMultiplier +

--- a/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/RecoveryTimeData.java
+++ b/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/RecoveryTimeData.java
@@ -107,35 +107,6 @@ public record RecoveryTimeData(
      * @since 0.50.10
      */
     public String getRecoveryTimeBreakdownString(boolean includeHTMLTags) {
-        StringBuilder breakdown = new StringBuilder(includeHTMLTags ? "<html>" : "");
-
-        breakdown.append(getFormattedTextAt(RESOURCE_BUNDLE,
-              "RecoveryTimeData.recoveryTimeBreakdown.baseRecoveryTime",
-              baseRecoveryTime));
-
-        breakdown.append(getFormattedTextAt(RESOURCE_BUNDLE,
-              "RecoveryTimeData.recoveryTimeBreakdown.weatherMultiplier",
-              weatherMultiplier));
-
-        breakdown.append(getFormattedTextAt(RESOURCE_BUNDLE,
-              "RecoveryTimeData.recoveryTimeBreakdown.windMultiplier",
-              windMultiplier));
-
-        breakdown.append(getFormattedTextAt(RESOURCE_BUNDLE,
-              "RecoveryTimeData.recoveryTimeBreakdown.temperatureMultiplier",
-              temperatureMultiplier));
-
-        breakdown.append(getFormattedTextAt(RESOURCE_BUNDLE,
-              "RecoveryTimeData.recoveryTimeBreakdown.gravityMultiplier",
-              gravityMultiplier));
-
-        breakdown.append(getFormattedTextAt(RESOURCE_BUNDLE,
-              "RecoveryTimeData.recoveryTimeBreakdown.atmosphereMultiplier",
-              atmosphereMultiplier));
-
-        breakdown.append(getFormattedTextAt(RESOURCE_BUNDLE,
-              "RecoveryTimeData.recoveryTimeBreakdown.lightMultiplier",
-              lightMultiplier));
 
         double totalMultiplier = BASE_MULTIPLIER +
                                        weatherMultiplier +

--- a/MekHQ/src/mekhq/campaign/personnel/skills/Appraisal.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Appraisal.java
@@ -93,7 +93,7 @@ public class Appraisal {
      * <p>The multiplier increases or decreases based on the negative margin of success from an appraisal skill
      * check.</p>
      *
-     * @param marginOfSuccessValue The return value of
+     * @param marginOfSuccessValue The return value of {@link MarginOfSuccess#getMarginValue(MarginOfSuccess)}
      *
      * @return The appraisal cost multiplier as a {@code double}.
      *

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -59,7 +59,6 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
-import javax.swing.JSplitPane;
 import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 import javax.swing.ScrollPaneConstants;

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -32,6 +32,7 @@
  */
 package mekhq.gui;
 
+import static megamek.client.ratgenerator.ForceDescriptor.RATING_5;
 import static mekhq.campaign.enums.DailyReportType.GENERAL;
 import static mekhq.campaign.enums.DailyReportType.PERSONNEL;
 import static mekhq.campaign.force.Formation.NO_ASSIGNED_SCENARIO;
@@ -58,6 +59,7 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JSplitPane;
 import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 import javax.swing.ScrollPaneConstants;
@@ -67,11 +69,15 @@ import javax.swing.table.TableRowSorter;
 
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.PrincessException;
+import megamek.client.generator.ReconfigurationParameters;
+import megamek.client.generator.TeamLoadOutGenerator;
 import megamek.client.ui.comboBoxes.MMComboBox;
 import megamek.codeUtilities.ObjectUtility;
 import megamek.common.annotations.Nullable;
+import megamek.common.containers.MunitionTree;
 import megamek.common.enums.Gender;
 import megamek.common.event.Subscribe;
+import megamek.common.game.Game;
 import megamek.common.options.OptionsConstants;
 import megamek.common.ui.FastJScrollPane;
 import megamek.common.units.Entity;
@@ -85,6 +91,7 @@ import mekhq.campaign.Hangar;
 import mekhq.campaign.autoResolve.AutoResolveMethod;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.events.GMModeEvent;
+import mekhq.campaign.events.OptionsChangedEvent;
 import mekhq.campaign.events.OrganizationChangedEvent;
 import mekhq.campaign.events.missions.MissionChangedEvent;
 import mekhq.campaign.events.missions.MissionCompletedEvent;
@@ -118,6 +125,7 @@ import mekhq.campaign.stratCon.StratConCampaignState;
 import mekhq.campaign.stratCon.StratConScenario;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Faction;
+import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.factionStanding.FactionStandings;
 import mekhq.gui.adapter.ScenarioTableMouseAdapter;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogNotification;
@@ -125,9 +133,11 @@ import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
 import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
 import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
 import mekhq.gui.dialog.CompleteMissionDialog;
+import mekhq.gui.dialog.CustomizeAtBContractDialog;
 import mekhq.gui.dialog.CustomizeMissionDialog;
 import mekhq.gui.dialog.CustomizeScenarioDialog;
 import mekhq.gui.dialog.MissionTypeDialog;
+import mekhq.gui.dialog.NewAtBContractDialog;
 import mekhq.gui.dialog.NewContractDialog;
 import mekhq.gui.dialog.RetirementDefectionDialog;
 import mekhq.gui.dialog.camOpsSalvage.SalvageFormationPicker;
@@ -138,6 +148,8 @@ import mekhq.gui.enums.MHQTabType;
 import mekhq.gui.model.ScenarioTableModel;
 import mekhq.gui.panels.TutorialHyperlinkPanel;
 import mekhq.gui.sorter.DateStringComparator;
+import mekhq.gui.view.AtBScenarioViewPanel;
+import mekhq.gui.view.LanceAssignmentView;
 import mekhq.gui.view.MissionViewPanel;
 import mekhq.gui.view.ScenarioViewPanel;
 
@@ -151,6 +163,8 @@ public final class BriefingTab extends CampaignGuiTab {
     private static final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.CampaignGUI",
           MekHQ.getMHQOptions().getLocale());
 
+    private LanceAssignmentView panLanceAssignment;
+    private JSplitPane splitScenario;
     private JTable scenarioTable;
     private MMComboBox<Mission> comboMission;
     private JScrollPane scrollMissionView;
@@ -363,9 +377,26 @@ public final class BriefingTab extends CampaignGuiTab {
         gridBagConstraints.weighty = 1.0;
         panScenario.add(scrollScenarioView, gridBagConstraints);
 
+        /* ATB */
+        panLanceAssignment = new LanceAssignmentView(getCampaign());
+        JScrollPane paneLanceDeployment = new FastJScrollPane(panLanceAssignment);
+        paneLanceDeployment.setBorder(null);
+        paneLanceDeployment.setMinimumSize(new Dimension(200, 300));
+        paneLanceDeployment.setPreferredSize(new Dimension(200, 300));
+        paneLanceDeployment.setVisible(getCampaignOptions().isUseStratCon());
+        splitScenario = new JSplitPane(JSplitPane.VERTICAL_SPLIT, panScenario, paneLanceDeployment);
+        splitScenario.setOneTouchExpandable(true);
+        splitScenario.setResizeWeight(1.0);
+
+        JSplitPane splitBrief = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, panMission, splitScenario);
+        splitBrief.setOneTouchExpandable(true);
+        splitBrief.setResizeWeight(0.5);
+        splitBrief.addPropertyChangeListener(JSplitPane.DIVIDER_LOCATION_PROPERTY, ev -> refreshScenarioView());
+
         JPanel pnlTutorial = new TutorialHyperlinkPanel("missionTab");
 
         setLayout(new BorderLayout());
+        add(splitBrief, BorderLayout.CENTER);
         add(pnlTutorial, BorderLayout.SOUTH);
     }
 
@@ -373,7 +404,9 @@ public final class BriefingTab extends CampaignGuiTab {
         MissionTypeDialog mtd = new MissionTypeDialog(getFrame(), true);
         mtd.setVisible(true);
         if (mtd.isContract()) {
-            NewContractDialog ncd = new NewContractDialog(getFrame(), true, getCampaign());
+            NewContractDialog ncd = getCampaignOptions().isUseStratCon() ?
+                                          new NewAtBContractDialog(getFrame(), true, getCampaign()) :
+                                          new NewContractDialog(getFrame(), true, getCampaign());
             ncd.setVisible(true);
             comboMission.setSelectedItem(ncd.getContract());
         }
@@ -390,10 +423,18 @@ public final class BriefingTab extends CampaignGuiTab {
             return;
         }
 
-        CustomizeMissionDialog cmd = new CustomizeMissionDialog(getFrame(), true, mission, getCampaign());
-        cmd.setVisible(true);
-        comboMission.setSelectedItem(cmd.getMission());
-
+        if (getCampaignOptions().isUseStratCon() && (mission instanceof AtBContract)) {
+            CustomizeAtBContractDialog cmd = new CustomizeAtBContractDialog(getFrame(),
+                  true,
+                  (AtBContract) mission,
+                  getCampaign());
+            cmd.setVisible(true);
+            comboMission.setSelectedItem(cmd.getAtBContract());
+        } else {
+            CustomizeMissionDialog cmd = new CustomizeMissionDialog(getFrame(), true, mission, getCampaign());
+            cmd.setVisible(true);
+            comboMission.setSelectedItem(cmd.getMission());
+        }
         MekHQ.triggerEvent(new MissionChangedEvent(mission));
     }
 
@@ -423,6 +464,12 @@ public final class BriefingTab extends CampaignGuiTab {
         if (!getCampaign().getPrisonerDefectors().isEmpty() &&
                   prisoners.handlePrisonerDefectors() == 0) { // This is the cancel choice index
             return;
+        }
+
+        if (campaignOptions.isUseStratCon() && (mission instanceof AtBContract)) {
+            if (((AtBContract) mission).contractExtended(getCampaign())) {
+                return;
+            }
         }
 
         getCampaign().completeMission(mission, status);
@@ -493,6 +540,10 @@ public final class BriefingTab extends CampaignGuiTab {
                     return;
                 }
             }
+        }
+
+        if (campaignOptions.isUseStratCon() && (mission instanceof AtBContract)) {
+            getCampaign().getContractMarket().checkForFollowup(getCampaign(), (AtBContract) mission);
         }
 
         // prompt autoAwards ceremony
@@ -1522,6 +1573,17 @@ public final class BriefingTab extends CampaignGuiTab {
             }
         }
 
+        if (getCampaignOptions().isUseStratCon() && (scenario instanceof AtBScenario atBScenario)) {
+            atBScenario.refresh(getCampaign());
+
+            // Autoconfigure munitions for all non-player forces once more, using finalized
+            // forces
+            if (getCampaignOptions().isAutoConfigMunitions()) {
+                autoconfigureBotMunitions(atBScenario, chosen);
+            }
+            configureBotAi(atBScenario);
+        }
+
         if (scenario.getStratConScenarioType().isConvoy() && (autoResolveBehaviorSettings != null)) {
             try {
                 autoResolveBehaviorSettings = autoResolveBehaviorSettings.getCopy();
@@ -1534,6 +1596,146 @@ public final class BriefingTab extends CampaignGuiTab {
         if (!chosen.isEmpty()) {
             getCampaignGui().getApplication().startHost(scenario, false, chosen, autoResolveBehaviorSettings);
         }
+    }
+
+    private void configureBotAi(AtBScenario scenario) {
+        Faction opFor = getEnemyFactionFromScenario(scenario);
+        boolean isPirate = opFor.isRebelOrPirate();
+        for (var bf : scenario.getBotForces()) {
+            bf.getBehaviorSettings().setIAmAPirate(isPirate);
+        }
+    }
+
+    /**
+     * Get the enemy faction from the Mission from the scenario
+     *
+     * @param scenario the scenario to get the enemy faction from
+     *
+     * @return the enemy faction
+     */
+    private Faction getEnemyFactionFromScenario(Scenario scenario) {
+        Mission mission = null;
+        if (scenario.getMissionId() != -1) {
+            mission = getCampaign().getMission(scenario.getMissionId());
+        }
+        if (mission == null) {
+            mission = comboMission.getSelectedItem();
+        }
+        String opForFactionCode = "IS";
+        Faction enemy;
+        if (mission instanceof AtBContract atBContract) {
+            enemy = atBContract.getEnemy();
+            if (enemy != null) {
+                return atBContract.getEnemy();
+            }
+            opForFactionCode = atBContract.getEnemyCode().isBlank() ? opForFactionCode : atBContract.getEnemyCode();
+        }
+        enemy = Factions.getInstance().getFaction(opForFactionCode);
+        return enemy;
+    }
+
+    /**
+     * Designed to fully kit out all non-player-controlled forces prior to battle. Does not do any checks for supplies,
+     * only for availability to each faction during the current timeframe.
+     *
+     */
+    private void autoconfigureBotMunitions(AtBScenario scenario, List<Unit> chosen) {
+        Game cGame = getCampaign().getGame();
+        boolean groundMap = scenario.getBoardType() == AtBScenario.T_GROUND;
+        boolean spaceMap = scenario.getBoardType() == AtBScenario.T_SPACE;
+        ArrayList<Entity> alliedEntities = new ArrayList<>();
+
+        ArrayList<String> allyFactionCodes = new ArrayList<>();
+        ArrayList<String> opForFactionCodes = new ArrayList<>();
+        String opForFactionCode = "IS";
+        String allyFaction = "IS";
+        int opForQuality = RATING_5;
+        HashMap<Integer, ArrayList<Entity>> botTeamMappings = new HashMap<>();
+        int allowedYear = cGame.getOptions().intOption(OptionsConstants.ALLOWED_YEAR);
+
+        // This had better be an AtB contract...
+        final Mission mission = comboMission.getSelectedItem();
+        if (mission instanceof AtBContract atbContract) {
+            opForFactionCode = (atbContract.getEnemyCode().isBlank()) ? opForFactionCode : atbContract.getEnemyCode();
+            opForQuality = atbContract.getEnemyQuality();
+            allyFactionCodes.add(atbContract.getEmployerCode());
+            allyFaction = atbContract.getEmployerName(allowedYear);
+        } else {
+            allyFactionCodes.add(allyFaction);
+        }
+        Faction opforFaction = Factions.getInstance().getFaction(opForFactionCode);
+        opForFactionCodes.add(opForFactionCode);
+        boolean isPirate = opforFaction.isRebelOrPirate();
+
+        // Collect player units to use as configuration fodder
+        ArrayList<Entity> playerEntities = new ArrayList<>();
+        for (final Unit unit : chosen) {
+            playerEntities.add(unit.getEntity());
+        }
+        allyFactionCodes.add(getCampaign().getFaction().getShortName());
+
+        // Split up bot forces into teams for separate handling
+        for (final BotForce botForce : scenario.getBotForces()) {
+            // Do not include Turrets
+            List<Entity> filteredEntityList =
+                  botForce.getFixedEntityList().stream().filter(
+                        e -> !(e.isBuildingEntityOrGunEmplacement())
+                  ).toList();
+            if (botForce.getName().contains(allyFaction)) {
+                // Stuff with our employer's name should be with us.
+                playerEntities.addAll(filteredEntityList);
+                alliedEntities.addAll(filteredEntityList);
+            } else {
+                int botTeam = botForce.getTeam();
+                if (!botTeamMappings.containsKey(botTeam)) {
+                    botTeamMappings.put(botTeam, new ArrayList<>());
+                }
+                botTeamMappings.get(botTeam).addAll(filteredEntityList);
+            }
+        }
+
+        // Configure generated units with appropriate munitions (for BV calculations)
+        TeamLoadOutGenerator tlg = new TeamLoadOutGenerator(cGame);
+
+        // Reconfigure each group separately so they only consider their own
+        // capabilities
+        for (ArrayList<Entity> entityList : botTeamMappings.values()) {
+            // bin fill ratio will be adjusted by the loadout generator based on piracy and
+            // quality
+            ReconfigurationParameters rp = TeamLoadOutGenerator.generateParameters(cGame,
+                  cGame.getOptions(),
+                  entityList,
+                  opForFactionCode,
+                  playerEntities,
+                  allyFactionCodes,
+                  opForQuality,
+                  ((isPirate) ? TeamLoadOutGenerator.UNSET_FILL_RATIO : 1.0f));
+            rp.isPirate = isPirate;
+            rp.groundMap = groundMap;
+            rp.spaceEnvironment = spaceMap;
+            MunitionTree mt = TeamLoadOutGenerator.generateMunitionTree(rp, entityList, "");
+            // We now have the ability to pre-create a munition availability map for use with special scenarios,
+            // representing limited-availability ammo in the hands of a specific force.
+            tlg.reconfigureEntities(entityList, opForFactionCode, mt, rp, null);
+        }
+
+        // Finally, reconfigure all allies (but not player entities) as one organization
+        ArrayList<Entity> allEnemyEntities = new ArrayList<>();
+        botTeamMappings.values().forEach(allEnemyEntities::addAll);
+        ReconfigurationParameters rp = TeamLoadOutGenerator.generateParameters(cGame,
+              cGame.getOptions(),
+              alliedEntities,
+              allyFactionCodes.get(0),
+              allEnemyEntities,
+              opForFactionCodes,
+              opForQuality,
+              (getCampaign().getFaction().isPirate()) ? TeamLoadOutGenerator.UNSET_FILL_RATIO : 1.0f);
+        rp.isPirate = getCampaign().getFaction().isPirate();
+        rp.groundMap = groundMap;
+        rp.spaceEnvironment = spaceMap;
+        MunitionTree mt = TeamLoadOutGenerator.generateMunitionTree(rp, alliedEntities, "");
+        tlg.reconfigureEntities(alliedEntities, allyFactionCodes.get(0), mt, rp, null);
+
     }
 
     private void joinScenario() {
@@ -1731,6 +1933,9 @@ public final class BriefingTab extends CampaignGuiTab {
         }
 
         changeMission();
+        if (getCampaignOptions().isUseStratCon()) {
+            refreshLanceAssignments();
+        }
     }
 
     public void refreshScenarioView() {
@@ -1753,8 +1958,13 @@ public final class BriefingTab extends CampaignGuiTab {
             return;
         }
         selectedScenario = scenario.getId();
-        scrollScenarioView.setViewportView(new ScenarioViewPanel(getFrame(), getCampaign(), scenario));
-
+        if (getCampaignOptions().isUseStratCon() && (scenario instanceof AtBScenario)) {
+            scrollScenarioView.setViewportView(new AtBScenarioViewPanel((AtBScenario) scenario,
+                  getCampaign(),
+                  getFrame()));
+        } else {
+            scrollScenarioView.setViewportView(new ScenarioViewPanel(getFrame(), getCampaign(), scenario));
+        }
         // This odd code is to make sure that the scrollbar stays at the top
         // I can't just call it here, because it ends up getting reset somewhere
         // later
@@ -1780,8 +1990,8 @@ public final class BriefingTab extends CampaignGuiTab {
         btnPrintRS.setEnabled(canStartGame);
     }
 
-    @Deprecated(since = "0.51.0", forRemoval = true)
     public void refreshLanceAssignments() {
+        panLanceAssignment.refresh();
     }
 
     /*
@@ -1932,6 +2142,13 @@ public final class BriefingTab extends CampaignGuiTab {
     private final ActionScheduler scenarioDataScheduler = new ActionScheduler(this::refreshScenarioTableData);
     private final ActionScheduler scenarioViewScheduler = new ActionScheduler(this::refreshScenarioView);
     private final ActionScheduler missionsScheduler = new ActionScheduler(this::refreshMissions);
+    private final ActionScheduler lanceAssignmentScheduler = new ActionScheduler(this::refreshLanceAssignments);
+
+    @Subscribe
+    public void handle(OptionsChangedEvent ev) {
+        splitScenario.getBottomComponent().setVisible(getCampaignOptions().isUseStratCon());
+        splitScenario.resetToPreferredSizes();
+    }
 
     @Subscribe
     public void handle(ScenarioChangedEvent evt) {
@@ -1954,6 +2171,9 @@ public final class BriefingTab extends CampaignGuiTab {
     @Subscribe
     public void handle(OrganizationChangedEvent ev) {
         scenarioDataScheduler.schedule();
+        if (getCampaignOptions().isUseStratCon()) {
+            lanceAssignmentScheduler.schedule();
+        }
     }
 
     @Subscribe

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -59,6 +59,7 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JSplitPane;
 import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 import javax.swing.ScrollPaneConstants;

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -70,6 +70,7 @@ import javax.swing.UIManager.LookAndFeelInfo;
 import javax.xml.parsers.DocumentBuilder;
 
 import megamek.Version;
+import megamek.client.generator.RandomUnitGenerator;
 import megamek.client.ui.clientGUI.GUIPreferences;
 import megamek.client.ui.dialogs.UnitLoadingDialog;
 import megamek.client.ui.dialogs.buttonDialogs.CommonSettingsDialog;
@@ -757,6 +758,12 @@ public class CampaignGUI extends JPanel {
         miPersonnelMarket.addActionListener(evt -> hirePersonMarket());
         miPersonnelMarket.setVisible(!getCampaign().getPersonnelMarket().isNone());
         menuMarket.add(miPersonnelMarket);
+
+        JMenuItem miContractMarket = new JMenuItem(resourceMap.getString("miContractMarket.text"));
+        miContractMarket.setMnemonic(KeyEvent.VK_C);
+        miContractMarket.addActionListener(evt -> showContractMarket());
+        miContractMarket.setVisible(getCampaign().getCampaignOptions().isUseStratCon());
+        menuMarket.add(miContractMarket);
 
         JMenuItem miUnitMarket = new JMenuItem(resourceMap.getString("miUnitMarket.text"));
         miUnitMarket.setMnemonic(KeyEvent.VK_U);
@@ -2148,7 +2155,9 @@ public class CampaignGUI extends JPanel {
         missionTypeDialog.setVisible(true);
 
         if (missionTypeDialog.isContract()) {
-            NewContractDialog newContractDialog = new NewContractDialog(getFrame(), true, getCampaign());
+            NewContractDialog newContractDialog = campaignOptions.isUseStratCon() ?
+                                                        new NewAtBContractDialog(getFrame(), true, getCampaign()) :
+                                                        new NewContractDialog(getFrame(), true, getCampaign());
             newContractDialog.setVisible(true);
         }
         return missionTypeDialog;
@@ -2261,6 +2270,7 @@ public class CampaignGUI extends JPanel {
     private void menuOptionsActionPerformed(final ActionEvent evt) {
         final CampaignOptions oldOptions = getCampaign().getCampaignOptions();
         // We need to handle it like this for now, as the options above get written to currently
+        boolean atb = oldOptions.isUseStratCon();
         boolean factionIntroDate = oldOptions.isFactionIntroDate();
         final RandomDivorceMethod randomDivorceMethod = oldOptions.getRandomDivorceMethod();
         final RandomMarriageMethod randomMarriageMethod = oldOptions.getRandomMarriageMethod();
@@ -2331,6 +2341,29 @@ public class CampaignGUI extends JPanel {
         AbstractContractMarket contractMarket = getCampaign().getContractMarket();
         if (contractMarket.getMethod() != newOptions.getContractMarketMethod()) {
             getCampaign().setContractMarket(newOptions.getContractMarketMethod().getContractMarket());
+        }
+
+        if (atb != newOptions.isUseStratCon()) {
+            if (newOptions.isUseStratCon()) {
+                getCampaign().initAtB(false);
+                // refresh lance assignment table
+                MekHQ.triggerEvent(new OrganizationChangedEvent(getCampaign(), getCampaign().getFormations()));
+            }
+            if (newOptions.isUseStratCon()) {
+                int loops = 0;
+                while (!RandomUnitGenerator.getInstance().isInitialized()) {
+                    try {
+                        Thread.sleep(50);
+                        if (++loops > 20) {
+                            // Wait for up to a second
+                            break;
+                        }
+                    } catch (InterruptedException ignore) {
+                    }
+                }
+            } else {
+                getCampaign().shutdownAtB();
+            }
         }
 
         getCampaign().initTurnover();

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -1194,24 +1194,53 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_SACK: {
-                String question;
-
-                if (people.length > 1) {
-                    question = resources.getString("confirmRemoveMultiple.text");
-                } else {
-                    question = String.format(resources.getString("confirmRemove.format"), people[0].getFullTitle());
-                }
-
-                if (JOptionPane.YES_OPTION ==
-                          JOptionPane.showConfirmDialog(null,
-                                question,
-                                resources.getString("removeQ.text"),
-                                JOptionPane.YES_NO_OPTION)) {
+                boolean showDialog = false;
+                List<Person> toRemove = new ArrayList<>();
+                if (getCampaignOptions().isUseStratCon()) {
                     for (Person person : people) {
-                        getCampaign().removePerson(person);
+                        if (!person.getPrimaryRole().isCivilian()) {
+                            if (getCampaign().getRetirementDefectionTracker()
+                                      .removeFromCampaign(person, false, true, getCampaign(), null)) {
+                                showDialog = true;
+                            } else {
+                                toRemove.add(person);
+                            }
+                        } else {
+                            toRemove.add(person);
+                        }
                     }
                 }
 
+                if (showDialog) {
+                    RetirementDefectionDialog rdd = new RetirementDefectionDialog(gui, null, false);
+
+                    if (rdd.wasAborted() ||
+                              !getCampaign().applyRetirement(rdd.totalPayout(), rdd.getUnitAssignments())) {
+                        for (Person person : people) {
+                            getCampaign().getRetirementDefectionTracker().removePayout(person);
+                        }
+                    } else {
+                        for (final Person person : toRemove) {
+                            getCampaign().removePerson(person);
+                        }
+                    }
+                } else {
+                    String question;
+                    if (people.length > 1) {
+                        question = resources.getString("confirmRemoveMultiple.text");
+                    } else {
+                        question = String.format(resources.getString("confirmRemove.format"), people[0].getFullTitle());
+                    }
+                    if (JOptionPane.YES_OPTION ==
+                              JOptionPane.showConfirmDialog(null,
+                                    question,
+                                    resources.getString("removeQ.text"),
+                                    JOptionPane.YES_NO_OPTION)) {
+                        for (Person person : people) {
+                            getCampaign().removePerson(person);
+                        }
+                    }
+                }
                 break;
             }
             case CMD_EMPLOY: {

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -1238,6 +1238,21 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
             menu.add(menuItem);
             popup.add(menu);
 
+            if (gui.getCampaign().getCampaignOptions().isUseStratCon()) {
+                JMenuItem optionStrategicForceOverride = new JMenuItem((formation.isCombatTeam() ? "Never" : "Always") +
+                                                                             " Consider Force a Combat Team");
+                optionStrategicForceOverride.setActionCommand(COMMAND_CHANGE_STRATEGIC_FORCE_OVERRIDE + forceIds);
+                optionStrategicForceOverride.addActionListener(this);
+                popup.add(optionStrategicForceOverride);
+
+                JMenuItem optionRemoveStrategicForceOverride = new JMenuItem("Remove Combat Team Override");
+                optionRemoveStrategicForceOverride.setActionCommand(COMMAND_REMOVE_STRATEGIC_FORCE_OVERRIDE + forceIds);
+                optionRemoveStrategicForceOverride.addActionListener(this);
+                optionRemoveStrategicForceOverride.setVisible(formation.getOverrideCombatTeam() !=
+                                                                    COMBAT_TEAM_OVERRIDE_NONE);
+                popup.add(optionRemoveStrategicForceOverride);
+            }
+
             if (StaticChecks.areAllForcesUnDeployed(gui.getCampaign(), formations) &&
                       StaticChecks.areAllStandardForces(formations)) {
                 menu = new JMenu("Deploy Force");

--- a/MekHQ/src/mekhq/gui/dialog/ContractMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ContractMarketDialog.java
@@ -247,6 +247,14 @@ public class ContractMarketDialog extends JDialog {
         spnSharePct = new JSpinner(new SpinnerNumberModel(sharePct, 20, 50, 10));
         spnSharePct.addChangeListener(evt -> {
             sharePct = (Integer) spnSharePct.getValue();
+            for (Contract c : contractMarket.getContracts()) {
+                if (campaign.getCampaignOptions().isUseStratCon() &&
+                          campaign.getCampaignOptions().isUseShareSystem() &&
+                          c instanceof AtBContract) {
+                    ((AtBContract) c).setAtBSharesPercent(sharePct);
+                    c.calculateContract(campaign);
+                }
+            }
             if (contractView != null) {
                 contractView.refreshAmounts();
             }
@@ -738,7 +746,12 @@ public class ContractMarketDialog extends JDialog {
             scrollContractView.setViewportView(null);
             return;
         }
-        contractView = new ContractSummaryPanel(selectedContract, campaign, false);
+        contractView = new ContractSummaryPanel(selectedContract,
+              campaign,
+              campaign.getCampaignOptions().isUseStratCon() &&
+                    selectedContract instanceof AtBContract &&
+                    !((AtBContract) selectedContract).isSubcontract() &&
+                    !campaign.isPirateCampaign());
         scrollContractView.setViewportView(contractView);
         // This odd code is to make sure that the scrollbar stays at the top
         // I can't just call it here, because it ends up getting reset somewhere later

--- a/MekHQ/src/mekhq/gui/dialog/CustomizeScenarioDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizeScenarioDialog.java
@@ -462,7 +462,8 @@ public class CustomizeScenarioDialog extends JDialog {
     private void btnOKActionPerformed(ActionEvent evt) {
         scenario.setName(txtName.getText());
         scenario.setDesc(txtDesc.getText());
-        if (!scenario.getStatus().isCurrent()) {
+        if (!scenario.getStatus().isCurrent() ||
+                  (campaign.getCampaignOptions().isUseStratCon() && (scenario instanceof AtBScenario))) {
             if (txtReport != null) {
                 scenario.setReport(txtReport.getText());
             }

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -427,6 +427,11 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
                 // GM Mode
                 campaign.setGMMode((preset == null) || preset.isGM());
 
+                // AtB
+                if (campaignOptions.isUseStratCon()) {
+                    campaign.initAtB(true);
+                }
+
                 // Turnover
                 campaign.initTurnover();
                 // endregion Progress 7

--- a/MekHQ/src/mekhq/gui/dialog/VocationalExperienceAwardDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/VocationalExperienceAwardDialog.java
@@ -39,6 +39,7 @@ import java.util.List;
 
 import mekhq.campaign.Campaign;
 import mekhq.campaign.campaignOptions.CampaignOptions;
+import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.personnel.Person;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
 
@@ -142,7 +143,16 @@ public class VocationalExperienceAwardDialog extends ImmersiveDialogSimple {
         int advancement = campaignOptions.getVocationalXP();
 
         if (campaign.hasActiveContract()) {
-            advancement *= 2;
+            if (campaignOptions.isUseStratCon()) {
+                for (AtBContract contract : campaign.getActiveAtBContracts()) {
+                    if (!contract.getContractType().isGarrisonType()) {
+                        advancement *= 2;
+                        break;
+                    }
+                }
+            } else {
+                advancement *= 2;
+            }
         }
 
         return getFormattedTextAt(RESOURCE_BUNDLE, "dialog.ooc", advancement);

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/DeploymentShortfallNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/DeploymentShortfallNagDialog.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2021-2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.dialog.nagDialogs;
+
+import static mekhq.MHQConstants.NAG_SHORT_DEPLOYMENT;
+import static mekhq.gui.dialog.nagDialogs.nagLogic.DeploymentShortfallNagLogic.hasDeploymentShortfall;
+
+import mekhq.MekHQ;
+import mekhq.campaign.Campaign;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogNag;
+
+/**
+ * A dialog class used to notify players about deployment shortfalls in their campaign.
+ *
+ * <p>The {@code DeploymentShortfallNagDialog} extends {@link ImmersiveDialogNag} and provides
+ * a specialized nag dialog designed to alert players when deployment shortfalls occur. It uses predefined parameters,
+ * such as the {@code NAG_SHORT_DEPLOYMENT} constant, and no specific specialization for its speaker, allowing for a
+ * default fallback during dialog creation.</p>
+ */
+public class DeploymentShortfallNagDialog extends ImmersiveDialogNag {
+    /**
+     * Constructs a new {@code DeploymentShortfallNagDialog} instance to display the deployment shortfall nag dialog.
+     *
+     * <p>This constructor initializes the nag dialog without a specific specialization, allowing the fallback
+     * mechanism to determine the appropriate speaker. The {@code NAG_SHORT_DEPLOYMENT} constant is used to manage
+     * dialog suppression, and the {@code "DeploymentShortfallNagDialog"} message key is utilized to retrieve localized
+     * content.</p>
+     *
+     * @param campaign The {@link Campaign} instance associated with this dialog. Provides access to campaign data and
+     *                 settings required for dialog construction.
+     */
+    public DeploymentShortfallNagDialog(final Campaign campaign) {
+        super(campaign, null, NAG_SHORT_DEPLOYMENT, "DeploymentShortfallNagDialog");
+    }
+
+    /**
+     * Determines whether a nag dialog should be displayed for deployment shortfalls in the specified campaign.
+     *
+     * <p>This method evaluates several conditions to decide if the nag dialog should be shown:</p>
+     * <ul>
+     *     <li>The campaign uses AtB (Against the Bot) rules.</li>
+     *     <li>The user has not ignored the nag dialog for deployment shortfalls in their options.</li>
+     *     <li>The campaign has a deployment shortfall, as determined by {@code #hasDeploymentShortfall}.</li>
+     * </ul>
+     *
+     * @param isUseAtB A flag indicating whether the campaign is using AtB rules.
+     * @param campaign The {@link Campaign} object used to check for deployment shortfalls.
+     *
+     * @return {@code true} if the nag dialog should be displayed due to deployment shortfalls; {@code false} otherwise.
+     */
+    public static boolean checkNag(boolean isUseAtB, Campaign campaign) {
+        return isUseAtB &&
+                     !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_SHORT_DEPLOYMENT) &&
+                     hasDeploymentShortfall(campaign);
+    }
+}

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
@@ -213,6 +213,24 @@ public class NagController {
             }
         }
 
+        // Outstanding Scenarios
+        if (OutstandingScenariosNagDialog.checkNag(campaign)) {
+            OutstandingScenariosNagDialog outstandingScenariosNagDialog = new OutstandingScenariosNagDialog(campaign);
+            if (outstandingScenariosNagDialog.shouldCancelAdvanceDay()) {
+                return true;
+            }
+        }
+
+        // Deployment Shortfall
+        final boolean isUseAtB = campaignOptions.isUseStratCon();
+
+        if (DeploymentShortfallNagDialog.checkNag(isUseAtB, campaign)) {
+            DeploymentShortfallNagDialog deploymentShortfallNagDialog = new DeploymentShortfallNagDialog(campaign);
+            if (deploymentShortfallNagDialog.shouldCancelAdvanceDay()) {
+                return true;
+            }
+        }
+
         // Prisoners of War
         final boolean hasActiveContract = campaign.hasActiveContract();
         final boolean hasPrisoners = !campaign.getCurrentPrisoners().isEmpty();

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/OutstandingScenariosNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/OutstandingScenariosNagDialog.java
@@ -34,8 +34,10 @@ package mekhq.gui.dialog.nagDialogs;
 
 import static mekhq.MHQConstants.NAG_OUTSTANDING_SCENARIOS;
 import static mekhq.gui.dialog.nagDialogs.nagLogic.OutstandingScenariosNagLogic.getOutstandingScenarios;
+import static mekhq.gui.dialog.nagDialogs.nagLogic.OutstandingScenariosNagLogic.hasOutStandingScenarios;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
+import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogNag;
 
@@ -71,5 +73,26 @@ public class OutstandingScenariosNagDialog extends ImmersiveDialogNag {
         String outstandingScenarios = getOutstandingScenarios(campaign);
 
         return getFormattedTextAt(RESOURCE_BUNDLE, key + ".ic", commanderAddress, outstandingScenarios);
+    }
+
+    /**
+     * Checks if a nag dialog should be displayed for outstanding scenarios in the given campaign.
+     *
+     * <p>The method evaluates the following conditions to determine if the nag dialog should appear:</p>
+     * <ul>
+     *     <li>If the campaign is set to use AtB (Against the Bot) rules.</li>
+     *     <li>If the nag dialog for outstanding scenarios has not been ignored in the user options.</li>
+     *     <li>If there are outstanding scenarios in the campaign.</li>
+     * </ul>
+     *
+     * @param campaign the {@link Campaign} to check for nagging conditions
+     *
+     * @return {@code true} if the nag dialog should be displayed, {@code false} otherwise
+     */
+    public static boolean checkNag(Campaign campaign) {
+
+        return campaign.getCampaignOptions().isUseStratCon() &&
+                     !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_OUTSTANDING_SCENARIOS) &&
+                     hasOutStandingScenarios(campaign);
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnableToAffordJumpNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnableToAffordJumpNagDialog.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2021-2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.dialog.nagDialogs;
+
+import static mekhq.MHQConstants.NAG_UNABLE_TO_AFFORD_JUMP;
+import static mekhq.campaign.Campaign.AdministratorSpecialization.TRANSPORT;
+import static mekhq.gui.dialog.nagDialogs.nagLogic.UnableToAffordJumpNagLogic.getNextJumpCost;
+import static mekhq.gui.dialog.nagDialogs.nagLogic.UnableToAffordJumpNagLogic.unableToAffordNextJump;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import mekhq.MekHQ;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogNag;
+
+/**
+ * A dialog class used to notify players when they are unable to afford a jump within the campaign.
+ *
+ * <p>The {@code UnableToAffordJumpNagDialog} extends {@link ImmersiveDialogNag} and is specifically designed
+ * to alert players about financial constraints preventing them from performing a jump. It utilizes predefined
+ * constants, including the {@code TRANSPORT} speaker and the {@code NAG_UNABLE_TO_AFFORD_JUMP} identifier, to configure
+ * the dialog's behavior and content.</p>
+ */
+public class UnableToAffordJumpNagDialog extends ImmersiveDialogNag {
+    /**
+     * Constructs a new {@code UnableToAffordJumpNagDialog} to display a warning about unaffordable jump expenses.
+     *
+     * <p>This constructor initializes the dialog with preconfigured values, such as the
+     * {@code NAG_UNABLE_TO_AFFORD_JUMP} constant for managing dialog suppression, the
+     * {@code "UnableToAffordJumpNagDialog"} localization key for retrieving dialog content, and the {@code TRANSPORT}
+     * speaker for delivering the message.</p>
+     *
+     * @param campaign The {@link Campaign} instance associated with this dialog. Provides access to campaign data
+     *                 required for constructing the nag dialog.
+     */
+    public UnableToAffordJumpNagDialog(final Campaign campaign) {
+        super(campaign, TRANSPORT, NAG_UNABLE_TO_AFFORD_JUMP, "UnableToAffordJumpNagDialog");
+    }
+
+    @Override
+    protected String getInCharacterMessage(Campaign campaign, String key, String commanderAddress) {
+        final String RESOURCE_BUNDLE = "mekhq.resources.NagDialogs";
+
+        Money nextJumpCost = getNextJumpCost(campaign);
+        Money currentFunds = campaign.getFunds();
+        Money deficit = nextJumpCost.minus(currentFunds);
+
+        return getFormattedTextAt(RESOURCE_BUNDLE,
+              key + ".ic",
+              commanderAddress,
+              nextJumpCost.toAmountString(),
+              currentFunds.toAmountString(),
+              deficit.toAmountString());
+    }
+
+    /**
+     * Checks if a nag dialog should be displayed for the inability to afford the next jump in the given campaign.
+     *
+     * <p>The method evaluates the following conditions to determine if the nag dialog should appear:</p>
+     * <ul>
+     *     <li>If the nag dialog for the inability to afford the next jump has not been ignored in the user options.</li>
+     *     <li>If the campaign is unable to afford the next jump.</li>
+     * </ul>
+     *
+     * @param campaign the {@link Campaign} to check for nagging conditions
+     *
+     * @return {@code true} if the nag dialog should be displayed, {@code false} otherwise
+     */
+    public static boolean checkNag(Campaign campaign) {
+
+        return !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_UNABLE_TO_AFFORD_JUMP) && unableToAffordNextJump(campaign);
+    }
+}

--- a/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
@@ -380,6 +380,13 @@ public class ForceViewPanel extends JScrollablePanel {
         pnlStats.add(lblTonnage2, gridBagConstraints);
         nextY++;
 
+        // if AtB is enabled, set tooltip to show lance weight breakdowns
+        if (campaign.getCampaignOptions().isUseStratCon()) {
+            // see Lance.java for lance weight breakdowns
+            lblTonnage1.setToolTipText(resourceMap.getString("tonnageToolTip.text"));
+            lblTonnage2.setToolTipText(resourceMap.getString("tonnageToolTip.text"));
+        }
+
         lblCost1.setName("lblCost1");
         lblCost1.setText(resourceMap.getString("lblCost1.text"));
         gridBagConstraints = new GridBagConstraints();

--- a/MekHQ/unittests/mekhq/campaign/market/ContractMarketAtBGenerationTests.java
+++ b/MekHQ/unittests/mekhq/campaign/market/ContractMarketAtBGenerationTests.java
@@ -1,0 +1,1974 @@
+/*
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.market;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyDouble;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.Vector;
+
+import mekhq.campaign.Campaign;
+import mekhq.campaign.CurrentLocation;
+import mekhq.campaign.Hangar;
+import mekhq.campaign.JumpPath;
+import mekhq.campaign.camOpsReputation.ReputationController;
+import mekhq.campaign.campaignOptions.CampaignOptions;
+import mekhq.campaign.enums.DragoonRating;
+import mekhq.campaign.finances.Accountant;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.force.Formation;
+import mekhq.campaign.market.contractMarket.AtbMonthlyContractMarket;
+import mekhq.campaign.mission.AtBContract;
+import mekhq.campaign.universe.Faction;
+import mekhq.campaign.universe.Factions;
+import mekhq.campaign.universe.PlanetarySystem;
+import mekhq.campaign.universe.RandomFactionGenerator;
+import mekhq.campaign.universe.Systems;
+import mekhq.campaign.universe.factionHints.FactionHints;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@Disabled // broken
+@Deprecated(since = "0.50.10", forRemoval = true)
+public class ContractMarketAtBGenerationTests {
+    public static List<Arguments> generateData() {
+        final List<Arguments> arguments = new ArrayList<>();
+        for (final int gameYear : Arrays.asList(2750, 3025, 3055, 3067, 3120)) {
+            for (int rating = DragoonRating.DRAGOON_F.getRating();
+                  rating <= DragoonRating.DRAGOON_ASTAR.getRating();
+                  rating++) {
+                arguments.add(Arguments.of(gameYear, rating, false));
+                arguments.add(Arguments.of(gameYear, rating, true));
+            }
+        }
+        return arguments;
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "generateData")
+    public void addMercWithoutRetainerAtBContractSucceeds(final int gameYear, final int unitRating,
+          final boolean isClanEnemy) {
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getRetainerEmployerCode()).thenReturn(null);
+        when(campaign.getAtBUnitRatingMod()).thenReturn(unitRating);
+        when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
+        when(campaign.getGameYear()).thenReturn(gameYear);
+
+        ReputationController camOpsReputation = mock(ReputationController.class);
+        when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
+        when(campaign.getReputation()).thenReturn(camOpsReputation);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+        when(campaignFaction.getShortName()).thenReturn("MERC");
+
+        CampaignOptions campaignOptions = mock(CampaignOptions.class);
+        when(campaignOptions.isVariableContractLength()).thenReturn(false);
+        when(campaignOptions.isUsePeacetimeCost()).thenReturn(false);
+        when(campaign.getCampaignOptions()).thenReturn(campaignOptions);
+
+        Accountant accountant = mock(Accountant.class);
+        when(accountant.getContractBase()).thenReturn(Money.of(1));
+        when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
+        when(campaign.getAccountant()).thenReturn(accountant);
+
+        Hangar hangar = mock(Hangar.class);
+        doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
+        when(campaign.getHangar()).thenReturn(hangar);
+
+        Formation forces = mock(Formation.class);
+        doReturn(new Vector<UUID>()).when(forces).getAllUnits(anyBoolean());
+        when(campaign.getFormations()).thenReturn(forces);
+
+        Factions factions = mock(Factions.class);
+        Factions.setInstance(factions);
+
+        String employer = "EMPLOYER";
+        String employerFullName = "Contract Employer";
+        Faction employerFaction = mock(Faction.class);
+        when(employerFaction.getShortName()).thenReturn(employer);
+        doReturn(employerFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(employerFaction).when(factions).getFaction(eq(employer));
+
+        String enemy = "ENEMY";
+        String enemyFullName = "Contract Enemy";
+        Faction enemyFaction = mock(Faction.class);
+        when(enemyFaction.getShortName()).thenReturn(enemy);
+        when(enemyFaction.isClan()).thenReturn(isClanEnemy);
+        doReturn(enemyFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(enemyFaction).when(factions).getFaction(eq(enemy));
+
+        Faction pirates = mock(Faction.class);
+        doReturn(pirates).when(factions).getFaction(eq("PIR"));
+
+        Faction rebels = mock(Faction.class);
+        doReturn(rebels).when(factions).getFaction(eq("REB"));
+
+        Systems systems = mock(Systems.class);
+        Systems.setInstance(systems);
+
+        String current = "CURRENT";
+        PlanetarySystem currentSystem = mock(PlanetarySystem.class);
+        when(currentSystem.getId()).thenReturn(current);
+        when(campaign.getCurrentSystem()).thenReturn(currentSystem);
+        doReturn(currentSystem).when(systems).getSystemById(eq(current));
+        doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
+
+        CurrentLocation currentLocation = mock(CurrentLocation.class);
+        when(campaign.getLocation()).thenReturn(currentLocation);
+
+        String missionTarget = "TARGET";
+        PlanetarySystem targetSystem = mock(PlanetarySystem.class);
+        when(targetSystem.getId()).thenReturn(missionTarget);
+        doReturn(targetSystem).when(systems).getSystemById(eq(missionTarget));
+        doReturn(targetSystem).when(campaign).getSystemByName(eq(missionTarget));
+
+        RandomFactionGenerator rfg = mock(RandomFactionGenerator.class);
+        RandomFactionGenerator.setInstance(rfg);
+        when(rfg.getEmployer()).thenReturn(employer);
+        when(rfg.getEmployerFaction()).thenReturn(employerFaction);
+        doReturn(enemy).when(rfg).getEnemy(eq(employer), anyBoolean());
+        doReturn(missionTarget).when(rfg).getMissionTarget(anyString(), anyString());
+
+        FactionHints hints = mock(FactionHints.class);
+        when(employerFaction.isISMajorOrSuperPower()).thenReturn(true);
+        when(enemyFaction.isISMajorOrSuperPower()).thenReturn(true);
+        doReturn(false).when(hints).isNeutral(eq(employerFaction));
+        doReturn(false).when(hints).isNeutral(eq(enemyFaction));
+        when(rfg.getFactionHints()).thenReturn(hints);
+
+        JumpPath jumpPath = mock(JumpPath.class);
+        when(jumpPath.getJumps()).thenReturn(1);
+        when(jumpPath.getFirstSystem()).thenReturn(currentSystem);
+        when(jumpPath.getLastSystem()).thenReturn(targetSystem);
+        doReturn(10.0).when(jumpPath).getTotalTime(any(), anyDouble());
+        doReturn(jumpPath).when(campaign).calculateJumpPath(eq(currentSystem), eq(targetSystem));
+        doReturn(Money.of(1)).when(campaign).calculateCostPerJump(anyBoolean(), anyBoolean());
+
+        assertNotNull(new AtbMonthlyContractMarket().addAtBContract(campaign));
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "generateData")
+    public void addMercWithoutRetainerMinorPowerAtBContractSucceeds(final int gameYear, final int unitRating,
+          final boolean isClanEnemy) {
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getRetainerEmployerCode()).thenReturn(null);
+        when(campaign.getAtBUnitRatingMod()).thenReturn(unitRating);
+        when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
+        when(campaign.getGameYear()).thenReturn(gameYear);
+
+        ReputationController camOpsReputation = mock(ReputationController.class);
+        when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
+        when(campaign.getReputation()).thenReturn(camOpsReputation);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+        when(campaignFaction.getShortName()).thenReturn("MERC");
+
+        CampaignOptions campaignOptions = mock(CampaignOptions.class);
+        when(campaignOptions.isVariableContractLength()).thenReturn(false);
+        when(campaignOptions.isUsePeacetimeCost()).thenReturn(false);
+        when(campaign.getCampaignOptions()).thenReturn(campaignOptions);
+
+        Accountant accountant = mock(Accountant.class);
+        when(accountant.getContractBase()).thenReturn(Money.of(1));
+        when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
+        when(campaign.getAccountant()).thenReturn(accountant);
+
+        Hangar hangar = mock(Hangar.class);
+        doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
+        when(campaign.getHangar()).thenReturn(hangar);
+
+        Formation forces = mock(Formation.class);
+        doReturn(new Vector<UUID>()).when(forces).getAllUnits(anyBoolean());
+        when(campaign.getFormations()).thenReturn(forces);
+
+        Factions factions = mock(Factions.class);
+        Factions.setInstance(factions);
+
+        String employer = "EMPLOYER";
+        String employerFullName = "Contract Employer";
+        Faction employerFaction = mock(Faction.class);
+        when(employerFaction.getShortName()).thenReturn(employer);
+        doReturn(employerFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(employerFaction).when(factions).getFaction(eq(employer));
+
+        String enemy = "ENEMY";
+        String enemyFullName = "Contract Enemy";
+        Faction enemyFaction = mock(Faction.class);
+        when(enemyFaction.getShortName()).thenReturn(enemy);
+        when(enemyFaction.isClan()).thenReturn(isClanEnemy);
+        doReturn(enemyFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(enemyFaction).when(factions).getFaction(eq(enemy));
+
+        Faction pirates = mock(Faction.class);
+        doReturn(pirates).when(factions).getFaction(eq("PIR"));
+
+        Faction rebels = mock(Faction.class);
+        doReturn(rebels).when(factions).getFaction(eq("REB"));
+
+        Systems systems = mock(Systems.class);
+        Systems.setInstance(systems);
+
+        String current = "CURRENT";
+        PlanetarySystem currentSystem = mock(PlanetarySystem.class);
+        when(currentSystem.getId()).thenReturn(current);
+        when(campaign.getCurrentSystem()).thenReturn(currentSystem);
+        doReturn(currentSystem).when(systems).getSystemById(eq(current));
+        doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
+
+        CurrentLocation currentLocation = mock(CurrentLocation.class);
+        when(campaign.getLocation()).thenReturn(currentLocation);
+
+        String missionTarget = "TARGET";
+        PlanetarySystem targetSystem = mock(PlanetarySystem.class);
+        when(targetSystem.getId()).thenReturn(missionTarget);
+        doReturn(targetSystem).when(systems).getSystemById(eq(missionTarget));
+        doReturn(targetSystem).when(campaign).getSystemByName(eq(missionTarget));
+
+        RandomFactionGenerator rfg = mock(RandomFactionGenerator.class);
+        RandomFactionGenerator.setInstance(rfg);
+        when(rfg.getEmployer()).thenReturn(employer);
+        when(rfg.getEmployerFaction()).thenReturn(employerFaction);
+        doReturn(enemy).when(rfg).getEnemy(eq(employer), anyBoolean());
+        doReturn(missionTarget).when(rfg).getMissionTarget(anyString(), anyString());
+
+        FactionHints hints = mock(FactionHints.class);
+        when(employerFaction.isISMajorOrSuperPower()).thenReturn(false);
+        when(enemyFaction.isISMajorOrSuperPower()).thenReturn(true);
+        doReturn(false).when(hints).isNeutral(eq(employerFaction));
+        doReturn(false).when(hints).isNeutral(eq(enemyFaction));
+        when(rfg.getFactionHints()).thenReturn(hints);
+
+        JumpPath jumpPath = mock(JumpPath.class);
+        when(jumpPath.getJumps()).thenReturn(1);
+        when(jumpPath.getFirstSystem()).thenReturn(currentSystem);
+        when(jumpPath.getLastSystem()).thenReturn(targetSystem);
+        doReturn(10.0).when(jumpPath).getTotalTime(any(), anyDouble());
+        doReturn(jumpPath).when(campaign).calculateJumpPath(eq(currentSystem), eq(targetSystem));
+        doReturn(Money.of(1)).when(campaign).calculateCostPerJump(anyBoolean(), anyBoolean());
+
+        AtbMonthlyContractMarket market = new AtbMonthlyContractMarket();
+
+        AtBContract contract = market.addAtBContract(campaign);
+        assertNotNull(contract);
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "generateData")
+    public void addMercWithoutRetainerEmployerNeutralAtBContractSucceeds(final int gameYear, final int unitRating,
+          final boolean isClanEnemy) {
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getRetainerEmployerCode()).thenReturn(null);
+        when(campaign.getAtBUnitRatingMod()).thenReturn(unitRating);
+        when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
+        when(campaign.getGameYear()).thenReturn(gameYear);
+
+        ReputationController camOpsReputation = mock(ReputationController.class);
+        when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
+        when(campaign.getReputation()).thenReturn(camOpsReputation);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+        when(campaignFaction.getShortName()).thenReturn("MERC");
+
+        CampaignOptions campaignOptions = mock(CampaignOptions.class);
+        when(campaignOptions.isVariableContractLength()).thenReturn(false);
+        when(campaignOptions.isUsePeacetimeCost()).thenReturn(false);
+        when(campaign.getCampaignOptions()).thenReturn(campaignOptions);
+
+        Accountant accountant = mock(Accountant.class);
+        when(accountant.getContractBase()).thenReturn(Money.of(1));
+        when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
+        when(campaign.getAccountant()).thenReturn(accountant);
+
+        Hangar hangar = mock(Hangar.class);
+        doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
+        when(campaign.getHangar()).thenReturn(hangar);
+
+        Formation forces = mock(Formation.class);
+        doReturn(new Vector<UUID>()).when(forces).getAllUnits(anyBoolean());
+        when(campaign.getFormations()).thenReturn(forces);
+
+        Factions factions = mock(Factions.class);
+        Factions.setInstance(factions);
+
+        String employer = "EMPLOYER";
+        String employerFullName = "Contract Employer";
+        Faction employerFaction = mock(Faction.class);
+        when(employerFaction.getShortName()).thenReturn(employer);
+        doReturn(employerFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(employerFaction).when(factions).getFaction(eq(employer));
+
+        String enemy = "ENEMY";
+        String enemyFullName = "Contract Enemy";
+        Faction enemyFaction = mock(Faction.class);
+        when(enemyFaction.getShortName()).thenReturn(enemy);
+        when(enemyFaction.isClan()).thenReturn(isClanEnemy);
+        doReturn(enemyFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(enemyFaction).when(factions).getFaction(eq(enemy));
+
+        Faction pirates = mock(Faction.class);
+        doReturn(pirates).when(factions).getFaction(eq("PIR"));
+
+        Faction rebels = mock(Faction.class);
+        doReturn(rebels).when(factions).getFaction(eq("REB"));
+
+        Systems systems = mock(Systems.class);
+        Systems.setInstance(systems);
+
+        String current = "CURRENT";
+        PlanetarySystem currentSystem = mock(PlanetarySystem.class);
+        when(currentSystem.getId()).thenReturn(current);
+        when(campaign.getCurrentSystem()).thenReturn(currentSystem);
+        doReturn(currentSystem).when(systems).getSystemById(eq(current));
+        doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
+
+        CurrentLocation currentLocation = mock(CurrentLocation.class);
+        when(campaign.getLocation()).thenReturn(currentLocation);
+
+        String missionTarget = "TARGET";
+        PlanetarySystem targetSystem = mock(PlanetarySystem.class);
+        when(targetSystem.getId()).thenReturn(missionTarget);
+        doReturn(targetSystem).when(systems).getSystemById(eq(missionTarget));
+        doReturn(targetSystem).when(campaign).getSystemByName(eq(missionTarget));
+
+        RandomFactionGenerator rfg = mock(RandomFactionGenerator.class);
+        RandomFactionGenerator.setInstance(rfg);
+        when(rfg.getEmployer()).thenReturn(employer);
+        when(rfg.getEmployerFaction()).thenReturn(employerFaction);
+        doReturn(enemy).when(rfg).getEnemy(eq(employer), anyBoolean());
+        doReturn(missionTarget).when(rfg).getMissionTarget(anyString(), anyString());
+
+        FactionHints hints = mock(FactionHints.class);
+        when(employerFaction.isISMajorOrSuperPower()).thenReturn(true);
+        when(enemyFaction.isISMajorOrSuperPower()).thenReturn(true);
+        doReturn(true).when(hints).isNeutral(eq(employerFaction));
+        doReturn(false).when(hints).isNeutral(eq(enemyFaction));
+        when(rfg.getFactionHints()).thenReturn(hints);
+
+        JumpPath jumpPath = mock(JumpPath.class);
+        when(jumpPath.getJumps()).thenReturn(1);
+        when(jumpPath.getFirstSystem()).thenReturn(currentSystem);
+        when(jumpPath.getLastSystem()).thenReturn(targetSystem);
+        doReturn(10.0).when(jumpPath).getTotalTime(any(), anyDouble());
+        doReturn(jumpPath).when(campaign).calculateJumpPath(eq(currentSystem), eq(targetSystem));
+        doReturn(Money.of(1)).when(campaign).calculateCostPerJump(anyBoolean(), anyBoolean());
+
+        AtbMonthlyContractMarket market = new AtbMonthlyContractMarket();
+
+        AtBContract contract = market.addAtBContract(campaign);
+        assertNotNull(contract);
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "generateData")
+    public void addMercWithoutRetainerEmployerNeutralAtWarAtBContractSucceeds(final int gameYear, final int unitRating,
+          final boolean isClanEnemy) {
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getRetainerEmployerCode()).thenReturn(null);
+        when(campaign.getAtBUnitRatingMod()).thenReturn(unitRating);
+        when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
+        when(campaign.getGameYear()).thenReturn(gameYear);
+
+        ReputationController camOpsReputation = mock(ReputationController.class);
+        when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
+        when(campaign.getReputation()).thenReturn(camOpsReputation);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+        when(campaignFaction.getShortName()).thenReturn("MERC");
+
+        CampaignOptions campaignOptions = mock(CampaignOptions.class);
+        when(campaignOptions.isVariableContractLength()).thenReturn(false);
+        when(campaignOptions.isUsePeacetimeCost()).thenReturn(false);
+        when(campaign.getCampaignOptions()).thenReturn(campaignOptions);
+
+        Accountant accountant = mock(Accountant.class);
+        when(accountant.getContractBase()).thenReturn(Money.of(1));
+        when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
+        when(campaign.getAccountant()).thenReturn(accountant);
+
+        Hangar hangar = mock(Hangar.class);
+        doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
+        when(campaign.getHangar()).thenReturn(hangar);
+
+        Formation forces = mock(Formation.class);
+        doReturn(new Vector<UUID>()).when(forces).getAllUnits(anyBoolean());
+        when(campaign.getFormations()).thenReturn(forces);
+
+        Factions factions = mock(Factions.class);
+        Factions.setInstance(factions);
+
+        String employer = "EMPLOYER";
+        String employerFullName = "Contract Employer";
+        Faction employerFaction = mock(Faction.class);
+        when(employerFaction.getShortName()).thenReturn(employer);
+        doReturn(employerFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(employerFaction).when(factions).getFaction(eq(employer));
+
+        String enemy = "ENEMY";
+        String enemyFullName = "Contract Enemy";
+        Faction enemyFaction = mock(Faction.class);
+        when(enemyFaction.getShortName()).thenReturn(enemy);
+        when(enemyFaction.isClan()).thenReturn(isClanEnemy);
+        doReturn(enemyFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(enemyFaction).when(factions).getFaction(eq(enemy));
+
+        Faction pirates = mock(Faction.class);
+        doReturn(pirates).when(factions).getFaction(eq("PIR"));
+
+        Faction rebels = mock(Faction.class);
+        doReturn(rebels).when(factions).getFaction(eq("REB"));
+
+        Systems systems = mock(Systems.class);
+        Systems.setInstance(systems);
+
+        String current = "CURRENT";
+        PlanetarySystem currentSystem = mock(PlanetarySystem.class);
+        when(currentSystem.getId()).thenReturn(current);
+        when(campaign.getCurrentSystem()).thenReturn(currentSystem);
+        doReturn(currentSystem).when(systems).getSystemById(eq(current));
+        doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
+
+        CurrentLocation currentLocation = mock(CurrentLocation.class);
+        when(campaign.getLocation()).thenReturn(currentLocation);
+
+        String missionTarget = "TARGET";
+        PlanetarySystem targetSystem = mock(PlanetarySystem.class);
+        when(targetSystem.getId()).thenReturn(missionTarget);
+        doReturn(targetSystem).when(systems).getSystemById(eq(missionTarget));
+        doReturn(targetSystem).when(campaign).getSystemByName(eq(missionTarget));
+
+        RandomFactionGenerator rfg = mock(RandomFactionGenerator.class);
+        RandomFactionGenerator.setInstance(rfg);
+        when(rfg.getEmployer()).thenReturn(employer);
+        when(rfg.getEmployerFaction()).thenReturn(employerFaction);
+        doReturn(enemy).when(rfg).getEnemy(eq(employer), anyBoolean());
+        doReturn(missionTarget).when(rfg).getMissionTarget(anyString(), anyString());
+
+        FactionHints hints = mock(FactionHints.class);
+        when(employerFaction.isISMajorOrSuperPower()).thenReturn(true);
+        when(enemyFaction.isISMajorOrSuperPower()).thenReturn(true);
+        doReturn(true).when(hints).isNeutral(eq(employerFaction));
+        doReturn(false).when(hints).isNeutral(eq(enemyFaction));
+        doReturn(true).when(hints).isAtWarWith(eq(employerFaction), eq(enemyFaction), any());
+        when(rfg.getFactionHints()).thenReturn(hints);
+
+        JumpPath jumpPath = mock(JumpPath.class);
+        when(jumpPath.getJumps()).thenReturn(1);
+        when(jumpPath.getFirstSystem()).thenReturn(currentSystem);
+        when(jumpPath.getLastSystem()).thenReturn(targetSystem);
+        doReturn(10.0).when(jumpPath).getTotalTime(any(), anyDouble());
+        doReturn(jumpPath).when(campaign).calculateJumpPath(eq(currentSystem), eq(targetSystem));
+        doReturn(Money.of(1)).when(campaign).calculateCostPerJump(anyBoolean(), anyBoolean());
+
+        AtbMonthlyContractMarket market = new AtbMonthlyContractMarket();
+
+        AtBContract contract = market.addAtBContract(campaign);
+        assertNotNull(contract);
+    }
+
+    /**
+     * This appears to be a test that a Mercenary campaign faction employer allows mercenary sub-faction contracts.
+     * Currently this test fails for reasons that are unclear; disabling temporarily.
+     *
+     * @param gameYear    see generateData() above
+     * @param unitRating
+     * @param isClanEnemy
+     */
+    @Disabled("XXX SME: Needs deprecated methods replaced.")
+    @ParameterizedTest
+    @MethodSource(value = "generateData")
+    public void mercEmployerRetries(final int gameYear, final int unitRating, final boolean isClanEnemy) {
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getRetainerEmployerCode()).thenReturn(null);
+        when(campaign.getAtBUnitRatingMod()).thenReturn(unitRating);
+        when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
+        when(campaign.getGameYear()).thenReturn(gameYear);
+
+        ReputationController camOpsReputation = mock(ReputationController.class);
+        when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
+        when(campaign.getReputation()).thenReturn(camOpsReputation);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+        when(campaignFaction.getShortName()).thenReturn("MERC");
+
+        CampaignOptions campaignOptions = mock(CampaignOptions.class);
+        when(campaignOptions.isVariableContractLength()).thenReturn(false);
+        when(campaignOptions.isUsePeacetimeCost()).thenReturn(false);
+        when(campaign.getCampaignOptions()).thenReturn(campaignOptions);
+
+        Accountant accountant = mock(Accountant.class);
+        when(accountant.getContractBase()).thenReturn(Money.of(1));
+        when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
+        when(campaign.getAccountant()).thenReturn(accountant);
+
+        Hangar hangar = mock(Hangar.class);
+        doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
+        when(campaign.getHangar()).thenReturn(hangar);
+
+        Formation forces = mock(Formation.class);
+        doReturn(new Vector<UUID>()).when(forces).getAllUnits(anyBoolean());
+        when(campaign.getFormations()).thenReturn(forces);
+
+        Factions factions = mock(Factions.class);
+        Factions.setInstance(factions);
+
+        String employer = "EMPLOYER";
+        String employerFullName = "Contract Employer";
+        Faction employerFaction = mock(Faction.class);
+        when(employerFaction.getShortName()).thenReturn(employer);
+        doReturn(employerFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(employerFaction).when(factions).getFaction(eq(employer));
+
+        String enemy = "ENEMY";
+        String enemyFullName = "Contract Enemy";
+        Faction enemyFaction = mock(Faction.class);
+        when(enemyFaction.getShortName()).thenReturn(enemy);
+        when(enemyFaction.isClan()).thenReturn(isClanEnemy);
+        doReturn(enemyFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(enemyFaction).when(factions).getFaction(eq(enemy));
+
+        Faction pirates = mock(Faction.class);
+        doReturn(pirates).when(factions).getFaction(eq("PIR"));
+
+        Faction rebels = mock(Faction.class);
+        doReturn(rebels).when(factions).getFaction(eq("REB"));
+
+        Faction mercenary = mock(Faction.class);
+        when(mercenary.isMercenary()).thenReturn(true);
+        doReturn(mercenary).when(factions).getFaction(eq("MERC"));
+
+        Systems systems = mock(Systems.class);
+        Systems.setInstance(systems);
+
+        String current = "CURRENT";
+        PlanetarySystem currentSystem = mock(PlanetarySystem.class);
+        when(currentSystem.getId()).thenReturn(current);
+        when(campaign.getCurrentSystem()).thenReturn(currentSystem);
+        doReturn(currentSystem).when(systems).getSystemById(eq(current));
+        doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
+
+        CurrentLocation currentLocation = mock(CurrentLocation.class);
+        when(campaign.getLocation()).thenReturn(currentLocation);
+
+        String missionTarget = "TARGET";
+        PlanetarySystem targetSystem = mock(PlanetarySystem.class);
+        when(targetSystem.getId()).thenReturn(missionTarget);
+        doReturn(targetSystem).when(systems).getSystemById(eq(missionTarget));
+        doReturn(targetSystem).when(campaign).getSystemByName(eq(missionTarget));
+
+        RandomFactionGenerator rfg = mock(RandomFactionGenerator.class);
+        RandomFactionGenerator.setInstance(rfg);
+        // Return "MERC" the first time to coerce a retry
+        when(rfg.getEmployer()).thenReturn("MERC").thenReturn(employer);
+        doReturn(enemy).when(rfg).getEnemy(eq(employer), anyBoolean());
+        doReturn(missionTarget).when(rfg).getMissionTarget(anyString(), anyString());
+
+        FactionHints hints = mock(FactionHints.class);
+        when(employerFaction.isISMajorOrSuperPower()).thenReturn(true);
+        when(enemyFaction.isISMajorOrSuperPower()).thenReturn(true);
+        doReturn(false).when(hints).isNeutral(eq(employerFaction));
+        doReturn(false).when(hints).isNeutral(eq(enemyFaction));
+        when(rfg.getFactionHints()).thenReturn(hints);
+        when(rfg.getEmployerFaction()).thenReturn(employerFaction);
+
+        JumpPath jumpPath = mock(JumpPath.class);
+        when(jumpPath.getJumps()).thenReturn(1);
+        when(jumpPath.getFirstSystem()).thenReturn(currentSystem);
+        when(jumpPath.getLastSystem()).thenReturn(targetSystem);
+        doReturn(10.0).when(jumpPath).getTotalTime(any(), anyDouble());
+        doReturn(jumpPath).when(campaign).calculateJumpPath(eq(currentSystem), eq(targetSystem));
+        doReturn(Money.of(1)).when(campaign).calculateCostPerJump(anyBoolean(), anyBoolean());
+
+        AtbMonthlyContractMarket market = new AtbMonthlyContractMarket();
+
+        AtBContract contract = market.addAtBContract(campaign);
+        assertNotNull(contract);
+        assertTrue(contract.isMercSubcontract());
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "generateData")
+    public void mercEmployerRetriesFail(final int gameYear, final int unitRating, final boolean isClanEnemy) {
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getRetainerEmployerCode()).thenReturn(null);
+        when(campaign.getAtBUnitRatingMod()).thenReturn(unitRating);
+        when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
+        when(campaign.getGameYear()).thenReturn(gameYear);
+
+        ReputationController camOpsReputation = mock(ReputationController.class);
+        when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
+        when(campaign.getReputation()).thenReturn(camOpsReputation);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+        when(campaignFaction.getShortName()).thenReturn("MERC");
+
+        Factions factions = mock(Factions.class);
+        Factions.setInstance(factions);
+
+        // Make a fake "MERC" employer for getFaction purposes in the rfg
+        Faction employerFaction = mock(Faction.class);
+        when(employerFaction.isMercenary()).thenReturn(true);
+
+        doReturn(employerFaction).when(factions).getFaction(eq("MERC"));
+
+        RandomFactionGenerator rfg = mock(RandomFactionGenerator.class);
+        RandomFactionGenerator.setInstance(rfg);
+        // Return "MERC" every time
+        when(rfg.getEmployer()).thenReturn("MERC");
+        when(rfg.getEmployerFaction()).thenReturn(employerFaction);
+
+        AtbMonthlyContractMarket market = new AtbMonthlyContractMarket();
+
+        AtBContract contract = market.addAtBContract(campaign);
+        assertNull(contract);
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "generateData")
+    public void mercMissingTargetRetries(final int gameYear, final int unitRating, final boolean isClanEnemy) {
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getRetainerEmployerCode()).thenReturn(null);
+        when(campaign.getAtBUnitRatingMod()).thenReturn(unitRating);
+        when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
+        when(campaign.getGameYear()).thenReturn(gameYear);
+
+        ReputationController camOpsReputation = mock(ReputationController.class);
+        when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
+        when(campaign.getReputation()).thenReturn(camOpsReputation);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+        when(campaignFaction.getShortName()).thenReturn("MERC");
+
+        CampaignOptions campaignOptions = mock(CampaignOptions.class);
+        when(campaignOptions.isVariableContractLength()).thenReturn(false);
+        when(campaignOptions.isUsePeacetimeCost()).thenReturn(false);
+        when(campaign.getCampaignOptions()).thenReturn(campaignOptions);
+
+        Accountant accountant = mock(Accountant.class);
+        when(accountant.getContractBase()).thenReturn(Money.of(1));
+        when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
+        when(campaign.getAccountant()).thenReturn(accountant);
+
+        Hangar hangar = mock(Hangar.class);
+        doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
+        when(campaign.getHangar()).thenReturn(hangar);
+
+        Formation forces = mock(Formation.class);
+        doReturn(new Vector<UUID>()).when(forces).getAllUnits(anyBoolean());
+        when(campaign.getFormations()).thenReturn(forces);
+
+        Factions factions = mock(Factions.class);
+        Factions.setInstance(factions);
+
+        String employer = "EMPLOYER";
+        String employerFullName = "Contract Employer";
+        Faction employerFaction = mock(Faction.class);
+        when(employerFaction.getShortName()).thenReturn(employer);
+        doReturn(employerFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(employerFaction).when(factions).getFaction(eq(employer));
+
+        String enemy = "ENEMY";
+        String enemyFullName = "Contract Enemy";
+        Faction enemyFaction = mock(Faction.class);
+        when(enemyFaction.getShortName()).thenReturn(enemy);
+        when(enemyFaction.isClan()).thenReturn(isClanEnemy);
+        doReturn(enemyFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(enemyFaction).when(factions).getFaction(eq(enemy));
+
+        Faction pirates = mock(Faction.class);
+        doReturn(pirates).when(factions).getFaction(eq("PIR"));
+
+        Faction rebels = mock(Faction.class);
+        doReturn(rebels).when(factions).getFaction(eq("REB"));
+
+        Systems systems = mock(Systems.class);
+        Systems.setInstance(systems);
+
+        String current = "CURRENT";
+        PlanetarySystem currentSystem = mock(PlanetarySystem.class);
+        when(currentSystem.getId()).thenReturn(current);
+        when(campaign.getCurrentSystem()).thenReturn(currentSystem);
+        doReturn(currentSystem).when(systems).getSystemById(eq(current));
+        doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
+
+        CurrentLocation currentLocation = mock(CurrentLocation.class);
+        when(campaign.getLocation()).thenReturn(currentLocation);
+
+        String missionTarget = "TARGET";
+        PlanetarySystem targetSystem = mock(PlanetarySystem.class);
+        when(targetSystem.getId()).thenReturn(missionTarget);
+        doReturn(targetSystem).when(systems).getSystemById(eq(missionTarget));
+        doReturn(targetSystem).when(campaign).getSystemByName(eq(missionTarget));
+
+        RandomFactionGenerator rfg = mock(RandomFactionGenerator.class);
+        RandomFactionGenerator.setInstance(rfg);
+        when(rfg.getEmployer()).thenReturn(employer);
+        when(rfg.getEmployerFaction()).thenReturn(employerFaction);
+        doReturn(enemy).when(rfg).getEnemy(eq(employer), anyBoolean());
+        // Don't find the mission target and force a retry
+        doReturn(null).doReturn(missionTarget).when(rfg).getMissionTarget(anyString(), anyString());
+
+        FactionHints hints = mock(FactionHints.class);
+        when(employerFaction.isISMajorOrSuperPower()).thenReturn(true);
+        when(enemyFaction.isISMajorOrSuperPower()).thenReturn(true);
+        doReturn(false).when(hints).isNeutral(eq(employerFaction));
+        doReturn(false).when(hints).isNeutral(eq(enemyFaction));
+        when(rfg.getFactionHints()).thenReturn(hints);
+
+        JumpPath jumpPath = mock(JumpPath.class);
+        when(jumpPath.getJumps()).thenReturn(1);
+        when(jumpPath.getFirstSystem()).thenReturn(currentSystem);
+        when(jumpPath.getLastSystem()).thenReturn(targetSystem);
+        doReturn(10.0).when(jumpPath).getTotalTime(any(), anyDouble());
+        doReturn(jumpPath).when(campaign).calculateJumpPath(eq(currentSystem), eq(targetSystem));
+        doReturn(Money.of(1)).when(campaign).calculateCostPerJump(anyBoolean(), anyBoolean());
+
+        AtbMonthlyContractMarket market = new AtbMonthlyContractMarket();
+
+        AtBContract contract = market.addAtBContract(campaign);
+        assertNotNull(contract);
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "generateData")
+    public void mercMissionTargetRetriesFail(final int gameYear, final int unitRating, final boolean isClanEnemy) {
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getRetainerEmployerCode()).thenReturn(null);
+        when(campaign.getAtBUnitRatingMod()).thenReturn(unitRating);
+        when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
+        when(campaign.getGameYear()).thenReturn(gameYear);
+
+        ReputationController camOpsReputation = mock(ReputationController.class);
+        when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
+        when(campaign.getReputation()).thenReturn(camOpsReputation);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+        when(campaignFaction.getShortName()).thenReturn("MERC");
+
+        CampaignOptions campaignOptions = mock(CampaignOptions.class);
+        when(campaignOptions.isVariableContractLength()).thenReturn(false);
+        when(campaignOptions.isUsePeacetimeCost()).thenReturn(false);
+        when(campaign.getCampaignOptions()).thenReturn(campaignOptions);
+
+        Accountant accountant = mock(Accountant.class);
+        when(accountant.getContractBase()).thenReturn(Money.of(1));
+        when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
+        when(campaign.getAccountant()).thenReturn(accountant);
+
+        Hangar hangar = mock(Hangar.class);
+        doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
+        when(campaign.getHangar()).thenReturn(hangar);
+
+        Formation forces = mock(Formation.class);
+        doReturn(new Vector<UUID>()).when(forces).getAllUnits(anyBoolean());
+        when(campaign.getFormations()).thenReturn(forces);
+
+        Factions factions = mock(Factions.class);
+        Factions.setInstance(factions);
+
+        String employer = "EMPLOYER";
+        String employerFullName = "Contract Employer";
+        Faction employerFaction = mock(Faction.class);
+        when(employerFaction.getShortName()).thenReturn(employer);
+        doReturn(employerFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(employerFaction).when(factions).getFaction(eq(employer));
+
+        String enemy = "ENEMY";
+        String enemyFullName = "Contract Enemy";
+        Faction enemyFaction = mock(Faction.class);
+        when(enemyFaction.getShortName()).thenReturn(enemy);
+        when(enemyFaction.isClan()).thenReturn(isClanEnemy);
+        doReturn(enemyFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(enemyFaction).when(factions).getFaction(eq(enemy));
+
+        Faction pirates = mock(Faction.class);
+        doReturn(pirates).when(factions).getFaction(eq("PIR"));
+
+        Faction rebels = mock(Faction.class);
+        doReturn(rebels).when(factions).getFaction(eq("REB"));
+
+        Systems systems = mock(Systems.class);
+        Systems.setInstance(systems);
+
+        String current = "CURRENT";
+        PlanetarySystem currentSystem = mock(PlanetarySystem.class);
+        when(currentSystem.getId()).thenReturn(current);
+        when(campaign.getCurrentSystem()).thenReturn(currentSystem);
+        doReturn(currentSystem).when(systems).getSystemById(eq(current));
+        doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
+
+        CurrentLocation currentLocation = mock(CurrentLocation.class);
+        when(campaign.getLocation()).thenReturn(currentLocation);
+
+        String missionTarget = "TARGET";
+        PlanetarySystem targetSystem = mock(PlanetarySystem.class);
+        when(targetSystem.getId()).thenReturn(missionTarget);
+        doReturn(targetSystem).when(systems).getSystemById(eq(missionTarget));
+        doReturn(targetSystem).when(campaign).getSystemByName(eq(missionTarget));
+
+        RandomFactionGenerator rfg = mock(RandomFactionGenerator.class);
+        RandomFactionGenerator.setInstance(rfg);
+        when(rfg.getEmployer()).thenReturn(employer);
+        when(rfg.getEmployerFaction()).thenReturn(employerFaction);
+        doReturn(enemy).when(rfg).getEnemy(eq(employer), anyBoolean());
+        // Don't ever find the mission target and force a retry failure
+        doReturn(null).when(rfg).getMissionTarget(anyString(), anyString());
+
+        FactionHints hints = mock(FactionHints.class);
+        when(employerFaction.isISMajorOrSuperPower()).thenReturn(true);
+        when(enemyFaction.isISMajorOrSuperPower()).thenReturn(true);
+        doReturn(false).when(hints).isNeutral(eq(employerFaction));
+        doReturn(false).when(hints).isNeutral(eq(enemyFaction));
+        when(rfg.getFactionHints()).thenReturn(hints);
+
+        AtbMonthlyContractMarket market = new AtbMonthlyContractMarket();
+
+        AtBContract contract = market.addAtBContract(campaign);
+        assertNull(contract);
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "generateData")
+    public void mercJumpPathRetries(final int gameYear, final int unitRating, final boolean isClanEnemy) {
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getRetainerEmployerCode()).thenReturn(null);
+        when(campaign.getAtBUnitRatingMod()).thenReturn(unitRating);
+        when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
+        when(campaign.getGameYear()).thenReturn(gameYear);
+
+        ReputationController camOpsReputation = mock(ReputationController.class);
+        when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
+        when(campaign.getReputation()).thenReturn(camOpsReputation);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+        when(campaignFaction.getShortName()).thenReturn("MERC");
+
+        CampaignOptions campaignOptions = mock(CampaignOptions.class);
+        when(campaignOptions.isVariableContractLength()).thenReturn(false);
+        when(campaignOptions.isUsePeacetimeCost()).thenReturn(false);
+        when(campaign.getCampaignOptions()).thenReturn(campaignOptions);
+
+        Accountant accountant = mock(Accountant.class);
+        when(accountant.getContractBase()).thenReturn(Money.of(1));
+        when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
+        when(campaign.getAccountant()).thenReturn(accountant);
+
+        Hangar hangar = mock(Hangar.class);
+        doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
+        when(campaign.getHangar()).thenReturn(hangar);
+
+        Formation forces = mock(Formation.class);
+        doReturn(new Vector<UUID>()).when(forces).getAllUnits(anyBoolean());
+        when(campaign.getFormations()).thenReturn(forces);
+
+        Factions factions = mock(Factions.class);
+        Factions.setInstance(factions);
+
+        String employer = "EMPLOYER";
+        String employerFullName = "Contract Employer";
+        Faction employerFaction = mock(Faction.class);
+        when(employerFaction.getShortName()).thenReturn(employer);
+        doReturn(employerFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(employerFaction).when(factions).getFaction(eq(employer));
+
+        String enemy = "ENEMY";
+        String enemyFullName = "Contract Enemy";
+        Faction enemyFaction = mock(Faction.class);
+        when(enemyFaction.getShortName()).thenReturn(enemy);
+        when(enemyFaction.isClan()).thenReturn(isClanEnemy);
+        doReturn(enemyFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(enemyFaction).when(factions).getFaction(eq(enemy));
+
+        Faction pirates = mock(Faction.class);
+        doReturn(pirates).when(factions).getFaction(eq("PIR"));
+
+        Faction rebels = mock(Faction.class);
+        doReturn(rebels).when(factions).getFaction(eq("REB"));
+
+        Systems systems = mock(Systems.class);
+        Systems.setInstance(systems);
+
+        String current = "CURRENT";
+        PlanetarySystem currentSystem = mock(PlanetarySystem.class);
+        when(currentSystem.getId()).thenReturn(current);
+        when(campaign.getCurrentSystem()).thenReturn(currentSystem);
+        doReturn(currentSystem).when(systems).getSystemById(eq(current));
+        doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
+
+        CurrentLocation currentLocation = mock(CurrentLocation.class);
+        when(campaign.getLocation()).thenReturn(currentLocation);
+
+        String missionTarget = "TARGET";
+        PlanetarySystem targetSystem = mock(PlanetarySystem.class);
+        when(targetSystem.getId()).thenReturn(missionTarget);
+        doReturn(targetSystem).when(systems).getSystemById(eq(missionTarget));
+        doReturn(targetSystem).when(campaign).getSystemByName(eq(missionTarget));
+
+        RandomFactionGenerator rfg = mock(RandomFactionGenerator.class);
+        RandomFactionGenerator.setInstance(rfg);
+        when(rfg.getEmployer()).thenReturn(employer);
+        when(rfg.getEmployerFaction()).thenReturn(employerFaction);
+        doReturn(enemy).when(rfg).getEnemy(eq(employer), anyBoolean());
+        doReturn(missionTarget).when(rfg).getMissionTarget(anyString(), anyString());
+
+        FactionHints hints = mock(FactionHints.class);
+        when(employerFaction.isISMajorOrSuperPower()).thenReturn(true);
+        when(enemyFaction.isISMajorOrSuperPower()).thenReturn(true);
+        doReturn(false).when(hints).isNeutral(eq(employerFaction));
+        doReturn(false).when(hints).isNeutral(eq(enemyFaction));
+        when(rfg.getFactionHints()).thenReturn(hints);
+
+        JumpPath jumpPath = mock(JumpPath.class);
+        when(jumpPath.getJumps()).thenReturn(1);
+        when(jumpPath.getFirstSystem()).thenReturn(currentSystem);
+        when(jumpPath.getLastSystem()).thenReturn(targetSystem);
+        doReturn(10.0).when(jumpPath).getTotalTime(any(), anyDouble());
+        // Fail to find a jump path at first, kicking off a retry
+        doReturn(null).doReturn(jumpPath).when(campaign).calculateJumpPath(eq(currentSystem), eq(targetSystem));
+        doReturn(Money.of(1)).when(campaign).calculateCostPerJump(anyBoolean(), anyBoolean());
+
+        AtbMonthlyContractMarket market = new AtbMonthlyContractMarket();
+
+        AtBContract contract = market.addAtBContract(campaign);
+        assertNotNull(contract);
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "generateData")
+    public void mercJumpPathFails(final int gameYear, final int unitRating, final boolean isClanEnemy) {
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getRetainerEmployerCode()).thenReturn(null);
+        when(campaign.getAtBUnitRatingMod()).thenReturn(unitRating);
+        when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
+        when(campaign.getGameYear()).thenReturn(gameYear);
+
+        ReputationController camOpsReputation = mock(ReputationController.class);
+        when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
+        when(campaign.getReputation()).thenReturn(camOpsReputation);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+        when(campaignFaction.getShortName()).thenReturn("MERC");
+
+        CampaignOptions campaignOptions = mock(CampaignOptions.class);
+        when(campaignOptions.isVariableContractLength()).thenReturn(false);
+        when(campaignOptions.isUsePeacetimeCost()).thenReturn(false);
+        when(campaign.getCampaignOptions()).thenReturn(campaignOptions);
+
+        Accountant accountant = mock(Accountant.class);
+        when(accountant.getContractBase()).thenReturn(Money.of(1));
+        when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
+        when(campaign.getAccountant()).thenReturn(accountant);
+
+        Hangar hangar = mock(Hangar.class);
+        doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
+        when(campaign.getHangar()).thenReturn(hangar);
+
+        Formation forces = mock(Formation.class);
+        doReturn(new Vector<UUID>()).when(forces).getAllUnits(anyBoolean());
+        when(campaign.getFormations()).thenReturn(forces);
+
+        Factions factions = mock(Factions.class);
+        Factions.setInstance(factions);
+
+        String employer = "EMPLOYER";
+        String employerFullName = "Contract Employer";
+        Faction employerFaction = mock(Faction.class);
+        when(employerFaction.getShortName()).thenReturn(employer);
+        doReturn(employerFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(employerFaction).when(factions).getFaction(eq(employer));
+
+        String enemy = "ENEMY";
+        String enemyFullName = "Contract Enemy";
+        Faction enemyFaction = mock(Faction.class);
+        when(enemyFaction.getShortName()).thenReturn(enemy);
+        when(enemyFaction.isClan()).thenReturn(isClanEnemy);
+        doReturn(enemyFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(enemyFaction).when(factions).getFaction(eq(enemy));
+
+        Faction pirates = mock(Faction.class);
+        doReturn(pirates).when(factions).getFaction(eq("PIR"));
+
+        Faction rebels = mock(Faction.class);
+        doReturn(rebels).when(factions).getFaction(eq("REB"));
+
+        Systems systems = mock(Systems.class);
+        Systems.setInstance(systems);
+
+        String current = "CURRENT";
+        PlanetarySystem currentSystem = mock(PlanetarySystem.class);
+        when(currentSystem.getId()).thenReturn(current);
+        when(campaign.getCurrentSystem()).thenReturn(currentSystem);
+        doReturn(currentSystem).when(systems).getSystemById(eq(current));
+        doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
+
+        CurrentLocation currentLocation = mock(CurrentLocation.class);
+        when(campaign.getLocation()).thenReturn(currentLocation);
+
+        String missionTarget = "TARGET";
+        PlanetarySystem targetSystem = mock(PlanetarySystem.class);
+        when(targetSystem.getId()).thenReturn(missionTarget);
+        doReturn(targetSystem).when(systems).getSystemById(eq(missionTarget));
+        doReturn(targetSystem).when(campaign).getSystemByName(eq(missionTarget));
+
+        RandomFactionGenerator rfg = mock(RandomFactionGenerator.class);
+        RandomFactionGenerator.setInstance(rfg);
+        when(rfg.getEmployer()).thenReturn(employer);
+        when(rfg.getEmployerFaction()).thenReturn(employerFaction);
+        doReturn(enemy).when(rfg).getEnemy(eq(employer), anyBoolean());
+        doReturn(missionTarget).when(rfg).getMissionTarget(anyString(), anyString());
+
+        FactionHints hints = mock(FactionHints.class);
+        when(employerFaction.isISMajorOrSuperPower()).thenReturn(true);
+        when(enemyFaction.isISMajorOrSuperPower()).thenReturn(true);
+        doReturn(false).when(hints).isNeutral(eq(employerFaction));
+        doReturn(false).when(hints).isNeutral(eq(enemyFaction));
+        when(rfg.getFactionHints()).thenReturn(hints);
+
+        // Fail to find a jump path
+        doReturn(null).when(campaign).calculateJumpPath(eq(currentSystem), eq(targetSystem));
+
+        AtbMonthlyContractMarket market = new AtbMonthlyContractMarket();
+
+        AtBContract contract = market.addAtBContract(campaign);
+        assertNull(contract);
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "generateData")
+    public void addMercWithRetainerAtBContractSucceeds(final int gameYear, final int unitRating,
+          final boolean isClanEnemy) {
+        String employer = "EMPLOYER";
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getRetainerEmployerCode()).thenReturn(employer);
+        when(campaign.getAtBUnitRatingMod()).thenReturn(unitRating);
+        when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
+        when(campaign.getGameYear()).thenReturn(gameYear);
+
+        ReputationController camOpsReputation = mock(ReputationController.class);
+        when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
+        when(campaign.getReputation()).thenReturn(camOpsReputation);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+        when(campaignFaction.getShortName()).thenReturn("MERC");
+
+        CampaignOptions campaignOptions = mock(CampaignOptions.class);
+        when(campaignOptions.isVariableContractLength()).thenReturn(false);
+        when(campaignOptions.isUsePeacetimeCost()).thenReturn(false);
+        when(campaign.getCampaignOptions()).thenReturn(campaignOptions);
+
+        Accountant accountant = mock(Accountant.class);
+        when(accountant.getContractBase()).thenReturn(Money.of(1));
+        when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
+        when(campaign.getAccountant()).thenReturn(accountant);
+
+        Hangar hangar = mock(Hangar.class);
+        doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
+        when(campaign.getHangar()).thenReturn(hangar);
+
+        Formation forces = mock(Formation.class);
+        doReturn(new Vector<UUID>()).when(forces).getAllUnits(anyBoolean());
+        when(campaign.getFormations()).thenReturn(forces);
+
+        Factions factions = mock(Factions.class);
+        Factions.setInstance(factions);
+
+        String employerFullName = "Contract Employer";
+        Faction employerFaction = mock(Faction.class);
+        when(employerFaction.getShortName()).thenReturn(employer);
+        doReturn(employerFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(employerFaction).when(factions).getFaction(eq(employer));
+
+        String enemy = "ENEMY";
+        String enemyFullName = "Contract Enemy";
+        Faction enemyFaction = mock(Faction.class);
+        when(enemyFaction.getShortName()).thenReturn(enemy);
+        when(enemyFaction.isClan()).thenReturn(isClanEnemy);
+        doReturn(enemyFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(enemyFaction).when(factions).getFaction(eq(enemy));
+
+        Faction pirates = mock(Faction.class);
+        doReturn(pirates).when(factions).getFaction(eq("PIR"));
+
+        Faction rebels = mock(Faction.class);
+        doReturn(rebels).when(factions).getFaction(eq("REB"));
+
+        Systems systems = mock(Systems.class);
+        Systems.setInstance(systems);
+
+        String current = "CURRENT";
+        PlanetarySystem currentSystem = mock(PlanetarySystem.class);
+        when(currentSystem.getId()).thenReturn(current);
+        when(campaign.getCurrentSystem()).thenReturn(currentSystem);
+        doReturn(currentSystem).when(systems).getSystemById(eq(current));
+        doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
+
+        CurrentLocation currentLocation = mock(CurrentLocation.class);
+        when(campaign.getLocation()).thenReturn(currentLocation);
+
+        String missionTarget = "TARGET";
+        PlanetarySystem targetSystem = mock(PlanetarySystem.class);
+        when(targetSystem.getId()).thenReturn(missionTarget);
+        doReturn(targetSystem).when(systems).getSystemById(eq(missionTarget));
+        doReturn(targetSystem).when(campaign).getSystemByName(eq(missionTarget));
+
+        RandomFactionGenerator rfg = mock(RandomFactionGenerator.class);
+        RandomFactionGenerator.setInstance(rfg);
+        when(rfg.getEmployer()).thenReturn(employer);
+        when(rfg.getEmployerFaction()).thenReturn(employerFaction);
+        doReturn(enemy).when(rfg).getEnemy(eq(employer), anyBoolean());
+        doReturn(missionTarget).when(rfg).getMissionTarget(anyString(), anyString());
+
+        FactionHints hints = mock(FactionHints.class);
+        when(employerFaction.isISMajorOrSuperPower()).thenReturn(true);
+        when(enemyFaction.isISMajorOrSuperPower()).thenReturn(true);
+        doReturn(false).when(hints).isNeutral(eq(employerFaction));
+        doReturn(false).when(hints).isNeutral(eq(enemyFaction));
+        when(rfg.getFactionHints()).thenReturn(hints);
+
+        JumpPath jumpPath = mock(JumpPath.class);
+        when(jumpPath.getJumps()).thenReturn(1);
+        when(jumpPath.getFirstSystem()).thenReturn(currentSystem);
+        when(jumpPath.getLastSystem()).thenReturn(targetSystem);
+        doReturn(10.0).when(jumpPath).getTotalTime(any(), anyDouble());
+        doReturn(jumpPath).when(campaign).calculateJumpPath(eq(currentSystem), eq(targetSystem));
+        doReturn(Money.of(1)).when(campaign).calculateCostPerJump(anyBoolean(), anyBoolean());
+
+        AtbMonthlyContractMarket market = new AtbMonthlyContractMarket();
+
+        AtBContract contract = market.addAtBContract(campaign);
+        assertNotNull(contract);
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "generateData")
+    public void addMercWithRetainerMinorPowerAtBContractSucceeds(final int gameYear, final int unitRating,
+          final boolean isClanEnemy) {
+        String employer = "EMPLOYER";
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getRetainerEmployerCode()).thenReturn(employer);
+        when(campaign.getAtBUnitRatingMod()).thenReturn(unitRating);
+        when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
+        when(campaign.getGameYear()).thenReturn(gameYear);
+
+        ReputationController camOpsReputation = mock(ReputationController.class);
+        when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
+        when(campaign.getReputation()).thenReturn(camOpsReputation);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+        when(campaignFaction.getShortName()).thenReturn("MERC");
+
+        CampaignOptions campaignOptions = mock(CampaignOptions.class);
+        when(campaignOptions.isVariableContractLength()).thenReturn(false);
+        when(campaignOptions.isUsePeacetimeCost()).thenReturn(false);
+        when(campaign.getCampaignOptions()).thenReturn(campaignOptions);
+
+        Accountant accountant = mock(Accountant.class);
+        when(accountant.getContractBase()).thenReturn(Money.of(1));
+        when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
+        when(campaign.getAccountant()).thenReturn(accountant);
+
+        Hangar hangar = mock(Hangar.class);
+        doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
+        when(campaign.getHangar()).thenReturn(hangar);
+
+        Formation forces = mock(Formation.class);
+        doReturn(new Vector<UUID>()).when(forces).getAllUnits(anyBoolean());
+        when(campaign.getFormations()).thenReturn(forces);
+
+        Factions factions = mock(Factions.class);
+        Factions.setInstance(factions);
+
+        String employerFullName = "Contract Employer";
+        Faction employerFaction = mock(Faction.class);
+        when(employerFaction.getShortName()).thenReturn(employer);
+        doReturn(employerFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(employerFaction).when(factions).getFaction(eq(employer));
+
+        String enemy = "ENEMY";
+        String enemyFullName = "Contract Enemy";
+        Faction enemyFaction = mock(Faction.class);
+        when(enemyFaction.getShortName()).thenReturn(enemy);
+        when(enemyFaction.isClan()).thenReturn(isClanEnemy);
+        doReturn(enemyFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(enemyFaction).when(factions).getFaction(eq(enemy));
+
+        Faction pirates = mock(Faction.class);
+        doReturn(pirates).when(factions).getFaction(eq("PIR"));
+
+        Faction rebels = mock(Faction.class);
+        doReturn(rebels).when(factions).getFaction(eq("REB"));
+
+        Systems systems = mock(Systems.class);
+        Systems.setInstance(systems);
+
+        String current = "CURRENT";
+        PlanetarySystem currentSystem = mock(PlanetarySystem.class);
+        when(currentSystem.getId()).thenReturn(current);
+        when(campaign.getCurrentSystem()).thenReturn(currentSystem);
+        doReturn(currentSystem).when(systems).getSystemById(eq(current));
+        doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
+
+        CurrentLocation currentLocation = mock(CurrentLocation.class);
+        when(campaign.getLocation()).thenReturn(currentLocation);
+
+        String missionTarget = "TARGET";
+        PlanetarySystem targetSystem = mock(PlanetarySystem.class);
+        when(targetSystem.getId()).thenReturn(missionTarget);
+        doReturn(targetSystem).when(systems).getSystemById(eq(missionTarget));
+        doReturn(targetSystem).when(campaign).getSystemByName(eq(missionTarget));
+
+        RandomFactionGenerator rfg = mock(RandomFactionGenerator.class);
+        RandomFactionGenerator.setInstance(rfg);
+        when(rfg.getEmployer()).thenReturn(employer);
+        when(rfg.getEmployerFaction()).thenReturn(employerFaction);
+        doReturn(enemy).when(rfg).getEnemy(eq(employer), anyBoolean());
+        doReturn(missionTarget).when(rfg).getMissionTarget(anyString(), anyString());
+
+        FactionHints hints = mock(FactionHints.class);
+        when(employerFaction.isISMajorOrSuperPower()).thenReturn(false);
+        when(enemyFaction.isISMajorOrSuperPower()).thenReturn(true);
+        doReturn(false).when(hints).isNeutral(eq(employerFaction));
+        doReturn(false).when(hints).isNeutral(eq(enemyFaction));
+        when(rfg.getFactionHints()).thenReturn(hints);
+
+        JumpPath jumpPath = mock(JumpPath.class);
+        when(jumpPath.getJumps()).thenReturn(1);
+        when(jumpPath.getFirstSystem()).thenReturn(currentSystem);
+        when(jumpPath.getLastSystem()).thenReturn(targetSystem);
+        doReturn(10.0).when(jumpPath).getTotalTime(any(), anyDouble());
+        doReturn(jumpPath).when(campaign).calculateJumpPath(eq(currentSystem), eq(targetSystem));
+        doReturn(Money.of(1)).when(campaign).calculateCostPerJump(anyBoolean(), anyBoolean());
+
+        AtbMonthlyContractMarket market = new AtbMonthlyContractMarket();
+
+        AtBContract contract = market.addAtBContract(campaign);
+        assertNotNull(contract);
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "generateData")
+    public void addMercWithRetainerEmployerNeutralAtBContractSucceeds(final int gameYear, final int unitRating,
+          final boolean isClanEnemy) {
+        String employer = "EMPLOYER";
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getRetainerEmployerCode()).thenReturn(employer);
+        when(campaign.getAtBUnitRatingMod()).thenReturn(unitRating);
+        when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
+        when(campaign.getGameYear()).thenReturn(gameYear);
+
+        ReputationController camOpsReputation = mock(ReputationController.class);
+        when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
+        when(campaign.getReputation()).thenReturn(camOpsReputation);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+        when(campaignFaction.getShortName()).thenReturn("MERC");
+
+        CampaignOptions campaignOptions = mock(CampaignOptions.class);
+        when(campaignOptions.isVariableContractLength()).thenReturn(false);
+        when(campaignOptions.isUsePeacetimeCost()).thenReturn(false);
+        when(campaign.getCampaignOptions()).thenReturn(campaignOptions);
+
+        Accountant accountant = mock(Accountant.class);
+        when(accountant.getContractBase()).thenReturn(Money.of(1));
+        when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
+        when(campaign.getAccountant()).thenReturn(accountant);
+
+        Hangar hangar = mock(Hangar.class);
+        doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
+        when(campaign.getHangar()).thenReturn(hangar);
+
+        Formation forces = mock(Formation.class);
+        doReturn(new Vector<UUID>()).when(forces).getAllUnits(anyBoolean());
+        when(campaign.getFormations()).thenReturn(forces);
+
+        Factions factions = mock(Factions.class);
+        Factions.setInstance(factions);
+
+        String employerFullName = "Contract Employer";
+        Faction employerFaction = mock(Faction.class);
+        when(employerFaction.getShortName()).thenReturn(employer);
+        doReturn(employerFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(employerFaction).when(factions).getFaction(eq(employer));
+
+        String enemy = "ENEMY";
+        String enemyFullName = "Contract Enemy";
+        Faction enemyFaction = mock(Faction.class);
+        when(enemyFaction.getShortName()).thenReturn(enemy);
+        when(enemyFaction.isClan()).thenReturn(isClanEnemy);
+        doReturn(enemyFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(enemyFaction).when(factions).getFaction(eq(enemy));
+
+        Faction pirates = mock(Faction.class);
+        doReturn(pirates).when(factions).getFaction(eq("PIR"));
+
+        Faction rebels = mock(Faction.class);
+        doReturn(rebels).when(factions).getFaction(eq("REB"));
+
+        Systems systems = mock(Systems.class);
+        Systems.setInstance(systems);
+
+        String current = "CURRENT";
+        PlanetarySystem currentSystem = mock(PlanetarySystem.class);
+        when(currentSystem.getId()).thenReturn(current);
+        when(campaign.getCurrentSystem()).thenReturn(currentSystem);
+        doReturn(currentSystem).when(systems).getSystemById(eq(current));
+        doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
+
+        CurrentLocation currentLocation = mock(CurrentLocation.class);
+        when(campaign.getLocation()).thenReturn(currentLocation);
+
+        String missionTarget = "TARGET";
+        PlanetarySystem targetSystem = mock(PlanetarySystem.class);
+        when(targetSystem.getId()).thenReturn(missionTarget);
+        doReturn(targetSystem).when(systems).getSystemById(eq(missionTarget));
+        doReturn(targetSystem).when(campaign).getSystemByName(eq(missionTarget));
+
+        RandomFactionGenerator rfg = mock(RandomFactionGenerator.class);
+        RandomFactionGenerator.setInstance(rfg);
+        when(rfg.getEmployer()).thenReturn(employer);
+        when(rfg.getEmployerFaction()).thenReturn(employerFaction);
+        doReturn(enemy).when(rfg).getEnemy(eq(employer), anyBoolean());
+        doReturn(missionTarget).when(rfg).getMissionTarget(anyString(), anyString());
+
+        FactionHints hints = mock(FactionHints.class);
+        when(employerFaction.isISMajorOrSuperPower()).thenReturn(true);
+        when(enemyFaction.isISMajorOrSuperPower()).thenReturn(true);
+        doReturn(true).when(hints).isNeutral(eq(employerFaction));
+        doReturn(false).when(hints).isNeutral(eq(enemyFaction));
+        when(rfg.getFactionHints()).thenReturn(hints);
+
+        JumpPath jumpPath = mock(JumpPath.class);
+        when(jumpPath.getJumps()).thenReturn(1);
+        when(jumpPath.getFirstSystem()).thenReturn(currentSystem);
+        when(jumpPath.getLastSystem()).thenReturn(targetSystem);
+        doReturn(10.0).when(jumpPath).getTotalTime(any(), anyDouble());
+        doReturn(jumpPath).when(campaign).calculateJumpPath(eq(currentSystem), eq(targetSystem));
+        doReturn(Money.of(1)).when(campaign).calculateCostPerJump(anyBoolean(), anyBoolean());
+
+        AtbMonthlyContractMarket market = new AtbMonthlyContractMarket();
+
+        AtBContract contract = market.addAtBContract(campaign);
+        assertNotNull(contract);
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "generateData")
+    public void addMercWithRetainerEmployerNeutralAtWarAtBContractSucceeds(final int gameYear, final int unitRating,
+          final boolean isClanEnemy) {
+        String employer = "EMPLOYER";
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getRetainerEmployerCode()).thenReturn(employer);
+        when(campaign.getAtBUnitRatingMod()).thenReturn(unitRating);
+        when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
+        when(campaign.getGameYear()).thenReturn(gameYear);
+
+        ReputationController camOpsReputation = mock(ReputationController.class);
+        when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
+        when(campaign.getReputation()).thenReturn(camOpsReputation);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+        when(campaignFaction.getShortName()).thenReturn("MERC");
+
+        CampaignOptions campaignOptions = mock(CampaignOptions.class);
+        when(campaignOptions.isVariableContractLength()).thenReturn(false);
+        when(campaignOptions.isUsePeacetimeCost()).thenReturn(false);
+        when(campaign.getCampaignOptions()).thenReturn(campaignOptions);
+
+        Accountant accountant = mock(Accountant.class);
+        when(accountant.getContractBase()).thenReturn(Money.of(1));
+        when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
+        when(campaign.getAccountant()).thenReturn(accountant);
+
+        Hangar hangar = mock(Hangar.class);
+        doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
+        when(campaign.getHangar()).thenReturn(hangar);
+
+        Formation forces = mock(Formation.class);
+        doReturn(new Vector<UUID>()).when(forces).getAllUnits(anyBoolean());
+        when(campaign.getFormations()).thenReturn(forces);
+
+        Factions factions = mock(Factions.class);
+        Factions.setInstance(factions);
+
+        String employerFullName = "Contract Employer";
+        Faction employerFaction = mock(Faction.class);
+        when(employerFaction.getShortName()).thenReturn(employer);
+        doReturn(employerFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(employerFaction).when(factions).getFaction(eq(employer));
+
+        String enemy = "ENEMY";
+        String enemyFullName = "Contract Enemy";
+        Faction enemyFaction = mock(Faction.class);
+        when(enemyFaction.getShortName()).thenReturn(enemy);
+        when(enemyFaction.isClan()).thenReturn(isClanEnemy);
+        doReturn(enemyFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(enemyFaction).when(factions).getFaction(eq(enemy));
+
+        Faction pirates = mock(Faction.class);
+        doReturn(pirates).when(factions).getFaction(eq("PIR"));
+
+        Faction rebels = mock(Faction.class);
+        doReturn(rebels).when(factions).getFaction(eq("REB"));
+
+        Systems systems = mock(Systems.class);
+        Systems.setInstance(systems);
+
+        String current = "CURRENT";
+        PlanetarySystem currentSystem = mock(PlanetarySystem.class);
+        when(currentSystem.getId()).thenReturn(current);
+        when(campaign.getCurrentSystem()).thenReturn(currentSystem);
+        doReturn(currentSystem).when(systems).getSystemById(eq(current));
+        doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
+
+        CurrentLocation currentLocation = mock(CurrentLocation.class);
+        when(campaign.getLocation()).thenReturn(currentLocation);
+
+        String missionTarget = "TARGET";
+        PlanetarySystem targetSystem = mock(PlanetarySystem.class);
+        when(targetSystem.getId()).thenReturn(missionTarget);
+        doReturn(targetSystem).when(systems).getSystemById(eq(missionTarget));
+        doReturn(targetSystem).when(campaign).getSystemByName(eq(missionTarget));
+
+        RandomFactionGenerator rfg = mock(RandomFactionGenerator.class);
+        RandomFactionGenerator.setInstance(rfg);
+        doReturn(enemy).when(rfg).getEnemy(eq(employer), anyBoolean());
+        doReturn(missionTarget).when(rfg).getMissionTarget(anyString(), anyString());
+
+        FactionHints hints = mock(FactionHints.class);
+        when(employerFaction.isISMajorOrSuperPower()).thenReturn(true);
+        when(enemyFaction.isISMajorOrSuperPower()).thenReturn(true);
+        doReturn(true).when(hints).isNeutral(eq(employerFaction));
+        doReturn(false).when(hints).isNeutral(eq(enemyFaction));
+        doReturn(true).when(hints).isAtWarWith(eq(employerFaction), eq(enemyFaction), any());
+        when(rfg.getFactionHints()).thenReturn(hints);
+
+        JumpPath jumpPath = mock(JumpPath.class);
+        when(jumpPath.getJumps()).thenReturn(1);
+        when(jumpPath.getFirstSystem()).thenReturn(currentSystem);
+        when(jumpPath.getLastSystem()).thenReturn(targetSystem);
+        doReturn(10.0).when(jumpPath).getTotalTime(any(), anyDouble());
+        doReturn(jumpPath).when(campaign).calculateJumpPath(eq(currentSystem), eq(targetSystem));
+        doReturn(Money.of(1)).when(campaign).calculateCostPerJump(anyBoolean(), anyBoolean());
+
+        AtbMonthlyContractMarket market = new AtbMonthlyContractMarket();
+
+        AtBContract contract = market.addAtBContract(campaign);
+        assertNotNull(contract);
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "generateData")
+    public void nonMercAtBContractSucceeds(final int gameYear, final int unitRating, final boolean isClanEnemy) {
+        String employer = "EMPLOYER";
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getRetainerEmployerCode()).thenReturn(null);
+        when(campaign.getAtBUnitRatingMod()).thenReturn(unitRating);
+        when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
+        when(campaign.getGameYear()).thenReturn(gameYear);
+
+        ReputationController camOpsReputation = mock(ReputationController.class);
+        when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
+        when(campaign.getReputation()).thenReturn(camOpsReputation);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(false);
+        when(campaignFaction.getShortName()).thenReturn(employer);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+        when(campaignFaction.getShortName()).thenReturn(employer);
+
+        CampaignOptions campaignOptions = mock(CampaignOptions.class);
+        when(campaignOptions.isVariableContractLength()).thenReturn(false);
+        when(campaignOptions.isUsePeacetimeCost()).thenReturn(false);
+        when(campaign.getCampaignOptions()).thenReturn(campaignOptions);
+
+        Accountant accountant = mock(Accountant.class);
+        when(accountant.getContractBase()).thenReturn(Money.of(1));
+        when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
+        when(campaign.getAccountant()).thenReturn(accountant);
+
+        Hangar hangar = mock(Hangar.class);
+        doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
+        when(campaign.getHangar()).thenReturn(hangar);
+
+        Formation forces = mock(Formation.class);
+        doReturn(new Vector<UUID>()).when(forces).getAllUnits(anyBoolean());
+        when(campaign.getFormations()).thenReturn(forces);
+
+        Factions factions = mock(Factions.class);
+        Factions.setInstance(factions);
+
+        String employerFullName = "Contract Employer";
+        Faction employerFaction = mock(Faction.class);
+        when(employerFaction.getShortName()).thenReturn(employer);
+        doReturn(employerFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(employerFaction).when(factions).getFaction(eq(employer));
+
+        String enemy = "ENEMY";
+        String enemyFullName = "Contract Enemy";
+        Faction enemyFaction = mock(Faction.class);
+        when(enemyFaction.getShortName()).thenReturn(enemy);
+        when(enemyFaction.isClan()).thenReturn(isClanEnemy);
+        doReturn(enemyFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(enemyFaction).when(factions).getFaction(eq(enemy));
+
+        Faction pirates = mock(Faction.class);
+        doReturn(pirates).when(factions).getFaction(eq("PIR"));
+
+        Faction rebels = mock(Faction.class);
+        doReturn(rebels).when(factions).getFaction(eq("REB"));
+
+        Systems systems = mock(Systems.class);
+        Systems.setInstance(systems);
+
+        String current = "CURRENT";
+        PlanetarySystem currentSystem = mock(PlanetarySystem.class);
+        when(currentSystem.getId()).thenReturn(current);
+        when(campaign.getCurrentSystem()).thenReturn(currentSystem);
+        doReturn(currentSystem).when(systems).getSystemById(eq(current));
+        doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
+
+        CurrentLocation currentLocation = mock(CurrentLocation.class);
+        when(campaign.getLocation()).thenReturn(currentLocation);
+
+        String missionTarget = "TARGET";
+        PlanetarySystem targetSystem = mock(PlanetarySystem.class);
+        when(targetSystem.getId()).thenReturn(missionTarget);
+        doReturn(targetSystem).when(systems).getSystemById(eq(missionTarget));
+        doReturn(targetSystem).when(campaign).getSystemByName(eq(missionTarget));
+
+        RandomFactionGenerator rfg = mock(RandomFactionGenerator.class);
+        RandomFactionGenerator.setInstance(rfg);
+        when(rfg.getEmployer()).thenReturn(employer);
+        when(rfg.getEmployerFaction()).thenReturn(employerFaction);
+        doReturn(enemy).when(rfg).getEnemy(eq(employer), anyBoolean());
+        doReturn(missionTarget).when(rfg).getMissionTarget(anyString(), anyString());
+
+        FactionHints hints = mock(FactionHints.class);
+        when(employerFaction.isISMajorOrSuperPower()).thenReturn(true);
+        when(enemyFaction.isISMajorOrSuperPower()).thenReturn(true);
+        doReturn(false).when(hints).isNeutral(eq(employerFaction));
+        doReturn(false).when(hints).isNeutral(eq(enemyFaction));
+        when(rfg.getFactionHints()).thenReturn(hints);
+
+        JumpPath jumpPath = mock(JumpPath.class);
+        when(jumpPath.getJumps()).thenReturn(1);
+        when(jumpPath.getFirstSystem()).thenReturn(currentSystem);
+        when(jumpPath.getLastSystem()).thenReturn(targetSystem);
+        doReturn(10.0).when(jumpPath).getTotalTime(any(), anyDouble());
+        doReturn(jumpPath).when(campaign).calculateJumpPath(eq(currentSystem), eq(targetSystem));
+        doReturn(Money.of(1)).when(campaign).calculateCostPerJump(anyBoolean(), anyBoolean());
+
+        AtbMonthlyContractMarket market = new AtbMonthlyContractMarket();
+
+        AtBContract contract = market.addAtBContract(campaign);
+        assertNotNull(contract);
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "generateData")
+    public void nonMercMinorPowerAtBContractSucceeds(final int gameYear, final int unitRating,
+          final boolean isClanEnemy) {
+        String employer = "EMPLOYER";
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getRetainerEmployerCode()).thenReturn(null);
+        when(campaign.getAtBUnitRatingMod()).thenReturn(unitRating);
+        when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
+        when(campaign.getGameYear()).thenReturn(gameYear);
+
+        ReputationController camOpsReputation = mock(ReputationController.class);
+        when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
+        when(campaign.getReputation()).thenReturn(camOpsReputation);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(false);
+        when(campaignFaction.getShortName()).thenReturn(employer);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+        when(campaignFaction.getShortName()).thenReturn(employer);
+
+        CampaignOptions campaignOptions = mock(CampaignOptions.class);
+        when(campaignOptions.isVariableContractLength()).thenReturn(false);
+        when(campaignOptions.isUsePeacetimeCost()).thenReturn(false);
+        when(campaign.getCampaignOptions()).thenReturn(campaignOptions);
+
+        Accountant accountant = mock(Accountant.class);
+        when(accountant.getContractBase()).thenReturn(Money.of(1));
+        when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
+        when(campaign.getAccountant()).thenReturn(accountant);
+
+        Hangar hangar = mock(Hangar.class);
+        doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
+        when(campaign.getHangar()).thenReturn(hangar);
+
+        Formation forces = mock(Formation.class);
+        doReturn(new Vector<UUID>()).when(forces).getAllUnits(anyBoolean());
+        when(campaign.getFormations()).thenReturn(forces);
+
+        Factions factions = mock(Factions.class);
+        Factions.setInstance(factions);
+
+        String employerFullName = "Contract Employer";
+        Faction employerFaction = mock(Faction.class);
+        when(employerFaction.getShortName()).thenReturn(employer);
+        doReturn(employerFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(employerFaction).when(factions).getFaction(eq(employer));
+
+        String enemy = "ENEMY";
+        String enemyFullName = "Contract Enemy";
+        Faction enemyFaction = mock(Faction.class);
+        when(enemyFaction.getShortName()).thenReturn(enemy);
+        when(enemyFaction.isClan()).thenReturn(isClanEnemy);
+        doReturn(enemyFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(enemyFaction).when(factions).getFaction(eq(enemy));
+
+        Faction pirates = mock(Faction.class);
+        doReturn(pirates).when(factions).getFaction(eq("PIR"));
+
+        Faction rebels = mock(Faction.class);
+        doReturn(rebels).when(factions).getFaction(eq("REB"));
+
+        Systems systems = mock(Systems.class);
+        Systems.setInstance(systems);
+
+        String current = "CURRENT";
+        PlanetarySystem currentSystem = mock(PlanetarySystem.class);
+        when(currentSystem.getId()).thenReturn(current);
+        when(campaign.getCurrentSystem()).thenReturn(currentSystem);
+        doReturn(currentSystem).when(systems).getSystemById(eq(current));
+        doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
+
+        CurrentLocation currentLocation = mock(CurrentLocation.class);
+        when(campaign.getLocation()).thenReturn(currentLocation);
+
+        String missionTarget = "TARGET";
+        PlanetarySystem targetSystem = mock(PlanetarySystem.class);
+        when(targetSystem.getId()).thenReturn(missionTarget);
+        doReturn(targetSystem).when(systems).getSystemById(eq(missionTarget));
+        doReturn(targetSystem).when(campaign).getSystemByName(eq(missionTarget));
+
+        RandomFactionGenerator rfg = mock(RandomFactionGenerator.class);
+        RandomFactionGenerator.setInstance(rfg);
+        when(rfg.getEmployer()).thenReturn(employer);
+        when(rfg.getEmployerFaction()).thenReturn(employerFaction);
+        doReturn(enemy).when(rfg).getEnemy(eq(employer), anyBoolean());
+        doReturn(missionTarget).when(rfg).getMissionTarget(anyString(), anyString());
+
+        FactionHints hints = mock(FactionHints.class);
+        when(employerFaction.isISMajorOrSuperPower()).thenReturn(false);
+        when(enemyFaction.isISMajorOrSuperPower()).thenReturn(true);
+        doReturn(false).when(hints).isNeutral(eq(employerFaction));
+        doReturn(false).when(hints).isNeutral(eq(enemyFaction));
+        when(rfg.getFactionHints()).thenReturn(hints);
+
+        JumpPath jumpPath = mock(JumpPath.class);
+        when(jumpPath.getJumps()).thenReturn(1);
+        when(jumpPath.getFirstSystem()).thenReturn(currentSystem);
+        when(jumpPath.getLastSystem()).thenReturn(targetSystem);
+        doReturn(10.0).when(jumpPath).getTotalTime(any(), anyDouble());
+        doReturn(jumpPath).when(campaign).calculateJumpPath(eq(currentSystem), eq(targetSystem));
+        doReturn(Money.of(1)).when(campaign).calculateCostPerJump(anyBoolean(), anyBoolean());
+
+        AtbMonthlyContractMarket market = new AtbMonthlyContractMarket();
+
+        AtBContract contract = market.addAtBContract(campaign);
+        assertNotNull(contract);
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "generateData")
+    public void nonMercNeutralAtBContractSucceeds(final int gameYear, final int unitRating, final boolean isClanEnemy) {
+        String employer = "EMPLOYER";
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getRetainerEmployerCode()).thenReturn(null);
+        when(campaign.getAtBUnitRatingMod()).thenReturn(unitRating);
+        when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
+        when(campaign.getGameYear()).thenReturn(gameYear);
+
+        ReputationController camOpsReputation = mock(ReputationController.class);
+        when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
+        when(campaign.getReputation()).thenReturn(camOpsReputation);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(false);
+        when(campaignFaction.getShortName()).thenReturn(employer);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+        when(campaignFaction.getShortName()).thenReturn(employer);
+
+        CampaignOptions campaignOptions = mock(CampaignOptions.class);
+        when(campaignOptions.isVariableContractLength()).thenReturn(false);
+        when(campaignOptions.isUsePeacetimeCost()).thenReturn(false);
+        when(campaign.getCampaignOptions()).thenReturn(campaignOptions);
+
+        Accountant accountant = mock(Accountant.class);
+        when(accountant.getContractBase()).thenReturn(Money.of(1));
+        when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
+        when(campaign.getAccountant()).thenReturn(accountant);
+
+        Hangar hangar = mock(Hangar.class);
+        doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
+        when(campaign.getHangar()).thenReturn(hangar);
+
+        Formation forces = mock(Formation.class);
+        doReturn(new Vector<UUID>()).when(forces).getAllUnits(anyBoolean());
+        when(campaign.getFormations()).thenReturn(forces);
+
+        Factions factions = mock(Factions.class);
+        Factions.setInstance(factions);
+
+        String employerFullName = "Contract Employer";
+        Faction employerFaction = mock(Faction.class);
+        when(employerFaction.getShortName()).thenReturn(employer);
+        doReturn(employerFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(employerFaction).when(factions).getFaction(eq(employer));
+
+        String enemy = "ENEMY";
+        String enemyFullName = "Contract Enemy";
+        Faction enemyFaction = mock(Faction.class);
+        when(enemyFaction.getShortName()).thenReturn(enemy);
+        when(enemyFaction.isClan()).thenReturn(isClanEnemy);
+        doReturn(enemyFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(enemyFaction).when(factions).getFaction(eq(enemy));
+
+        Faction pirates = mock(Faction.class);
+        doReturn(pirates).when(factions).getFaction(eq("PIR"));
+
+        Faction rebels = mock(Faction.class);
+        doReturn(rebels).when(factions).getFaction(eq("REB"));
+
+        Systems systems = mock(Systems.class);
+        Systems.setInstance(systems);
+
+        String current = "CURRENT";
+        PlanetarySystem currentSystem = mock(PlanetarySystem.class);
+        when(currentSystem.getId()).thenReturn(current);
+        when(campaign.getCurrentSystem()).thenReturn(currentSystem);
+        doReturn(currentSystem).when(systems).getSystemById(eq(current));
+        doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
+
+        CurrentLocation currentLocation = mock(CurrentLocation.class);
+        when(campaign.getLocation()).thenReturn(currentLocation);
+
+        String missionTarget = "TARGET";
+        PlanetarySystem targetSystem = mock(PlanetarySystem.class);
+        when(targetSystem.getId()).thenReturn(missionTarget);
+        doReturn(targetSystem).when(systems).getSystemById(eq(missionTarget));
+        doReturn(targetSystem).when(campaign).getSystemByName(eq(missionTarget));
+
+        RandomFactionGenerator rfg = mock(RandomFactionGenerator.class);
+        RandomFactionGenerator.setInstance(rfg);
+        when(rfg.getEmployer()).thenReturn(employer);
+        when(rfg.getEmployerFaction()).thenReturn(employerFaction);
+        doReturn(enemy).when(rfg).getEnemy(eq(employer), anyBoolean());
+        doReturn(missionTarget).when(rfg).getMissionTarget(anyString(), anyString());
+
+        FactionHints hints = mock(FactionHints.class);
+        when(employerFaction.isISMajorOrSuperPower()).thenReturn(true);
+        when(enemyFaction.isISMajorOrSuperPower()).thenReturn(true);
+        doReturn(true).when(hints).isNeutral(eq(employerFaction));
+        doReturn(false).when(hints).isNeutral(eq(enemyFaction));
+        when(rfg.getFactionHints()).thenReturn(hints);
+
+        JumpPath jumpPath = mock(JumpPath.class);
+        when(jumpPath.getJumps()).thenReturn(1);
+        when(jumpPath.getFirstSystem()).thenReturn(currentSystem);
+        when(jumpPath.getLastSystem()).thenReturn(targetSystem);
+        doReturn(10.0).when(jumpPath).getTotalTime(any(), anyDouble());
+        doReturn(jumpPath).when(campaign).calculateJumpPath(eq(currentSystem), eq(targetSystem));
+        doReturn(Money.of(1)).when(campaign).calculateCostPerJump(anyBoolean(), anyBoolean());
+
+        AtbMonthlyContractMarket market = new AtbMonthlyContractMarket();
+
+        AtBContract contract = market.addAtBContract(campaign);
+        assertNotNull(contract);
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "generateData")
+    public void nonMercNeutralAtWarAtBContractSucceeds(final int gameYear, final int unitRating,
+          final boolean isClanEnemy) {
+        String employer = "EMPLOYER";
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getRetainerEmployerCode()).thenReturn(null);
+        when(campaign.getAtBUnitRatingMod()).thenReturn(unitRating);
+        when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
+        when(campaign.getGameYear()).thenReturn(gameYear);
+
+        ReputationController camOpsReputation = mock(ReputationController.class);
+        when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
+        when(campaign.getReputation()).thenReturn(camOpsReputation);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(false);
+        when(campaignFaction.getShortName()).thenReturn(employer);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+        when(campaignFaction.getShortName()).thenReturn(employer);
+
+        CampaignOptions campaignOptions = mock(CampaignOptions.class);
+        when(campaignOptions.isVariableContractLength()).thenReturn(false);
+        when(campaignOptions.isUsePeacetimeCost()).thenReturn(false);
+        when(campaign.getCampaignOptions()).thenReturn(campaignOptions);
+
+        Accountant accountant = mock(Accountant.class);
+        when(accountant.getContractBase()).thenReturn(Money.of(1));
+        when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
+        when(campaign.getAccountant()).thenReturn(accountant);
+
+        Hangar hangar = mock(Hangar.class);
+        doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
+        when(campaign.getHangar()).thenReturn(hangar);
+
+        Formation forces = mock(Formation.class);
+        doReturn(new Vector<UUID>()).when(forces).getAllUnits(anyBoolean());
+        when(campaign.getFormations()).thenReturn(forces);
+
+        Factions factions = mock(Factions.class);
+        Factions.setInstance(factions);
+
+        String employerFullName = "Contract Employer";
+        Faction employerFaction = mock(Faction.class);
+        when(employerFaction.getShortName()).thenReturn(employer);
+        doReturn(employerFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(employerFaction).when(factions).getFaction(eq(employer));
+
+        String enemy = "ENEMY";
+        String enemyFullName = "Contract Enemy";
+        Faction enemyFaction = mock(Faction.class);
+        when(enemyFaction.getShortName()).thenReturn(enemy);
+        when(enemyFaction.isClan()).thenReturn(isClanEnemy);
+        doReturn(enemyFullName).when(employerFaction).getFullName(anyInt());
+        doReturn(enemyFaction).when(factions).getFaction(eq(enemy));
+
+        Faction pirates = mock(Faction.class);
+        doReturn(pirates).when(factions).getFaction(eq("PIR"));
+
+        Faction rebels = mock(Faction.class);
+        doReturn(rebels).when(factions).getFaction(eq("REB"));
+
+        Systems systems = mock(Systems.class);
+        Systems.setInstance(systems);
+
+        String current = "CURRENT";
+        PlanetarySystem currentSystem = mock(PlanetarySystem.class);
+        when(currentSystem.getId()).thenReturn(current);
+        when(campaign.getCurrentSystem()).thenReturn(currentSystem);
+        doReturn(currentSystem).when(systems).getSystemById(eq(current));
+        doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
+
+        CurrentLocation currentLocation = mock(CurrentLocation.class);
+        when(campaign.getLocation()).thenReturn(currentLocation);
+
+        String missionTarget = "TARGET";
+        PlanetarySystem targetSystem = mock(PlanetarySystem.class);
+        when(targetSystem.getId()).thenReturn(missionTarget);
+        doReturn(targetSystem).when(systems).getSystemById(eq(missionTarget));
+        doReturn(targetSystem).when(campaign).getSystemByName(eq(missionTarget));
+
+        RandomFactionGenerator rfg = mock(RandomFactionGenerator.class);
+        RandomFactionGenerator.setInstance(rfg);
+        doReturn(enemy).when(rfg).getEnemy(eq(employer), anyBoolean());
+        doReturn(missionTarget).when(rfg).getMissionTarget(anyString(), anyString());
+
+        FactionHints hints = mock(FactionHints.class);
+        when(employerFaction.isISMajorOrSuperPower()).thenReturn(true);
+        when(enemyFaction.isISMajorOrSuperPower()).thenReturn(true);
+        doReturn(true).when(hints).isNeutral(eq(employerFaction));
+        doReturn(false).when(hints).isNeutral(eq(enemyFaction));
+        doReturn(true).when(hints).isAtWarWith(eq(employerFaction), eq(enemyFaction), any());
+        when(rfg.getFactionHints()).thenReturn(hints);
+
+        JumpPath jumpPath = mock(JumpPath.class);
+        when(jumpPath.getJumps()).thenReturn(1);
+        when(jumpPath.getFirstSystem()).thenReturn(currentSystem);
+        when(jumpPath.getLastSystem()).thenReturn(targetSystem);
+        doReturn(10.0).when(jumpPath).getTotalTime(any(), anyDouble());
+        doReturn(jumpPath).when(campaign).calculateJumpPath(eq(currentSystem), eq(targetSystem));
+        doReturn(Money.of(1)).when(campaign).calculateCostPerJump(anyBoolean(), anyBoolean());
+
+        AtbMonthlyContractMarket market = new AtbMonthlyContractMarket();
+
+        AtBContract contract = market.addAtBContract(campaign);
+        assertNotNull(contract);
+    }
+
+    @AfterAll
+    public static void cleanupAfterTests() {
+        Factions.setInstance(null);
+        Systems.setInstance(null);
+        RandomFactionGenerator.setInstance(null);
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/market/TestPartsStore.java
+++ b/MekHQ/unittests/mekhq/campaign/market/TestPartsStore.java
@@ -47,4 +47,9 @@ public class TestPartsStore extends PartsStore {
     public void stock(Campaign campaign) {
         // Does nothing
     }
+
+    public void reallyStock(Campaign campaign) {
+        // runs the real stock(); high memory and CPU time use.
+        super.stock(campaign);
+    }
 }


### PR DESCRIPTION
Final pass and cleanup to bring back Briefing Tab, contract functionality, and bot force ammo autoconfig.

1. Restore Briefing Tab functionality.
2. Restore Contract updating.
3. Replace all remaining usages of `isUseAtB()` with `isUseStratCon()`.
4. Fix a couple of contradictory checks of `isUseStratCon() && !isUseStratCon()` that came out of earlier `isUseAtB()` fix.
5. Returns some nags and tests that were removed due to `AtB` sweep.

Testing:
1. Ran new campaigns with various settings and confirmed contract market, missions, and scenarios work as expected.
2. Ran all 3 projects' unit tests.
3. Quadruple-checked differences between current Head and proposed reverted code vs. last major StratCon updates (ca. 11/22/2025)

NOTE: this should also conclude the removal of any remaining ShipSearch code.