### PR TITLE
Fixes #8914 Stop permanent diseases spreading in transit

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/Inoculations.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/Inoculations.java
@@ -681,15 +681,26 @@ public class Inoculations {
           Set<InjuryType> activeCanonDiseases) {}
 
     /**
-     * Scans all personnel for disease-related injuries and the presence of any Super Spreader flaw. Returns both the
-     * collected set of active diseases and whether at least one Super Spreader is present.
+     * Scans all personnel for transmissible disease-related injuries and the presence of any Super Spreader flaw.
+     * Returns the collected sets of active diseases (split by canon vs. generic) and whether at least one Super
+     * Spreader is present.
+     *
+     * <p>Permanent infections are deliberately excluded from both returned sets. The carrier still has the disease
+     * on their medical sheet and it still counts as a permanent Hit; it simply does not contribute to the unit-wide
+     * contagion pool the spread roll iterates over. Without this exclusion, a permanent canon disease such as
+     * Knights-Grasse Syndrome would stay in the active-spread set forever (the carrier never recovers) and cascade
+     * through the unit on the next jump, when vaccinations are suppressed for close-confines reasons.</p>
      *
      * @param allPersonnel the collection of personnel to evaluate
      *
      * @return a {@link DiseaseScanResult} containing:
      *       <ul>
      *         <li>{@code hasSuperSpreader} — {@code true} if any person has the Super Spreader flaw</li>
-     *         <li>{@code activeDiseases} — the set of all disease-type injuries present across the personnel</li>
+     *         <li>{@code activeDiseases} — non-permanent disease-typed injuries with the {@link InjurySubType#DISEASE_GENERIC}
+     *               subtype present across the personnel</li>
+     *         <li>{@code activeCanonDiseases} — non-permanent disease-typed injuries with the
+     *               {@link InjurySubType#DISEASE_CANON_GENERIC} or {@link InjurySubType#DISEASE_CANON_BIOWEAPON}
+     *               subtype present across the personnel</li>
      *       </ul>
      *
      * @author Illiani

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/Inoculations.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/Inoculations.java
@@ -695,7 +695,7 @@ public class Inoculations {
      * @author Illiani
      * @since 0.50.10
      */
