### PR TITLE
Fix #8905: Expanded Roll Information for Weekly Training Skill Checks

### DIFF
--- a/MekHQ/resources/mekhq/resources/Education.properties
+++ b/MekHQ/resources/mekhq/resources/Education.properties
@@ -114,7 +114,7 @@ inForLife.text={0} could not be converted to your faction due to one or more SPA
 noCommander.text=%s has %s<b>No Commander</b>%s, so nothing can be taught.
 notLearningAnything.text=%s has learned all they can from %s and %s<b>should be reassigned</b>%s.
 learningStarted.text=<b>%s</b> has begun their on-site education.
-learnedProgress.text=%s attempted to teach using their <b>Training</b> skill: %s<b>%s</b>%s.
+learnedProgress.text=%s attempted to teach using their <b>Training</b> skill: %s<b>%s</b>%s (See 'Skill Checks' tab for details).
 learnedNewSkill.text=Thanks to the teaching of %s, %s has %s<b>improved</b>%s their <i>%s</i> to <b>%s+</b>.
 trainingCombatTeam.skillCheck=Training Combat Team
 #### Graduation Events (positive)

--- a/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
@@ -38,6 +38,7 @@ import static java.lang.Math.max;
 import static java.lang.Math.round;
 import static mekhq.campaign.enums.DailyReportType.GENERAL;
 import static mekhq.campaign.enums.DailyReportType.PERSONNEL;
+import static mekhq.campaign.enums.DailyReportType.SKILL_CHECKS;
 import static mekhq.campaign.personnel.PersonnelOptions.ATOW_TOUGHNESS;
 import static mekhq.campaign.personnel.PersonnelOptions.FLAW_GLASS_JAW;
 import static mekhq.campaign.personnel.skills.SkillType.S_TRAINING;
@@ -401,17 +402,20 @@ public class TrainingCombatTeams {
               new ArrayList<>(),
               0,
               true,
-              false,
+              true,
               useAgingEffects,
               isClanCampaign,
               today);
         int raw = skillCheck.getMarginOfSuccess();
         MarginOfSuccess marginOfSuccess = getMarginOfSuccessObject(raw);
 
-        String report = String.format(resources.getString("learnedProgress.text"),
+        String personnelReport = String.format(resources.getString("learnedProgress.text"),
               educator.getHyperlinkedFullTitle(), spanOpeningWithCustomColor(marginOfSuccess.getColor()),
               marginOfSuccess.getLabel(), CLOSING_SPAN_TAG);
-        campaign.addReport(PERSONNEL, report);
+        campaign.addReport(PERSONNEL, personnelReport);
+
+        String skillRollReport = skillCheck.getResultsText();
+        campaign.addReport(SKILL_CHECKS, skillRollReport);
 
         return raw;
     }


### PR DESCRIPTION
Fix #8905

Added follow-up expanded skill check information to Skill Checks tab.