### PR TITLE
Fix #8947: Fixed Management Skill Using Skill TN Not Level

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
@@ -231,7 +231,7 @@ public class RetirementDefectionTracker {
                         SkillModifierData skillModifierData = commander.getSkillModifierData(true);
 
                         modifier -= commander.getSkill(SkillType.S_LEADER)
-                                          .getFinalSkillValue(skillModifierData);
+                                          .getTotalSkillLevel(skillModifierData);
                     }
                 } else {
                     modifier -= getManagementSkillModifier(person);
@@ -632,7 +632,7 @@ public class RetirementDefectionTracker {
         if (commander.hasSkill(SkillType.S_LEADER)) {
             SkillModifierData skillModifierData = commander.getSkillModifierData();
 
-            return commander.getSkill(SkillType.S_LEADER).getFinalSkillValue(skillModifierData);
+            return commander.getSkill(SkillType.S_LEADER).getTotalSkillLevel(skillModifierData);
         } else {
             return 0;
         }


### PR DESCRIPTION
Fix #8947

Management skill was previously using Skill Target Number, not Skill Level. This meant that the better a characters' Leadership, the worse their modifier to subordinates' turnover TN. Now we correctly use Skill Level.