### PR TITLE
Add dismissal from infirmary to daily medical log (fixes #8664)

### DIFF
--- a/MekHQ/src/mekhq/campaign/log/MedicalLogger.java
+++ b/MekHQ/src/mekhq/campaign/log/MedicalLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2018-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -32,12 +32,15 @@
  */
 package mekhq.campaign.log;
 
+import static mekhq.campaign.enums.DailyReportType.MEDICAL;
+
 import java.text.MessageFormat;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.ResourceBundle;
 
 import mekhq.MekHQ;
+import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Injury;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.GenderDescriptors;
@@ -225,6 +228,12 @@ public class MedicalLogger {
     public static void dismissedFromInfirmary(Person person, LocalDate date) {
         person.addMedicalLogEntry(new MedicalLogEntry(date,
               logEntriesResourceMap.getString("dismissedFromInfirmary.text")));
+    }
+
+    public static void dismissedFromInfirmary(Person person, Campaign campaign) {
+        String message = person.getHyperlinkedName() + " " +
+                         logEntriesResourceMap.getString("dismissedFromInfirmary.text").toLowerCase();
+        campaign.addReport(MEDICAL, message);
     }
 
     public static void deliveredBaby(Person patient, Person baby, LocalDate date) {

--- a/MekHQ/src/mekhq/campaign/personnel/medical/MedicalController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/MedicalController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -50,6 +50,7 @@ import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.events.persons.PersonMedicalAssignmentEvent;
+import mekhq.campaign.log.MedicalLogger;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
 import mekhq.campaign.personnel.medical.advancedMedical.InjuryUtil;
@@ -147,6 +148,7 @@ public class MedicalController {
             // Handle Advanced Medical
             if (isUseAdvancedMedical) {
                 if (isUseAltAdvancedMedical) {
+                    AdvancedMedicalAlternateHealing.setCampaign(campaign);
                     AdvancedMedicalAlternateHealing.processNewDay(campaign.getLocalDate(),
                           campaign.getCampaignOptions().isUseFatigue(), campaign.getCampaignOptions().getFatigueRate(),
                           patient, doctor);
@@ -232,7 +234,11 @@ public class MedicalController {
         LOGGER.debug(skillCheckUtility.getResultsText());
 
         if (skillCheckUtility.isSuccess()) {
+            boolean inInfirmary = !(null == patient.getDoctorId());
             patient.heal();
+            if (inInfirmary && !patient.needsFixing() && patient.getPrisonerStatus().isFreeOrBondsman()) {
+                MedicalLogger.dismissedFromInfirmary(patient, campaign);
+            }
             Unit unit = patient.getUnit();
             if (unit != null) {
                 unit.resetPilotAndEntity();

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedical/InjuryUtil.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedical/InjuryUtil.java
@@ -599,7 +599,7 @@ public final class InjuryUtil {
                     dismissed = true;
                     MedicalLogger.dismissedFromInfirmary(person, campaign.getLocalDate());
                     //employed only; prisoners would probably be too much needless spam
-                    if (!person.getPrisonerStatus().isPrisoner()) {
+                    if (person.getPrisonerStatus().isFreeOrBondsman()) {
                         MedicalLogger.dismissedFromInfirmary(person, campaign);
                     }
                 }

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedical/InjuryUtil.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedical/InjuryUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2016-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -598,6 +598,10 @@ public final class InjuryUtil {
                 } else if (!person.needsFixing()) {
                     dismissed = true;
                     MedicalLogger.dismissedFromInfirmary(person, campaign.getLocalDate());
+                    //employed only; prisoners would probably be too much needless spam
+                    if (!person.getPrisonerStatus().isPrisoner()) {
+                        MedicalLogger.dismissedFromInfirmary(person, campaign);
+                    }
                 }
 
                 if (dismissed) {

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateHealing.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateHealing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -50,6 +50,7 @@ import java.util.Set;
 
 import megamek.common.TargetRollModifier;
 import megamek.common.annotations.Nullable;
+import mekhq.campaign.Campaign;
 import mekhq.campaign.log.MedicalLogger;
 import mekhq.campaign.log.PatientLogger;
 import mekhq.campaign.personnel.Injury;
@@ -74,6 +75,12 @@ import mekhq.campaign.personnel.skills.enums.SkillAttribute;
 public class AdvancedMedicalAlternateHealing {
     private static final String RESOURCE_BUNDLE = "mekhq.resources.AdvancedMedicalAlternateHealing";
     private static final int PROSTHETIC_PENALTY = 4; // Interstellar Operations page 70
+
+    private static Campaign campaign;
+
+    public static void setCampaign(Campaign campaign) {
+        AdvancedMedicalAlternateHealing.campaign = campaign;
+    }
 
     /**
      * Processes the start-of-day healing for a given patient.
@@ -451,6 +458,9 @@ public class AdvancedMedicalAlternateHealing {
             patient.removeInjury(injury, today);
 
             if (patient.getInjuries().isEmpty()) {
+                if (!(null == patient.getDoctorId()) && patient.getPrisonerStatus().isFreeOrBondsman()) {
+                    MedicalLogger.dismissedFromInfirmary(patient, campaign);
+                }
                 // AAM doesn't use 'days to wait for healing' so we just set it to '1.' If the player toggles AAM off,
                 // they will get a free day's worth of healing the next day, but that's not a huge issue.
                 patient.setDoctorId(null, 1); // Clear old doctor assignment, if any


### PR DESCRIPTION
When there are a large number of personnel getting wounded it can be hard to track who has recovered.

This PR fixes that by adding a log entry to the daily medical log when a person is dismissed from the infirmary. Prisoners are excluded from this, as reporting about those is not needed.

Fixes #8664 