### PR TITLE
Fix wooden foot prosthesis appearing under Leg slot (Fixes #8917)

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AlternateInjuries.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AlternateInjuries.java
@@ -1903,7 +1903,7 @@ public class AlternateInjuries {
         WoodenFoot() {
             super();
             this.simpleName = getTextAt(RESOURCE_BUNDLE, "AlternateInjuries.WOODEN_LIMB.simpleName");
-            this.allowedLocations = Set.of(LEFT_LEG, RIGHT_LEG);
+            this.allowedLocations = Set.of(LEFT_FOOT, RIGHT_FOOT);
             this.injuryEffect = TYPE_1_LIMB_REPLACEMENT;
         }
 


### PR DESCRIPTION
## Summary

The wooden foot prosthesis was being offered under the **leg** slot in the Advanced Surgery dialog instead of the **foot** slot — every other foot prosthetic in the same file appears under the foot slot as expected. One-line copy-paste typo in ``WoodenFoot.allowedLocations``.

## Bug Fixed

- **Wooden foot in the leg slot** (``AlternateInjuries.WoodenFoot``): ``allowedLocations`` was set to ``Set.of(LEFT_LEG, RIGHT_LEG)``, almost certainly lifted from ``PegLeg`` directly above it. Advanced Surgery filters prosthetic offers by ``allowedLocations``, so the wooden foot was never reachable as a foot replacement and inappropriately competed with leg prosthetics in the leg slot.

## Changes

1. **AlternateInjuries.java** - ``WoodenFoot.allowedLocations`` corrected from ``Set.of(LEFT_LEG, RIGHT_LEG)`` to ``Set.of(LEFT_FOOT, RIGHT_FOOT)``, matching every other foot prosthetic class in the file (``SimpleFoot``, ``ProstheticFoot``, ``AdvancedProstheticFoot``, ``MyomerFoot``, ``ClonedFoot``).

## Files Changed

- ``MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AlternateInjuries.java`` - One-line change at line 1906; the rest of the ``WoodenFoot`` class (``simpleName``, ``injuryEffect``, ``getName`` override) is already consistent with the other foot prosthetics and is untouched.

## Testing

- ``./gradlew compileJava checkstyleMain`` clean.
- Manual repro: gave a character a missing-foot injury, opened Advanced Surgery. Before the fix the Wooden Limb option appeared under the Leg slot alongside Peg Leg / Simple Leg / etc. After the fix it appears under the Foot slot alongside Simple Foot / Prosthetic Foot / Advanced Prosthetic Foot / Myomer Foot / Cloned Foot, and is no longer offered for the leg location. Confirmed by the reporter that this is the expected placement.

## Scope notes

- Single-character typo fix. No public API change. No new dependencies. No test scaffolding because the bug is in a static field initializer of a singleton ``InjuryType`` and there is no existing unit test infrastructure for ``allowedLocations`` validation in this directory.
- ``BodyLocation.LEFT_FOOT`` / ``RIGHT_FOOT`` were already wildcard-imported via ``import static mekhq.campaign.personnel.medical.BodyLocation.*`` and are used by every neighbouring foot-prosthetic class in the same file.