### PR TITLE
Added Financial Stipend to Mitigate Effects of Mental Breaks

### DIFF
--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -155,7 +155,7 @@ unableToEnterSystem.outlawed.ic=%s, I regret to inform you that we're unable to 
   travel somewhere else?
 unableToEnterSystem.outlawed.ooc=Outlawing can occur as the result of supremely low Faction Standing, or accepting a \
   contract from an enemy of the system owners.
-painkillerAddiction.transaction=Medicine costs for {0}
+medicalCosts.transaction=Medicine costs for {0}
 # Bioweapon Attack
 bioweaponAttack.inCharacter={0}, this is an emergency.\
   <p>I''ve just confirmed the release of an engineered biological agent within the current system. Multiple \

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -1576,7 +1576,7 @@ public class CampaignNewDayManager {
         if (personnelOptions.booleanOption(COMPULSION_PAINKILLER_ADDICTION)) {
             int totalProstheticCount = getTotalProstheticCount(person);
 
-            Money cost = Money.of(PersonnelOptions.PAINKILLER_COST * totalProstheticCount);
+            Money cost = Money.of(PersonnelOptions.MEDICINE_COST * totalProstheticCount);
             if (!payForMedicine(person, cost)) {
                 checkForDiscontinuationSyndrome(person,
                       isUseAdvancedMedical,
@@ -1624,10 +1624,9 @@ public class CampaignNewDayManager {
             }
         }
 
+        // Must be before MADNESS_CLINICAL_PARANOIA && MADNESS_HYSTERIA
         boolean resetClinicalParanoia = true; // See comment at end of method
         if (personnelOptions.booleanOption(MADNESS_CLINICAL_PARANOIA)) {
-            resetClinicalParanoia = false;
-
             Money cost = getMedicalCostFromSPAXPCost(MADNESS_CLINICAL_PARANOIA);
 
             if (!payForMedicine(person, cost)) {
@@ -1638,6 +1637,8 @@ public class CampaignNewDayManager {
                 if (!report.isBlank()) {
                     campaign.addReport(MEDICAL, report);
                 }
+
+                resetClinicalParanoia = false;
             }
         }
 
@@ -1692,8 +1693,6 @@ public class CampaignNewDayManager {
         }
 
         if (personnelOptions.booleanOption(MADNESS_HYSTERIA)) {
-            resetClinicalParanoia = false;
-
             Money cost = getMedicalCostFromSPAXPCost(MADNESS_HYSTERIA);
 
             if (!payForMedicine(person, cost)) {
@@ -1707,6 +1706,8 @@ public class CampaignNewDayManager {
                 if (!report.isBlank()) {
                     campaign.addReport(MEDICAL, report);
                 }
+
+                resetClinicalParanoia = false;
             }
         }
 
@@ -1752,7 +1753,7 @@ public class CampaignNewDayManager {
      *
      * <p>
      *     Cost is derived from the XP cost of the Flaw divided by 100 (rounded normally). It has a minimum value of
-     *     {@link PersonnelOptions#PAINKILLER_COST}.
+     *     {@link PersonnelOptions#MEDICINE_COST}.
      * </p>
      *
      * @param spaKey the key representing a special ability, used to fetch its associated cost multiplier.
@@ -1767,11 +1768,9 @@ public class CampaignNewDayManager {
 
         SpecialAbility specialAbility = specialAbilityMap.get(spaKey);
 
-        double multiplier = specialAbility == null ? 1.0 : specialAbility.getCost() / 100.0;
-        int cost = (int) round(PersonnelOptions.PAINKILLER_COST * multiplier);
-
-        // The cost of Flaws is always negative, so we need to invert the sign
-        cost = max(-cost, PersonnelOptions.PAINKILLER_COST);
+        int xpCost = specialAbility == null ? 0 : specialAbility.getCost();
+        int roundedCostUnits = max(1, (int) round(Math.abs(xpCost) / 100.0));
+        int cost = PersonnelOptions.MEDICINE_COST * roundedCostUnits;
 
         return Money.of(cost);
     }

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -35,6 +35,7 @@ package mekhq.campaign;
 
 import static java.lang.Math.ceil;
 import static java.lang.Math.max;
+import static java.lang.Math.round;
 import static megamek.common.compute.Compute.d6;
 import static megamek.common.compute.Compute.randomInt;
 import static mekhq.campaign.enums.DailyReportType.ACQUISITIONS;
@@ -137,6 +138,7 @@ import mekhq.campaign.personnel.InjuryType;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.RandomDependents;
+import mekhq.campaign.personnel.SpecialAbility;
 import mekhq.campaign.personnel.autoAwards.AutoAwardsController;
 import mekhq.campaign.personnel.education.Academy;
 import mekhq.campaign.personnel.education.EducationController;
@@ -1575,8 +1577,7 @@ public class CampaignNewDayManager {
             int totalProstheticCount = getTotalProstheticCount(person);
 
             Money cost = Money.of(PersonnelOptions.PAINKILLER_COST * totalProstheticCount);
-            if (!finances.debit(TransactionType.MEDICAL_EXPENSES, today, cost,
-                  getFormattedTextAt(RESOURCE_BUNDLE, "painkillerAddiction.transaction", person.getFullTitle()))) {
+            if (!payForMedicine(person, cost)) {
                 checkForDiscontinuationSyndrome(person,
                       isUseAdvancedMedical,
                       isUseAltAdvancedMedical,
@@ -1594,103 +1595,185 @@ public class CampaignNewDayManager {
         }
 
         if (personnelOptions.booleanOption(MADNESS_FLASHBACKS)) {
-            int modifier = getCompulsionCheckModifier(MADNESS_FLASHBACKS);
-            boolean failedWillpowerCheck = !performQuickAttributeCheck(person, SkillAttribute.WILLPOWER, null,
-                  null, modifier);
-            person.processCripplingFlashbacks(campaign,
-                  isUseAdvancedMedical,
-                  isUseAltAdvancedMedical,
-                  true,
-                  failedWillpowerCheck);
+            Money cost = getMedicalCostFromSPAXPCost(MADNESS_FLASHBACKS);
+
+            if (!payForMedicine(person, cost)) {
+                int modifier = getCompulsionCheckModifier(MADNESS_FLASHBACKS);
+
+                boolean failedWillpowerCheck = performPersonalityBreakCheck(person, modifier);
+
+                person.processCripplingFlashbacks(campaign,
+                      isUseAdvancedMedical,
+                      isUseAltAdvancedMedical,
+                      true,
+                      failedWillpowerCheck);
+            }
         }
 
         if (personnelOptions.booleanOption(MADNESS_SPLIT_PERSONALITY)) {
-            int modifier = getCompulsionCheckModifier(MADNESS_SPLIT_PERSONALITY);
-            boolean failedWillpowerCheck = !performQuickAttributeCheck(person, SkillAttribute.WILLPOWER, null,
-                  null, modifier);
-            String report = person.processSplitPersonality(true,
-                  failedWillpowerCheck);
-            if (!report.isBlank()) {
-                campaign.addReport(MEDICAL, report);
+            Money cost = getMedicalCostFromSPAXPCost(MADNESS_SPLIT_PERSONALITY);
+
+            if (!payForMedicine(person, cost)) {
+                int modifier = getCompulsionCheckModifier(MADNESS_SPLIT_PERSONALITY);
+                boolean failedWillpowerCheck = performPersonalityBreakCheck(person, modifier);
+                String report = person.processSplitPersonality(true,
+                      failedWillpowerCheck);
+                if (!report.isBlank()) {
+                    campaign.addReport(MEDICAL, report);
+                }
             }
         }
 
-        boolean resetClinicalParanoia = true;
+        boolean resetClinicalParanoia = true; // See comment at end of method
         if (personnelOptions.booleanOption(MADNESS_CLINICAL_PARANOIA)) {
-            int modifier = getCompulsionCheckModifier(MADNESS_CLINICAL_PARANOIA);
-            boolean failedWillpowerCheck = !performQuickAttributeCheck(person, SkillAttribute.WILLPOWER, null,
-                  null, modifier);
-            String report = person.processClinicalParanoia(true,
-                  failedWillpowerCheck);
-            if (!report.isBlank()) {
-                campaign.addReport(MEDICAL, report);
-            }
-
             resetClinicalParanoia = false;
+
+            Money cost = getMedicalCostFromSPAXPCost(MADNESS_CLINICAL_PARANOIA);
+
+            if (!payForMedicine(person, cost)) {
+                int modifier = getCompulsionCheckModifier(MADNESS_CLINICAL_PARANOIA);
+                boolean failedWillpowerCheck = performPersonalityBreakCheck(person, modifier);
+                String report = person.processClinicalParanoia(true,
+                      failedWillpowerCheck);
+                if (!report.isBlank()) {
+                    campaign.addReport(MEDICAL, report);
+                }
+            }
         }
 
         if (personnelOptions.booleanOption(MADNESS_REGRESSION)) {
-            int modifier = getCompulsionCheckModifier(MADNESS_REGRESSION);
-            boolean failedWillpowerCheck = !performQuickAttributeCheck(person, SkillAttribute.WILLPOWER, null,
-                  null, modifier);
-            String report = person.processChildlikeRegression(campaign,
-                  isUseAdvancedMedical,
-                  isUseAltAdvancedMedical,
-                  true,
-                  failedWillpowerCheck);
-            if (!report.isBlank()) {
-                campaign.addReport(MEDICAL, report);
+            Money cost = getMedicalCostFromSPAXPCost(MADNESS_REGRESSION);
+
+            if (!payForMedicine(person, cost)) {
+                int modifier = getCompulsionCheckModifier(MADNESS_REGRESSION);
+                boolean failedWillpowerCheck = performPersonalityBreakCheck(person, modifier);
+                String report = person.processChildlikeRegression(campaign,
+                      isUseAdvancedMedical,
+                      isUseAltAdvancedMedical,
+                      true,
+                      failedWillpowerCheck);
+                if (!report.isBlank()) {
+                    campaign.addReport(MEDICAL, report);
+                }
             }
         }
 
         if (personnelOptions.booleanOption(MADNESS_CATATONIA)) {
-            int modifier = getCompulsionCheckModifier(MADNESS_CATATONIA);
-            boolean failedWillpowerCheck = !performQuickAttributeCheck(person, SkillAttribute.WILLPOWER, null,
-                  null, modifier);
-            String report = person.processCatatonia(campaign,
-                  isUseAdvancedMedical,
-                  isUseAltAdvancedMedical,
-                  true,
-                  failedWillpowerCheck);
-            if (!report.isBlank()) {
-                campaign.addReport(MEDICAL, report);
+            Money cost = getMedicalCostFromSPAXPCost(MADNESS_CATATONIA);
+
+            if (!payForMedicine(person, cost)) {
+                int modifier = getCompulsionCheckModifier(MADNESS_CATATONIA);
+                boolean failedWillpowerCheck = performPersonalityBreakCheck(person, modifier);
+                String report = person.processCatatonia(campaign,
+                      isUseAdvancedMedical,
+                      isUseAltAdvancedMedical,
+                      true,
+                      failedWillpowerCheck);
+                if (!report.isBlank()) {
+                    campaign.addReport(MEDICAL, report);
+                }
             }
         }
 
         if (personnelOptions.booleanOption(MADNESS_BERSERKER)) {
-            int modifier = getCompulsionCheckModifier(MADNESS_BERSERKER);
-            boolean failedWillpowerCheck = !performQuickAttributeCheck(person, SkillAttribute.WILLPOWER, null,
-                  null, modifier);
-            String report = person.processBerserkerFrenzy(campaign,
-                  isUseAdvancedMedical,
-                  true,
-                  failedWillpowerCheck);
-            if (!report.isBlank()) {
-                campaign.addReport(MEDICAL, report);
+            Money cost = getMedicalCostFromSPAXPCost(MADNESS_BERSERKER);
+
+            if (!payForMedicine(person, cost)) {
+                int modifier = getCompulsionCheckModifier(MADNESS_BERSERKER);
+                boolean failedWillpowerCheck = performPersonalityBreakCheck(person, modifier);
+                String report = person.processBerserkerFrenzy(campaign,
+                      isUseAdvancedMedical,
+                      true,
+                      failedWillpowerCheck);
+                if (!report.isBlank()) {
+                    campaign.addReport(MEDICAL, report);
+                }
             }
         }
 
         if (personnelOptions.booleanOption(MADNESS_HYSTERIA)) {
-            int modifier = getCompulsionCheckModifier(MADNESS_HYSTERIA);
-            boolean failedWillpowerCheck = !performQuickAttributeCheck(person, SkillAttribute.WILLPOWER, null,
-                  null, modifier);
-            String report = person.processHysteria(campaign,
-                  true,
-                  isUseAdvancedMedical,
-                  isUseAltAdvancedMedical,
-                  failedWillpowerCheck);
-            if (!report.isBlank()) {
-                campaign.addReport(MEDICAL, report);
-            }
-
             resetClinicalParanoia = false;
+
+            Money cost = getMedicalCostFromSPAXPCost(MADNESS_HYSTERIA);
+
+            if (!payForMedicine(person, cost)) {
+                int modifier = getCompulsionCheckModifier(MADNESS_HYSTERIA);
+                boolean failedWillpowerCheck = performPersonalityBreakCheck(person, modifier);
+                String report = person.processHysteria(campaign,
+                      true,
+                      isUseAdvancedMedical,
+                      isUseAltAdvancedMedical,
+                      failedWillpowerCheck);
+                if (!report.isBlank()) {
+                    campaign.addReport(MEDICAL, report);
+                }
+            }
         }
 
-        // This is necessary to stop a character from getting permanently locked in a paranoia state if the
-        // relevant madness are removed.
+        // This is necessary to stop a character from getting permanently locked in a paranoia state if the relevant
+        // madness is removed.
         if (resetClinicalParanoia) {
             person.setSufferingFromClinicalParanoia(false);
         }
+    }
+
+    /**
+     * Determines if a willpower check has failed for the given person with the specified modifier.
+     *
+     * @param person The person for whom the willpower check is being performed.
+     * @param modifier An integer value representing the modification to the willpower check.
+     * @return {@code true} if the willpower check has failed; {@code false} otherwise.
+     *
+     * @since 0.51.0
+     * @author Illiani
+     */
+    private static boolean performPersonalityBreakCheck(Person person, int modifier) {
+        return !performQuickAttributeCheck(person, SkillAttribute.WILLPOWER, null,
+              null, modifier);
+    }
+
+    /**
+     * Processes the payment for medicine by debiting the specified cost from the person's finances.
+     *
+     * @param person the person for whom the payment is being made
+     * @param cost the amount of money to be debited for the medicine
+     * @return {@code true} if the payment was successful
+     *
+     * @since 0.51.0
+     * @author Illiani
+     */
+    private boolean payForMedicine(Person person, Money cost) {
+        return finances.debit(TransactionType.MEDICAL_EXPENSES, today, cost,
+              getFormattedTextAt(RESOURCE_BUNDLE, "medicalCosts.transaction", person.getFullTitle()));
+    }
+
+    /**
+     * Calculates the medical cost to ignore a Flaw or negative SPA.
+     *
+     * <p>
+     *     Cost is derived from the XP cost of the Flaw divided by 100 (rounded normally). It has a minimum value of
+     *     {@link PersonnelOptions#PAINKILLER_COST}.
+     * </p>
+     *
+     * @param spaKey the key representing a special ability, used to fetch its associated cost multiplier.
+     * @return the calculated medical cost, which is derived from the base painkiller cost and adjusted based on the
+     * special ability's cost multiplier. Returns at least the base painkiller cost.
+     *
+     * @since 0.51.0
+     * @author Illiani
+     */
+    private static Money getMedicalCostFromSPAXPCost(String spaKey) {
+        Map<String, SpecialAbility> specialAbilityMap = SpecialAbility.getSpecialAbilities();
+
+        SpecialAbility specialAbility = specialAbilityMap.get(spaKey);
+
+        double multiplier = specialAbility == null ? 1.0 : specialAbility.getCost() / 100.0;
+        int cost = (int) round(PersonnelOptions.PAINKILLER_COST * multiplier);
+
+        // The cost of Flaws is always negative, so we need to invert the sign
+        cost = max(-cost, PersonnelOptions.PAINKILLER_COST);
+
+        return Money.of(cost);
     }
 
     private static int getTotalProstheticCount(Person person) {
@@ -1723,8 +1806,7 @@ public class CampaignNewDayManager {
     private void checkForDiscontinuationSyndrome(Person person, boolean isUseAdvancedMedical,
           boolean isUseAltAdvancedMedical, boolean isUseFatigue, int fatigueRate) {
         int modifier = getCompulsionCheckModifier(COMPULSION_ADDICTION);
-        boolean failedWillpowerCheck = !performQuickAttributeCheck(person, SkillAttribute.WILLPOWER, null,
-              null, modifier);
+        boolean failedWillpowerCheck = performPersonalityBreakCheck(person, modifier);
         person.processDiscontinuationSyndrome(campaign,
               isUseAdvancedMedical,
               isUseAltAdvancedMedical,

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -184,7 +184,7 @@ public class PersonnelOptions extends PilotOptions {
     public static final int COMPULSION_CHECK_MODIFIER_SEVERE = 7; // ATOW pg 110
     public static final int COMPULSION_CHECK_MODIFIER_EXTREME = 10; // ATOW pg 110
 
-    public static final int PAINKILLER_COST = 42; // 7 days of codeine, ATOW pg 319
+    public static final int MEDICINE_COST = 42; // 7 days of codeine, ATOW pg 319
 
     // ATOW pg 112 (Reputation, Connections)
     public static final Map<String, int[]> DARK_SECRET_MODIFIERS = Map.of(


### PR DESCRIPTION
See Also: https://github.com/MegaMek/mm-data/pull/356

Previously mental breaks were far too disruptive, far more than was intended. This is due to a disconnect between the behavior ATOW expects and the behavior of the average MHQ player. i.e. ATOW expects the player to spend xp on Willpower to resist the breaks, mhq players don't want to do that (or don't know to do that).

Now campaigns are required to pay a small stipend per week. If paid the mental break will not occur. This cost is `42 * n`, where `n` is the XP cost of the Flaw divided by `100` (rounded normally), with a minimum of `42`.