### PR TITLE
Reorganize Personnel GM Mode submenu into themed groups (Fixes #8923)

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -370,6 +370,12 @@ originalUnitMenu.text=Original Unit
 originalUnitToCurrent.text=Set the Current Unit as Original
 removeOriginalUnit.text=Wipe Original Unit Record
 ### GM Menu
+gmMenu.statusIdentity.text=Status & Identity
+gmMenu.skillsXp.text=Skills & XP
+gmMenu.medical.text=Medical
+gmMenu.familyProcreation.text=Family & Procreation
+gmMenu.personalityRoleplay.text=Personality & Roleplay
+gmMenu.tools.text=Tools
 changePrisonerStatus.text=Change Prisoner Status
 removePerson.text=Remove Person
 editHits.text=Edit Hits

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -160,6 +160,7 @@ import mekhq.campaign.universe.PlanetarySystem;
 import mekhq.campaign.universe.factionStanding.FactionStandings;
 import mekhq.gui.CampaignGUI;
 import mekhq.gui.PersonnelTab;
+import mekhq.gui.baseComponents.JScrollableMenu;
 import mekhq.gui.control.EditLogControl.LogType;
 import mekhq.gui.dialog.*;
 import mekhq.gui.displayWrappers.RankDisplay;
@@ -4064,23 +4065,29 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
         if (getCampaign().isGM()) {
             popup.addSeparator();
 
-            menu = new JMenu(resources.getString("GMMode.text"));
+            // The GM Mode menu and each of its themed sub-submenus are JScrollableMenu so that:
+            //   1. Empty sub-submenus are auto-suppressed (replaces deprecated JMenuHelpers.addMenuIfNonEmpty).
+            //   2. Large genealogy flyouts (Add/Remove Parent/Child on big rosters) get a MenuScroller automatically.
+            // The JScrollableMenu local type is required for the add() overrides to dispatch correctly; the WARNING
+            // in JScrollableMenu's javadoc covers this.
+            JScrollableMenu gmMenu = new JScrollableMenu("GMMode", resources.getString("GMMode.text"));
 
             // Top-level shortcuts: highest-traffic actions stay one click away.
             menuItem = new JMenuItem(resources.getString("editPerson.text"));
             menuItem.setActionCommand(CMD_EDIT);
             menuItem.addActionListener(this);
-            menu.add(menuItem);
+            gmMenu.add(menuItem);
 
             menuItem = new JMenuItem(resources.getString("addXP.text"));
             menuItem.setActionCommand(CMD_ADD_XP);
             menuItem.addActionListener(this);
-            menu.add(menuItem);
+            gmMenu.add(menuItem);
 
-            menu.addSeparator();
+            gmMenu.addSeparator();
 
             // Status & Identity submenu
-            JMenu statusIdentityMenu = new JMenu(resources.getString("gmMenu.statusIdentity.text"));
+            JScrollableMenu statusIdentityMenu = new JScrollableMenu("gmMenu.statusIdentity",
+                  resources.getString("gmMenu.statusIdentity.text"));
 
             JMenu changePrisonerStatusMenu = new JMenu(resources.getString("changePrisonerStatus.text"));
             changePrisonerStatusMenu.add(newCheckboxMenu(PrisonerStatus.FREE.toString(),
@@ -4110,10 +4117,11 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             menuItem.addActionListener(this);
             statusIdentityMenu.add(menuItem);
 
-            JMenuHelpers.addMenuIfNonEmpty(menu, statusIdentityMenu);
+            gmMenu.add(statusIdentityMenu);
 
             // Skills & XP submenu
-            JMenu skillsXpMenu = new JMenu(resources.getString("gmMenu.skillsXp.text"));
+            JScrollableMenu skillsXpMenu = new JScrollableMenu("gmMenu.skillsXp",
+                  resources.getString("gmMenu.skillsXp.text"));
 
             menuItem = new JMenuItem(resources.getString("setXP.text"));
             menuItem.setActionCommand(CMD_SET_XP);
@@ -4153,10 +4161,11 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
             skillsXpMenu.add(attributesMenu);
 
-            JMenuHelpers.addMenuIfNonEmpty(menu, skillsXpMenu);
+            gmMenu.add(skillsXpMenu);
 
             // Medical submenu
-            JMenu medicalMenu = new JMenu(resources.getString("gmMenu.medical.text"));
+            JScrollableMenu medicalMenu = new JScrollableMenu("gmMenu.medical",
+                  resources.getString("gmMenu.medical.text"));
 
             if (!getCampaignOptions().isUseAdvancedMedical()) {
                 menuItem = new JMenuItem(resources.getString("editHits.text"));
@@ -4211,10 +4220,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 medicalMenu.add(menuItem);
             }
 
-            JMenuHelpers.addMenuIfNonEmpty(menu, medicalMenu);
+            gmMenu.add(medicalMenu);
 
-            // Family & Procreation submenu
-            JMenu familyMenu = new JMenu(resources.getString("gmMenu.familyProcreation.text"));
+            // Family & Procreation submenu. JScrollableMenu so the genealogy flyouts (Add/Remove Parent/Child)
+            // get auto-scrollers when the active roster pushes them past the threshold.
+            JScrollableMenu familyMenu = new JScrollableMenu("gmMenu.familyProcreation",
+                  resources.getString("gmMenu.familyProcreation.text"));
 
             if (getCampaignOptions().isUseManualProcreation()) {
                 if (Stream.of(selected)
@@ -4321,10 +4332,11 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 }
             }
 
-            JMenuHelpers.addMenuIfNonEmpty(menu, familyMenu);
+            gmMenu.add(familyMenu);
 
             // Personality & Roleplay submenu
-            JMenu personalityMenu = new JMenu(resources.getString("gmMenu.personalityRoleplay.text"));
+            JScrollableMenu personalityMenu = new JScrollableMenu("gmMenu.personalityRoleplay",
+                  resources.getString("gmMenu.personalityRoleplay.text"));
 
             if (getCampaignOptions().isUseLoyaltyModifiers()) {
                 menuItem = new JMenuItem(resources.getString("regenerateLoyalty.text"));
@@ -4374,10 +4386,11 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             menuItem.addActionListener(this);
             personalityMenu.add(menuItem);
 
-            JMenuHelpers.addMenuIfNonEmpty(menu, personalityMenu);
+            gmMenu.add(personalityMenu);
 
             // Tools submenu
-            JMenu toolsMenu = new JMenu(resources.getString("gmMenu.tools.text"));
+            JScrollableMenu toolsMenu = new JScrollableMenu("gmMenu.tools",
+                  resources.getString("gmMenu.tools.text"));
 
             if (oneSelected) {
                 menuItem = new JMenuItem(resources.getString("loadGMTools.text"));
@@ -4385,9 +4398,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 toolsMenu.add(menuItem);
             }
 
-            JMenuHelpers.addMenuIfNonEmpty(menu, toolsMenu);
+            gmMenu.add(toolsMenu);
 
-            JMenuHelpers.addMenuIfNonEmpty(popup, menu);
+            // Pre-existing usage; popup is a JPopupMenu so we keep the helper here. Migrating to
+            // JScrollablePopupMenu requires changing the popup variable type, which is out of scope
+            // for this presentation refactor.
+            JMenuHelpers.addMenuIfNonEmpty(popup, gmMenu);
         }
         // endregion GM Menu
 

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -4066,115 +4066,155 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
             menu = new JMenu(resources.getString("GMMode.text"));
 
-            menuItem = new JMenu(resources.getString("changePrisonerStatus.text"));
-            menuItem.add(newCheckboxMenu(PrisonerStatus.FREE.toString(),
-                  makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.FREE.name()),
-                  (person.getPrisonerStatus() == PrisonerStatus.FREE)));
-            menuItem.add(newCheckboxMenu(PrisonerStatus.PRISONER.toString(),
-                  makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.PRISONER.name()),
-                  (person.getPrisonerStatus() == PrisonerStatus.PRISONER)));
-            menuItem.add(newCheckboxMenu(PrisonerStatus.PRISONER_DEFECTOR.toString(),
-                  makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.PRISONER_DEFECTOR.name()),
-                  (person.getPrisonerStatus() == PrisonerStatus.PRISONER_DEFECTOR)));
-            menuItem.add(newCheckboxMenu(PrisonerStatus.BONDSMAN.toString(),
-                  makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.BONDSMAN.name()),
-                  (person.getPrisonerStatus() == PrisonerStatus.BONDSMAN)));
-            menu.add(menuItem);
-
-            if (StaticChecks.areAllPrisoners(selected)) {
-                menu.add(newMenuItem(resources.getString("ransom.text"), CMD_RANSOM));
-            }
-
-            if (Stream.of(selected).allMatch(p -> p.getStatus().isPoW())) {
-                menu.add(newMenuItem(resources.getString("ransom.text"), CMD_RANSOM_FRIENDLY));
-            }
-
-            menuItem = new JMenuItem(resources.getString("removePerson.text"));
-            menuItem.setActionCommand(CMD_REMOVE);
+            // Top-level shortcuts: highest-traffic actions stay one click away.
+            menuItem = new JMenuItem(resources.getString("editPerson.text"));
+            menuItem.setActionCommand(CMD_EDIT);
             menuItem.addActionListener(this);
             menu.add(menuItem);
