### PR TITLE
Fix #8862: Added Notice to Clarify Surgeon Selection for Advanced Surgeries

### DIFF
--- a/MekHQ/resources/mekhq/resources/AdvancedReplacementLimbDialog.properties
+++ b/MekHQ/resources/mekhq/resources/AdvancedReplacementLimbDialog.properties
@@ -39,7 +39,8 @@ AdvancedReplacementLimbDialog.button.gmMode=(GM) Relaunch in GM Mode
 AdvancedReplacementLimbDialog.combo.none.label=None
 AdvancedReplacementLimbDialog.combo.none.tooltip=No treatment selected
 AdvancedReplacementLimbDialog.status.selected=<b>Selected:</b> {0} surgery(s)
-AdvancedReplacementLimbDialog.status.difficulty=<b>Surgery Skill Level Required:</b> {0}
+AdvancedReplacementLimbDialog.status.difficulty=<b>Surgery Skill Level Required:</b> {0} (Top-Ranked Surgeon Will\
+  \ Be Used, Regardless of Skill Level)
 AdvancedReplacementLimbDialog.status.localSurgeon=<b>Using Local Surgeon</b> Cost increased tenfold
 AdvancedReplacementLimbDialog.status.localSurgeon.transit=<b>Unable to find a local surgeon in space</b>
 AdvancedReplacementLimbDialog.status.surgeon=<b>Surgeon:</b> {0} (Skill Level {1}, TN {2}+)


### PR DESCRIPTION
Fix #8862

For Advanced Surgeries, when selecting which doctor will perform the surgery the highest ranked surgeon will be picked. Even if that character is of lower skill than another character. This can create confusion in the event a lower ranked surgeon can perform the surgery but the senior surgeon cannot.

It would be possible to change this so that the highest _skilled_ surgeon performs the surgery however we need to ensure that this remains predictable as certain SPAs can influence the TN.

Therefore we have kept the picker working the same, but instead went ahead and added some text to clarify how surgeon is picked.