### PR TITLE
Show mental break skill checks

### DIFF
--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -155,7 +155,7 @@ unableToEnterSystem.outlawed.ic=%s, I regret to inform you that we're unable to 
   travel somewhere else?
 unableToEnterSystem.outlawed.ooc=Outlawing can occur as the result of supremely low Faction Standing, or accepting a \
   contract from an enemy of the system owners.
-painkillerAddiction.transaction=Medicine costs for {0}
+medicalCosts.transaction=Medicine costs for {0}
 # Bioweapon Attack
 bioweaponAttack.inCharacter={0}, this is an emergency.\
   <p>I''ve just confirmed the release of an engineered biological agent within the current system. Multiple \

--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -156,6 +156,7 @@ unableToEnterSystem.outlawed.ic=%s, I regret to inform you that we're unable to 
 unableToEnterSystem.outlawed.ooc=Outlawing can occur as the result of supremely low Faction Standing, or accepting a \
   contract from an enemy of the system owners.
 medicalCosts.transaction=Medicine costs for {0}
+mentalBreak.check=Resisting Mental Break
 # Bioweapon Attack
 bioweaponAttack.inCharacter={0}, this is an emergency.\
   <p>I''ve just confirmed the release of an engineered biological agent within the current system. Multiple \

--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -157,6 +157,7 @@ unableToEnterSystem.outlawed.ooc=Outlawing can occur as the result of supremely 
   contract from an enemy of the system owners.
 medicalCosts.transaction=Medicine costs for {0}
 mentalBreak.check=Resisting Mental Break
+discontinuationSyndrome.check=Resisting Discontinuation Syndrome
 # Bioweapon Attack
 bioweaponAttack.inCharacter={0}, this is an emergency.\
   <p>I''ve just confirmed the release of an engineered biological agent within the current system. Multiple \

--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -347,6 +347,9 @@ miTryingToConceive.toolTipText=If this is selected, the person has a chance to h
 miHidePersonality.text=Hide Personality
 miHidePersonality.toolTipText=If this is selected, the character's personality description will be hidden. This is useful\
   \ if you want to write your own description.
+coverIllicitMedicalExpenses.text=Cover Illicit Medical Expenses
+coverIllicitMedicalExpenses.toolTipText=If this is selected, the campaign will pay for any illicit substances the \
+  character imbibes.
 ### Randomization Menu
 randomizationMenu.text=Randomization
 miRandomName.single.text=Randomize Name

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -45,6 +45,7 @@ import static mekhq.campaign.enums.DailyReportType.GENERAL;
 import static mekhq.campaign.enums.DailyReportType.MEDICAL;
 import static mekhq.campaign.enums.DailyReportType.PERSONNEL;
 import static mekhq.campaign.enums.DailyReportType.POLITICS;
+import static mekhq.campaign.enums.DailyReportType.SKILL_CHECKS;
 import static mekhq.campaign.enums.DailyReportType.TECHNICAL;
 import static mekhq.campaign.force.CombatTeam.recalculateCombatTeams;
 import static mekhq.campaign.force.Formation.FORMATION_ORIGIN;
@@ -84,6 +85,7 @@ import static mekhq.campaign.universe.Faction.MERCENARY_FACTION_CODE;
 import static mekhq.campaign.universe.Faction.PIRATE_FACTION_CODE;
 import static mekhq.campaign.universe.factionStanding.FactionStandingUtilities.PIRACY_SUCCESS_INDEX_FACTION_CODE;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
 import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
 import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
 
@@ -158,6 +160,7 @@ import mekhq.campaign.personnel.medical.MedicalController;
 import mekhq.campaign.personnel.medical.advancedMedicalAlternate.AdvancedMedicalAlternateImplants;
 import mekhq.campaign.personnel.medical.advancedMedicalAlternate.InjurySubType;
 import mekhq.campaign.personnel.medical.advancedMedicalAlternate.Inoculations;
+import mekhq.campaign.personnel.skills.AttributeCheckUtility;
 import mekhq.campaign.personnel.skills.EscapeSkills;
 import mekhq.campaign.personnel.skills.QuickTrain;
 import mekhq.campaign.personnel.skills.enums.AgingMilestone;