-
-            if (oneSelected) {
-                JMenu subMenu = new JMenu(resources.getString("refundSkill.text"));
-                for (Skill skill : person.getSkills().getSkills()) {
-                    String label = skill.getType().getName();
-                    JMenuItem menuSkill = new JMenuItem(label);
-                    menuSkill.setActionCommand(makeCommand(CMD_REFUND_SKILL, label));
-                    menuSkill.addActionListener(this);
-                    subMenu.add(menuSkill);
-                }
-                menu.add(subMenu);
-            }
-
-            if (!getCampaignOptions().isUseAdvancedMedical()) {
-                menuItem = new JMenuItem(resources.getString("editHits.text"));
-                menuItem.setActionCommand(CMD_EDIT_HITS);
-                menuItem.addActionListener(this);
-                menu.add(menuItem);
-            }
 
             menuItem = new JMenuItem(resources.getString("addXP.text"));
             menuItem.setActionCommand(CMD_ADD_XP);
             menuItem.addActionListener(this);
             menu.add(menuItem);
 
+            menu.addSeparator();
+
+            // Status & Identity submenu
+            JMenu statusIdentityMenu = new JMenu(resources.getString("gmMenu.statusIdentity.text"));
+
+            JMenu changePrisonerStatusMenu = new JMenu(resources.getString("changePrisonerStatus.text"));
+            changePrisonerStatusMenu.add(newCheckboxMenu(PrisonerStatus.FREE.toString(),
+                  makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.FREE.name()),
+                  (person.getPrisonerStatus() == PrisonerStatus.FREE)));
+            changePrisonerStatusMenu.add(newCheckboxMenu(PrisonerStatus.PRISONER.toString(),
+                  makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.PRISONER.name()),
+                  (person.getPrisonerStatus() == PrisonerStatus.PRISONER)));
+            changePrisonerStatusMenu.add(newCheckboxMenu(PrisonerStatus.PRISONER_DEFECTOR.toString(),
+                  makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.PRISONER_DEFECTOR.name()),
+                  (person.getPrisonerStatus() == PrisonerStatus.PRISONER_DEFECTOR)));
+            changePrisonerStatusMenu.add(newCheckboxMenu(PrisonerStatus.BONDSMAN.toString(),
+                  makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.BONDSMAN.name()),
+                  (person.getPrisonerStatus() == PrisonerStatus.BONDSMAN)));
+            statusIdentityMenu.add(changePrisonerStatusMenu);
+
+            if (StaticChecks.areAllPrisoners(selected)) {
+                statusIdentityMenu.add(newMenuItem(resources.getString("ransom.text"), CMD_RANSOM));
+            }
+
+            if (Stream.of(selected).allMatch(p -> p.getStatus().isPoW())) {
+                statusIdentityMenu.add(newMenuItem(resources.getString("ransom.text"), CMD_RANSOM_FRIENDLY));
+            }
+
+            menuItem = new JMenuItem(resources.getString("removePerson.text"));
+            menuItem.setActionCommand(CMD_REMOVE);
+            menuItem.addActionListener(this);
+            statusIdentityMenu.add(menuItem);
+
+            JMenuHelpers.addMenuIfNonEmpty(menu, statusIdentityMenu);
+
+            // Skills & XP submenu
+            JMenu skillsXpMenu = new JMenu(resources.getString("gmMenu.skillsXp.text"));
+
             menuItem = new JMenuItem(resources.getString("setXP.text"));
             menuItem.setActionCommand(CMD_SET_XP);
             menuItem.addActionListener(this);
