### PR TITLE
Honor faction lineage when checking academy access (Fixes #8915)

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
@@ -34,6 +34,7 @@ package mekhq.campaign.personnel.education;
 
 import static java.lang.Math.min;
 
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -59,6 +60,7 @@ import mekhq.campaign.personnel.skills.Skill;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Factions;
+import mekhq.campaign.universe.Planet;
 import mekhq.campaign.universe.PlanetarySystem;
 import mekhq.campaign.universe.RandomFactionGenerator;
 import mekhq.campaign.universe.factionHints.FactionHints;
@@ -699,6 +701,231 @@ public class Academy implements Comparable<Academy> {
         }
 
         return null;
+    }
+
+    /**
+     * Campus-aware variant of {@link #getFilteredFaction(Campaign, Person, List)} that resolves
+     * faction-restricted academy access against the campus system's <em>current</em> controller, applying the
+     * BattleTech-canonical FedCom era rules and a general bidirectional faction-lineage check (#8915).
+     *
+     * <p>The legacy restricted branch denies any combination where the person's origin faction does not
+     * literally equal the system's current controller. That breaks across mergers and splits:
+     * a Lyran-origin character on FedCom-controlled Tharkad in 3050 was denied Nagelring even though the
+     * academy is the same institution and the character has a legitimate institutional connection.</p>
+     *
+     * <p>The new check asks: <em>who owns the academy now, and does this character's nationality support
+     * entry?</em> The "support entry" question is resolved in three ways, in order:</p>
+     *
+     * <ol>
+     *   <li><strong>Direct equality</strong> against the person's effective faction (origin, with a
+     *       birthworld fallback for FC-origin characters in 3068+).</li>
+     *   <li><strong>FedCom era rules</strong> — see {@link #isFedComCompatible(String, String, LocalDate)}
+     *       for the LA / FS / FC matrix across the 3028-3057, 3058-3067, and 3068+ eras.</li>
+     *   <li><strong>General lineage</strong> via {@link Faction#isLineageCompatible(Faction)} — handles
+     *       CGB↔RD, FRR↔RD, WOB↔CS, and any other bidirectional fallBackFactions relationship.</li>
+     * </ol>
+     *
+     * <p>Campaign faction is gated identically — symmetric with origin.</p>
+     *
+     * <p>For non-restricted academies (faction-conflict / reeducation camp / general), the at-war check
+     * is unchanged and runs against the campus's current controllers via the legacy method.</p>
+     *
+     * @param campaign the campaign being played
+     * @param person   the person whose eligibility is being checked
+     * @param campusId the planetary-system id where the academy (or local campus) is located
+     *
+     * @return the faction short name granting access, or {@code null} if no eligible faction exists for
+     *       this person at this campus
+     */
+    public String getFilteredFactionAtCampus(Campaign campaign, Person person, String campusId) {
+        if (campusId == null) {
+            return null;
+        }
+        PlanetarySystem campus = campaign.getSystemById(campusId);
+        if (campus == null) {
+            return null;
+        }
+
+        if (isFactionRestricted) {
+            return getFilteredFactionRestricted(campaign, person, campus);
+        }
+
+        // For non-restricted academies, retain the legacy at-war behavior against current controllers.
+        return getFilteredFaction(campaign, person, campus.getFactions(campaign.getLocalDate()));
+    }
+
+    /**
+     * Restricted-academy access check: for each current controller of the campus, test the person's
+     * effective faction and the campaign faction against direct equality, the FedCom era rules, and the
+     * general lineage walk. Returns the first compatible owner short name, or {@code null} if none match.
+     *
+     * @param campaign the campaign being played (provides today's date)
+     * @param person   the person whose eligibility is being checked
+     * @param campus   the planetary system hosting the academy or local campus
+     *
+     * @return the owner short name granting access, or {@code null} if no current owner is compatible
+     */
+    private String getFilteredFactionRestricted(Campaign campaign, Person person, PlanetarySystem campus) {
+        LocalDate today = campaign.getLocalDate();
+        List<String> currentOwners = campus.getFactions(today);
+        if (currentOwners == null || currentOwners.isEmpty()) {
+            return null;
+        }
+
+        String effectiveOrigin = effectiveFactionFor(person, today);
+        String campaignShort = campaign.getFaction().getShortName();
+        Factions factionsRegistry = Factions.getInstance();
+
+        for (String ownerShort : currentOwners) {
+            Faction owner = factionsRegistry.getFaction(ownerShort);
+            if (owner == null) {
+                continue;
+            }
+
+            // Origin checks
+            if (effectiveOrigin != null) {
+                if (effectiveOrigin.equals(ownerShort)) {
+                    return ownerShort;
+                }
+                if (isFedComCompatible(effectiveOrigin, ownerShort, today)) {
+                    return ownerShort;
+                }
+            }
+            Faction originFaction = person.getOriginFaction();
+            // Skip the general lineage walk for FC origin: FC.fallBackFactions = [LA, FS] would match
+            // BOTH Lyran and FedSuns owners regardless of birthworld side, defeating the era rules
+            // and the FC-origin birthworld fallback in effectiveFactionFor. FC's compatibility is
+            // fully described by isFedComCompatible above. Other FedCom codes (LA, FS) are harmless
+            // here because their fallBackFactions are meta-only ([IS]), excluded by isLineageCompatible.
+            if (originFaction != null && !"FC".equals(originFaction.getShortName())
+                      && originFaction.isLineageCompatible(owner)) {
+                return ownerShort;
+            }
+
+            // Campaign-faction checks (same gates, in case the unit's national affiliation grants access
+            // even when the individual character's origin does not — e.g. a Davion merc unit on tour)
+            if (campaignShort != null) {
+                if (campaignShort.equals(ownerShort)) {
+                    return ownerShort;
+                }
+                if (isFedComCompatible(campaignShort, ownerShort, today)) {
+                    return ownerShort;
+                }
+            }
+            Faction campaignFaction = campaign.getFaction();
+            if (campaignFaction != null && !"FC".equals(campaignFaction.getShortName())
+                      && campaignFaction.isLineageCompatible(owner)) {
+                return ownerShort;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the faction short name to test against academy owners for this person, applying the
+     * birthworld fallback only for FC-origin characters in the post-FedCom era (3068+). For every other
+     * origin (LA, FS, DC, CC, ...) returns {@code person.getOriginFaction().getShortName()} directly.
+     *
+     * <p>FedCom (FC) ended in 3067. An FC-origin character in 3068+ has no current state to map to;
+     * we infer their post-FedCom alignment from their birthworld:</p>
+     *
+     * <ol>
+     *   <li>Look up the birthworld's faction at the character's birth date (literal owner).</li>
+     *   <li>If that returns a usable LA / FS / other code, use it.</li>
+     *   <li>If it returns FC itself (offers no LA/FS routing) or is empty, fall back to the birthworld's
+     *       <em>current</em> owner — most worlds reverted to their geographic alignment after the
+     *       3057 secession and 3067 dissolution.</li>
+     * </ol>
+     *
+     * @param person the person whose effective faction we want
+     * @param today  the campaign's current date
+     *
+     * @return the effective faction short name, or {@code null} if the person has no origin faction
+     */
+    private static String effectiveFactionFor(Person person, LocalDate today) {
+        Faction origin = person.getOriginFaction();
+        if (origin == null) {
+            return null;
+        }
+        String originShort = origin.getShortName();
+        if (!"FC".equals(originShort) || today.getYear() <= 3067) {
+            return originShort;
+        }
+
+        // FC origin in post-FedCom era: derive effective faction from birthworld.
+        Planet birthPlanet = person.getOriginPlanet();
+        if (birthPlanet == null) {
+            return originShort;
+        }
+        LocalDate birth = person.getDateOfBirth();
+        String fromBirth = firstUsableNonFc(birth == null ? null : birthPlanet.getFactions(birth));
+        if (fromBirth != null) {
+            return fromBirth;
+        }
+        // Fallback: birthworld's current owner (post-split reversion).
+        String fromCurrent = firstUsableNonFc(birthPlanet.getFactions(today));
+        return fromCurrent != null ? fromCurrent : originShort;
+    }
+
+    private static String firstUsableNonFc(List<String> codes) {
+        if (codes == null) {
+            return null;
+        }
+        for (String code : codes) {
+            if (code != null && !"FC".equals(code) && !"ABN".equals(code)) {
+                return code;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Encodes the BattleTech-canonical FedCom academy access rules. Returns {@code true} only when both
+     * {@code origin} and {@code owner} are members of the FedCom set ({@code LA}, {@code FS}, {@code FC})
+     * and the era allows the cross-faction grant.
+     *
+     * <ul>
+     *   <li><strong>3028-3057</strong> (FedCom proper, before LA secession): every FedCom citizen may
+     *       attend any FedCom academy.</li>
+     *   <li><strong>3058-3067</strong> (LA seceded; Davion half retains FedCom name): Lyran academies
+     *       (owner = LA) admit LA only; FedSuns and FedCom academies (owner = FS or FC) admit LA, FS,
+     *       FC.</li>
+     *   <li><strong>3068+</strong> (Yvonne reverts to "Federated Suns"; FC defunct): each side admits
+     *       only its own. FC-origin characters reach this method via {@link #effectiveFactionFor} which
+     *       has already mapped them to LA or FS through the birthworld fallback.</li>
+     * </ul>
+     *
+     * <p>Returns {@code false} for any combination outside the FedCom set, or when the date and the
+     * specific (owner, origin) pair fall outside the allowed era rules. Direct equality and the general
+     * lineage check are handled separately at the call site.</p>
+     */
+    private static boolean isFedComCompatible(String origin, String owner, LocalDate today) {
+        if (origin == null || owner == null) {
+            return false;
+        }
+        if (!isFedComCode(origin) || !isFedComCode(owner)) {
+            return false;
+        }
+
+        int year = today.getYear();
+        if (year >= 3028 && year <= 3057) {
+            return true; // any FedCom citizen at any FedCom academy
+        }
+        if (year >= 3058 && year <= 3067) {
+            // Lyran academies are LA-only; Davion-side and FedCom-labelled academies still accept all.
+            if ("LA".equals(owner)) {
+                return "LA".equals(origin);
+            }
+            return true;
+        }
+        // 3068+: direct equality only — handled by the equality check at the call site, not here.
+        // Returning false from this method delegates that case to the equality and lineage gates.
+        return false;
+    }
+
+    private static boolean isFedComCode(String code) {
+        return "LA".equals(code) || "FS".equals(code) || "FC".equals(code);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/universe/Faction.java
+++ b/MekHQ/src/mekhq/campaign/universe/Faction.java
@@ -173,6 +173,60 @@ public class Faction {
         return alternativeFactionCodes;
     }
 
+    /**
+     * Tests whether this faction is institutionally compatible with another faction via the
+     * {@code fallBackFactions} successor/predecessor data already populated in the YAML faction files.
+     *
+     * <p>Used by faction-restricted academy access (and any future eligibility check) for non-FedCom
+     * faction successions: Clan Ghost Bear / Free Rasalhague Republic into Rasalhague Dominion, ComStar
+     * into Word of Blake, and similar mergers/splits. The check is bidirectional — either side's
+     * {@code fallBackFactions} can carry the relationship — because the YAMLs only declare the
+     * successor's predecessors (e.g. {@code RD.fallBackFactions = [CGB, FRR]}), never the inverse.
+     *
+     * <p>Meta-faction codes are excluded so that {@code LA} and {@code FS} are not considered
+     * compatible just because both list {@code IS} as a fallback. The exclusion list is the codes
+     * {@code IS}, {@code CLAN.IS}, and any code starting with {@code Periphery.} or {@code CLAN.} —
+     * these are general-category fallbacks for missing-data lookups in
+     * {@link mekhq.campaign.universe.RandomFactionGenerator}, not real institutional ancestry.
+     *
+     * <p>FedCom-specific era rules (LA seceding 3057, Yvonne reverting to Federated Suns 3067) are
+     * handled separately at the call site; this method intentionally does not look at the date.
+     *
+     * @param other the other faction to test compatibility against
+     *
+     * @return {@code true} if this and {@code other} are the same faction, or if either lists the
+     *       other in its {@code fallBackFactions} (after meta-code exclusion); {@code false} otherwise
+     */
+    public boolean isLineageCompatible(final @Nullable Faction other) {
+        if (other == null) {
+            return false;
+        }
+        if (this.equals(other)) {
+            return true;
+        }
+        if (containsNonMetaCode(this.alternativeFactionCodes, other.shortName)) {
+            return true;
+        }
+        return containsNonMetaCode(other.alternativeFactionCodes, this.shortName);
+    }
+
+    private static boolean containsNonMetaCode(@Nullable String[] codes, String target) {
+        if (codes == null || isMetaFactionCode(target)) {
+            return false;
+        }
+        for (String code : codes) {
+            if (target.equals(code)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isMetaFactionCode(String code) {
+        return "IS".equals(code) || "CLAN.IS".equals(code)
+                     || code.startsWith("Periphery.") || code.startsWith("CLAN.");
+    }
+
     public Color getColor() {
         return color;
     }

--- a/MekHQ/src/mekhq/campaign/universe/Faction.java
+++ b/MekHQ/src/mekhq/campaign/universe/Faction.java
@@ -183,11 +183,17 @@ public class Faction {
      * {@code fallBackFactions} can carry the relationship — because the YAMLs only declare the
      * successor's predecessors (e.g. {@code RD.fallBackFactions = [CGB, FRR]}), never the inverse.
      *
-     * <p>Meta-faction codes are excluded so that {@code LA} and {@code FS} are not considered
-     * compatible just because both list {@code IS} as a fallback. The exclusion list is the codes
-     * {@code IS}, {@code CLAN.IS}, and any code starting with {@code Periphery.} or {@code CLAN.} —
-     * these are general-category fallbacks for missing-data lookups in
-     * {@link mekhq.campaign.universe.RandomFactionGenerator}, not real institutional ancestry.
+     * <p>Meta-faction codes are excluded as compatibility <em>targets</em>: a real faction is never
+     * considered "compatible" with the abstract meta-faction {@code IS} (or {@code CLAN.IS}, or any
+     * {@code Periphery.*} / {@code CLAN.*} code) just because the real faction's
+     * {@code fallBackFactions} list includes that meta code as a generic data-lookup fallback. Most
+     * playable Inner Sphere factions list {@code IS} as a fallback for the
+     * {@link mekhq.campaign.universe.RandomFactionGenerator} machinery, so without this exclusion
+     * any of them would erroneously test compatible with the abstract IS umbrella.
+     *
+     * <p>The exclusion does <em>not</em> change comparisons between two real factions: LA and FS, for
+     * example, are correctly considered incompatible by this method because neither lists the other's
+     * short code in its fallbacks, regardless of any shared meta entries.
      *
      * <p>FedCom-specific era rules (LA seceding 3057, Yvonne reverting to Federated Suns 3067) are
      * handled separately at the call site; this method intentionally does not look at the date.

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -4956,10 +4956,11 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 }
             } else if (academy.isLocal()) {
                 // are any of the local academies accepting applicants from person's Faction or
-                // campaign's Faction?
-                String faction = academy.getFilteredFaction(campaign,
+                // campaign's Faction? Use the campus-aware variant so faction-restricted local academies
+                // resolve against the system's faction history (handles mergers/splits — see #8915).
+                String faction = academy.getFilteredFactionAtCampus(campaign,
                       person,
-                      campaign.getSystemById(campaign.getCurrentSystem().getId()).getFactions(campaign.getLocalDate()));
+                      campaign.getCurrentSystem().getId());
 
                 if (faction == null) {
                     if (showIneligibleAcademies) {
@@ -4995,10 +4996,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 List<String> campuses = new ArrayList<>();
 
                 for (String campusId : academy.getLocationSystems()) {
-                    PlanetarySystem system = campaign.getSystemById(campusId);
-
-                    if (academy.getFilteredFaction(campaign, person, system.getFactions(campaign.getLocalDate())) !=
-                              null) {
+                    if (academy.getFilteredFactionAtCampus(campaign, person, campusId) != null) {
                         campuses.add(campusId);
                     }
                 }
@@ -5023,9 +5021,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                             educationJMenuItemAdder(academy, militaryMenu, civilianMenu, academyOption);
                         }
                     } else {
-                        String faction = academy.getFilteredFaction(campaign,
-                              person,
-                              campaign.getSystemById(nearestCampus).getFactions(campaign.getLocalDate()));
+                        String faction = academy.getFilteredFactionAtCampus(campaign, person, nearestCampus);
 
                         if (faction != null) {
                             JMenu academyOption = new JMenu(academy.getName());
@@ -5118,21 +5114,17 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
             if (academy.isLocal()) {
                 // find the first faction that accepts applications from all persons in
-                // personnel
+                // personnel — campus-aware variant resolves faction-restricted academies via system history
+                String currentCampus = campaign.getCurrentSystem().getId();
                 Optional<String> suitableFaction = personnel.stream()
-                                                         .map(person -> academy.getFilteredFaction(campaign,
-                                                               person,
-                                                               campaign.getCurrentSystem()
-                                                                     .getFactions(campaign.getLocalDate())))
+                                                         .map(person -> academy.getFilteredFactionAtCampus(campaign,
+                                                               person, currentCampus))
                                                          .filter(faction -> personnel.stream()
                                                                                   .allMatch(person -> Objects.equals(
                                                                                         faction,
-                                                                                        academy.getFilteredFaction(
-                                                                                              campaign,
-                                                                                              person,
-                                                                                              campaign.getCurrentSystem()
-                                                                                                    .getFactions(
-                                                                                                          campaign.getLocalDate())))))
+                                                                                        academy.getFilteredFactionAtCampus(
+                                                                                              campaign, person,
+                                                                                              currentCampus))))
                                                          .distinct()
                                                          .filter(Objects::nonNull)
                                                          .findFirst();
@@ -5163,20 +5155,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 List<String> suitableCampuses = personnel.stream()
                                                       .flatMap(person -> academy.getLocationSystems()
                                                                                .stream()
-                                                                               .filter(campus -> academy.getFilteredFaction(
-                                                                                     campaign,
-                                                                                     person,
-                                                                                     campaign.getSystemById(campus)
-                                                                                           .getFactions(campaign.getLocalDate())) !=
-                                                                                                       null))
+                                                                               .filter(campus -> academy.getFilteredFactionAtCampus(
+                                                                                     campaign, person, campus) != null))
                                                       .distinct()
                                                       .filter(campus -> personnel.stream()
-                                                                              .allMatch(person -> academy.getFilteredFaction(
-                                                                                    campaign,
-                                                                                    person,
-                                                                                    campaign.getSystemById(campus)
-                                                                                          .getFactions(campaign.getLocalDate())) !=
-                                                                                                        null))
+                                                                              .allMatch(person -> academy.getFilteredFactionAtCampus(
+                                                                                    campaign, person, campus) != null))
                                                       .collect(Collectors.toList());
 
                 if (!suitableCampuses.isEmpty()) {
@@ -5184,20 +5168,14 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                     // find what factions accept an application from all members of the group
                     Optional<String> suitableFaction = personnel.stream()
-                                                             .map(person -> academy.getFilteredFaction(campaign,
-                                                                   person,
-                                                                   campaign.getSystemById(nearestCampus)
-                                                                         .getFactions(campaign.getLocalDate())))
+                                                             .map(person -> academy.getFilteredFactionAtCampus(campaign,
+                                                                   person, nearestCampus))
                                                              .distinct()
                                                              .filter(faction -> personnel.stream()
                                                                                       .allMatch(person -> faction.equals(
-                                                                                            academy.getFilteredFaction(
-                                                                                                  campaign,
-                                                                                                  person,
-                                                                                                  campaign.getSystemById(
-                                                                                                              nearestCampus)
-                                                                                                        .getFactions(
-                                                                                                              campaign.getLocalDate())))))
+                                                                                            academy.getFilteredFactionAtCampus(
+                                                                                                  campaign, person,
+                                                                                                  nearestCampus))))
                                                              .findFirst();
 
                     if (suitableFaction.isPresent()) {


### PR DESCRIPTION
## Summary

Faction-restricted academies were inaccessible to characters whose origin faction had merged into or split from the system's current controller. The legacy gate compared the system's current controller to the person's origin faction by literal equality only — no lineage, no era awareness, no birthworld fallback. This change replaces that gate with three layered checks against the campus system's current controller(s): direct equality on an effective faction (with a birthworld fallback for FC-origin in 3068+), the BattleTech-canonical FedCom era rules, and a general bidirectional ``fallBackFactions`` lineage walk for non-FedCom successions (CGB↔RD, WOB↔CS, etc.).

## Bug Fixed

- **Lineage-blind academy gate** (Fixes #8915): a Lyran Alliance-origin character on Federated Commonwealth-controlled Tharkad in 3050 was denied Nagelring even though the academy is the same institution and the character has a legitimate institutional connection. Same failure shape across all FedCom-era worlds, FedCom-Civil-War-era split worlds, and any other faction succession (Ghost Bear / Free Rasalhague Republic into Rasalhague Dominion, ComStar into Word of Blake).

Fixes #8915

## Changes

1. **Faction.java** — new public ``isLineageCompatible(Faction other)`` method. Bidirectional ``fallBackFactions`` walk with meta-faction exclusions (``IS``, ``CLAN.IS``, ``Periphery.*``, ``CLAN.*``) so unrelated factions don't appear "compatible" via shared meta-ancestry. Builds on the existing convention used by ``RandomFactionGenerator.findSuperStateFaction``.
2. **Academy.java** — new public ``getFilteredFactionAtCampus(Campaign, Person, String campusId)`` entry plus private helpers ``getFilteredFactionRestricted``, ``effectiveFactionFor``, ``isFedComCompatible``, ``isFedComCode``, ``firstUsableNonFc``. The algorithm:
   - **Direct equality** on the effective faction (origin, with FC-origin → birthworld fallback in 3068+).
   - **FedCom era rules** encoding the LA/FS/FC matrix across 3028-3057 (full FedCom, all citizens any FedCom academy), 3058-3067 (LA seceded; Davion-side keeps FedCom name), 3068+ (each side admits only its own).
   - **General lineage walk** via ``Faction.isLineageCompatible``, skipped for FC origin specifically (FC's ``fallBackFactions`` of ``[LA, FS]`` would otherwise grant cross-realm access regardless of the birthworld fallback).
   - Campaign faction gated identically, symmetric with origin.
3. **PersonnelTableMouseAdapter.java** — five academy-eligibility call sites updated from passing ``system.getFactions(today)`` into the legacy three-arg method to passing ``systemId`` into the new method. The re-enrollment site at line 2751 is unchanged because it uses ``person.getEduAcademyFaction()`` as a singleton faction code (a semantically distinct case the legacy method still serves correctly).

## Files Changed

- ``MekHQ/src/mekhq/campaign/universe/Faction.java`` — +54 lines: ``isLineageCompatible`` plus private helpers ``containsNonMetaCode`` and ``isMetaFactionCode``.
- ``MekHQ/src/mekhq/campaign/personnel/education/Academy.java`` — +227 lines: replaces the old ``isFactionRestricted`` branch logic with the layered algorithm above.
- ``MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java`` — 66 lines updated across five call sites.

## Testing

- ``./gradlew compileJava checkstyleMain`` clean.
- ``./gradlew test --tests "mekhq.campaign.personnel.education.*" --tests "mekhq.campaign.universe.*"`` passes.
- **In-game matrix on a Quick Start campaign** (today = 3071, on Skye, jump range 200, ``showIneligibleAcademies`` off):

| Origin | Birthworld | Lyran academies | FedSuns academies | Draconis academies |
|---|---|---|---|---|
| LA | Alarion (Lyran) | shown | hidden | hidden |
| FC | Alarion (Lyran-side) | shown | hidden | hidden |
| FC | Colorado (Davion-side) | hidden | shown | hidden |
| DC | (default) | hidden | hidden | shown |
| CGB | (Clan-area) | hidden | hidden | hidden |

  - LA-origin Koji at Sanglamore on Skye in 3071 → granted (direct).
  - FC-origin Koji on Lyran-side birthworld → birthworld-at-birth fallback yields LA → only Lyran academies shown.
  - FC-origin Koji moved to Davion-side birthworld → fallback yields FS → only FedSuns academies shown.
  - DC-origin Koji → only DC academies (Sun Tzu, Sun Zhang, University of Proserpina, Wisdom of the Dragon, Aerospace and Interstellar Institute, Hachiman, Internal Security College, Kensai Kami, etc.).
  - CGB-origin Koji → no false grants from any IS faction-restricted set; the data has no Clan-restricted prestigious academies (canonical: Clans use sibkos, not academies), so only open-admission entries appear.
  - Open-admission academies (Brotherhood Monastery, Ecole Militaire, Hero Training Institute, Tri-M Mercenary Academy, Raina University on Skye) appear consistently across origins via the unchanged legacy at-war check on the campus's current controllers.

## Scope notes

- **Other filters are unchanged**: construction/destruction/closure year window, planet population, age min/max, education-level minimum (``isQualified``), prior-rejection (``hasRejectedApplication``), max-jump-count range. Only the faction-eligibility decision is rewritten.
- **Re-enrollment path** at ``PersonnelTableMouseAdapter.java:2751`` is intentionally unchanged. It uses the legacy three-arg ``getFilteredFaction`` with ``person.getEduAcademyFaction()`` as the faction list (a saved single faction code from a prior enrollment, semantically distinct from the current-system-controllers case).
- **3067-3079 academy data gap** (Nagelring 3067-3085, NAIS 3067-3079, Robinson 3071-3079, etc.) is out of scope for this PR. Those academies will continue to be missing during their respective gaps regardless of this fix; the cause is ``destructionYear``/``constructionYear`` data in mm-data with no transitional entry, addressable on the data side.
- **No mm-data PR is required.** The existing ``fallBackFactions`` data covers FC↔LA, FC↔FS, RD↔CGB, RD↔FRR, WOB↔CS. The FedCom era specifics are encoded in code rather than data because they're date-aware in a way the YAML schema doesn't currently express.