### PR TITLE
Fix #8913: Fixed Free Infantry Conditional

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
@@ -642,7 +642,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             new MASHTheaterTrackingCampaignOptionsChangedConfirmationDialog(campaign);
         }
 
-        boolean newIsTrackPrisoners = !newOptions.trackPrisoners();
+        boolean newIsTrackPrisoners = newOptions.trackPrisoners();
         if (!isStartUp && newIsTrackPrisoners && !oldIsTrackPrisoners) { // Has tracking changed?
             new PrisonerTrackingCampaignOptionsChangedConfirmationDialog(campaign);
         }


### PR DESCRIPTION
Fix #8913

Free infantry were being issued when prisoners of war stopped being tracked, not when they _were_ being newly tracked. Now they are.