-            menu.add(menuItem);
-
-            menuItem = new JMenuItem(resources.getString("editPerson.text"));
-            menuItem.setActionCommand(CMD_EDIT);
-            menuItem.addActionListener(this);
-            menu.add(menuItem);
+            skillsXpMenu.add(menuItem);
 
             if (oneSelected) {
-                menuItem = new JMenuItem(resources.getString("loadGMTools.text"));
-                menuItem.addActionListener(evt -> loadGMToolsForPerson(person));
-                menu.add(menuItem);
+                JMenu refundSkillMenu = new JMenu(resources.getString("refundSkill.text"));
+                for (Skill skill : person.getSkills().getSkills()) {
+                    String label = skill.getType().getName();
+                    JMenuItem menuSkill = new JMenuItem(label);
+                    menuSkill.setActionCommand(makeCommand(CMD_REFUND_SKILL, label));
+                    menuSkill.addActionListener(this);
+                    refundSkillMenu.add(menuSkill);
+                }
+                skillsXpMenu.add(refundSkillMenu);
             }
 
-            if (getCampaignOptions().isUseAdvancedMedical()) {
-                menuItem = new JMenuItem(resources.getString("removeAllInjuries.text"));
-                menuItem.setActionCommand(CMD_CLEAR_INJURIES);
+            if (getCampaignOptions().isUseAbilities()) {
+                menuItem = new JMenuItem(resources.getString("addRandomSPA.text"));
+                menuItem.setActionCommand(CMD_ADD_RANDOM_ABILITY);
                 menuItem.addActionListener(this);
-                menu.add(menuItem);
+                skillsXpMenu.add(menuItem);
+            }
 
-                menuItem = new JMenuItem(resources.getString("removeAllProsthetics.text"));
-                menuItem.setActionCommand(CMD_CLEAR_PROSTHETICS);
+            JMenu attributesMenu = new JMenu(resources.getString("spendOnAttributes.set"));
+            for (SkillAttribute attribute : SkillAttribute.values()) {
+                if (attribute.isNone()) {
+                    continue;
+                }
+                menuItem = new JMenuItem(attribute.getLabel());
+                menuItem.setToolTipText(wordWrap(String.format(resources.getString("spendOnAttributes.tooltip"))));
+                menuItem.setActionCommand(makeCommand(CMD_SET_ATTRIBUTE, String.valueOf(attribute)));
                 menuItem.addActionListener(this);
-                menu.add(menuItem);
+                menuItem.setEnabled(getCampaign().isGM());
+                attributesMenu.add(menuItem);
+            }
+            skillsXpMenu.add(attributesMenu);
 
+            JMenuHelpers.addMenuIfNonEmpty(menu, skillsXpMenu);
+
+            // Medical submenu
+            JMenu medicalMenu = new JMenu(resources.getString("gmMenu.medical.text"));
+
+            if (!getCampaignOptions().isUseAdvancedMedical()) {
+                menuItem = new JMenuItem(resources.getString("editHits.text"));
+                menuItem.setActionCommand(CMD_EDIT_HITS);
+                menuItem.addActionListener(this);
+                medicalMenu.add(menuItem);
+            } else {
                 if (oneSelected) {
+                    menuItem = new JMenuItem(resources.getString("editInjuries.text"));
+                    menuItem.setActionCommand(CMD_EDIT_INJURIES);
+                    menuItem.addActionListener(this);
+                    medicalMenu.add(menuItem);
+
                     for (Injury i : person.getInjuries()) {
                         menuItem = new JMenuItem(String.format(resources.getString("removeInjury.format"),
                               i.getName()));
                         menuItem.setActionCommand(makeCommand(CMD_REMOVE_INJURY, i.getUUID().toString()));
                         menuItem.addActionListener(this);
-                        menu.add(menuItem);
+                        medicalMenu.add(menuItem);
                     }
+                }
 
-                    menuItem = new JMenuItem(resources.getString("editInjuries.text"));
-                    menuItem.setActionCommand(CMD_EDIT_INJURIES);
-                    menuItem.addActionListener(this);
-                    menu.add(menuItem);
+                if (medicalMenu.getItemCount() > 0) {
+                    medicalMenu.addSeparator();
                 }
 
                 menuItem = new JMenuItem(resources.getString("addRandomInjury.format"));
                 menuItem.setActionCommand(CMD_ADD_RANDOM_INJURY);
                 menuItem.addActionListener(this);
-                menu.add(menuItem);
+                medicalMenu.add(menuItem);
 
                 menuItem = new JMenuItem(resources.getString("addRandomInjuries.format"));
                 menuItem.setActionCommand(CMD_ADD_RANDOM_INJURIES);
                 menuItem.addActionListener(this);
-                menu.add(menuItem);
+                medicalMenu.add(menuItem);
 
                 menuItem = new JMenuItem(resources.getString("addRandomDisease.format"));
                 menuItem.setActionCommand(CMD_ADD_RANDOM_DISEASE);
                 menuItem.addActionListener(this);
-                menu.add(menuItem);
+                medicalMenu.add(menuItem);
+
+                medicalMenu.addSeparator();
+
+                menuItem = new JMenuItem(resources.getString("removeAllInjuries.text"));
+                menuItem.setActionCommand(CMD_CLEAR_INJURIES);
+                menuItem.addActionListener(this);
+                medicalMenu.add(menuItem);
+
+                menuItem = new JMenuItem(resources.getString("removeAllProsthetics.text"));
+                menuItem.setActionCommand(CMD_CLEAR_PROSTHETICS);
+                menuItem.addActionListener(this);
+                medicalMenu.add(menuItem);
             }
+
+            JMenuHelpers.addMenuIfNonEmpty(menu, medicalMenu);
+
+            // Family & Procreation submenu
+            JMenu familyMenu = new JMenu(resources.getString("gmMenu.familyProcreation.text"));
 
             if (getCampaignOptions().isUseManualProcreation()) {
                 if (Stream.of(selected)
@@ -4185,7 +4225,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                                                                        "addPregnancies.text"));
                     menuItem.setActionCommand(CMD_ADD_PREGNANCY);
                     menuItem.addActionListener(this);
-                    menu.add(menuItem);
+                    familyMenu.add(menuItem);
                 }
 
                 if (Stream.of(selected).anyMatch(Person::isPregnant)) {
@@ -4194,83 +4234,13 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                                                                        "removePregnancies.text"));
                     menuItem.setActionCommand(CMD_REMOVE_PREGNANCY);
                     menuItem.addActionListener(this);