@@ -1605,7 +1608,7 @@ public class CampaignNewDayManager {
             if (!payForMedicine(person, cost)) {
                 int modifier = getCompulsionCheckModifier(MADNESS_FLASHBACKS);
 
-                boolean failedWillpowerCheck = performPersonalityBreakCheck(person, modifier);
+                boolean failedWillpowerCheck = performPersonalityBreakCheck(campaign, person, modifier);
 
                 person.processCripplingFlashbacks(campaign,
                       isUseAdvancedMedical,
@@ -1620,7 +1623,7 @@ public class CampaignNewDayManager {
 
             if (!payForMedicine(person, cost)) {
                 int modifier = getCompulsionCheckModifier(MADNESS_SPLIT_PERSONALITY);
-                boolean failedWillpowerCheck = performPersonalityBreakCheck(person, modifier);
+                boolean failedWillpowerCheck = performPersonalityBreakCheck(campaign, person, modifier);
                 String report = person.processSplitPersonality(true,
                       failedWillpowerCheck);
                 if (!report.isBlank()) {
@@ -1637,7 +1640,7 @@ public class CampaignNewDayManager {
 
             if (!payForMedicine(person, cost)) {
                 int modifier = getCompulsionCheckModifier(MADNESS_CLINICAL_PARANOIA);
-                boolean failedWillpowerCheck = performPersonalityBreakCheck(person, modifier);
+                boolean failedWillpowerCheck = performPersonalityBreakCheck(campaign, person, modifier);
                 String report = person.processClinicalParanoia(true,
                       failedWillpowerCheck);
                 if (!report.isBlank()) {
@@ -1651,7 +1654,7 @@ public class CampaignNewDayManager {
 
             if (!payForMedicine(person, cost)) {
                 int modifier = getCompulsionCheckModifier(MADNESS_REGRESSION);
-                boolean failedWillpowerCheck = performPersonalityBreakCheck(person, modifier);
+                boolean failedWillpowerCheck = performPersonalityBreakCheck(campaign, person, modifier);
                 String report = person.processChildlikeRegression(campaign,
                       isUseAdvancedMedical,
                       isUseAltAdvancedMedical,
@@ -1668,7 +1671,7 @@ public class CampaignNewDayManager {
 
             if (!payForMedicine(person, cost)) {
                 int modifier = getCompulsionCheckModifier(MADNESS_CATATONIA);
-                boolean failedWillpowerCheck = performPersonalityBreakCheck(person, modifier);
+                boolean failedWillpowerCheck = performPersonalityBreakCheck(campaign, person, modifier);
                 String report = person.processCatatonia(campaign,
                       isUseAdvancedMedical,
                       isUseAltAdvancedMedical,
@@ -1685,7 +1688,7 @@ public class CampaignNewDayManager {
 
             if (!payForMedicine(person, cost)) {
                 int modifier = getCompulsionCheckModifier(MADNESS_BERSERKER);
-                boolean failedWillpowerCheck = performPersonalityBreakCheck(person, modifier);
+                boolean failedWillpowerCheck = performPersonalityBreakCheck(campaign, person, modifier);
                 String report = person.processBerserkerFrenzy(campaign,
                       isUseAdvancedMedical,
                       true,
@@ -1703,7 +1706,7 @@ public class CampaignNewDayManager {
 
             if (!payForMedicine(person, cost)) {
                 int modifier = getCompulsionCheckModifier(MADNESS_HYSTERIA);
-                boolean failedWillpowerCheck = performPersonalityBreakCheck(person, modifier);
+                boolean failedWillpowerCheck = performPersonalityBreakCheck(campaign, person, modifier);
                 String report = person.processHysteria(campaign,
                       true,
                       isUseAdvancedMedical,
@@ -1725,6 +1728,7 @@ public class CampaignNewDayManager {
     /**
      * Determines if a willpower check has failed for the given person with the specified modifier.
      *
+     * @param campaign The campaign context, needed for reporting skill check results.
      * @param person The person for whom the willpower check is being performed.
      * @param modifier An integer value representing the modification to the willpower check.
      * @return {@code true} if the willpower check has failed; {@code false} otherwise.
@@ -1732,9 +1736,20 @@ public class CampaignNewDayManager {
      * @since 0.51.0
      * @author Illiani
      */
-    private static boolean performPersonalityBreakCheck(Person person, int modifier) {
-        return !performQuickAttributeCheck(person, SkillAttribute.WILLPOWER, null,
-              null, modifier);
+    private static boolean performPersonalityBreakCheck(Campaign campaign, Person person, int modifier) {
+        String reason = getTextAt(RESOURCE_BUNDLE, "mentalBreak.check");
+        AttributeCheckUtility attributeCheck = new AttributeCheckUtility(reason,
+              person,
+              SkillAttribute.WILLPOWER,
+              null,
+              null,
+              modifier,
+              true,
+              true);
+
+        campaign.addReport(SKILL_CHECKS, attributeCheck.getResultsText());
+
+        return !attributeCheck.isSuccess();
     }
 
     /**
@@ -1811,7 +1826,7 @@ public class CampaignNewDayManager {
     private void checkForDiscontinuationSyndrome(Person person, boolean isUseAdvancedMedical,
           boolean isUseAltAdvancedMedical, boolean isUseFatigue, int fatigueRate) {
         int modifier = getCompulsionCheckModifier(COMPULSION_ADDICTION);
-        boolean failedWillpowerCheck = performPersonalityBreakCheck(person, modifier);
+        boolean failedWillpowerCheck = performPersonalityBreakCheck(campaign, person, modifier);
         person.processDiscontinuationSyndrome(campaign,
               isUseAdvancedMedical,
               isUseAltAdvancedMedical,

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -35,6 +35,7 @@ package mekhq.campaign;
 
 import static java.lang.Math.ceil;
 import static java.lang.Math.max;
+import static java.lang.Math.round;
 import static megamek.common.compute.Compute.d6;
 import static megamek.common.compute.Compute.randomInt;
 import static mekhq.campaign.enums.DailyReportType.ACQUISITIONS;
@@ -137,6 +138,7 @@ import mekhq.campaign.personnel.InjuryType;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.RandomDependents;
+import mekhq.campaign.personnel.SpecialAbility;
 import mekhq.campaign.personnel.autoAwards.AutoAwardsController;
 import mekhq.campaign.personnel.education.Academy;
 import mekhq.campaign.personnel.education.EducationController;
@@ -1575,8 +1577,7 @@ public class CampaignNewDayManager {
             int totalProstheticCount = getTotalProstheticCount(person);
 
             Money cost = Money.of(PersonnelOptions.PAINKILLER_COST * totalProstheticCount);
-            if (!finances.debit(TransactionType.MEDICAL_EXPENSES, today, cost,
-                  getFormattedTextAt(RESOURCE_BUNDLE, "painkillerAddiction.transaction", person.getFullTitle()))) {
+            if (!payForMedicine(person, cost)) {
                 checkForDiscontinuationSyndrome(person,
                       isUseAdvancedMedical,
                       isUseAltAdvancedMedical,
@@ -1594,103 +1595,185 @@ public class CampaignNewDayManager {
         }
 
         if (personnelOptions.booleanOption(MADNESS_FLASHBACKS)) {
-            int modifier = getCompulsionCheckModifier(MADNESS_FLASHBACKS);
-            boolean failedWillpowerCheck = !performQuickAttributeCheck(person, SkillAttribute.WILLPOWER, null,
-                  null, modifier);
-            person.processCripplingFlashbacks(campaign,
-                  isUseAdvancedMedical,
-                  isUseAltAdvancedMedical,
-                  true,
-                  failedWillpowerCheck);
+            Money cost = getMedicalCostFromSPAXPCost(MADNESS_FLASHBACKS);
+
+            if (!payForMedicine(person, cost)) {
+                int modifier = getCompulsionCheckModifier(MADNESS_FLASHBACKS);
+
+                boolean failedWillpowerCheck = performPersonalityBreakCheck(person, modifier);
+
+                person.processCripplingFlashbacks(campaign,
+                      isUseAdvancedMedical,
+                      isUseAltAdvancedMedical,
+                      true,
+                      failedWillpowerCheck);
+            }
         }
 
         if (personnelOptions.booleanOption(MADNESS_SPLIT_PERSONALITY)) {
-            int modifier = getCompulsionCheckModifier(MADNESS_SPLIT_PERSONALITY);
-            boolean failedWillpowerCheck = !performQuickAttributeCheck(person, SkillAttribute.WILLPOWER, null,
-                  null, modifier);
-            String report = person.processSplitPersonality(true,
-                  failedWillpowerCheck);
-            if (!report.isBlank()) {
-                campaign.addReport(MEDICAL, report);
+            Money cost = getMedicalCostFromSPAXPCost(MADNESS_SPLIT_PERSONALITY);
+
+            if (!payForMedicine(person, cost)) {
+                int modifier = getCompulsionCheckModifier(MADNESS_SPLIT_PERSONALITY);
+                boolean failedWillpowerCheck = performPersonalityBreakCheck(person, modifier);
+                String report = person.processSplitPersonality(true,
+                      failedWillpowerCheck);
+                if (!report.isBlank()) {
+                    campaign.addReport(MEDICAL, report);
+                }
             }
         }
 
-        boolean resetClinicalParanoia = true;
+        boolean resetClinicalParanoia = true; // See comment at end of method
         if (personnelOptions.booleanOption(MADNESS_CLINICAL_PARANOIA)) {
-            int modifier = getCompulsionCheckModifier(MADNESS_CLINICAL_PARANOIA);
-            boolean failedWillpowerCheck = !performQuickAttributeCheck(person, SkillAttribute.WILLPOWER, null,
-                  null, modifier);
-            String report = person.processClinicalParanoia(true,
-                  failedWillpowerCheck);
-            if (!report.isBlank()) {
-                campaign.addReport(MEDICAL, report);
-            }
-
             resetClinicalParanoia = false;
+
+            Money cost = getMedicalCostFromSPAXPCost(MADNESS_CLINICAL_PARANOIA);
+
+            if (!payForMedicine(person, cost)) {
+                int modifier = getCompulsionCheckModifier(MADNESS_CLINICAL_PARANOIA);
+                boolean failedWillpowerCheck = performPersonalityBreakCheck(person, modifier);
+                String report = person.processClinicalParanoia(true,
+                      failedWillpowerCheck);
+                if (!report.isBlank()) {
+                    campaign.addReport(MEDICAL, report);
+                }
+            }
         }
 
         if (personnelOptions.booleanOption(MADNESS_REGRESSION)) {
-            int modifier = getCompulsionCheckModifier(MADNESS_REGRESSION);
-            boolean failedWillpowerCheck = !performQuickAttributeCheck(person, SkillAttribute.WILLPOWER, null,
-                  null, modifier);
-            String report = person.processChildlikeRegression(campaign,
-                  isUseAdvancedMedical,
-                  isUseAltAdvancedMedical,
-                  true,
-                  failedWillpowerCheck);
-            if (!report.isBlank()) {
-                campaign.addReport(MEDICAL, report);
+            Money cost = getMedicalCostFromSPAXPCost(MADNESS_REGRESSION);
+
+            if (!payForMedicine(person, cost)) {
+                int modifier = getCompulsionCheckModifier(MADNESS_REGRESSION);
+                boolean failedWillpowerCheck = performPersonalityBreakCheck(person, modifier);
+                String report = person.processChildlikeRegression(campaign,
+                      isUseAdvancedMedical,
+                      isUseAltAdvancedMedical,
+                      true,
+                      failedWillpowerCheck);
+                if (!report.isBlank()) {
+                    campaign.addReport(MEDICAL, report);
+                }
             }
         }
 
         if (personnelOptions.booleanOption(MADNESS_CATATONIA)) {
-            int modifier = getCompulsionCheckModifier(MADNESS_CATATONIA);
-            boolean failedWillpowerCheck = !performQuickAttributeCheck(person, SkillAttribute.WILLPOWER, null,
-                  null, modifier);
-            String report = person.processCatatonia(campaign,
-                  isUseAdvancedMedical,
-                  isUseAltAdvancedMedical,
-                  true,
-                  failedWillpowerCheck);
-            if (!report.isBlank()) {
-                campaign.addReport(MEDICAL, report);
+            Money cost = getMedicalCostFromSPAXPCost(MADNESS_CATATONIA);
+
+            if (!payForMedicine(person, cost)) {
+                int modifier = getCompulsionCheckModifier(MADNESS_CATATONIA);
+                boolean failedWillpowerCheck = performPersonalityBreakCheck(person, modifier);
+                String report = person.processCatatonia(campaign,
+                      isUseAdvancedMedical,
+                      isUseAltAdvancedMedical,
+                      true,
+                      failedWillpowerCheck);
+                if (!report.isBlank()) {
+                    campaign.addReport(MEDICAL, report);
+                }
             }
         }
 
         if (personnelOptions.booleanOption(MADNESS_BERSERKER)) {
-            int modifier = getCompulsionCheckModifier(MADNESS_BERSERKER);
-            boolean failedWillpowerCheck = !performQuickAttributeCheck(person, SkillAttribute.WILLPOWER, null,
-                  null, modifier);
-            String report = person.processBerserkerFrenzy(campaign,
-                  isUseAdvancedMedical,
-                  true,
-                  failedWillpowerCheck);
-            if (!report.isBlank()) {
-                campaign.addReport(MEDICAL, report);
+            Money cost = getMedicalCostFromSPAXPCost(MADNESS_BERSERKER);
+
+            if (!payForMedicine(person, cost)) {
+                int modifier = getCompulsionCheckModifier(MADNESS_BERSERKER);
+                boolean failedWillpowerCheck = performPersonalityBreakCheck(person, modifier);
+                String report = person.processBerserkerFrenzy(campaign,
+                      isUseAdvancedMedical,
+                      true,
+                      failedWillpowerCheck);
+                if (!report.isBlank()) {
+                    campaign.addReport(MEDICAL, report);
+                }
             }
         }
 
         if (personnelOptions.booleanOption(MADNESS_HYSTERIA)) {
-            int modifier = getCompulsionCheckModifier(MADNESS_HYSTERIA);
-            boolean failedWillpowerCheck = !performQuickAttributeCheck(person, SkillAttribute.WILLPOWER, null,
-                  null, modifier);
-            String report = person.processHysteria(campaign,
-                  true,
-                  isUseAdvancedMedical,
-                  isUseAltAdvancedMedical,
-                  failedWillpowerCheck);
-            if (!report.isBlank()) {
-                campaign.addReport(MEDICAL, report);
-            }
-
             resetClinicalParanoia = false;
+
+            Money cost = getMedicalCostFromSPAXPCost(MADNESS_HYSTERIA);
+
+            if (!payForMedicine(person, cost)) {
+                int modifier = getCompulsionCheckModifier(MADNESS_HYSTERIA);
+                boolean failedWillpowerCheck = performPersonalityBreakCheck(person, modifier);
+                String report = person.processHysteria(campaign,
+                      true,
+                      isUseAdvancedMedical,
+                      isUseAltAdvancedMedical,
+                      failedWillpowerCheck);
+                if (!report.isBlank()) {
+                    campaign.addReport(MEDICAL, report);
+                }
+            }
         }
 
-        // This is necessary to stop a character from getting permanently locked in a paranoia state if the
-        // relevant madness are removed.
+        // This is necessary to stop a character from getting permanently locked in a paranoia state if the relevant
+        // madness is removed.
         if (resetClinicalParanoia) {
             person.setSufferingFromClinicalParanoia(false);
         }
+    }
+
+    /**
+     * Determines if a willpower check has failed for the given person with the specified modifier.
+     *
+     * @param person The person for whom the willpower check is being performed.
+     * @param modifier An integer value representing the modification to the willpower check.
+     * @return {@code true} if the willpower check has failed; {@code false} otherwise.
+     *
+     * @since 0.51.0
+     * @author Illiani
+     */
+    private static boolean performPersonalityBreakCheck(Person person, int modifier) {
+        return !performQuickAttributeCheck(person, SkillAttribute.WILLPOWER, null,
+              null, modifier);
+    }
+
+    /**
+     * Processes the payment for medicine by debiting the specified cost from the person's finances.
+     *
+     * @param person the person for whom the payment is being made
+     * @param cost the amount of money to be debited for the medicine
+     * @return {@code true} if the payment was successful
+     *
+     * @since 0.51.0
+     * @author Illiani
+     */
+    private boolean payForMedicine(Person person, Money cost) {
+        return finances.debit(TransactionType.MEDICAL_EXPENSES, today, cost,
+              getFormattedTextAt(RESOURCE_BUNDLE, "medicalCosts.transaction", person.getFullTitle()));
+    }
+
+    /**
+     * Calculates the medical cost to ignore a Flaw or negative SPA.
+     *
+     * <p>
+     *     Cost is derived from the XP cost of the Flaw divided by 100 (rounded normally). It has a minimum value of
+     *     {@link PersonnelOptions#PAINKILLER_COST}.
+     * </p>
+     *
+     * @param spaKey the key representing a special ability, used to fetch its associated cost multiplier.
+     * @return the calculated medical cost, which is derived from the base painkiller cost and adjusted based on the
+     * special ability's cost multiplier. Returns at least the base painkiller cost.
+     *
+     * @since 0.51.0
+     * @author Illiani
+     */
+    private static Money getMedicalCostFromSPAXPCost(String spaKey) {
+        Map<String, SpecialAbility> specialAbilityMap = SpecialAbility.getSpecialAbilities();
+
+        SpecialAbility specialAbility = specialAbilityMap.get(spaKey);
+
+        double multiplier = specialAbility == null ? 1.0 : specialAbility.getCost() / 100.0;
+        int cost = (int) round(PersonnelOptions.PAINKILLER_COST * multiplier);
+
+        // The cost of Flaws is always negative, so we need to invert the sign
+        cost = max(-cost, PersonnelOptions.PAINKILLER_COST);
+
+        return Money.of(cost);
     }
 
     private static int getTotalProstheticCount(Person person) {
@@ -1723,8 +1806,7 @@ public class CampaignNewDayManager {
     private void checkForDiscontinuationSyndrome(Person person, boolean isUseAdvancedMedical,
           boolean isUseAltAdvancedMedical, boolean isUseFatigue, int fatigueRate) {
         int modifier = getCompulsionCheckModifier(COMPULSION_ADDICTION);
-        boolean failedWillpowerCheck = !performQuickAttributeCheck(person, SkillAttribute.WILLPOWER, null,
-              null, modifier);
+        boolean failedWillpowerCheck = performPersonalityBreakCheck(person, modifier);
         person.processDiscontinuationSyndrome(campaign,
               isUseAdvancedMedical,
               isUseAltAdvancedMedical,

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -1826,7 +1826,20 @@ public class CampaignNewDayManager {
     private void checkForDiscontinuationSyndrome(Person person, boolean isUseAdvancedMedical,
           boolean isUseAltAdvancedMedical, boolean isUseFatigue, int fatigueRate) {
         int modifier = getCompulsionCheckModifier(COMPULSION_ADDICTION);
-        boolean failedWillpowerCheck = performPersonalityBreakCheck(campaign, person, modifier);
+
+        String reason = getTextAt(RESOURCE_BUNDLE, "discontinuationSyndrome.check");
+        AttributeCheckUtility attributeCheck = new AttributeCheckUtility(reason,
+              person,
+              SkillAttribute.WILLPOWER,
+              null,
+              null,
+              modifier,
+              true,
+              true);
+
+        campaign.addReport(SKILL_CHECKS, attributeCheck.getResultsText());
+
+        boolean failedWillpowerCheck = attributeCheck.isSuccess();
         person.processDiscontinuationSyndrome(campaign,
               isUseAdvancedMedical,
               isUseAltAdvancedMedical,

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -1587,11 +1587,16 @@ public class CampaignNewDayManager {
         }
 
         if (personnelOptions.booleanOption(COMPULSION_ADDICTION)) {
-            checkForDiscontinuationSyndrome(person,
-                  isUseAdvancedMedical,
-                  isUseAltAdvancedMedical,
-                  isUseFatigue,
-                  fatigueRate);
+            boolean isCampaignSubsidizedDrugAbuse = person.isCoverIllicitMedicalExpenses();
+
+            Money cost = getMedicalCostFromSPAXPCost(COMPULSION_ADDICTION);
+            if (!isCampaignSubsidizedDrugAbuse || !payForMedicine(person, cost)) {
+                checkForDiscontinuationSyndrome(person,
+                      isUseAdvancedMedical,
+                      isUseAltAdvancedMedical,
+                      isUseFatigue,
+                      fatigueRate);
+            }
         }
 
         if (personnelOptions.booleanOption(MADNESS_FLASHBACKS)) {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -406,6 +406,7 @@ public class Person {
     private boolean salvageSupervisor;
     private boolean underProtection;
     private boolean neverAssignMaintenanceAutomatically;
+    private boolean coverIllicitMedicalExpenses;
     // this is a flag used in determine whether a person is a potential marriage candidate provided that they are not
     // married, are old enough, etc.
     @Deprecated(since = "0.50.10", forRemoval = true)
@@ -639,6 +640,7 @@ public class Person {
         }
         underProtection = false;
         neverAssignMaintenanceAutomatically = false;
+        coverIllicitMedicalExpenses = true;
 
         // region Flags
         setClanPersonnel(originFaction.isClan());
@@ -3124,6 +3126,14 @@ public class Person {
         this.neverAssignMaintenanceAutomatically = neverAssignMaintenanceAutomatically;
     }
 
+    public boolean isCoverIllicitMedicalExpenses() {
+        return coverIllicitMedicalExpenses;
+    }
+
+    public void setCoverIllicitMedicalExpenses(final boolean coverIllicitMedicalExpenses) {
+        this.coverIllicitMedicalExpenses = coverIllicitMedicalExpenses;
+    }
+
     public boolean isEmployed() {
         return status != PersonnelStatus.CAMP_FOLLOWER;
     }
@@ -3738,6 +3748,10 @@ public class Person {
                   indent,
                   "neverAssignMaintenanceAutomatically",
                   neverAssignMaintenanceAutomatically);
+            MHQXMLUtility.writeSimpleXMLTag(pw,
+                  indent,
+                  "coverIllicitMedicalExpenses",
+                  coverIllicitMedicalExpenses);
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "marriageable", marriageable);
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "prefersMen", prefersMen);
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "prefersWomen", prefersWomen);
@@ -4365,6 +4379,8 @@ public class Person {
                     person.setUnderProtection(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (nodeName.equalsIgnoreCase("neverAssignMaintenanceAutomatically")) {
                     person.setNeverAssignMaintenanceAutomatically(Boolean.parseBoolean(wn2.getTextContent().trim()));
+                } else if (nodeName.equalsIgnoreCase("coverIllicitMedicalExpenses")) {
+                    person.setCoverIllicitMedicalExpenses(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (nodeName.equalsIgnoreCase("marriageable")) { // Legacy: <50.10
                     boolean marriageable = Boolean.parseBoolean(wn2.getTextContent().trim());
                     CampaignOptions campaignOptions = campaign.getCampaignOptions();

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -3955,6 +3955,17 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
         }));
         menu.add(cbMenuItem);
 
+        cbMenuItem = new JCheckBoxMenuItem(resources.getString("coverIllicitMedicalExpenses.text"));
+        cbMenuItem.setToolTipText(MultiLineTooltip.splitToolTip(resources.getString("coverIllicitMedicalExpenses.toolTipText"),
+              100));
+        cbMenuItem.setName("coverIllicitMedicalExpenses");
+        cbMenuItem.setSelected(selected.length == 1 && person.isCoverIllicitMedicalExpenses());
+        cbMenuItem.addActionListener(evt -> Stream.of(selected).forEach(selectedPerson -> {
+            selectedPerson.setCoverIllicitMedicalExpenses(!selectedPerson.isCoverIllicitMedicalExpenses());
+            MekHQ.triggerEvent(new PersonChangedEvent(selectedPerson));
+        }));
+        menu.add(cbMenuItem);
+
         JMenuHelpers.addMenuIfNonEmpty(popup, menu);
         // endregion Flags Menu
 


### PR DESCRIPTION
# Requires #8963

Previously mental break skill checks were hidden from the player, this was done in a pre-tabbed daily report world. We hid skill checks to avoid message spam. Now we have tabbed daily reports this is no longer an issue.