-    private static DiseaseScanResult getActiveDiseases(List<Person> allPersonnel) {
+    static DiseaseScanResult getActiveDiseases(List<Person> allPersonnel) {
         boolean hasSuperSpreader = false;
         Set<InjuryType> activeDiseases = new HashSet<>();
         Set<InjuryType> activeCanonDiseases = new HashSet<>();
@@ -711,6 +711,13 @@ public class Inoculations {
                 InjuryType type = injury.getType();
 
                 if (subType.isDisease()) {
+                    // Permanent infections do not act as contagion vectors. Without this guard, a permanent
+                    // canon disease (e.g. Knights-Grasse Syndrome) keeps its InjuryType in the active-spread
+                    // set forever — the carrier never recovers — and on the next jump the disease cascades
+                    // through the unit because vaccinations are suppressed in transit.
+                    if (injury.isPermanent()) {
+                        continue;
+                    }
                     if (subType.isCanonDisease()) {
                         activeCanonDiseases.add(type);
                         continue;

--- a/MekHQ/unittests/mekhq/campaign/personnel/medical/advancedMedicalAlternate/InoculationsTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/medical/advancedMedicalAlternate/InoculationsTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMek, `Mek and AeroTek are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.personnel.medical.advancedMedicalAlternate;
+
+import static mekhq.campaign.personnel.PersonnelOptions.FLAW_SUPER_SPREADER;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import mekhq.campaign.personnel.Injury;
+import mekhq.campaign.personnel.InjuryType;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.PersonnelOptions;
+import mekhq.campaign.personnel.medical.advancedMedicalAlternate.Inoculations.DiseaseScanResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class InoculationsTest {
+
+    @Test
+    @DisplayName("Permanent disease carriers do not contribute their disease to the unit-wide spread set")
+    void getActiveDiseases_excludesPermanentInfections() {
+        InjuryType permanentType = mock(InjuryType.class);
+        Injury permanentInjury = injury(permanentType, InjurySubType.DISEASE_GENERIC, true);
+        Person carrier = personWith(permanentInjury);
+
+        InjuryType genericType = mock(InjuryType.class);
+        Injury genericInjury = injury(genericType, InjurySubType.DISEASE_GENERIC, false);
+        Person infected = personWith(genericInjury);
+
+        InjuryType bioweaponType = mock(InjuryType.class);
+        Injury bioweaponInjury = injury(bioweaponType, InjurySubType.DISEASE_CANON_BIOWEAPON, false);
+        Person attacked = personWith(bioweaponInjury);
+
+        DiseaseScanResult result = Inoculations.getActiveDiseases(List.of(carrier, infected, attacked));
+
+        assertFalse(result.activeDiseases().contains(permanentType),
+              "Permanent disease must not appear in the active spread set");
+        assertFalse(result.activeCanonDiseases().contains(permanentType),
+              "Permanent disease must not appear in the canon spread set");
+        assertTrue(result.activeDiseases().contains(genericType),
+              "Non-permanent generic disease should remain in the spread set");
+        assertTrue(result.activeCanonDiseases().contains(bioweaponType),
+              "Non-permanent canon bioweapon should remain in the canon spread set");
+    }
+
+    @Test
+    @DisplayName("A unit whose only carrier has a permanent disease reports an empty active-disease set")
+    void getActiveDiseases_permanentOnlyUnitReportsEmpty() {
+        InjuryType permanentType = mock(InjuryType.class);
+        Injury permanentInjury = injury(permanentType, InjurySubType.DISEASE_GENERIC, true);
+        Person carrier = personWith(permanentInjury);
+
+        DiseaseScanResult result = Inoculations.getActiveDiseases(List.of(carrier));
+
+        assertTrue(result.activeDiseases().isEmpty(),
+              "Active diseases set must be empty when only permanent infections exist");
+        assertTrue(result.activeCanonDiseases().isEmpty(),
+              "Active canon diseases set must be empty when only permanent infections exist");
+    }
+
+    private static Injury injury(InjuryType type, InjurySubType subType, boolean permanent) {
+        Injury injury = mock(Injury.class);
+        when(injury.getType()).thenReturn(type);
+        when(injury.getSubType()).thenReturn(subType);
+        when(injury.isPermanent()).thenReturn(permanent);
+        return injury;
+    }
+
+    private static Person personWith(Injury... injuries) {
+        Person person = mock(Person.class);
+        PersonnelOptions options = mock(PersonnelOptions.class);
+        when(options.booleanOption(FLAW_SUPER_SPREADER)).thenReturn(false);
+        when(person.getOptions()).thenReturn(options);
+        when(person.getInjuries()).thenReturn(List.of(injuries));
+        return person;
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/personnel/medical/advancedMedicalAlternate/InoculationsTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/medical/advancedMedicalAlternate/InoculationsTest.java
@@ -78,6 +78,28 @@ public class InoculationsTest {
     }
 
     @Test
+    @DisplayName("Permanent canon-bioweapon carriers are excluded from the canon spread set")
+    void getActiveDiseases_excludesPermanentCanonBioweapons() {
+        InjuryType permanentBioweaponType = mock(InjuryType.class);
+        Injury permanentBioweaponInjury = injury(permanentBioweaponType, InjurySubType.DISEASE_CANON_BIOWEAPON, true);
+        Person permanentCarrier = personWith(permanentBioweaponInjury);
+
+        InjuryType activeBioweaponType = mock(InjuryType.class);
+        Injury activeBioweaponInjury = injury(activeBioweaponType, InjurySubType.DISEASE_CANON_BIOWEAPON, false);
+        Person activeCarrier = personWith(activeBioweaponInjury);
+
+        DiseaseScanResult result =
+              Inoculations.getActiveDiseases(List.of(permanentCarrier, activeCarrier));
+
+        assertFalse(result.activeCanonDiseases().contains(permanentBioweaponType),
+              "Permanent canon bioweapon must not appear in the canon spread set");
+        assertTrue(result.activeCanonDiseases().contains(activeBioweaponType),
+              "Non-permanent canon bioweapon should remain in the canon spread set");
+        assertTrue(result.activeDiseases().isEmpty(),
+              "Generic spread set must be empty when only canon-typed injuries are present");
+    }
+
+    @Test
     @DisplayName("A unit whose only carrier has a permanent disease reports an empty active-disease set")
     void getActiveDiseases_permanentOnlyUnitReportsEmpty() {
         InjuryType permanentType = mock(InjuryType.class);

--- a/MekHQ/unittests/mekhq/campaign/personnel/medical/advancedMedicalAlternate/InoculationsTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/medical/advancedMedicalAlternate/InoculationsTest.java
@@ -19,7 +19,7 @@
  * NOTICE: The MegaMek organization is a non-profit group of volunteers
  * creating free software for the BattleTech community.
  *
- * MechWarrior, BattleMek, `Mek and AeroTek are registered trademarks
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
  * of The Topps Company, Inc. All Rights Reserved.
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of


### PR DESCRIPTION
## Summary

Permanent canon diseases (Knights-Grasse Syndrome, Kaer Pathogen, Kilen-Watts Syndrome, Ockham's Blood Disease, Delphi Curse, etc.) cascaded through the unit on the first Monday after a jump because the carrier never recovers and vaccines are intentionally suppressed in transit. This filters them out of the unit-wide active-spread set so they remain a chronic condition for the carrier without acting as a contagion vector.

## Bug Fixed

- **Permanent disease spread cascade** (Inoculations.java): `getActiveDiseases` collected every disease-typed injury across all personnel into the active-spread set without checking permanence. A permanent infection keeps its `InjuryType` in the set forever, and on the next jump the spread roll cascades it through the unit. Confirmed in-game by player report (Knights-Grasse Syndrome cascading through the company on departure from a contract).

Fixes #8914

## Changes

1. **Inoculations.java** - `getActiveDiseases` now skips injuries where `injury.isPermanent()` is true, so permanent infections are excluded from the unit-wide contagion pool. The injury still appears on the carrier's medical sheet, still counts as a permanent Hit, and still triggers any associated `InjuryEffect`. Method visibility dropped from `private` to package-private to enable direct testing.
2. **InoculationsTest.java** (NEW) - Two unit tests: (a) mixed-carrier list confirms permanent infections excluded while non-permanent generic and non-permanent canon bioweapon entries stay in their respective sets; (b) permanent-only carrier yields empty active-disease sets, allowing the existing 1-in-1000 new-disease introduction roll to fire again.

## Files Changed

- `MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/Inoculations.java` - Adds `isPermanent()` early-exit in `getActiveDiseases`; drops method to package-private.
- `MekHQ/unittests/mekhq/campaign/personnel/medical/advancedMedicalAlternate/InoculationsTest.java` - NEW: two `getActiveDiseases` tests.

## Testing

- **Unit tests**: 2 new tests in `InoculationsTest`, both passing. Surrounding `mekhq.campaign.personnel.medical.advancedMedicalAlternate.*` and `PersonTest` packages still green.
- **Manual testing**: Quick Start campaign, Canopus IV, 3025-era.
  - GM-added Knights-Grasse Syndrome (permanent) to one character via `EditPersonnelInjuriesDialog`. Issued Vaccine Mandate. Jumped. Advanced through 2 Mondays in transit. **Result:** no spread alerts, carrier still has Knights-Grasse, spot-checked other personnel are clean. ✓
  - Negative control: GM-added Brisbane Virus (non-permanent canon) to another character mid-transit. Advanced through next Monday. **Result:** `MEDICAL ALERT: Brisbane Virus is spreading…` lines appeared as expected — fix is targeted, not over-aggressive. ✓

## Scope notes

- Bioweapon spread is **not** modified: `getSpreadingBioweapons` builds its set from `CanonicalDiseaseType.getAllActiveBioweapons(systemCode, today, ...)`, i.e. from the system's canonical-outbreak status rather than from carriers, so permanent bioweapons on personnel were never a spread vector via this path.
- The deadly permanent bioweapons (Landmark Supervirus, Neo Smallpox, Nykvarn Virus) move the carrier to `PersonnelStatus.CONTAGIOUS_DISEASE`, removing them from `getPersonnelFilteringOutDepartedAndAbsent()`. They are unaffected by this change.
- Edge case: a unit whose only active disease is a permanent canon one becomes eligible for the existing 1-in-1000 "introduce a new disease" roll again. This matches the system's existing rationale comment about keeping the galaxy dynamic.