-                    menu.add(menuItem);
+                    familyMenu.add(menuItem);
                 }
             }
-
-            if (getCampaignOptions().isUseLoyaltyModifiers()) {
-                menuItem = new JMenuItem(resources.getString("regenerateLoyalty.text"));
-                menuItem.setActionCommand(CMD_LOYALTY);
-                menuItem.addActionListener(this);
-                menu.add(menuItem);
-            }
-
-            if (getCampaignOptions().isUseRandomPersonalities()) {
-                menuItem = new JMenuItem(resources.getString("regeneratePersonality.text"));
-                menuItem.setActionCommand(CMD_PERSONALITY);
-                menuItem.addActionListener(this);
-                menu.add(menuItem);
-            }
-
-            if (getCampaignOptions().isUseAbilities()) {
-                menuItem = new JMenuItem(resources.getString("addRandomSPA.text"));
-                menuItem.setActionCommand(CMD_ADD_RANDOM_ABILITY);
-                menuItem.addActionListener(this);
-                menu.add(menuItem);
-            }
-
-            menuItem = new JMenuItem(resources.getString("generateRoleplaySkills.text"));
-            menuItem.setActionCommand(CMD_GENERATE_ROLEPLAY_SKILLS);
-            menuItem.addActionListener(this);
-            menu.add(menuItem);
-
-            menuItem = new JMenuItem(resources.getString("removeRoleplaySkills.text"));
-            menuItem.setActionCommand(CMD_REMOVE_ROLEPLAY_SKILLS);
-            menuItem.addActionListener(this);
-            menu.add(menuItem);
-
-            RandomSkillPreferences randomSkillPreferences = getCampaign().getRandomSkillPreferences();
-            boolean isRandomizeAttributes = randomSkillPreferences.isRandomizeAttributes();
-
-            menuItem = new JMenuItem(resources.getString("generateRoleplayAttributes." + (isRandomizeAttributes ?
-                                                                                                "random" : "reset")));
-            menuItem.setActionCommand(CMD_GENERATE_ROLEPLAY_ATTRIBUTES);
-            menuItem.addActionListener(this);
-            menu.add(menuItem);
-
-            boolean isRandomizeTraits = randomSkillPreferences.isRandomizeTraits();
-            menuItem = new JMenuItem(resources.getString("generateRoleplayTraits." + (isRandomizeTraits ?
-                                                                                            "random" : "reset")));
-            menuItem.setActionCommand(CMD_GENERATE_ROLEPLAY_TRAITS);
-            menuItem.addActionListener(this);
-            menu.add(menuItem);
-
-            JMenu attributesMenu = new JMenu(resources.getString("spendOnAttributes.set"));
-
-            for (SkillAttribute attribute : SkillAttribute.values()) {
-                if (attribute.isNone()) {
-                    continue;
-                }
-
-                // Set
-                menuItem = new JMenuItem(attribute.getLabel());
-                menuItem.setToolTipText(wordWrap(String.format(resources.getString("spendOnAttributes.tooltip"))));
-                menuItem.setActionCommand(makeCommand(CMD_SET_ATTRIBUTE, String.valueOf(attribute)));
-                menuItem.addActionListener(this);
-                menuItem.setEnabled(getCampaign().isGM());
-                attributesMenu.add(menuItem);
-            }
-            menu.add(attributesMenu);
-
-            menuItem = new JMenuItem(resources.getString("generateRandomCivilianProfession.text"));
-            menuItem.setToolTipText(wordWrap(String.format(resources.getString(
-                  "generateRandomCivilianProfession.tooltip"))));
-            menuItem.setActionCommand(makeCommand(CMD_RANDOM_PROFESSION));
-            menuItem.addActionListener(this);
-            menuItem.setEnabled(getCampaign().isGM());
-            menu.add(menuItem);
 
             if (oneSelected) {
+                int genealogyStartCount = familyMenu.getItemCount();
+
                 Genealogy personGenealogy = person.getGenealogy();
                 List<Person> personParents = personGenealogy.getParents();
 
@@ -4292,7 +4262,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                         newParentMenu.add(newParentItem);
                     }
                     if (newParentMenu.getItemCount() > 0) {
-                        menu.add(newParentMenu);
+                        familyMenu.add(newParentMenu);
                     }
                 }
 
