### PR TITLE
Add Show All Factions toggle to origin-faction picker (Fixes #8929)

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/CreateCharacterDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CreateCharacterDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2013-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -78,7 +78,6 @@ import megamek.common.options.Option;
 import megamek.common.options.OptionsConstants;
 import megamek.common.ui.FastJScrollPane;
 import megamek.common.units.Crew;
-import megamek.common.universe.FactionTag;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -98,11 +97,11 @@ import mekhq.campaign.randomEvents.personalities.enums.PersonalityQuirk;
 import mekhq.campaign.randomEvents.personalities.enums.Reasoning;
 import mekhq.campaign.randomEvents.personalities.enums.Social;
 import mekhq.campaign.universe.Faction;
-import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.Planet;
 import mekhq.campaign.universe.PlanetarySystem;
 import mekhq.gui.utilities.MarkdownEditorPanel;
 import mekhq.gui.utilities.MarkdownRenderer;
+import mekhq.gui.utilities.OriginFactionPickerHelper;
 
 /**
  * This dialog is used to create a character in story arcs from a pool of XP
@@ -168,6 +167,7 @@ public class CreateCharacterDialog extends JDialog implements DialogOptionListen
     private JTextField textBloodname;
     private MarkdownEditorPanel txtBio;
     private JComboBox<Faction> choiceFaction;
+    private JCheckBox chkShowAllFactions;
     private JComboBox<PlanetarySystem> choiceSystem;
     private DefaultComboBoxModel<PlanetarySystem> allSystems;
     private JCheckBox chkOnlyOurFaction;
@@ -434,7 +434,13 @@ public class CreateCharacterDialog extends JDialog implements DialogOptionListen
         gridBagConstraints.insets = new Insets(0, 5, 0, 0);
         demographicPanel.add(new JLabel("Origin Faction:"), gridBagConstraints);
 
-        DefaultComboBoxModel<Faction> factionsModel = getFactionsComboBoxModel();
+        // Decide the initial faction-picker model up front so we can construct the JComboBox with
+        // the right contents from the start. Mirrors CustomizePersonDialog (PR #8937, issue #8929).
+        boolean originSurvivesStrictFilter = OriginFactionPickerHelper.wouldStrictFilterAdmit(
+              person.getOriginFaction(), person, campaign.getGameYear(), person.getJoinedCampaign());
+        boolean openExpanded = person.getOriginFaction() != null && !originSurvivesStrictFilter;
+        DefaultComboBoxModel<Faction> factionsModel = OriginFactionPickerHelper.buildModel(
+              person, campaign.getGameYear(), person.getJoinedCampaign(), openExpanded);
         choiceFaction = new JComboBox<>(factionsModel);
         choiceFaction.setRenderer(new DefaultListCellRenderer() {
             @Override
@@ -474,6 +480,23 @@ public class CreateCharacterDialog extends JDialog implements DialogOptionListen
         gridBagConstraints.insets = new Insets(5, 5, 0, 0);
         demographicPanel.add(choiceFaction, gridBagConstraints);
         choiceFaction.setEnabled(editOrigin);
+
+        // "Show All Factions" sibling checkbox. Default unchecked = strict lifespan filter (the
+        // canonically correct view); checked = unfiltered (escape hatch for long-lived or
+        // unusual-origin characters). State mirrors the model we just built. See issue #8929.
+        chkShowAllFactions = new JCheckBox("Show All Factions");
+        chkShowAllFactions.setSelected(openExpanded);
+        chkShowAllFactions.addActionListener(e -> rebuildFactionsModelPreservingSelection());
+        chkShowAllFactions.setEnabled(editOrigin);
+
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 2;
+        gridBagConstraints.gridy = y;
+        gridBagConstraints.gridwidth = 1;
+        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
+        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.insets = new Insets(5, 5, 0, 0);
+        demographicPanel.add(chkShowAllFactions, gridBagConstraints);
 
         y++;
 
@@ -1128,38 +1151,20 @@ public class CreateCharacterDialog extends JDialog implements DialogOptionListen
         preferences.manage(new JWindowPreference(this));
     }
 
-    private DefaultComboBoxModel<Faction> getFactionsComboBoxModel() {
-        int year = campaign.getGameYear();
-        List<Faction> orderedFactions = Factions.getInstance()
-                                              .getFactions()
-                                              .stream()
-                                              .sorted((a, b) -> a.getFullName(year)
-                                                                      .compareToIgnoreCase(b.getFullName(year)))
-                                              .toList();
-
-        DefaultComboBoxModel<Faction> factionsModel = new DefaultComboBoxModel<>();
-        for (Faction faction : orderedFactions) {
-            // Always include the person's faction
-            if (faction.equals(person.getOriginFaction())) {
-                factionsModel.addElement(faction);
-            } else {
-                if (faction.is(FactionTag.HIDDEN) || faction.is(FactionTag.SPECIAL)) {
-                    continue;
-                }
-
-                // Allow factions between the person's birthday
-                // and when they were recruited, or now if we're
-                // not tracking recruitment.
-                int endYear = person.getJoinedCampaign() != null ?
-                                    Math.min(person.getJoinedCampaign().getYear(), year) :
-                                    year;
-                if (faction.validBetween(person.getDateOfBirth().getYear(), endYear)) {
-                    factionsModel.addElement(faction);
-                }
-            }
-        }
-
-        return factionsModel;
+    /**
+     * Rebuilds {@code choiceFaction}'s model after a "Show All Factions" toggle, preserving the
+     * current selection across the swap. If there was no current selection (or the previously
+     * selected faction has been filtered out by the new model), the index is explicitly set to
+     * {@code -1} — otherwise Swing's combobox auto-selects the first item on a model swap, which
+     * would silently assign an unintended origin when OK is clicked.
+     */
+    private void rebuildFactionsModelPreservingSelection() {
+        Faction current = (Faction) choiceFaction.getSelectedItem();
+        DefaultComboBoxModel<Faction> rebuilt = OriginFactionPickerHelper.buildModel(
+              person, campaign.getGameYear(), person.getJoinedCampaign(), chkShowAllFactions.isSelected());
+        choiceFaction.setModel(rebuilt);
+        int idx = (current != null) ? rebuilt.getIndexOf(current) : -1;
+        choiceFaction.setSelectedIndex(idx);
     }
 
 

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -76,7 +76,6 @@ import megamek.common.options.OptionsConstants;
 import megamek.common.ui.FastJScrollPane;
 import megamek.common.units.Crew;
 import megamek.common.units.Entity;
-import megamek.common.universe.FactionTag;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -97,7 +96,6 @@ import mekhq.campaign.randomEvents.personalities.enums.Reasoning;
 import mekhq.campaign.randomEvents.personalities.enums.Social;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Faction;
-import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.Planet;
 import mekhq.campaign.universe.PlanetarySystem;
 import mekhq.gui.baseComponents.AbstractMHQScrollablePanel;
@@ -107,6 +105,7 @@ import mekhq.gui.control.EditLogControl;
 import mekhq.gui.control.EditLogControl.LogType;
 import mekhq.gui.control.EditScenarioLogControl;
 import mekhq.gui.utilities.MarkdownEditorPanel;
+import mekhq.gui.utilities.OriginFactionPickerHelper;
 
 /**
  * This dialog is used to both hire new pilots and to edit existing ones
@@ -434,9 +433,11 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
         // then maybe rebuild) fired the choiceFaction selection-change listener during init, while
         // chkClan and chkOnlyOurFaction were still null — Copilot review on PR #8937. Build now,
         // attach listener after, and the rebuild path is reserved for the post-construction toggle.
-        boolean originSurvivesStrictFilter = wouldStrictFilterAdmit(person.getOriginFaction());
+        boolean originSurvivesStrictFilter = OriginFactionPickerHelper.wouldStrictFilterAdmit(
+              person.getOriginFaction(), person, campaign.getGameYear(), person.getRecruitment());
         boolean openExpanded = person.getOriginFaction() != null && !originSurvivesStrictFilter;
-        DefaultComboBoxModel<Faction> factionsModel = getFactionsComboBoxModel(openExpanded);
+        DefaultComboBoxModel<Faction> factionsModel = OriginFactionPickerHelper.buildModel(
+              person, campaign.getGameYear(), person.getRecruitment(), openExpanded);
         choiceFaction = new JComboBox<>(factionsModel);
         choiceFaction.setRenderer(new DefaultListCellRenderer() {
             @Override
@@ -1392,27 +1393,6 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
         }
     }
 
-    private DefaultComboBoxModel<Faction> getFactionsComboBoxModel() {
-        return getFactionsComboBoxModel(false);
-    }
-
-    /**
-     * @return {@code true} if {@code faction} would survive the strict lifespan filter on its own
-     *       (independent of the "always include person's origin" exception). Used at dialog open
-     *       to decide whether to auto-check "Show All Factions" so the dropdown actually reflects
-     *       what's selected.
-     */
-    private boolean wouldStrictFilterAdmit(Faction faction) {
-        if (faction == null || faction.is(FactionTag.HIDDEN) || faction.is(FactionTag.SPECIAL)) {
-            return false;
-        }
-        int year = campaign.getGameYear();
-        int endYear = person.getRecruitment() != null
-              ? Math.min(person.getRecruitment().getYear(), year)
-              : year;
-        return faction.validBetween(person.getDateOfBirth().getYear(), endYear);
-    }
-
     /**
      * Rebuilds {@code choiceFaction}'s model after a "Show All Factions" toggle, preserving the
      * current selection across the swap. If there was no current selection (or the previously
@@ -1422,67 +1402,11 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
      */
     private void rebuildFactionsModelPreservingSelection() {
         Faction current = (Faction) choiceFaction.getSelectedItem();
-        DefaultComboBoxModel<Faction> rebuilt = getFactionsComboBoxModel(chkShowAllFactions.isSelected());
+        DefaultComboBoxModel<Faction> rebuilt = OriginFactionPickerHelper.buildModel(
+              person, campaign.getGameYear(), person.getRecruitment(), chkShowAllFactions.isSelected());
         choiceFaction.setModel(rebuilt);
         int idx = (current != null) ? rebuilt.getIndexOf(current) : -1;
         choiceFaction.setSelectedIndex(idx);
-    }
-
-    /**
-     * Builds the origin-faction picker model.
-     *
-     * <p>Default ({@code showAllFactions == false}): only factions whose {@code yearsActive} overlap
-     * the person's lifespan window {@code [birthYear .. min(recruitment, currentYear)]} appear, with
-     * {@code HIDDEN} and {@code SPECIAL}-tagged factions always excluded. This is the canonically
-     * correct behavior — a 3151-era character can't be born in the long-dissolved Federated
-     * Commonwealth.</p>
-     *
-     * <p>When {@code showAllFactions == true}: drops the lifespan filter entirely. Useful for
-     * legitimate but unusual cases (long-lived characters whose origin is now-defunct, deliberate
-     * "I want my Dark Age character to have a Word of Blake background" choices). {@code HIDDEN}
-     * and {@code SPECIAL} stay excluded — those are meta-factions and aggregates that aren't
-     * legitimate origins regardless of era.</p>
-     *
-     * <p>The person's existing origin faction is always included in both modes so editing a
-     * character whose origin is filtered out by the lifespan check doesn't silently lose the
-     * assignment. See issue #8929.</p>
-     */
-    private DefaultComboBoxModel<Faction> getFactionsComboBoxModel(boolean showAllFactions) {
-        int year = campaign.getGameYear();
-        List<Faction> orderedFactions = Factions.getInstance()
-                                              .getFactions()
-                                              .stream()
-                                              .sorted((a, b) -> a.getFullName(year)
-                                                                      .compareToIgnoreCase(b.getFullName(year)))
-                                              .toList();
-
-        DefaultComboBoxModel<Faction> factionsModel = new DefaultComboBoxModel<>();
-        for (Faction faction : orderedFactions) {
-            // Always include the person's faction
-            if (faction.equals(person.getOriginFaction())) {
-                factionsModel.addElement(faction);
-                continue;
-            }
-            if (faction.is(FactionTag.HIDDEN) || faction.is(FactionTag.SPECIAL)) {
-                continue;
-            }
-            if (showAllFactions) {
-                factionsModel.addElement(faction);
-                continue;
-            }
-
-            // Allow factions between the person's birthday
-            // and when they were recruited, or now if we're
-            // not tracking recruitment.
-            int endYear = person.getRecruitment() != null ?
-                                Math.min(person.getRecruitment().getYear(), year) :
-                                year;
-            if (faction.validBetween(person.getDateOfBirth().getYear(), endYear)) {
-                factionsModel.addElement(faction);
-            }
-        }
-
-        return factionsModel;
     }
 
     private DefaultComboBoxModel<PlanetarySystem> getPlanetarySystemsComboBoxModel() {

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -429,7 +429,14 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
         gridBagConstraints.insets = new Insets(0, 5, 0, 0);
         panDemographics.add(new JLabel("Origin Faction:"), gridBagConstraints);
 
-        DefaultComboBoxModel<Faction> factionsModel = getFactionsComboBoxModel();
+        // Decide the initial faction-picker model up front so we can construct the JComboBox with
+        // the right contents from the start. The earlier approach (build strict, attach listener,
+        // then maybe rebuild) fired the choiceFaction selection-change listener during init, while
+        // chkClan and chkOnlyOurFaction were still null — Copilot review on PR #8937. Build now,
+        // attach listener after, and the rebuild path is reserved for the post-construction toggle.
+        boolean originSurvivesStrictFilter = wouldStrictFilterAdmit(person.getOriginFaction());
+        boolean openExpanded = person.getOriginFaction() != null && !originSurvivesStrictFilter;
+        DefaultComboBoxModel<Faction> factionsModel = getFactionsComboBoxModel(openExpanded);
         choiceFaction = new JComboBox<>(factionsModel);
         choiceFaction.setRenderer(new DefaultListCellRenderer() {
             @Override
@@ -471,21 +478,12 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
 
         // "Show All Factions" sibling checkbox. Default unchecked = strict lifespan filter (the
         // canonically correct view); checked = unfiltered (escape hatch for long-lived or
-        // unusual-origin characters). If the person's existing origin faction would already be
-        // filtered out by the strict view we auto-check the box so the dropdown reflects what's
-        // actually selected — same fall-back-to-all pattern used for the system picker (#8935).
-        // See issue #8929.
+        // unusual-origin characters). State is set to mirror the model we just built, so the
+        // checkbox is consistent with what's displayed without needing to fire the toggle handler
+        // during construction. See issue #8929.
         chkShowAllFactions = new JCheckBox("Show All Factions");
-        // Strict-mode model still has the origin faction in it (we always include the person's
-        // origin defensively), but the checkbox should reflect whether the strict *filter* would
-        // have admitted it on its own. If not — auto-check so the user sees the broader pool the
-        // assignment came from instead of a model that looks complete-yet-isn't.
-        boolean originSurvivesStrictFilter = wouldStrictFilterAdmit(person.getOriginFaction());
-        chkShowAllFactions.setSelected(person.getOriginFaction() != null && !originSurvivesStrictFilter);
+        chkShowAllFactions.setSelected(openExpanded);
         chkShowAllFactions.addActionListener(e -> rebuildFactionsModelPreservingSelection());
-        if (chkShowAllFactions.isSelected()) {
-            rebuildFactionsModelPreservingSelection();
-        }
 
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 2;
@@ -1417,21 +1415,17 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
 
     /**
      * Rebuilds {@code choiceFaction}'s model after a "Show All Factions" toggle, preserving the
-     * current selection across the swap. The selection is restored by reference; if the previously
-     * selected faction has been filtered out by the new model (impossible today since the person's
-     * origin is always included, but defensive), the listener leaves the index at -1 — same shape
-     * as Swing's default behavior.
+     * current selection across the swap. If there was no current selection (or the previously
+     * selected faction has been filtered out by the new model), the index is explicitly set to
+     * {@code -1} — otherwise Swing's combobox auto-selects the first item on a model swap, which
+     * would silently assign an unintended origin when OK is clicked. (Copilot review on PR #8937.)
      */
     private void rebuildFactionsModelPreservingSelection() {
         Faction current = (Faction) choiceFaction.getSelectedItem();
         DefaultComboBoxModel<Faction> rebuilt = getFactionsComboBoxModel(chkShowAllFactions.isSelected());
         choiceFaction.setModel(rebuilt);
-        if (current != null) {
-            int idx = rebuilt.getIndexOf(current);
-            if (idx >= 0) {
-                choiceFaction.setSelectedIndex(idx);
-            }
-        }
+        int idx = (current != null) ? rebuilt.getIndexOf(current) : -1;
+        choiceFaction.setSelectedIndex(idx);
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -156,6 +156,7 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
     private JTextField textBloodname;
     private MarkdownEditorPanel txtBio;
     private JComboBox<Faction> choiceFaction;
+    private JCheckBox chkShowAllFactions;
     private JComboBox<PlanetarySystem> choiceSystem;
     private DefaultComboBoxModel<PlanetarySystem> allSystems;
     private JCheckBox chkOnlyOurFaction;
@@ -467,6 +468,33 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
         gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
         gridBagConstraints.insets = new Insets(5, 5, 0, 0);
         panDemographics.add(choiceFaction, gridBagConstraints);
+
+        // "Show All Factions" sibling checkbox. Default unchecked = strict lifespan filter (the
+        // canonically correct view); checked = unfiltered (escape hatch for long-lived or
+        // unusual-origin characters). If the person's existing origin faction would already be
+        // filtered out by the strict view we auto-check the box so the dropdown reflects what's
+        // actually selected — same fall-back-to-all pattern used for the system picker (#8935).
+        // See issue #8929.
+        chkShowAllFactions = new JCheckBox("Show All Factions");
+        // Strict-mode model still has the origin faction in it (we always include the person's
+        // origin defensively), but the checkbox should reflect whether the strict *filter* would
+        // have admitted it on its own. If not — auto-check so the user sees the broader pool the
+        // assignment came from instead of a model that looks complete-yet-isn't.
+        boolean originSurvivesStrictFilter = wouldStrictFilterAdmit(person.getOriginFaction());
+        chkShowAllFactions.setSelected(person.getOriginFaction() != null && !originSurvivesStrictFilter);
+        chkShowAllFactions.addActionListener(e -> rebuildFactionsModelPreservingSelection());
+        if (chkShowAllFactions.isSelected()) {
+            rebuildFactionsModelPreservingSelection();
+        }
+
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 2;
+        gridBagConstraints.gridy = y;
+        gridBagConstraints.gridwidth = 1;
+        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
+        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.insets = new Insets(5, 5, 0, 0);
+        panDemographics.add(chkShowAllFactions, gridBagConstraints);
 
         y++;
 
@@ -1367,6 +1395,65 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
     }
 
     private DefaultComboBoxModel<Faction> getFactionsComboBoxModel() {
+        return getFactionsComboBoxModel(false);
+    }
+
+    /**
+     * @return {@code true} if {@code faction} would survive the strict lifespan filter on its own
+     *       (independent of the "always include person's origin" exception). Used at dialog open
+     *       to decide whether to auto-check "Show All Factions" so the dropdown actually reflects
+     *       what's selected.
+     */
+    private boolean wouldStrictFilterAdmit(Faction faction) {
+        if (faction == null || faction.is(FactionTag.HIDDEN) || faction.is(FactionTag.SPECIAL)) {
+            return false;
+        }
+        int year = campaign.getGameYear();
+        int endYear = person.getRecruitment() != null
+              ? Math.min(person.getRecruitment().getYear(), year)
+              : year;
+        return faction.validBetween(person.getDateOfBirth().getYear(), endYear);
+    }
+
+    /**
+     * Rebuilds {@code choiceFaction}'s model after a "Show All Factions" toggle, preserving the
+     * current selection across the swap. The selection is restored by reference; if the previously
+     * selected faction has been filtered out by the new model (impossible today since the person's
+     * origin is always included, but defensive), the listener leaves the index at -1 — same shape
+     * as Swing's default behavior.
+     */
+    private void rebuildFactionsModelPreservingSelection() {
+        Faction current = (Faction) choiceFaction.getSelectedItem();
+        DefaultComboBoxModel<Faction> rebuilt = getFactionsComboBoxModel(chkShowAllFactions.isSelected());
+        choiceFaction.setModel(rebuilt);
+        if (current != null) {
+            int idx = rebuilt.getIndexOf(current);
+            if (idx >= 0) {
+                choiceFaction.setSelectedIndex(idx);
+            }
+        }
+    }
+
+    /**
+     * Builds the origin-faction picker model.
+     *
+     * <p>Default ({@code showAllFactions == false}): only factions whose {@code yearsActive} overlap
+     * the person's lifespan window {@code [birthYear .. min(recruitment, currentYear)]} appear, with
+     * {@code HIDDEN} and {@code SPECIAL}-tagged factions always excluded. This is the canonically
+     * correct behavior — a 3151-era character can't be born in the long-dissolved Federated
+     * Commonwealth.</p>
+     *
+     * <p>When {@code showAllFactions == true}: drops the lifespan filter entirely. Useful for
+     * legitimate but unusual cases (long-lived characters whose origin is now-defunct, deliberate
+     * "I want my Dark Age character to have a Word of Blake background" choices). {@code HIDDEN}
+     * and {@code SPECIAL} stay excluded — those are meta-factions and aggregates that aren't
+     * legitimate origins regardless of era.</p>
+     *
+     * <p>The person's existing origin faction is always included in both modes so editing a
+     * character whose origin is filtered out by the lifespan check doesn't silently lose the
+     * assignment. See issue #8929.</p>
+     */
+    private DefaultComboBoxModel<Faction> getFactionsComboBoxModel(boolean showAllFactions) {
         int year = campaign.getGameYear();
         List<Faction> orderedFactions = Factions.getInstance()
                                               .getFactions()
@@ -1380,20 +1467,24 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
             // Always include the person's faction
             if (faction.equals(person.getOriginFaction())) {
                 factionsModel.addElement(faction);
-            } else {
-                if (faction.is(FactionTag.HIDDEN) || faction.is(FactionTag.SPECIAL)) {
-                    continue;
-                }
+                continue;
+            }
+            if (faction.is(FactionTag.HIDDEN) || faction.is(FactionTag.SPECIAL)) {
+                continue;
+            }
+            if (showAllFactions) {
+                factionsModel.addElement(faction);
+                continue;
+            }
 
-                // Allow factions between the person's birthday
-                // and when they were recruited, or now if we're
-                // not tracking recruitment.
-                int endYear = person.getRecruitment() != null ?
-                                    Math.min(person.getRecruitment().getYear(), year) :
-                                    year;
-                if (faction.validBetween(person.getDateOfBirth().getYear(), endYear)) {
-                    factionsModel.addElement(faction);
-                }
+            // Allow factions between the person's birthday
+            // and when they were recruited, or now if we're
+            // not tracking recruitment.
+            int endYear = person.getRecruitment() != null ?
+                                Math.min(person.getRecruitment().getYear(), year) :
+                                year;
+            if (faction.validBetween(person.getDateOfBirth().getYear(), endYear)) {
+                factionsModel.addElement(faction);
             }
         }
 

--- a/MekHQ/src/mekhq/gui/utilities/OriginFactionPickerHelper.java
+++ b/MekHQ/src/mekhq/gui/utilities/OriginFactionPickerHelper.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.utilities;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import javax.swing.DefaultComboBoxModel;
+
+import megamek.common.universe.FactionTag;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.universe.Faction;
+import mekhq.campaign.universe.Factions;
+
+/**
+ * Shared origin-faction picker logic for {@code CustomizePersonDialog} and
+ * {@code CreateCharacterDialog}. Centralizes the strict lifespan filter and the
+ * "Show All Factions" model variant so the two dialogs cannot drift.
+ *
+ * <p>See PR #8937 (issue #8929) for behavior context.</p>
+ */
+public final class OriginFactionPickerHelper {
+    private OriginFactionPickerHelper() {}
+
+    /**
+     * @return {@code true} if {@code faction} would survive the strict lifespan filter on its
+     *       own (independent of the "always include person's origin" exception). Used at dialog
+     *       open to decide whether to auto-check "Show All Factions" so the dropdown actually
+     *       reflects what's selected.
+     *
+     * @param faction     the faction to test, or {@code null} (returns {@code false})
+     * @param person      the person whose lifespan window applies
+     * @param currentYear the current campaign year (lifespan window upper bound)
+     * @param endDate     the recruitment / joined-campaign date, or {@code null} if recruitment
+     *                    is not tracked. The lifespan window upper bound is
+     *                    {@code min(endDate.getYear(), currentYear)}.
+     */
+    public static boolean wouldStrictFilterAdmit(Faction faction, Person person, int currentYear,
+          LocalDate endDate) {
+        if (faction == null || faction.is(FactionTag.HIDDEN) || faction.is(FactionTag.SPECIAL)) {
+            return false;
+        }
+        int endYear = (endDate != null) ? Math.min(endDate.getYear(), currentYear) : currentYear;
+        return faction.validBetween(person.getDateOfBirth().getYear(), endYear);
+    }
+
+    /**
+     * Builds the origin-faction picker model.
+     *
+     * <p>Default ({@code showAllFactions == false}): only factions whose {@code yearsActive}
+     * overlap the person's lifespan window {@code [birthYear .. min(endDate, currentYear)]}
+     * appear, with {@code HIDDEN} and {@code SPECIAL}-tagged factions always excluded. This is
+     * the canonically correct behavior — a 3151-era character cannot be born in the long-
+     * dissolved Federated Commonwealth.</p>
+     *
+     * <p>When {@code showAllFactions == true}: drops the lifespan filter entirely. Useful for
+     * legitimate but unusual cases (long-lived characters whose origin is now-defunct, deliberate
+     * "I want my Dark Age character to have a Word of Blake background" choices). {@code HIDDEN}
+     * and {@code SPECIAL} stay excluded — those are meta-factions and aggregates that aren't
+     * legitimate origins regardless of era.</p>
+     *
+     * <p>The person's existing origin faction is always included in both modes so editing a
+     * character whose origin is filtered out by the lifespan check does not silently lose the
+     * assignment.</p>
+     *
+     * @param person          the person whose origin is being picked
+     * @param currentYear     the current campaign year (lifespan window upper bound)
+     * @param endDate         the recruitment / joined-campaign date, or {@code null} if
+     *                        recruitment is not tracked. The lifespan window upper bound is
+     *                        {@code min(endDate.getYear(), currentYear)}.
+     * @param showAllFactions whether to drop the lifespan filter
+     */
+    public static DefaultComboBoxModel<Faction> buildModel(Person person, int currentYear,
+          LocalDate endDate, boolean showAllFactions) {
+        List<Faction> orderedFactions = Factions.getInstance()
+                                              .getFactions()
+                                              .stream()
+                                              .sorted((a, b) -> a.getFullName(currentYear)
+                                                                      .compareToIgnoreCase(b.getFullName(currentYear)))
+                                              .toList();
+
+        DefaultComboBoxModel<Faction> factionsModel = new DefaultComboBoxModel<>();
+        for (Faction faction : orderedFactions) {
+            // Always include the person's origin faction
+            if (faction.equals(person.getOriginFaction())) {
+                factionsModel.addElement(faction);
+                continue;
+            }
+            if (faction.is(FactionTag.HIDDEN) || faction.is(FactionTag.SPECIAL)) {
+                continue;
+            }
+            if (showAllFactions) {
+                factionsModel.addElement(faction);
+                continue;
+            }
+
+            int endYear = (endDate != null) ? Math.min(endDate.getYear(), currentYear) : currentYear;
+            if (faction.validBetween(person.getDateOfBirth().getYear(), endYear)) {
+                factionsModel.addElement(faction);
+            }
+        }
+
+        return factionsModel;
+    }
+}


### PR DESCRIPTION
## Summary

The Customize Person origin-faction picker filter at `getFactionsComboBoxModel` gates on `Faction.validBetween(personBirthYear, min(recruitment, currentYear))` — the person's lifespan window. Strictly correct per the canonical year ranges, but offers no escape hatch for legitimate-but-unusual cases like a long-lived character whose origin is now-defunct (FC, FRR, TH, ComStar from a Dark Age perspective). Mirrors #8935's "Show All Worlds" pattern with a sibling "Show All Factions" checkbox.

## Bug Fixed

- **Missing factions in the picker for Dark Age characters**: a 3151-era character can't be set as FedCom-origin or Free Rasalhague Republic-origin even though those are perfectly legitimate ancestor states for a long-lived freeborn character. Reported by Tzahr in #8929.
- **No safe-edit path for existing characters with defunct origins**: opening Customize Person on a character whose origin doesn't survive the strict filter showed a dropdown that looked complete but actually only contained currently-valid factions plus their existing origin — confusing UX, easy to accidentally clear the assignment.

## Changes Made

1. **`getFactionsComboBoxModel(boolean showAllFactions)`** overload — drops the lifespan filter when `true`. `HIDDEN` and `SPECIAL` tags still excluded in both modes (those are meta-factions like the IS umbrella, MERC, IND — not legitimate origins regardless of era).
2. **`chkShowAllFactions`** sibling checkbox next to the picker — column 2 of the same row, mirroring the system picker's "Show All Worlds" placement.
3. **Auto-check on open** — if the person's existing origin would be filtered out by strict mode, the checkbox opens checked so the dropdown reflects the broader pool the assignment came from. Person's origin is always included in either model so editing never silently clears it.
4. **`wouldStrictFilterAdmit`** helper — predicate version of the strict filter, used for the auto-check decision.
5. **`rebuildFactionsModelPreservingSelection`** — toggle handler that swaps models while preserving the current selection.

## Files Changed

- `MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java` — All listed changes; single file.

## Behavior reference

| Scenario | Default checkbox state | Picker shows |
|---|---|---|
| 3151 character, no origin set | unchecked | factions valid in 3151 |
| 3151 character, FS origin (still extant) | unchecked | factions valid in 3151 |
| 3151 character, FC origin (defunct since 3067) | **auto-checked** | all non-meta factions, FC selectable |
| User toggles unchecked → checked | checked | all non-meta factions |
| User toggles checked → unchecked | unchecked | factions valid in lifespan |

## Testing

- Compile + checkstyle clean.
- `mekhq.gui.dialog.*` and `mekhq.campaign.universe.*` test suites pass.
- Manual smoke test in 3151 campaign:
  - Default character → picker shows currently-extant factions only.
  - FedCom-origin character → checkbox auto-checks at open, dropdown includes FC and other historical states; toggling unchecks restores strict view.
  - Toggling checkbox preserves the current selection across model rebuild.

## Related

- mm-data #328 — companion data audit. 59 faction YAMLs missing `yearsActive` (Amaris Empire, Vesper Marches, Capellan Hegemony, etc.) default to always-valid and slip through the strict filter today; that issue tracks the data fix. Together this PR + #328 give an accurate filter when on, permissive escape hatch when off.
- MekHQ #8936 — related "Quick Start company generator assigns nonsense origin factions" issue, same Tier-3 meta-faction question (MERC/IE as origins) but a different code path.

## Out of scope

- The deeper "origin faction is a strict subset of Faction" refactor (positive `ORIGIN_ELIGIBLE` tag or dedicated type) is noted on #8936 and is a separate future ticket — touches every `getOriginFaction()` callsite. Out of scope here; this PR is the minimal user-facing escape hatch.
- Data-side `yearsActive` corrections for individual factions live in mm-data #328.
