### PR TITLE
Fix the reported Exam value by using the calculated value fixes #8776

### DIFF
--- a/MekHQ/src/mekhq/campaign/randomEvents/personalities/PersonalityController.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/personalities/PersonalityController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2024-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -232,8 +232,7 @@ public class PersonalityController {
 
         // Reasoning and personality quirk are handled differently to general personality traits.
         // Build the description proper
-        Reasoning reasoning = person.getReasoning();
-        String examResults = reasoning.getExamResults();
+        String examResults = person.getReasoning().getExamResults(person.getPerformanceExamScore());
         StringBuilder interviewersNotes = new StringBuilder("<html>");
 
         interviewersNotes.append(examResults);

--- a/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/Reasoning.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/Reasoning.java
@@ -197,7 +197,7 @@ public enum Reasoning {
      * @deprecated use {@link #getExamResults(int)} instead.
      *
      */
-    @Deprecated(since = "{SEMVER}", forRemoval = true)
+    @Deprecated(since = "0.51.00", forRemoval = true)
     public String getExamResults() {
         return getFormattedTextAt(RESOURCE_BUNDLE, "examResults.text", getExamScore());
     }

--- a/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/Reasoning.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/Reasoning.java
@@ -213,8 +213,8 @@ public enum Reasoning {
      * @author Illiani
      * @since 0.50.06
      */
-    public String getExamResults(int examscore) {
-        return getFormattedTextAt(RESOURCE_BUNDLE, "examResults.text", examscore);
+    public String getExamResults(final int examScore) {
+        return getFormattedTextAt(RESOURCE_BUNDLE, "examResults.text", examScore);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/Reasoning.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/Reasoning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2024-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -194,18 +194,27 @@ public enum Reasoning {
     }
 
     /**
+     * @deprecated use {@link #getExamResults(int)} instead.
+     *
+     */
+    @Deprecated(since = "{SEMVER}", forRemoval = true)
+    public String getExamResults() {
+        return getFormattedTextAt(RESOURCE_BUNDLE, "examResults.text", getExamScore());
+    }
+
+    /**
      * Retrieves the formatted exam results text.
      *
-     * <p>Calculates the result percentage based on the current {@code level} relative to {@code GENIUS.level},
-     * and uses this value to format the exam results text from the resource bundle.</p>
+     * <p>Uses the supplied result percentage (that was calculated earlier using {@link #getExamScore()} ) to format
+     * the exam results text from the resource bundle.</p>
      *
-     * @return the formatted exam results string with the calculated percentage inserted.
+     * @return the formatted exam results string with the supplied result percentage inserted.
      *
      * @author Illiani
      * @since 0.50.06
      */
-    public String getExamResults() {
-        return getFormattedTextAt(RESOURCE_BUNDLE, "examResults.text", getExamScore());
+    public String getExamResults(int examscore) {
+        return getFormattedTextAt(RESOURCE_BUNDLE, "examResults.text", examscore);
     }
 
     /**

--- a/MekHQ/unittests/mekhq/campaign/randomEvents/personalities/enums/ReasoningTest.java
+++ b/MekHQ/unittests/mekhq/campaign/randomEvents/personalities/enums/ReasoningTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -37,6 +37,7 @@ import static mekhq.campaign.randomEvents.personalities.enums.Reasoning.OBTUSE;
 import static mekhq.campaign.randomEvents.personalities.enums.Reasoning.UNDER_PERFORMING;
 import static mekhq.utilities.MHQInternationalization.isResourceKeyValid;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -82,5 +83,13 @@ public class ReasoningTest {
             String label = status.getLabel();
             assertTrue(isResourceKeyValid(label));
         }
+    }
+
+    @Test
+    public void testGetExamResultsWithSpecificScore() {
+        int testScore = 55;
+        String result = Reasoning.AVERAGE.getExamResults(testScore);
+        assertNotNull(result);
+        assertTrue(result.contains("55"));
     }
 }


### PR DESCRIPTION
The Personel market shows an 'Exam %' column in the table with all personnel, while the detail pane of an individual person shows an 'Performance Exam' item. These two items refer to the same thing, but the values (almost) never match. The reason is that calculating the value involves a small random up-or-down modifier.

This PR fixes this by using the stored value of the calculation (which is used in the column) to feed to the detail pane, instead of calculating the value a second time.

fixes #8776 

NOTE: PR #8909 fixes the seperate issue of the tooltip showing the wrong state that is also mentioned in #8776