### PR TITLE
Give POW awards automatically at mission end

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/autoAwards/AutoAwardsController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/autoAwards/AutoAwardsController.java
@@ -96,7 +96,7 @@ public class AutoAwardsController {
         // we have to do multiple isEmpty() checks as, at any point in the removal process, we could end up with null personnel
         if (!personnel.isEmpty()) {
             // This is the main workhorse function
-            ProcessAwards(personnel, false, null, isManualPrompt, null);
+            ProcessAwards(personnel, false, null, isManualPrompt);
         } else {
             logger.info("AutoAwards found no personnel, skipping the Award Ceremony");
 
@@ -132,7 +132,7 @@ public class AutoAwardsController {
         // we have to do multiple isEmpty() checks as, at any point in the removal process, we could end up with null personnel
         if (!personnel.isEmpty()) {
             // This is the main workhorse function
-            ProcessAwards(personnel, false, null, isManualPrompt, null);
+            ProcessAwards(personnel, false, null, isManualPrompt);
         } else {
             logger.info("AutoAwards found no personnel, skipping the Award Ceremony");
         }
@@ -212,7 +212,7 @@ public class AutoAwardsController {
 
         // beginning the processing & filtering of Misc Awards
         if (!miscAwards.isEmpty()) {
-            processedData = MiscAwardsManager(personnel, false, true, wasCivilianHelp, scenarioKills, null);
+            processedData = MiscAwardsManager(personnel, false, true, wasCivilianHelp, scenarioKills);
 
             if (processedData != null) {
                 allAwardData.put(allAwardDataKey, processedData);
@@ -257,7 +257,7 @@ public class AutoAwardsController {
         // we have to do multiple isEmpty() checks as, at any point in the removal process, we could end up with null personnel
         if (!personnel.isEmpty()) {
             // This is the main workhorse function
-            ProcessAwards(personnel, false, academyAttributes, false, null);
+            ProcessAwards(personnel, false, academyAttributes, false);
         } else {
             logger.info("AutoAwards found no personnel, skipping the Award Ceremony");
         }
@@ -671,6 +671,19 @@ public class AutoAwardsController {
      * @param missionWasSuccessful true if the mission was successful, false otherwise
      * @param academyAttributes    a map of academy attributes, null if not processing graduation awards
      * @param isManualPrompt       whether autoAwards was triggered manually
+     */
+    private void ProcessAwards(List<UUID> personnel, Boolean missionWasSuccessful,
+          @Nullable HashMap<UUID, List<Object>> academyAttributes, boolean isManualPrompt) {
+        ProcessAwards(personnel, missionWasSuccessful, academyAttributes, isManualPrompt, null);
+    }
+
+    /**
+     * Process the awards for the given personnel.
+     *
+     * @param personnel            the List of personnel to process awards for
+     * @param missionWasSuccessful true if the mission was successful, false otherwise
+     * @param academyAttributes    a map of academy attributes, null if not processing graduation awards
+     * @param isManualPrompt       whether autoAwards was triggered manually
      * @param POWPersonnel         a list of persons that have been a prisoner of war in the current mission
      */
     private void ProcessAwards(List<UUID> personnel, Boolean missionWasSuccessful,
@@ -997,6 +1010,22 @@ public class AutoAwardsController {
         } else {
             return null;
         }
+    }
+
+    /**
+     * This method is the manager for processing Miscellaneous Awards.
+     *
+     * @param personnel            the personnel to be processed
+     * @param missionWasSuccessful true if the mission was successful, false otherwise
+     * @param wasCivilianHelp      true if the scenario (if relevant) was AtB Scenario type CIVILIAN_HELP
+     * @param wasScenario          true if the award is for a scenario, false otherwise
+     * @param scenarioKills        a map of personnel and their corresponding list of Kills
+     *
+     * @return a map containing the award data, or null if no awards are applicable
+     */
+    private Map<Integer, List<Object>> MiscAwardsManager(HashMap<UUID, Integer> personnel, boolean missionWasSuccessful,
+          boolean wasScenario, boolean wasCivilianHelp, HashMap<UUID, List<Kill>> scenarioKills) {
+        return MiscAwardsManager(personnel, missionWasSuccessful, wasScenario, wasCivilianHelp, scenarioKills, null);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/autoAwards/AutoAwardsController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/autoAwards/AutoAwardsController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2024-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -96,7 +96,7 @@ public class AutoAwardsController {
         // we have to do multiple isEmpty() checks as, at any point in the removal process, we could end up with null personnel
         if (!personnel.isEmpty()) {
             // This is the main workhorse function
-            ProcessAwards(personnel, false, null, isManualPrompt);
+            ProcessAwards(personnel, false, null, isManualPrompt, null);
         } else {
             logger.info("AutoAwards found no personnel, skipping the Award Ceremony");
 
@@ -132,7 +132,7 @@ public class AutoAwardsController {
         // we have to do multiple isEmpty() checks as, at any point in the removal process, we could end up with null personnel
         if (!personnel.isEmpty()) {
             // This is the main workhorse function
-            ProcessAwards(personnel, false, null, isManualPrompt);
+            ProcessAwards(personnel, false, null, isManualPrompt, null);
         } else {
             logger.info("AutoAwards found no personnel, skipping the Award Ceremony");
         }
@@ -146,8 +146,10 @@ public class AutoAwardsController {
      * @param campaign             the campaign to be processed
      * @param mission              the mission just completed
      * @param missionWasSuccessful true if the Mission was a complete Success, otherwise false
+     * @param POWPersonnel         a list of persons that have been a prisoner of war in the current mission
      */
-    public void PostMissionController(Campaign campaign, Mission mission, Boolean missionWasSuccessful) {
+    public void PostMissionController(Campaign campaign, Mission mission, Boolean missionWasSuccessful,
+          @Nullable List<Person> POWPersonnel) {
         logger.info("autoAwards (Mission Conclusion) has started");
 
         this.campaign = campaign;
@@ -160,7 +162,7 @@ public class AutoAwardsController {
         // we have to do multiple isEmpty() checks as, at any point in the removal process, we could end up with null personnel
         if (!personnel.isEmpty()) {
             // This is the main workhorse function
-            ProcessAwards(personnel, missionWasSuccessful, null, false);
+            ProcessAwards(personnel, missionWasSuccessful, null, false, POWPersonnel);
         } else {
             logger.info("AutoAwards found no personnel, skipping the Award Ceremony");
         }
@@ -210,7 +212,7 @@ public class AutoAwardsController {
 
         // beginning the processing & filtering of Misc Awards
         if (!miscAwards.isEmpty()) {
-            processedData = MiscAwardsManager(personnel, false, true, wasCivilianHelp, scenarioKills);
+            processedData = MiscAwardsManager(personnel, false, true, wasCivilianHelp, scenarioKills, null);
 
             if (processedData != null) {
                 allAwardData.put(allAwardDataKey, processedData);
@@ -255,7 +257,7 @@ public class AutoAwardsController {
         // we have to do multiple isEmpty() checks as, at any point in the removal process, we could end up with null personnel
         if (!personnel.isEmpty()) {
             // This is the main workhorse function
-            ProcessAwards(personnel, false, academyAttributes, false);
+            ProcessAwards(personnel, false, academyAttributes, false, null);
         } else {
             logger.info("AutoAwards found no personnel, skipping the Award Ceremony");
         }
@@ -669,9 +671,11 @@ public class AutoAwardsController {
      * @param missionWasSuccessful true if the mission was successful, false otherwise
      * @param academyAttributes    a map of academy attributes, null if not processing graduation awards
      * @param isManualPrompt       whether autoAwards was triggered manually
+     * @param POWPersonnel         a list of persons that have been a prisoner of war in the current mission
      */
     private void ProcessAwards(List<UUID> personnel, Boolean missionWasSuccessful,
-          @Nullable HashMap<UUID, List<Object>> academyAttributes, boolean isManualPrompt) {
+          @Nullable HashMap<UUID, List<Object>> academyAttributes, boolean isManualPrompt,
+          @Nullable List<Person> POWPersonnel) {
         Map<Integer, Map<Integer, List<Object>>> allAwardData = new HashMap<>();
         Map<Integer, List<Object>> processedData;
         int allAwardDataKey = 0;
@@ -717,7 +721,7 @@ public class AutoAwardsController {
                 personnelMap.put(person, 0);
             }
 
-            processedData = MiscAwardsManager(personnelMap, missionWasSuccessful, false, false, null);
+            processedData = MiscAwardsManager(personnelMap, missionWasSuccessful, false, false, null, POWPersonnel);
 
             if (processedData != null) {
                 allAwardData.put(allAwardDataKey, processedData);
@@ -1003,12 +1007,13 @@ public class AutoAwardsController {
      * @param wasCivilianHelp      true if the scenario (if relevant) was AtB Scenario type CIVILIAN_HELP
      * @param wasScenario          true if the award is for a scenario, false otherwise
      * @param scenarioKills        a map of personnel and their corresponding list of Kills
+     * @param POWPersonnel         a list of persons that have been a prisoner of war in the current mission
      *
      * @return a map containing the award data, or null if no awards are applicable
      */
     private Map<Integer, List<Object>> MiscAwardsManager(HashMap<UUID, Integer> personnel, boolean missionWasSuccessful,
           boolean wasScenario,
-          boolean wasCivilianHelp, HashMap<UUID, List<Kill>> scenarioKills) {
+          boolean wasCivilianHelp, HashMap<UUID, List<Kill>> scenarioKills, @Nullable List<Person> POWPersonnel) {
         Map<Integer, List<Object>> awardData = new HashMap<>();
         int awardDataKey = 0;
 
@@ -1060,7 +1065,8 @@ public class AutoAwardsController {
                       wasCivilianHelp,
                       personalKills.size(),
                       personnel.get(person),
-                      supportPersonOfTheYear
+                      supportPersonOfTheYear,
+                      POWPersonnel
                 );
             } catch (Exception e) {
                 data = null;

--- a/MekHQ/src/mekhq/campaign/personnel/autoAwards/MiscAwards.java
+++ b/MekHQ/src/mekhq/campaign/personnel/autoAwards/MiscAwards.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2024-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -48,6 +48,7 @@ import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.Contract;
 import mekhq.campaign.mission.Mission;
 import mekhq.campaign.personnel.Award;
+import mekhq.campaign.personnel.Person;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.PlanetarySystem;
@@ -68,12 +69,14 @@ public class MiscAwards {
      * @param killCount              the number of kills (null if not applicable)
      * @param injuryCount            the number of injuries (null if not applicable)
      * @param supportPersonOfTheYear a UUID identifying the candidate for Support Person of the Year awards
+     * @param POWPersonnel           a list of persons that have been a prisoner of war in the current mission
      *
      * @return a map of eligible awards grouped by their respective IDs
      */
     public static Map<Integer, List<Object>> MiscAwardsProcessor(Campaign campaign, @Nullable Mission mission,
           UUID person, List<Award> awards, Boolean missionWasSuccessful, boolean isCivilianHelp,
-          @Nullable Integer killCount, @Nullable Integer injuryCount, @Nullable UUID supportPersonOfTheYear) {
+          @Nullable Integer killCount, @Nullable Integer injuryCount, @Nullable UUID supportPersonOfTheYear,
+          @Nullable List<Person> POWPersonnel) {
         List<Award> eligibleAwards = new ArrayList<>();
 
         for (Award award : awards) {
@@ -109,7 +112,7 @@ public class MiscAwards {
                     }
                 }
                 case "prisonerofwar" -> {
-                    if (mission != null && prisonerOfWar(campaign, award, person)) {
+                    if (mission != null && prisonerOfWar(campaign, award, person, POWPersonnel)) {
                         eligibleAwards.add(award);
                     }
                 }
@@ -265,15 +268,18 @@ public class MiscAwards {
     /**
      * Checks if a person is a prisoner of war in a given campaign and is eligible to receive an award.
      *
-     * @param campaign the campaign in which the person is participating
-     * @param award    the award to be given
-     * @param person   the unique identifier of the person to check
+     * @param campaign     the campaign in which the person is participating
+     * @param award        the award to be given
+     * @param person       the unique identifier of the person to check
+     * @param POWPersonnel a list of persons that have been a prisoner of war in the current mission
      *
-     * @return true if the person is a prisoner of war and is eligible to receive the award, false otherwise
+     * @return true if the person has been a prisoner of war in the current mission and is eligible to receive the
+     *       award, false otherwise
      */
-    private static boolean prisonerOfWar(Campaign campaign, Award award, UUID person) {
+    private static boolean prisonerOfWar(Campaign campaign, Award award, UUID person,
+          @Nullable List<Person> POWPersonnel) {
         if (award.canBeAwarded(campaign.getPerson(person))) {
-            return campaign.getPerson(person).getStatus().isPoW();
+            return POWPersonnel.stream().anyMatch(p -> p.getId() == person);
         }
 
         return false;

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -496,6 +496,8 @@ public final class BriefingTab extends CampaignGuiTab {
         // Prisoners
         boolean wasOverallSuccess = cmd.getStatus() == SUCCESS || cmd.getStatus() == PARTIAL;
 
+        List<Person> POWPersonnel = getCampaign().getFriendlyPrisoners();
+
         // We only resolve prisoners if there are no active Missions
         if (getCampaign().getActiveMissions(false).isEmpty()) {
             if (!getCampaign().getFriendlyPrisoners().isEmpty()) {
@@ -554,7 +556,8 @@ public final class BriefingTab extends CampaignGuiTab {
             // Successes as Success
             autoAwardsController.PostMissionController(getCampaign(),
                   mission,
-                  Objects.equals(String.valueOf(cmd.getStatus()), "Success"));
+                  Objects.equals(String.valueOf(cmd.getStatus()), "Success"),
+                  POWPersonnel);
         }
 
         // Update Faction Standings


### PR DESCRIPTION
Currently, POW awards are never given automatically. The reason for this is that this award is based on the POW status of a person, but this status is cleared (just) before the auto awards are processed at mission end.

This PR fixes this issue by building a list of current POWs at mission end, and then using that list to determine which persons should get the award.

Unfortunately, due to the way auto awards are set up, this list needs to be passed on through several methods before it can actually be used to determine if a person should get the award. Overloaded methods help with this but it is still not ideal.