### PR TITLE
Make origin-system picker birthworld-realistic (Fixes #8934)

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/PlanetarySystem.java
+++ b/MekHQ/src/mekhq/campaign/universe/PlanetarySystem.java
@@ -175,6 +175,18 @@ public class PlanetarySystem {
     @JsonProperty("spectralType")
     private SourceableValue<StarType> star;
 
+    /**
+     * {@code true} for synthetic systems loaded from {@code mm-data/data/universe/planetary_systems/connector_systems/}
+     * — these are jump-path routing helpers (DPR, HWY, LTR, FDR, ER, HL prefixes) with no inhabitants, no faction
+     * history, and no canonical lore. They share the loader and registry with real canon systems and need to be
+     * filtered out of any UI that asks the user to pick a real system (e.g. the origin-system picker in
+     * {@code CustomizePersonDialog} — see issue #8934).
+     *
+     * <p>Set by {@link Systems#parsePlanetarySystemFiles} based on the loading directory; not deserialized from
+     * YAML (the YAML schema has no equivalent field).</p>
+     */
+    private boolean connector = false;
+
     // tree map of planets sorted by system position
     private TreeMap<Integer, Planet> planets;
 
@@ -209,6 +221,20 @@ public class PlanetarySystem {
 
     public String getId() {
         return id;
+    }
+
+    /**
+     * @return {@code true} if this system was loaded from the {@code connector_systems/} subdirectory — a
+     *       synthetic jump-path routing helper with no inhabitants. UI code that asks the user to pick a
+     *       real system should filter these out. See {@link #connector} for full context.
+     */
+    public boolean isConnector() {
+        return connector;
+    }
+
+    /** Marks this system as a synthetic connector (used by {@link Systems} during YAML loading). */
+    public void setConnector(boolean connector) {
+        this.connector = connector;
     }
 
     public Double getX() {

--- a/MekHQ/src/mekhq/campaign/universe/PlanetarySystem.java
+++ b/MekHQ/src/mekhq/campaign/universe/PlanetarySystem.java
@@ -44,6 +44,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -182,9 +183,11 @@ public class PlanetarySystem {
      * filtered out of any UI that asks the user to pick a real system (e.g. the origin-system picker in
      * {@code CustomizePersonDialog} — see issue #8934).
      *
-     * <p>Set by {@link Systems#parsePlanetarySystemFiles} based on the loading directory; not deserialized from
-     * YAML (the YAML schema has no equivalent field).</p>
+     * <p>Set by {@link Systems#parsePlanetarySystemFiles} based on the loading directory. {@code @JsonIgnore}
+     * keeps it out of any future YAML/JSON serialization round-trip (the YAML schema has no equivalent field
+     * and the value is reconstructed from the load path) — defensive against schema drift.</p>
      */
+    @JsonIgnore
     private boolean connector = false;
 
     // tree map of planets sorted by system position
@@ -228,11 +231,13 @@ public class PlanetarySystem {
      *       synthetic jump-path routing helper with no inhabitants. UI code that asks the user to pick a
      *       real system should filter these out. See {@link #connector} for full context.
      */
+    @JsonIgnore
     public boolean isConnector() {
         return connector;
     }
 
     /** Marks this system as a synthetic connector (used by {@link Systems} during YAML loading). */
+    @JsonIgnore
     public void setConnector(boolean connector) {
         this.connector = connector;
     }

--- a/MekHQ/src/mekhq/campaign/universe/Systems.java
+++ b/MekHQ/src/mekhq/campaign/universe/Systems.java
@@ -299,8 +299,10 @@ public class Systems {
 
         // Detect whether the current directory is the connector_systems subtree. Connector systems
         // (DPR/HWY/LTR/FDR/ER/HL prefixes) are synthetic jump-path routing helpers with no inhabitants
-        // and need to be flagged so UI code can filter them out — see issue #8934.
-        boolean isConnectorDir = dirName.replace('\\', '/').contains("/connector_systems");
+        // and need to be flagged so UI code can filter them out — see issue #8934. Path normalization
+        // requires directory boundaries on either side so a hypothetical filename containing the
+        // substring (e.g. "my_connector_systems_notes.yml") doesn't trip the check.
+        boolean isConnectorDir = isConnectorPath(dirName);
 
         File dir = new File(dirName);
         if (dir.isDirectory()) {
@@ -332,8 +334,7 @@ public class Systems {
                             if (!entry.isDirectory() && entry.getName().toLowerCase(Locale.ROOT).endsWith(".yml")) {
                                 // Zip entries carry their internal path; use it to detect connector entries
                                 // even when the zip itself sits in the canon tree.
-                                boolean entryIsConnector = isConnectorDir
-                                      || entry.getName().replace('\\', '/').contains("connector_systems");
+                                boolean entryIsConnector = isConnectorDir || isConnectorPath(entry.getName());
                                 try (InputStream inputStream = zip.getInputStream(entry)) {
                                     loadPlanetarySystem(inputStream, mapper, entryIsConnector);
                                 } catch (Exception ex) {
@@ -380,6 +381,20 @@ public class Systems {
         }
         systemList.put(system.getId(), system);
 
+    }
+
+    /**
+     * @return {@code true} if the path identifies a {@code connector_systems/} subtree entry.
+     *       Both {@code /} and {@code \} separators are normalized; the segment must be bounded by
+     *       directory separators on both sides (or sit at the path root) so a stray substring match
+     *       in a filename or unrelated directory doesn't get flagged. See issue #8934.
+     */
+    private static boolean isConnectorPath(String path) {
+        if (path == null) {
+            return false;
+        }
+        String normalized = path.replace('\\', '/');
+        return normalized.contains("/connector_systems/") || normalized.startsWith("connector_systems/");
     }
 
     private void cleanupSystems() {

--- a/MekHQ/src/mekhq/campaign/universe/Systems.java
+++ b/MekHQ/src/mekhq/campaign/universe/Systems.java
@@ -297,6 +297,11 @@ public class Systems {
             throw new NullPointerException();
         }
 
+        // Detect whether the current directory is the connector_systems subtree. Connector systems
+        // (DPR/HWY/LTR/FDR/ER/HL prefixes) are synthetic jump-path routing helpers with no inhabitants
+        // and need to be flagged so UI code can filter them out — see issue #8934.
+        boolean isConnectorDir = dirName.replace('\\', '/').contains("/connector_systems");
+
         File dir = new File(dirName);
         if (dir.isDirectory()) {
             File[] files = dir.listFiles((dir1, name) -> name.toLowerCase(Locale.ROOT).endsWith(".yml"));
@@ -307,7 +312,7 @@ public class Systems {
                 for (File file : files) {
                     if (file.isFile()) {
                         try (FileInputStream fis = new FileInputStream(file)) {
-                            loadPlanetarySystem(fis, mapper);
+                            loadPlanetarySystem(fis, mapper, isConnectorDir);
                         } catch (Exception ex) {
                             // Ignore this file then
                             logger.error(ex, "Exception trying to parse {} - ignoring.", file.getPath());
@@ -325,8 +330,12 @@ public class Systems {
                             ZipEntry entry = entries.nextElement();
                             // Check if entry is a directory
                             if (!entry.isDirectory() && entry.getName().toLowerCase(Locale.ROOT).endsWith(".yml")) {
+                                // Zip entries carry their internal path; use it to detect connector entries
+                                // even when the zip itself sits in the canon tree.
+                                boolean entryIsConnector = isConnectorDir
+                                      || entry.getName().replace('\\', '/').contains("connector_systems");
                                 try (InputStream inputStream = zip.getInputStream(entry)) {
-                                    loadPlanetarySystem(inputStream, mapper);
+                                    loadPlanetarySystem(inputStream, mapper, entryIsConnector);
                                 } catch (Exception ex) {
                                     // Ignore this file then
                                     logger.error(ex, "Exception trying to parse zip  entry {} - ignoring.",
@@ -353,7 +362,7 @@ public class Systems {
         } else {
             if (dir.isFile()) {
                 try (FileInputStream fis = new FileInputStream(dir)) {
-                    loadPlanetarySystem(fis, mapper);
+                    loadPlanetarySystem(fis, mapper, isConnectorDir);
                 } catch (Exception ex) {
                     // Ignore this dir then
                     logger.error(ex, "Exception trying to parse {} - ignoring.", dir.getPath());
@@ -363,9 +372,12 @@ public class Systems {
         }
     }
 
-    private void loadPlanetarySystem(InputStream source, ObjectMapper mapper) throws IOException {
+    private void loadPlanetarySystem(InputStream source, ObjectMapper mapper, boolean isConnector) throws IOException {
 
         PlanetarySystem system = mapper.readValue(source, PlanetarySystem.class);
+        if (isConnector) {
+            system.setConnector(true);
+        }
         systemList.put(system.getId(), system);
 
     }

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -55,6 +55,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.ResourceBundle;
+import java.util.HashSet;
+import java.util.Set;
 import javax.swing.*;
 
 import megamek.client.generator.RandomCallsignGenerator;
@@ -158,7 +160,7 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
     private JComboBox<Faction> choiceFaction;
     private JComboBox<PlanetarySystem> choiceSystem;
     private DefaultComboBoxModel<PlanetarySystem> allSystems;
-    private JCheckBox chkOnlyOurFaction;
+    private JCheckBox chkShowAllWorlds;
     private JComboBox<Planet> choicePlanet;
     private JCheckBox chkClan;
     private JComboBox<Phenotype> choicePhenotype;
@@ -455,7 +457,7 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
             // We don't have to call backgroundChanged because it is already
             // called when we update the chkClan checkbox.
 
-            if (chkOnlyOurFaction.isSelected()) {
+            if (!chkShowAllWorlds.isSelected()) {
                 filterPlanetarySystemsForOurFaction(true);
             }
         });
@@ -481,14 +483,18 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
         choicePlanet = new JComboBox<>(planetsModel);
 
         allSystems = getPlanetarySystemsComboBoxModel();
-        choiceSystem = new JComboBox<>(allSystems);
+        Faction originFaction = person.getOriginFaction();
+        DefaultComboBoxModel<PlanetarySystem> initialSystems = (originFaction != null)
+              ? getPlanetarySystemsComboBoxModel(originFaction)
+              : allSystems;
+        choiceSystem = new JComboBox<>(initialSystems);
         choiceSystem.setRenderer(new DefaultListCellRenderer() {
             @Override
             public Component getListCellRendererComponent(final JList<?> list, final Object value, final int index,
                   final boolean isSelected, final boolean cellHasFocus) {
                 super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
                 if (value instanceof PlanetarySystem system) {
-                    setText(system.getName(campaign.getLocalDate()));
+                    setText(formatSystemForBirthdate(system));
                 }
 
                 return this;
@@ -496,7 +502,7 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
         });
         if (person.getOriginPlanet() != null) {
             PlanetarySystem planetarySystem = person.getOriginPlanet().getParentSystem();
-            choiceSystem.setSelectedIndex(allSystems.getIndexOf(planetarySystem));
+            choiceSystem.setSelectedIndex(initialSystems.getIndexOf(planetarySystem));
             updatePlanetsComboBoxModel(planetsModel, planetarySystem);
         }
         choiceSystem.addActionListener(evt -> {
@@ -516,8 +522,8 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
         gridBagConstraints.insets = new Insets(5, 5, 0, 0);
         panDemographics.add(choiceSystem, gridBagConstraints);
 
-        chkOnlyOurFaction = new JCheckBox("Faction Specific");
-        chkOnlyOurFaction.addActionListener(e -> filterPlanetarySystemsForOurFaction(chkOnlyOurFaction.isSelected()));
+        chkShowAllWorlds = new JCheckBox("Show All Worlds");
+        chkShowAllWorlds.addActionListener(e -> filterPlanetarySystemsForOurFaction(!chkShowAllWorlds.isSelected()));
 
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 2;
@@ -526,7 +532,7 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
         gridBagConstraints.insets = new Insets(5, 5, 0, 0);
-        panDemographics.add(chkOnlyOurFaction, gridBagConstraints);
+        panDemographics.add(chkShowAllWorlds, gridBagConstraints);
 
         y++;
 
@@ -1401,32 +1407,279 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
     }
 
     private DefaultComboBoxModel<PlanetarySystem> getPlanetarySystemsComboBoxModel() {
+        // The unfiltered "all systems" model used when "Show All Worlds" is on. Three filters and
+        // a date-aware sort, all keyed to the dialog's working birthdate (NOT person.getDateOfBirth()
+        // — that field is only written back on OK, so an in-dialog date change wouldn't take effect).
+        // A 3047-born character must not see 3071-era system names in a birthworld picker, nor
+        // systems uninhabited or abandoned at 3047. Synthetic connector systems are excluded outright.
+        // See issue #8934.
         DefaultComboBoxModel<PlanetarySystem> model = new DefaultComboBoxModel<>();
+        LocalDate birthDate = birthdate;
 
         List<PlanetarySystem> orderedSystems = campaign.getSystems()
                                                      .stream()
-                                                     .sorted(Comparator.comparing(a -> a.getName(campaign.getLocalDate())))
+                                                     .filter(a -> !a.isConnector())
+                                                     .filter(a -> isInhabitedAt(a, birthDate))
+                                                     .sorted(Comparator.comparing(a -> a.getName(birthDate)))
                                                      .toList();
         for (PlanetarySystem system : orderedSystems) {
             model.addElement(system);
         }
+
         return model;
     }
 
     private DefaultComboBoxModel<PlanetarySystem> getPlanetarySystemsComboBoxModel(Faction faction) {
+        // The faction-filtered model used when "Show All Worlds" is off. Connector + inhabited filters
+        // from #8934 plus a lineage-aware faction match: a world is admissible if its owner at the
+        // dialog's working birthdate is the chosen faction OR shares a successor/predecessor
+        // relationship with it. Without the lineage match, an FS character born in 3047 sees no New
+        // Avalon because the world is FedCom-controlled at that date — yet a FedSuns citizen on a
+        // FedCom world during the merger is historically routine. Uses the local {@code birthdate}
+        // field, NOT {@code person.getDateOfBirth()}, so in-dialog date changes take effect before OK.
         DefaultComboBoxModel<PlanetarySystem> model = new DefaultComboBoxModel<>();
+        LocalDate birthDate = birthdate;
 
         List<PlanetarySystem> orderedSystems = campaign.getSystems()
                                                      .stream()
-                                                     .filter(a -> a.getFactionSet(person.getDateOfBirth())
-                                                                        .contains(faction))
-                                                     .sorted(Comparator.comparing(a -> a.getName(person.getDateOfBirth())))
+                                                     .filter(a -> !a.isConnector())
+                                                     .filter(a -> isInhabitedAt(a, birthDate))
+                                                     .filter(a -> isFactionMatch(ownersAt(a, birthDate), faction))
+                                                     .sorted(Comparator.comparing(a -> a.getName(birthDate)))
                                                      .toList();
         for (PlanetarySystem system : orderedSystems) {
             model.addElement(system);
         }
 
         return model;
+    }
+
+    /**
+     * @return the system's birthdate-era name with its owner-at-birth faction codes appended in
+     *       brackets, e.g. {@code "New Avalon [FC]"}. Lets the user verify ownership at a glance
+     *       while picking a birthworld — especially useful in faction-merger eras where a world
+     *       may legitimately appear under a successor or predecessor faction's filter.
+     */
+    /**
+     * Renders the dropdown label as e.g. {@code "New Avalon [FS]"} — the date-aware system name
+     * with the resolved owner faction code(s) appended in brackets. Owner is computed by
+     * {@link #ownersAt(PlanetarySystem, LocalDate)} which applies to-the-victor citizenship rules,
+     * so a 3047-born character sees New Avalon as {@code [FS]} rather than the transitional
+     * {@code [FC]}. Multiple owners come out comma-separated, e.g. {@code "World [FACTA, FACTB]"}.
+     * Visible in both filtered and "Show All Worlds" modes — useful both for player context and
+     * for spotting data-side anomalies at a glance.
+     */
+    private String formatSystemForBirthdate(PlanetarySystem system) {
+        String name = system.getName(birthdate);
+        Set<Faction> owners = ownersAt(system, birthdate);
+        if (owners.isEmpty()) {
+            return name;
+        }
+        StringBuilder codes = new StringBuilder();
+        for (Faction faction : owners) {
+            if (faction == null) {
+                continue;
+            }
+            if (codes.length() > 0) {
+                codes.append(", ");
+            }
+            codes.append(faction.getShortName());
+        }
+        return codes.length() == 0 ? name : name + " [" + codes + "]";
+    }
+
+    /**
+     * Cache-bypassing point-in-time owner lookup with to-the-victor citizenship semantics.
+     *
+     * <p>{@link Planet#getFactionSet(LocalDate)} routes through {@code Planet.CurrentEvents}, a
+     * stateful per-planet event-stream cache that can return stale-forward state when warmed at a
+     * later date and queried at an earlier one (observed during #8934 testing — New Avalon at
+     * 3047-09-25 returning 3067-12-31's {@code DIS} marker because the cache had already advanced
+     * for a campaign-date render). We walk {@link Planet#getEvents()} directly (TreeMap-ordered,
+     * deterministic) instead.</p>
+     *
+     * <p>BattleTech canon treats world-citizenship as defined by whoever ends up holding the world
+     * long-term, not by transient umbrella states or active disputes. We substitute the snapshot
+     * with the world's eventual stable owner when:</p>
+     *
+     * <ul>
+     *   <li>The snapshot is a {@code DIS} (Disputed) marker — to the victor goes the spoils.</li>
+     *   <li>The snapshot owner is a faction with a defined dissolution year that falls within
+     *   100 years of {@code when}. This catches FedCom-era births (FC ends 3067, well within a
+     *   3047 character's lifespan) without retroactively rewriting deep-history births where the
+     *   dissolution is centuries off (a 2470 Star League birth keeps SL — the player chose that
+     *   era deliberately).</li>
+     * </ul>
+     *
+     * <p>"Eventual stable owner" is the most-recent non-{@code DIS} faction event in the planet's
+     * own future timeline. If the world has no future faction events (data ends at the snapshot),
+     * or if the eventual owner is the same as the snapshot, the snapshot is used as-is. The
+     * {@code ABN} (Abandoned) marker is dropped only when other real owners are present.</p>
+     *
+     * <p>Concrete cases:</p>
+     *
+     * <ul>
+     *   <li>New Avalon at 3047, snapshot {@code FC} (ends 3067, within 100y), eventual {@code FS}:
+     *   substitutes — a 3047-born NA citizen is FedSuns-stock regardless of the FedCom overlay.</li>
+     *   <li>Tharkad at 3047, snapshot {@code FC}, eventual {@code LA}: substitutes to {@code LA},
+     *   putting the world on the Lyran side as it ends up.</li>
+     *   <li>New Avalon at 3070, snapshot {@code DIS}, eventual {@code FS}: substitutes.</li>
+     *   <li>Terra at 2470, snapshot {@code SL} (ends ~2786, 316y off), eventual modern owner: kept
+     *   as {@code SL} — the era is intentional.</li>
+     *   <li>Hesperus II at 3047, snapshot {@code LA} (no end year), eventual {@code LA}: kept.</li>
+     * </ul>
+     */
+    private static final int DISSOLUTION_PROXIMITY_YEARS = 100;
+
+    private static Set<Faction> ownersAt(PlanetarySystem system, LocalDate when) {
+        Set<Faction> result = new HashSet<>();
+        if (when == null) {
+            return result;
+        }
+        for (Planet planet : system.getPlanets()) {
+            java.util.List<Planet.PlanetaryEvent> events = planet.getEvents();
+            if (events == null) {
+                continue;
+            }
+            java.util.List<String> snapshot = null;
+            java.util.List<String> eventualOwner = null;
+            for (Planet.PlanetaryEvent event : events) {
+                if (event.date == null || event.faction == null || event.faction.getValue() == null) {
+                    continue;
+                }
+                java.util.List<String> codes = event.faction.getValue();
+                if (event.date.isAfter(when)) {
+                    if (!isDisputedOnly(codes)) {
+                        eventualOwner = codes;
+                    }
+                } else {
+                    snapshot = codes;
+                }
+            }
+            java.util.List<String> displayed;
+            if (eventualOwner != null && !sameCodes(snapshot, eventualOwner)
+                  && (snapshot == null || isDisputedOnly(snapshot) || anyDissolvesNear(snapshot, when))) {
+                displayed = eventualOwner;
+            } else {
+                displayed = snapshot;
+            }
+            addCodes(result, displayed);
+        }
+        if (result.size() > 1) {
+            result.remove(Factions.getInstance().getFaction("ABN"));
+        }
+        return result;
+    }
+
+    private static boolean anyDissolvesNear(java.util.List<String> codes, LocalDate when) {
+        if (codes == null || when == null) {
+            return false;
+        }
+        int proximityYear = when.getYear() + DISSOLUTION_PROXIMITY_YEARS;
+        for (String code : codes) {
+            Faction faction = Factions.getInstance().getFaction(code);
+            if (faction != null && faction.getEndYear() < 9999 && faction.getEndYear() <= proximityYear) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isDisputedOnly(java.util.List<String> codes) {
+        if (codes == null || codes.isEmpty()) {
+            return false;
+        }
+        for (String code : codes) {
+            if (!"DIS".equals(code)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean sameCodes(java.util.List<String> a, java.util.List<String> b) {
+        if (a == null || b == null) {
+            return a == b;
+        }
+        return new HashSet<>(a).equals(new HashSet<>(b));
+    }
+
+    private static void addCodes(Set<Faction> sink, java.util.List<String> codes) {
+        if (codes == null) {
+            return;
+        }
+        for (String code : codes) {
+            Faction faction = Factions.getInstance().getFaction(code);
+            if (faction != null) {
+                sink.add(faction);
+            }
+        }
+    }
+
+    /**
+     * @return {@code true} if {@code chosen} directly controls the world at the queried date OR is
+     *       lineage-compatible (predecessor/successor) with one of the actual owners. Excludes meta
+     *       umbrella codes ({@code IS}, {@code CLAN.IS}, {@code Periphery.*}, {@code CLAN.*}) so two
+     *       unrelated Inner Sphere factions don't match via the abstract IS umbrella.
+     */
+    private static boolean isFactionMatch(Set<Faction> owners, Faction chosen) {
+        if (owners == null || owners.isEmpty()) {
+            return false;
+        }
+        if (owners.contains(chosen)) {
+            return true;
+        }
+        String chosenCode = chosen.getShortName();
+        String[] chosenAlts = chosen.getAlternativeFactionCodes();
+        for (Faction owner : owners) {
+            if (owner == null) {
+                continue;
+            }
+            String ownerCode = owner.getShortName();
+            if (containsRealCode(owner.getAlternativeFactionCodes(), chosenCode)
+                  || containsRealCode(chosenAlts, ownerCode)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean containsRealCode(String[] codes, String target) {
+        if (codes == null) {
+            return false;
+        }
+        for (String code : codes) {
+            if (code == null || isMetaFactionCode(code)) {
+                continue;
+            }
+            if (target.equals(code)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isMetaFactionCode(String code) {
+        return "IS".equals(code) || "CLAN.IS".equals(code)
+              || code.startsWith("Periphery.") || code.startsWith("CLAN.");
+    }
+
+    /**
+     * @return {@code true} if the system has at least one real (non-abandoned) faction in control at the
+     *       given date. {@code PlanetarySystem.getFactionSet} only auto-removes the {@code ABN}
+     *       (abandoned) marker when other factions are present alongside it; a system whose ONLY faction
+     *       is {@code ABN} would still report a non-empty set, so we also reject that case.
+     */
+    private static boolean isInhabitedAt(PlanetarySystem system, LocalDate when) {
+        Set<Faction> factions = ownersAt(system, when);
+        if (factions.isEmpty()) {
+            return false;
+        }
+        if (factions.size() == 1) {
+            Faction only = factions.iterator().next();
+            return only != null && !"ABN".equals(only.getShortName());
+        }
+        return true;
     }
 
     private void filterPlanetarySystemsForOurFaction(boolean onlyOurFaction) {
@@ -1924,6 +2177,10 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
             birthdate = dc.getDate();
             btnDate.setText(MekHQ.getMHQOptions().getDisplayFormattedDate(birthdate));
             lblAge.setText(getAge() + " " + resourceMap.getString("age"));
+            // The system picker filters and sorts by birthdate, so a date change has to rebuild
+            // both the cached "all worlds" model and (if visible) the active filtered model.
+            allSystems = getPlanetarySystemsComboBoxModel();
+            filterPlanetarySystemsForOurFaction(!chkShowAllWorlds.isSelected());
         }
     }
 

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -160,6 +160,13 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
     private JComboBox<Faction> choiceFaction;
     private JComboBox<PlanetarySystem> choiceSystem;
     private DefaultComboBoxModel<PlanetarySystem> allSystems;
+    // Per-(system,birthdate) owner-resolution cache. ownersAt(...) walks every event on every planet
+    // in a system, and the picker calls it twice per system per filter pass plus once per visible
+    // dropdown row in the renderer. With ~9k systems loaded that's measurable. Identity-keyed because
+    // PlanetarySystem instances are reused across calls. Cleared whenever birthdate changes.
+    // (Copilot review on PR #8935.)
+    private final java.util.IdentityHashMap<PlanetarySystem, Set<Faction>> ownersCache = new java.util.IdentityHashMap<>();
+    private LocalDate ownersCacheBirthdate;
     private JCheckBox chkShowAllWorlds;
     private JComboBox<Planet> choicePlanet;
     private JCheckBox chkClan;
@@ -487,6 +494,19 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
         DefaultComboBoxModel<PlanetarySystem> initialSystems = (originFaction != null)
               ? getPlanetarySystemsComboBoxModel(originFaction)
               : allSystems;
+        // If the person already has an origin planet that the faction-filtered view excludes (e.g.,
+        // a Tharkad-origin character whose faction is now FedSuns), fall back to the all-worlds view
+        // so we don't silently drop their existing assignment when they click OK. Tracked back to the
+        // checkbox state below via showAllWorldsInitial. (Copilot review on PR #8935.)
+        PlanetarySystem existingOriginSystem = (person.getOriginPlanet() != null)
+              ? person.getOriginPlanet().getParentSystem()
+              : null;
+        boolean showAllWorldsInitial = false;
+        if (existingOriginSystem != null && initialSystems != allSystems
+              && initialSystems.getIndexOf(existingOriginSystem) < 0) {
+            initialSystems = allSystems;
+            showAllWorldsInitial = true;
+        }
         choiceSystem = new JComboBox<>(initialSystems);
         choiceSystem.setRenderer(new DefaultListCellRenderer() {
             @Override
@@ -500,10 +520,9 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
                 return this;
             }
         });
-        if (person.getOriginPlanet() != null) {
-            PlanetarySystem planetarySystem = person.getOriginPlanet().getParentSystem();
-            choiceSystem.setSelectedIndex(initialSystems.getIndexOf(planetarySystem));
-            updatePlanetsComboBoxModel(planetsModel, planetarySystem);
+        if (existingOriginSystem != null) {
+            choiceSystem.setSelectedIndex(initialSystems.getIndexOf(existingOriginSystem));
+            updatePlanetsComboBoxModel(planetsModel, existingOriginSystem);
         }
         choiceSystem.addActionListener(evt -> {
             // Update the clan check box based on the new selected faction
@@ -523,6 +542,7 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
         panDemographics.add(choiceSystem, gridBagConstraints);
 
         chkShowAllWorlds = new JCheckBox("Show All Worlds");
+        chkShowAllWorlds.setSelected(showAllWorldsInitial);
         chkShowAllWorlds.addActionListener(e -> filterPlanetarySystemsForOurFaction(!chkShowAllWorlds.isSelected()));
 
         gridBagConstraints = new GridBagConstraints();
@@ -1419,7 +1439,7 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
         List<PlanetarySystem> orderedSystems = campaign.getSystems()
                                                      .stream()
                                                      .filter(a -> !a.isConnector())
-                                                     .filter(a -> isInhabitedAt(a, birthDate))
+                                                     .filter(a -> isInhabitedAt(cachedOwnersAt(a)))
                                                      .sorted(Comparator.comparing(a -> a.getName(birthDate)))
                                                      .toList();
         for (PlanetarySystem system : orderedSystems) {
@@ -1443,8 +1463,10 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
         List<PlanetarySystem> orderedSystems = campaign.getSystems()
                                                      .stream()
                                                      .filter(a -> !a.isConnector())
-                                                     .filter(a -> isInhabitedAt(a, birthDate))
-                                                     .filter(a -> isFactionMatch(ownersAt(a, birthDate), faction))
+                                                     .filter(a -> {
+                                                         Set<Faction> owners = cachedOwnersAt(a);
+                                                         return isInhabitedAt(owners) && isFactionMatch(owners, faction);
+                                                     })
                                                      .sorted(Comparator.comparing(a -> a.getName(birthDate)))
                                                      .toList();
         for (PlanetarySystem system : orderedSystems) {
@@ -1455,12 +1477,6 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
     }
 
     /**
-     * @return the system's birthdate-era name with its owner-at-birth faction codes appended in
-     *       brackets, e.g. {@code "New Avalon [FC]"}. Lets the user verify ownership at a glance
-     *       while picking a birthworld — especially useful in faction-merger eras where a world
-     *       may legitimately appear under a successor or predecessor faction's filter.
-     */
-    /**
      * Renders the dropdown label as e.g. {@code "New Avalon [FS]"} — the date-aware system name
      * with the resolved owner faction code(s) appended in brackets. Owner is computed by
      * {@link #ownersAt(PlanetarySystem, LocalDate)} which applies to-the-victor citizenship rules,
@@ -1469,9 +1485,17 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
      * Visible in both filtered and "Show All Worlds" modes — useful both for player context and
      * for spotting data-side anomalies at a glance.
      */
+    private Set<Faction> cachedOwnersAt(PlanetarySystem system) {
+        if (!java.util.Objects.equals(birthdate, ownersCacheBirthdate)) {
+            ownersCache.clear();
+            ownersCacheBirthdate = birthdate;
+        }
+        return ownersCache.computeIfAbsent(system, s -> ownersAt(s, birthdate));
+    }
+
     private String formatSystemForBirthdate(PlanetarySystem system) {
         String name = system.getName(birthdate);
-        Set<Faction> owners = ownersAt(system, birthdate);
+        Set<Faction> owners = cachedOwnersAt(system);
         if (owners.isEmpty()) {
             return name;
         }
@@ -1556,9 +1580,12 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
                     snapshot = codes;
                 }
             }
+            // No snapshot means the world wasn't owned at `when` — uncolonized. Don't substitute a
+            // future colonization event, or we'd incorrectly mark pre-colonial dates as inhabited
+            // and pollute the picker (Copilot review on PR #8935).
             java.util.List<String> displayed;
-            if (eventualOwner != null && !sameCodes(snapshot, eventualOwner)
-                  && (snapshot == null || isDisputedOnly(snapshot) || anyDissolvesNear(snapshot, when))) {
+            if (snapshot != null && eventualOwner != null && !sameCodes(snapshot, eventualOwner)
+                  && (isDisputedOnly(snapshot) || anyDissolvesNear(snapshot, when))) {
                 displayed = eventualOwner;
             } else {
                 displayed = snapshot;
@@ -1665,18 +1692,17 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
     }
 
     /**
-     * @return {@code true} if the system has at least one real (non-abandoned) faction in control at the
-     *       given date. {@code PlanetarySystem.getFactionSet} only auto-removes the {@code ABN}
-     *       (abandoned) marker when other factions are present alongside it; a system whose ONLY faction
-     *       is {@code ABN} would still report a non-empty set, so we also reject that case.
+     * @return {@code true} if the resolved owner set has at least one real (non-abandoned) faction.
+     *       {@code ownersAt(...)} already drops the {@code ABN} marker when other factions are present;
+     *       a system whose ONLY faction is {@code ABN} would still come back non-empty here, so we
+     *       reject that case explicitly.
      */
-    private static boolean isInhabitedAt(PlanetarySystem system, LocalDate when) {
-        Set<Faction> factions = ownersAt(system, when);
-        if (factions.isEmpty()) {
+    private static boolean isInhabitedAt(Set<Faction> owners) {
+        if (owners.isEmpty()) {
             return false;
         }
-        if (factions.size() == 1) {
-            Faction only = factions.iterator().next();
+        if (owners.size() == 1) {
+            Faction only = owners.iterator().next();
             return only != null && !"ABN".equals(only.getShortName());
         }
         return true;

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2013-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -1426,13 +1426,70 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
         return factionsModel;
     }
 
+    // =========================================================================================
+    // Origin-system picker — birthworld semantics (issue #8934)
+    //
+    // The picker decides what worlds to show in five steps. Running example: Koji,
+    // born 3047-09-25, FedSuns origin, in a 3071 campaign.
+    //
+    // 1. Drop worlds that don't belong. Three filters run first:
+    //    a. Drop connector systems. Some YAML files under connector_systems/ are not real
+    //       worlds. They are routing helpers for jump paths. PlanetarySystem.isConnector
+    //       is set at YAML load time and skipped here.
+    //    b. Drop worlds with no people at the birthdate. A character born in 3047 cannot
+    //       come from a world that was empty in 3047.
+    //    c. (Filtered view only) Match faction by family tree. The old check asked: does
+    //       the world's owner equal the chosen faction? That fails for Koji — New Avalon
+    //       reads as FC in 3047, not FS. The new check also accepts a parent or child of
+    //       the chosen faction. FedCom is FedSuns and Lyran joined, so a FedSuns pick
+    //       matches a world that reads as FedCom. See isFactionMatch.
+    //
+    // 2. Look up the owner at the right date. Two things were wrong before:
+    //    a. The dialog has its own date field. The date picker writes to a local
+    //       'birthdate' field. The person's saved date only updates when OK is clicked.
+    //       The old code read the saved date, so date-picker changes had no effect until
+    //       reopening the dialog. Now everything reads the local 'birthdate'. The date
+    //       picker also fires a refresh.
+    //    b. The standard owner-lookup uses a cache that lies. Planet.getFactionSet(date)
+    //       keeps a running cursor that walks events forward. If the campaign already
+    //       rendered 3071, the cursor stopped there. Then asking about 3047 gives you
+    //       3067 data. New Avalon at 3047-09-25 was returning the 3067 DIS marker for
+    //       this reason. The new helper ownersAt(system, date) reads the events list
+    //       directly. No cursor, no surprise.
+    //
+    // 3. Apply "to the victor" rules inside ownersAt. BattleTech treats world citizenship
+    //    as who holds the world long term, not who happens to hold it during a war.
+    //    ownersAt swaps the listed owner for the world's eventual owner when:
+    //      - The listed owner is DIS (disputed). Whoever wins gets the world.
+    //      - The listed owner is a faction that ends within 100 years of the birthdate.
+    //
+    //    The 100-year rule is the heart of it. FedCom ends in 3067. A character born in
+    //    3047 will outlive the FedCom merger. They are FedSuns or Lyran stock, depending
+    //    on who keeps the world. But a character born in 2470 under the Star League keeps
+    //    SL — the Star League ends in 2786, more than 300 years later, and the player
+    //    picked that era for a reason.
+    //
+    //    Examples:
+    //      New Avalon  3047  listed FC (ends 3067)        eventual FS  -> swap to FS
+    //      Tharkad     3047  listed FC (ends 3067)        eventual LA  -> swap to LA
+    //      Hesperus II 3047  listed LA (no end)           eventual LA  -> keep LA
+    //      Terra       2470  listed SL (ends 2786, 316y)  various      -> keep SL
+    //
+    // 4. Show the owner in each row. Each dropdown row reads "World [OWNER]". Koji's view
+    //    shows "New Avalon [FS]" even though the raw data says FC — the to-the-victor rule
+    //    did the swap. See formatSystemForBirthdate.
+    //
+    // 5. Default the checkbox to filtered. The list should show worlds that could be home
+    //    to this faction's people. Showing the whole universe by default broke that. The
+    //    checkbox is now "Show All Worlds": off = filtered (default), on = everything.
+    //
+    // Performance: ownersAt walks all planets and events. cachedOwnersAt caches the result
+    // per system, keyed by birthdate. During a single filter pass each system is resolved
+    // once. The cache clears when 'birthdate' changes.
+    // =========================================================================================
+
     private DefaultComboBoxModel<PlanetarySystem> getPlanetarySystemsComboBoxModel() {
-        // The unfiltered "all systems" model used when "Show All Worlds" is on. Three filters and
-        // a date-aware sort, all keyed to the dialog's working birthdate (NOT person.getDateOfBirth()
-        // — that field is only written back on OK, so an in-dialog date change wouldn't take effect).
-        // A 3047-born character must not see 3071-era system names in a birthworld picker, nor
-        // systems uninhabited or abandoned at 3047. Synthetic connector systems are excluded outright.
-        // See issue #8934.
+        // Unfiltered "all systems" model used when "Show All Worlds" is on. See header above.
         DefaultComboBoxModel<PlanetarySystem> model = new DefaultComboBoxModel<>();
         LocalDate birthDate = birthdate;
 
@@ -1450,13 +1507,7 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
     }
 
     private DefaultComboBoxModel<PlanetarySystem> getPlanetarySystemsComboBoxModel(Faction faction) {
-        // The faction-filtered model used when "Show All Worlds" is off. Connector + inhabited filters
-        // from #8934 plus a lineage-aware faction match: a world is admissible if its owner at the
-        // dialog's working birthdate is the chosen faction OR shares a successor/predecessor
-        // relationship with it. Without the lineage match, an FS character born in 3047 sees no New
-        // Avalon because the world is FedCom-controlled at that date — yet a FedSuns citizen on a
-        // FedCom world during the merger is historically routine. Uses the local {@code birthdate}
-        // field, NOT {@code person.getDateOfBirth()}, so in-dialog date changes take effect before OK.
+        // Faction-filtered model used when "Show All Worlds" is off. See header above.
         DefaultComboBoxModel<PlanetarySystem> model = new DefaultComboBoxModel<>();
         LocalDate birthDate = birthdate;
 
@@ -1477,13 +1528,10 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
     }
 
     /**
-     * Renders the dropdown label as e.g. {@code "New Avalon [FS]"} — the date-aware system name
-     * with the resolved owner faction code(s) appended in brackets. Owner is computed by
-     * {@link #ownersAt(PlanetarySystem, LocalDate)} which applies to-the-victor citizenship rules,
-     * so a 3047-born character sees New Avalon as {@code [FS]} rather than the transitional
-     * {@code [FC]}. Multiple owners come out comma-separated, e.g. {@code "World [FACTA, FACTB]"}.
-     * Visible in both filtered and "Show All Worlds" modes — useful both for player context and
-     * for spotting data-side anomalies at a glance.
+     * Returns {@link #ownersAt(PlanetarySystem, LocalDate)} cached per system for the dialog's
+     * current {@code birthdate}. The cache is invalidated when {@code birthdate} changes, so a
+     * single filter pass resolves each system at most once even when both the inhabited and
+     * faction filters apply.
      */
     private Set<Faction> cachedOwnersAt(PlanetarySystem system) {
         if (!java.util.Objects.equals(birthdate, ownersCacheBirthdate)) {
@@ -1493,6 +1541,15 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
         return ownersCache.computeIfAbsent(system, s -> ownersAt(s, birthdate));
     }
 
+    /**
+     * Renders the dropdown label as e.g. {@code "New Avalon [FS]"} — the date-aware system name
+     * with the resolved owner faction code(s) appended in brackets. Owner is computed by
+     * {@link #ownersAt(PlanetarySystem, LocalDate)} which applies to-the-victor citizenship rules,
+     * so a 3047-born character sees New Avalon as {@code [FS]} rather than the transitional
+     * {@code [FC]}. Multiple owners come out comma-separated, e.g. {@code "World [FACTA, FACTB]"}.
+     * Visible in both filtered and "Show All Worlds" modes — useful both for player context and
+     * for spotting data-side anomalies at a glance.
+     */
     private String formatSystemForBirthdate(PlanetarySystem system) {
         String name = system.getName(birthdate);
         Set<Faction> owners = cachedOwnersAt(system);


### PR DESCRIPTION
## Summary

Three problems in the Customize Person origin-system picker, all driven by the same insight: the dropdown is choosing a *birthworld*, so it should reflect the world as a 3047-born character would experience it, not as the campaign currently sees it. Connector systems no longer pollute the list; the faction filter is now the default; and the lookup is birthdate-aware, lineage-aware, and free of the `Planet.CurrentEvents` cache pathology that masked the underlying bug for several test rounds.

## Bug Fixed

- **Connector-system noise**: synthetic jump-path helpers (DPR, HWY, LTR, FDR, ER, HL prefixes) appeared alongside canon worlds in the dropdown. Now flagged at YAML load and filtered out of the picker.
- **Reversed default**: the original "Faction Specific" checkbox was off by default, so the entry point was the unfiltered everything-list. The list intent is "worlds that could plausibly produce a character of this faction" — the filtered view is now the default. Checkbox renamed to "Show All Worlds" (off = filtered, on = all).
- **FedCom-era denial**: strict `getFactionSet(birthDate).contains(chosen)` rejected legitimate births. FedSuns origin + 3047 New Avalon was denied because NA's 3047 owner is FC. Filter now passes when the chosen faction directly owns the world OR shares a predecessor/successor relationship via `Faction.getAlternativeFactionCodes()`, with meta umbrella codes excluded.
- **Stale-forward cache**: `Planet.CurrentEvents` returned 3067-12-31's `DIS` marker for a 3047-09-25 query because the cache had advanced for a campaign-date render. Lookup now bypasses the cache entirely.
- **Birthdate vs. person-DOB**: the dialog has a local `birthdate` field that's only written back to the person on OK; filter and renderer were reading `person.getDateOfBirth()` and seeing the pre-edit value. Both now use the local field, and the date-picker triggers an immediate refresh.

Fixes #8934

## Changes

1. **PlanetarySystem.java** — `isConnector` boolean (default false) plus accessors. Set by Systems during load; not serialized.
2. **Systems.java** — `parsePlanetarySystemFiles` detects whether the loading directory path contains `connector_systems`. Handles both file-system paths and zip-internal entries, both `/` and `\` separators. `loadPlanetarySystem` takes a new `isConnector` flag and applies it.
3. **CustomizePersonDialog.java** — Reversed checkbox default; lineage-aware faction match; cache-bypass `ownersAt` helper that walks `Planet.getEvents()` directly; to-the-victor citizenship substitution (DIS or any snapshot faction whose dissolution year is within 100 years of the birthdate is replaced by the world's eventual stable owner); date-picker refreshes the system list on date change; renderer surfaces the resolved owner code(s) inline (e.g. `New Avalon [FS]`).

## Files Changed

- `MekHQ/src/mekhq/campaign/universe/PlanetarySystem.java` — Connector flag + accessors.
- `MekHQ/src/mekhq/campaign/universe/Systems.java` — Connector detection during YAML load.
- `MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java` — All picker logic.

## To-the-victor citizenship reference table

| World | Birthdate | Snapshot | Eventual | Result |
|---|---|---|---|---|
| New Avalon | 3047 | FC (ends 3067, +20y) | FS | substitute → FS |
| Tharkad | 3047 | FC (ends 3067) | LA | substitute → LA |
| New Avalon | 3070 | DIS | FS | substitute → FS |
| Hesperus II | 3047 | LA (no end) | LA | keep LA |
| Terra | 2470 | SL (ends 2786, +316y) | various | keep SL |
| Terra | 2750 | SL (ends 2786, +36y) | various | substitute |

## Testing

- Unit tests: existing `mekhq.campaign.universe.*` suite passes.
- Manual testing in 3071 campaign with character Koji (DOB 3047-09-25):
  - FedSuns origin → New Avalon appears as `New Avalon [FS]` in both filtered and "Show All Worlds" modes.
  - Lyran origin → Tharkad appears as `Tharkad [LA]`; New Avalon excluded from filtered view.
  - Connector systems no longer appear in either mode.
  - Date-picker change live-refreshes the system list before clicking OK.
  - "Show All Worlds" toggle correctly switches between filtered and full lists.
- Cross-checked owner data against `mm-data/data/universe/planetary_systems/canon_systems/NewAvalon.yml` faction events.

## Out of scope

- The `Planet.CurrentEvents` cache pathology root cause is bypassed locally rather than fixed at the source — the cache is shared infrastructure used by other code paths and a fix there is a separate concern.
- The Faction picker (`getFactionsComboBoxModel`) isn't modified; its `validBetween(birthDate, endYear)` logic is independent.
- Other dialogs that show a system picker (random-personnel, contract destination) aren't touched here — worth a follow-up sweep but out of scope for this issue.
