### PR TITLE
Fix #8851: Fix Temp Vessel Crew being hired for Superheavy Meks

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -8362,7 +8362,8 @@ public class Campaign implements ITechManager {
                  VEHICLE_CREW_NAVAL,
                  VESSEL_PILOT -> unit.getDriverRole() == role;
             case VESSEL_GUNNER -> unit.getGunnerRole() == role;
-            case VESSEL_CREW -> unit.canTakeMoreVesselCrew(); // ??
+            case VESSEL_CREW -> (unit.getEntity() instanceof Aero aero && !(aero instanceof ConvFighter)) &&
+                                      unit.canTakeMoreVesselCrew();
             default -> false;
         };
     }


### PR DESCRIPTION
Fixes #8851 

Temp vessel crew will no longer be hired to try and crew superheavy meks.