### PR TITLE
Fix #8869: Fixed Generic Pay Multiplier for LAM, Small Craft, Conv. Fighters (feat. LostWhen)

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AlternatePaymentModelValues.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AlternatePaymentModelValues.java
@@ -276,7 +276,12 @@ public enum AlternatePaymentModelValues {
     private static Money getUnitContractValue(Entity entity, boolean excludeInfantry, double combatMultiplier,
           double dropShipMultiplier, double warShipMultiplier, double jumpShipMultiplier) {
         int weightClass = entity.getWeightClass();
+
         if (entity.isAerospaceFighter()) {
+            if (entity.isConventionalFighter()) {
+                return CONVENTIONAL_FIGHTER.getValue().multipliedBy(combatMultiplier);
+            }
+
             Money base = switch (weightClass) {
                 case WEIGHT_LIGHT -> AEROSPACE_FIGHTER_LIGHT.getValue();
                 case WEIGHT_MEDIUM -> AEROSPACE_FIGHTER_MEDIUM.getValue();
@@ -379,11 +384,6 @@ public enum AlternatePaymentModelValues {
                                            SUPPORT_VEHICLE_HEAVY.getValue() :
                                            SUPPORT_VEHICLE_SUPER_HEAVY.getValue();
             return base.multipliedBy(combatMultiplier);
-        }
-
-        // Must be before Aerospace Fighter
-        if (entity.isConventionalFighter()) {
-            return CONVENTIONAL_FIGHTER.getValue().multipliedBy(combatMultiplier);
         }
 
         return Money.zero();

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AlternatePaymentModelValues.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AlternatePaymentModelValues.java
@@ -291,7 +291,7 @@ public enum AlternatePaymentModelValues {
 
         if (entity.isBattleMek()) {
             if (entity instanceof LandAirMek) {
-                return LAM.getValue();
+                return LAM.getValue().multipliedBy(combatMultiplier);
             }
 
             Money base = switch (weightClass) {
@@ -362,7 +362,7 @@ public enum AlternatePaymentModelValues {
 
         // Must be after large craft
         if (entity.isSmallCraft()) {
-            return SMALL_CRAFT.getValue();
+            return SMALL_CRAFT.getValue().multipliedBy(combatMultiplier);
         }
 
         if (entity.isProtoMek()) {
@@ -383,7 +383,7 @@ public enum AlternatePaymentModelValues {
 
         // Must be before Aerospace Fighter
         if (entity.isConventionalFighter()) {
-            return CONVENTIONAL_FIGHTER.getValue();
+            return CONVENTIONAL_FIGHTER.getValue().multipliedBy(combatMultiplier);
         }
 
         return Money.zero();

--- a/MekHQ/unittests/mekhq/campaign/market/contractMarket/AlternatePaymentModelValuesTest.java
+++ b/MekHQ/unittests/mekhq/campaign/market/contractMarket/AlternatePaymentModelValuesTest.java
@@ -264,16 +264,17 @@ class AlternatePaymentModelValuesTest {
             when(entity.isSmallCraft()).thenReturn(true);
 
             Money result = invokeGetUnitContractValue(entity, false, 0.25, 0, 0, 0);
-            assertEquals(AlternatePaymentModelValues.SMALL_CRAFT.getValue(), result);
+            assertEquals(AlternatePaymentModelValues.SMALL_CRAFT.getValue().multipliedBy(0.25), result);
         }
 
         @Test
         void conventionalFighter_usesConventionalFighterValue() throws Exception {
             Entity entity = mock(Entity.class);
+            when(entity.isAerospaceFighter()).thenReturn(true);
             when(entity.isConventionalFighter()).thenReturn(true);
 
-            Money result = invokeGetUnitContractValue(entity, false, 1.0, 0, 0, 0);
-            assertEquals(AlternatePaymentModelValues.CONVENTIONAL_FIGHTER.getValue(), result);
+            Money result = invokeGetUnitContractValue(entity, false, 0.95, 0, 0, 0);
+            assertEquals(AlternatePaymentModelValues.CONVENTIONAL_FIGHTER.getValue().multipliedBy(0.95), result);
         }
 
         @Test
@@ -282,7 +283,7 @@ class AlternatePaymentModelValuesTest {
             when(lam.isBattleMek()).thenReturn(true);
 
             Money result = invokeGetUnitContractValue(lam, false, 0.25, 0, 0, 0);
-            assertEquals(AlternatePaymentModelValues.LAM.getValue(), result);
+            assertEquals(AlternatePaymentModelValues.LAM.getValue().multipliedBy(0.25), result);
         }
 
         @Test


### PR DESCRIPTION
Fix #8869

Several unit types were missing their multiplier causing them to be significantly overvalued. Code provided by @LostWhen