@@ -4307,7 +4277,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     removeParentMenu.add(removeParentItem);
                 }
                 if (removeParentMenu.getItemCount() > 0) {
-                    menu.add(removeParentMenu);
+                    familyMenu.add(removeParentMenu);
                 }
 
                 JMenu newChildMenu = new JMenu(resources.getString("child.add"));
@@ -4330,7 +4300,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     newChildMenu.add(newChildItem);
                 }
                 if (newChildMenu.getItemCount() > 0) {
-                    menu.add(newChildMenu);
+                    familyMenu.add(newChildMenu);
                 }
 
                 JMenu removeChildMenu = new JMenu(resources.getString("child.remove"));
@@ -4343,9 +4313,79 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     removeChildMenu.add(removeChildItem);
                 }
                 if (removeChildMenu.getItemCount() > 0) {
-                    menu.add(removeChildMenu);
+                    familyMenu.add(removeChildMenu);
+                }
+
+                if (genealogyStartCount > 0 && familyMenu.getItemCount() > genealogyStartCount) {
+                    familyMenu.insertSeparator(genealogyStartCount);
                 }
             }
+
+            JMenuHelpers.addMenuIfNonEmpty(menu, familyMenu);
+
+            // Personality & Roleplay submenu
+            JMenu personalityMenu = new JMenu(resources.getString("gmMenu.personalityRoleplay.text"));
+
+            if (getCampaignOptions().isUseLoyaltyModifiers()) {
+                menuItem = new JMenuItem(resources.getString("regenerateLoyalty.text"));
+                menuItem.setActionCommand(CMD_LOYALTY);
+                menuItem.addActionListener(this);
+                personalityMenu.add(menuItem);
+            }
+
+            if (getCampaignOptions().isUseRandomPersonalities()) {
+                menuItem = new JMenuItem(resources.getString("regeneratePersonality.text"));
+                menuItem.setActionCommand(CMD_PERSONALITY);
+                menuItem.addActionListener(this);
+                personalityMenu.add(menuItem);
+            }
+
+            menuItem = new JMenuItem(resources.getString("generateRandomCivilianProfession.text"));
+            menuItem.setToolTipText(wordWrap(String.format(resources.getString(
+                  "generateRandomCivilianProfession.tooltip"))));
+            menuItem.setActionCommand(makeCommand(CMD_RANDOM_PROFESSION));
+            menuItem.addActionListener(this);
+            menuItem.setEnabled(getCampaign().isGM());
+            personalityMenu.add(menuItem);
+
+            RandomSkillPreferences randomSkillPreferences = getCampaign().getRandomSkillPreferences();
+            boolean isRandomizeAttributes = randomSkillPreferences.isRandomizeAttributes();
+
+            menuItem = new JMenuItem(resources.getString("generateRoleplayAttributes." + (isRandomizeAttributes ?
+                                                                                                "random" : "reset")));
+            menuItem.setActionCommand(CMD_GENERATE_ROLEPLAY_ATTRIBUTES);
+            menuItem.addActionListener(this);
+            personalityMenu.add(menuItem);
+
+            boolean isRandomizeTraits = randomSkillPreferences.isRandomizeTraits();
+            menuItem = new JMenuItem(resources.getString("generateRoleplayTraits." + (isRandomizeTraits ?
+                                                                                            "random" : "reset")));
+            menuItem.setActionCommand(CMD_GENERATE_ROLEPLAY_TRAITS);
+            menuItem.addActionListener(this);
+            personalityMenu.add(menuItem);
+
+            menuItem = new JMenuItem(resources.getString("generateRoleplaySkills.text"));
+            menuItem.setActionCommand(CMD_GENERATE_ROLEPLAY_SKILLS);
+            menuItem.addActionListener(this);
+            personalityMenu.add(menuItem);
+
+            menuItem = new JMenuItem(resources.getString("removeRoleplaySkills.text"));
+            menuItem.setActionCommand(CMD_REMOVE_ROLEPLAY_SKILLS);
+            menuItem.addActionListener(this);
+            personalityMenu.add(menuItem);
+
+            JMenuHelpers.addMenuIfNonEmpty(menu, personalityMenu);
+
+            // Tools submenu
+            JMenu toolsMenu = new JMenu(resources.getString("gmMenu.tools.text"));
+
+            if (oneSelected) {
+                menuItem = new JMenuItem(resources.getString("loadGMTools.text"));
+                menuItem.addActionListener(evt -> loadGMToolsForPerson(person));
+                toolsMenu.add(menuItem);
+            }
+
+            JMenuHelpers.addMenuIfNonEmpty(menu, toolsMenu);
 
             JMenuHelpers.addMenuIfNonEmpty(popup, menu);
         }


