### PR TITLE
Fix: Restore Briefing Room tab content (regression from 61afd91a11)

### DIFF
--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -58,6 +58,7 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JSplitPane;
 import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 import javax.swing.ScrollPaneConstants;
@@ -363,9 +364,15 @@ public final class BriefingTab extends CampaignGuiTab {
         gridBagConstraints.weighty = 1.0;
         panScenario.add(scrollScenarioView, gridBagConstraints);
 
+        JSplitPane splitBrief = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, panMission, panScenario);
+        splitBrief.setOneTouchExpandable(true);
+        splitBrief.setResizeWeight(0.5);
+        splitBrief.addPropertyChangeListener(JSplitPane.DIVIDER_LOCATION_PROPERTY, ev -> refreshScenarioView());
+
         JPanel pnlTutorial = new TutorialHyperlinkPanel("missionTab");
 
         setLayout(new BorderLayout());
+        add(splitBrief, BorderLayout.CENTER);
         add(pnlTutorial, BorderLayout.SOUTH);
     }
 


### PR DESCRIPTION
Commit 61afd91a11 removed the JSplitPane wiring in BriefingTab.initTab() and its add(splitBrief, BorderLayout.CENTER) call without a replacement, leaving the Briefing Room tab empty except for the tutorial hyperlink bar at the bottom. Restore a horizontal JSplitPane between the mission and scenario panels and attach it to BorderLayout.CENTER.