### PR TITLE
Fixed Bloodmark Handling in Education System

### DIFF
--- a/MekHQ/resources/mekhq/resources/Education.properties
+++ b/MekHQ/resources/mekhq/resources/Education.properties
@@ -87,6 +87,7 @@ eventWarExpelled.text=%s's education has been interrupted by the outbreak of war
 eventTrainingAccident.text=%s has suffered a serious training accident. %s
 eventTrainingAccidentWounded.text=They've %sbeen hospitalized%s for %s days while they recover.
 eventTrainingAccidentKilled.text=Sadly, %sthey didn't survive%s.
+eventTrainingAccidentSuspicious.text=The accident occurred under suspicious circumstances.
 #### Graduation (Inner Sphere)
 dropOut.text=%s has %sdropped out%s of their education or training. Tomorrow they will begin their journey back to the unit.
 dropOutHomeSchooled.text=%s has %sdropped out%s of their in-unit education or training.

--- a/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
+++ b/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
@@ -254,6 +254,9 @@ BLOODMARK.definition=Bloodmarks are a type of <a href='GLOSSARY:ATOW_TRAITS'>Tra
   <br>- <b>Bloodmark 5:</b> 1-in-5</p>\
   <p>If a Bloodhunt is successful, the character is dealt d6 <i>Hits</i> and the check is made again. This process is\
   \ repeated until the character is either killed or the Bloodhunt is unsuccessful.</p>\
+  <p><b>Education</b>: Characters in education are not traditionally Bloodhunted. Instead, their chance of having a \
+  training 'accident' are increased based on their Bloodmark level. Furthermore, if a character has a Bloodmark they \
+  can suffer training 'accidents' even while in non-military academies.</p>\
   <p>Additional information about the Bloodmark Trait can be found in the 'Bloodmark' section of <b>A Time of War</b>.</p>
 ### C
 CANONICAL_DISEASES.title=Canonical Diseases & Bioweapons

--- a/MekHQ/src/mekhq/campaign/personnel/Bloodmark.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Bloodmark.java
@@ -173,6 +173,10 @@ public class Bloodmark {
             return false;
         }
 
+        if (target.getEduEducationTime() != 0) { // Student Bloodmarks are handled by the education system
+            return false;
+        }
+
         List<LocalDate> bloodhuntSchedule = target.getBloodhuntSchedule();
         if (bloodhuntSchedule.isEmpty()) {
             return false;

--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -33,6 +33,7 @@
 package mekhq.campaign.personnel.education;
 
 import static java.lang.Math.max;
+import static java.lang.Math.round;
 import static megamek.common.compute.Compute.d6;
 import static megamek.common.compute.Compute.randomInt;
 import static mekhq.campaign.enums.DailyReportType.FINANCES;
@@ -864,15 +865,23 @@ public class EducationController {
      */
     private static void checkForTrainingAccidents(Campaign campaign, Academy academy, Person person,
           ResourceBundle resources) {
-        if (academy.isMilitary()) {
-            int militaryDiceSize = campaign.getCampaignOptions().getMilitaryAcademyAccidents();
+        int bloodmarkSeverity = person.getBloodmark();
+        double bloodmarkDivisor = bloodmarkSeverity + 1;
+
+        int accidentDieSize = campaign.getCampaignOptions().getMilitaryAcademyAccidents();
+        accidentDieSize = (int) round(accidentDieSize / bloodmarkDivisor);
+
+        boolean isMilitary = academy.isMilitary();
+        boolean isBloodmarked = bloodmarkSeverity != 0;
+
+        if (academy.isMilitary() || bloodmarkSeverity != 0) {
             int roll;
 
-            if (militaryDiceSize > 1) {
-                roll = randomInt(militaryDiceSize);
+            if (accidentDieSize > 1) {
+                roll = randomInt(accidentDieSize);
 
                 if (academy.isHomeSchool()) {
-                    int secondRoll = randomInt(militaryDiceSize);
+                    int secondRoll = randomInt(accidentDieSize);
 
                     if (secondRoll < roll) {
                         roll = secondRoll;
@@ -894,6 +903,10 @@ public class EducationController {
                         String reportMessage = String.format(resources.getString("eventTrainingAccident.text"),
                               person.getHyperlinkedFullTitle(),
                               resultString);
+
+                        if (bloodmarkSeverity != 0) {
+                            reportMessage += ' ' + resources.getString("eventTrainingAccidentSuspicious.text");
+                        }
 
                         campaign.addReport(PERSONNEL, reportMessage);
 
@@ -926,6 +939,10 @@ public class EducationController {
         String reportMessage = String.format(resources.getString("eventTrainingAccident.text"),
               person.getHyperlinkedFullTitle(),
               resultString);
+
+        if (person.getBloodmark() != 0) {
+            reportMessage += ' ' + resources.getString("eventTrainingAccidentSuspicious.text");
+        }
 
         campaign.addReport(PERSONNEL, reportMessage);
 

--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -871,9 +871,6 @@ public class EducationController {
         int accidentDieSize = campaign.getCampaignOptions().getMilitaryAcademyAccidents();
         accidentDieSize = (int) round(accidentDieSize / bloodmarkDivisor);
 
-        boolean isMilitary = academy.isMilitary();
-        boolean isBloodmarked = bloodmarkSeverity != 0;
-
         if (academy.isMilitary() || bloodmarkSeverity != 0) {
             int roll;
 

--- a/MekHQ/src/mekhq/campaign/utilities/glossary/GlossaryEntry.java
+++ b/MekHQ/src/mekhq/campaign/utilities/glossary/GlossaryEntry.java
@@ -62,7 +62,7 @@ public enum GlossaryEntry {
     ATOW_TRAITS("ATOW_TRAITS", new Version("0.50.06")),
     ATTRIBUTE_SCORES("ATTRIBUTE_SCORES", new Version("0.50.06")),
     AUTOINFIRMARY("AUTOINFIRMARY", new Version("0.50.06")),
-    BLOODMARK("BLOODMARK", new Version("0.50.07")),
+    BLOODMARK("BLOODMARK", new Version("0.51.00")),
     CAPITAL_SYSTEMS("CAPITAL_SYSTEMS", new Version("0.50.06")),
     CHALLENGE_SKULLS("CHALLENGE_SKULLS", new Version("0.50.11")),
     CHANGING_FILTERS_HANGAR("CHANGING_FILTERS_HANGAR", new Version("0.50.06")),


### PR DESCRIPTION
Previously if a student had a Bloodmark value they could be Bloodhunted and injured. This resulted in injuries that couldn't be healed, because the character wasn't with the campaign. The student would then continue schooling with six broken arms and their bowels hanging out. Not ideal.

This PR addresses this by hooking into the Education injury system. Now Bloodmarked characters have an increased risk of 'accidents' while at school.