### PR DESCRIPTION
## Summary

The right-click ``GM Mode`` submenu on the Personnel tab was a flat list of 28-32 items with no grouping or visual structure, scrolling on smaller resolutions and slowing routine GM actions. This restructures it around six themed sub-submenus while promoting the two highest-traffic items (``Edit Person``, ``Add XP``) to the top level so they remain one click away. Pure presentation refactor — no behaviour or action wiring changes.

## Changes Made

- **Top-level shortcuts**: ``Edit Person`` and ``Add XP`` stay directly under ``GM Mode`` for one-click access, followed by a separator.
- **Status & Identity**: ``Change Prisoner Status``, conditional ``Ransom`` / ``Ransom (Friendly)``, ``Remove Person``.
- **Skills & XP**: ``Set XP``, ``Refund Skill`` (single-select), ``Add Random SPA`` (gated by Abilities option), ``Set Attribute``.
- **Medical**: edit-hits or full advanced-medical block (mutually exclusive). Internal separators split per-injury edits, the random-add block, and the bulk-wipe block.
- **Family & Procreation**: pregnancy items above genealogy submenus, with an internal separator inserted only when both halves render.
- **Personality & Roleplay**: ``Regenerate Loyalty``, ``Regenerate Personality``, ``Generate Random Civilian Profession``, roleplay attributes/traits/skills randomizers.
- **Tools**: ``Load GM Tools`` (single-select).

Every sub-submenu is wrapped in ``JMenuHelpers.addMenuIfNonEmpty`` (the existing pattern used by the Randomization and Original Unit submenus higher up in the same method), so groups whose contents are entirely hidden by the current campaign options or selection state disappear from the menu rather than appearing empty.

**No item is added, removed, or rewired.** Every existing action command, listener, and visibility condition is preserved exactly; only the parent ``JMenu`` each item lives in changes.

## Changes

1. **PersonnelTableMouseAdapter.java** - Replaces the flat GM Menu region (lines 4063-4352 in the previous version) with the seven-group structure described above. Each sub-submenu is a local ``JMenu`` populated with the existing items under the same conditions, then attached to the parent via ``JMenuHelpers.addMenuIfNonEmpty``.
2. **GUI.properties** - Adds six resource keys for the new sub-submenu titles: ``gmMenu.statusIdentity.text``, ``gmMenu.skillsXp.text``, ``gmMenu.medical.text``, ``gmMenu.familyProcreation.text``, ``gmMenu.personalityRoleplay.text``, ``gmMenu.tools.text``.

## Files Changed

- ``MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java`` - Refactor of the GM Menu region only; rest of the file untouched.
- ``MekHQ/resources/mekhq/resources/GUI.properties`` - Six new resource keys above the existing ``### GM Menu`` block.

## Testing

- ``./gradlew compileJava`` clean.
- Manual smoke test on Quick Start campaign:
  - GM ON: top-level shortcuts (Edit Person, Add XP) plus all six themed groups appear; both shortcuts open their respective dialogs.
  - GM OFF: GM Mode menu absent (unchanged).
  - Single-select vs multi-select: Refund Skill, Edit Injuries, per-injury removal, parent/child submenus, and Tools (Load GM Tools) appear only on single-select; multi-select hides them and the Tools group auto-suppresses.
  - Advanced Medical ON: Medical submenu shows Edit Injuries + per-injury removals, separator, three Add Random items, separator, Remove All x2.
  - Advanced Medical OFF: Medical submenu collapses to just Edit Hits.
  - Manual Procreation ON, eligible character: Add Pregnancy appears under Family & Procreation. Pregnant character: Remove Pregnancy appears.
  - Loyalty / Random Personalities / Abilities options each gate their respective items as before.
  - Prisoner status switch: Ransom appears under Status & Identity once all selected are prisoners.

Early reviewer feedback was positive after walking through the menu live.

## Scope notes

- This is a presentation-only change. No campaign data, action commands, or domain logic is touched.
- The Randomization and Original Unit submenus higher up the popup are not modified.
- Six new translation keys added to ``GUI.properties``; no existing keys modified or removed.