### PR TITLE
Added Button to Access Quick Tech Assignment

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignGUI.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignGUI.properties
@@ -275,7 +275,7 @@ chkHideMothballed.text=Hide Mothballed
 chkHideMothballed.toolTipText=Hide mothballed units from the current view
 btnAssignTechs.text=Quick Assign Maintenance Techs
 btnAssignTechs.toolTipText=Assign maintenance techs to all unmaintained units, where possible. This is identical \
-  to the system found in MekHQ Options that assignments techs on new day.
+  to the system found in MekHQ Options that assigns techs on new day.
 lblUnitView.text=View:
 btnAddMission.toolTipText=Add a new mission. Missions are long-term assignments consisting of multiple scenarios.
 btnAddMission.text=Add Mission

--- a/MekHQ/resources/mekhq/resources/CampaignGUI.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignGUI.properties
@@ -273,6 +273,9 @@ choiceUnit.MothballedUnits.filter=All Mothballed Units
 choiceUnit.UnmaintainedUnits.filter=All Unmaintained Units
 chkHideMothballed.text=Hide Mothballed
 chkHideMothballed.toolTipText=Hide mothballed units from the current view
+btnAssignTechs.text=Quick Assign Maintenance Techs
+btnAssignTechs.toolTipText=Assign maintenance techs to all unmaintained units, where possible. This is identical \
+  to the system found in MekHQ Options that assignments techs on new day.
 lblUnitView.text=View:
 btnAddMission.toolTipText=Add a new mission. Missions are long-term assignments consisting of multiple scenarios.
 btnAddMission.text=Add Mission

--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -940,6 +940,9 @@ optionStratConDeployConfirmation.toolTipText=This allows you to skip the confirm
 optionAbandonUnitsConfirmation.text=Hide Abandon Units Confirmation Dialog
 optionAbandonUnitsConfirmation.toolTipText=This allows you to skip the confirmation dialog which confirms whether \
   you are happy abandoning non-jump capable units
+optionAssignTechsConfirmation.text=Hide Quick Assign Techs Confirmation Dialog
+optionAssignTechsConfirmation.toolTipText=This allows you to skip the confirmation dialog which confirms whether \
+  you are happy assigning techs to unmaintained units
 ## Miscellaneous Tab
 miscellaneousTab.title=Miscellaneous Options
 lblUserDir.text=User Files Directory:

--- a/MekHQ/resources/mekhq/resources/ImmersiveDialogConfirmation.properties
+++ b/MekHQ/resources/mekhq/resources/ImmersiveDialogConfirmation.properties
@@ -47,3 +47,14 @@ ImmersiveDialogConfirmation.confirmationFactionStandingsUltimatum.text.primary=T
   select 'confirm,' the consequences of your decision cannot be reversed.
 ImmersiveDialogConfirmation.confirmationAbandonUnits.text.primary=If you select 'confirm,' all non-jump capable units\
   \ will be permanently abandoned or sold (depending on the chosen option). This cannot be reversed.
+ImmersiveDialogConfirmation.confirmationAssignTechs.text.primary=If you select 'confirm,' all unmaintained units will\
+  \ be assigned a tech (where possible).\
+  <p>Assignment follows the following rules:</p>\
+  <p><b>-</b> All unmaintained units are sorted so that the most valuable units are assigned techs first.\
+  <br><b>-</b> All techs are sorted so that the tech with the fewest assigned units first. Tech skill is used as a \
+  tie-breaker.\
+  <br><b>-</b> Units that already have a tech assigned are ignored.</p>\
+  <h2 style="text-align:center">Did You Know?</h2>\
+  This process can be automated using the new day option found in MekHQ Options.\
+  <p>If selected, periodically, techs will be assigned to units without tech assignments. This follows the rules \
+  outlined above.</p>

--- a/MekHQ/resources/mekhq/resources/ImmersiveDialogConfirmation.properties
+++ b/MekHQ/resources/mekhq/resources/ImmersiveDialogConfirmation.properties
@@ -56,5 +56,5 @@ ImmersiveDialogConfirmation.confirmationAssignTechs.text.primary=If you select '
   <br><b>-</b> Units that already have a tech assigned are ignored.</p>\
   <h2 style="text-align:center">Did You Know?</h2>\
   This process can be automated using the new day option found in MekHQ Options.\
-  <p>If selected, periodically, techs will be assigned to units without tech assignments. This follows the rules \
+  <p>If selected, on each new day, techs will be assigned to units without tech assignments. This follows the rules \
   outlined above.</p>

--- a/MekHQ/src/mekhq/MHQConstants.java
+++ b/MekHQ/src/mekhq/MHQConstants.java
@@ -241,6 +241,7 @@ public final class MHQConstants extends SuiteConstants {
     public static final String CONFIRMATION_STRATCON_BATCHALL_BREACH = "confirmationStratConBatchallBreach";
     public static final String CONFIRMATION_STRATCON_DEPLOY = "confirmationStratConDeploy";
     public static final String CONFIRMATION_ABANDON_UNITS = "confirmationAbandonUnits";
+    public static final String CONFIRMATION_ASSIGN_TECHS = "confirmationAssignTechs";
     // endregion Nag Tab
 
     // region Miscellaneous Options

--- a/MekHQ/src/mekhq/gui/HangarTab.java
+++ b/MekHQ/src/mekhq/gui/HangarTab.java
@@ -74,7 +74,10 @@ import mekhq.campaign.events.units.UnitNewEvent;
 import mekhq.campaign.events.units.UnitRemovedEvent;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.UnitOrder;
+import mekhq.campaign.utilities.AutomatedTechAssignments;
 import mekhq.gui.adapter.UnitTableMouseAdapter;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogConfirmation;
+import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
 import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
 import mekhq.gui.enums.MHQTabType;
 import mekhq.gui.model.UnitTableModel;
@@ -85,6 +88,8 @@ import mekhq.gui.sorter.UnitStatusSorter;
 import mekhq.gui.sorter.UnitTypeSorter;
 import mekhq.gui.sorter.WeightClassSorter;
 import mekhq.gui.view.UnitViewPanel;
+
+import static mekhq.MHQConstants.CONFIRMATION_ASSIGN_TECHS;
 
 /**
  * Displays a table of all units in the force.
@@ -108,6 +113,7 @@ public final class HangarTab extends CampaignGuiTab {
     private JComboBox<String> choiceUnit;
     private JComboBox<String> choiceUnitView;
     private JCheckBox chkHideMothballed;
+    private JButton btnAssignTechs;
     private JScrollPane scrollUnitView;
 
     private UnitTableModel unitModel;
@@ -204,6 +210,18 @@ public final class HangarTab extends CampaignGuiTab {
         gridBagConstraints.insets = new Insets(5, 5, 0, 0);
         add(choiceUnitView, gridBagConstraints);
 
+        btnAssignTechs = new RoundedJButton(resourceMap.getString("btnAssignTechs.text"));
+        btnAssignTechs.setToolTipText(resourceMap.getString("btnAssignTechs.toolTipText"));
+        btnAssignTechs.addActionListener(ev -> quickAssignTechs());
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 5;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.fill = GridBagConstraints.NONE;
+        gridBagConstraints.weightx = 1.0;
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
+        gridBagConstraints.insets = new Insets(5, 5, 0, 0);
+        add(btnAssignTechs, gridBagConstraints);
+
         unitModel = new UnitTableModel(getCampaign());
         unitTable = new JTable(unitModel);
         unitTable.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
@@ -267,6 +285,22 @@ public final class HangarTab extends CampaignGuiTab {
         add(splitUnit, gridBagConstraints);
 
         UnitTableMouseAdapter.connect(getCampaignGui(), unitTable, unitModel, splitUnit);
+    }
+
+    private void quickAssignTechs() {
+        boolean wasConfirmedOverall;
+
+        if (!MekHQ.getMHQOptions().getNagDialogIgnore(CONFIRMATION_ASSIGN_TECHS)) {
+            ImmersiveDialogConfirmation confirmation = new ImmersiveDialogConfirmation(getCampaign(),
+                  CONFIRMATION_ASSIGN_TECHS);
+            wasConfirmedOverall = confirmation.wasConfirmed();
+        } else {
+            wasConfirmedOverall = true;
+        }
+
+        if (wasConfirmedOverall) {
+            AutomatedTechAssignments.handleTheAutomaticAssignmentOfUnmaintainedUnits(getCampaign());
+        }
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
@@ -238,6 +238,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
     private JCheckBox optionStratConBatchallBreachConfirmation;
     private JCheckBox optionStratConDeployConfirmation;
     private JCheckBox optionAbandonUnitsConfirmation;
+    private JCheckBox optionAssignTechsConfirmation;
 
     // endregion Nag Tab
 
@@ -1283,6 +1284,12 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
               "optionAbandonUnitsConfirmation.toolTipText"));
         optionAbandonUnitsConfirmation.setName("optionAbandonUnitsConfirmation");
 
+        optionAssignTechsConfirmation = new JCheckBox(resources.getString(
+              "optionAssignTechsConfirmation.text"));
+        optionAssignTechsConfirmation.setToolTipText(resources.getString(
+              "optionAssignTechsConfirmation.toolTipText"));
+        optionAssignTechsConfirmation.setName("optionAssignTechsConfirmation");
+
 
         // Layout the UI
         final JPanel panel = new JPanel();
@@ -1319,7 +1326,8 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
                                       .addComponent(optionBeginTransitConfirmation)
                                       .addComponent(optionStratConBatchallBreachConfirmation)
                                       .addComponent(optionStratConDeployConfirmation)
-                                      .addComponent(optionAbandonUnitsConfirmation));
+                                      .addComponent(optionAbandonUnitsConfirmation)
+                                      .addComponent(optionAssignTechsConfirmation));
 
         layout.setHorizontalGroup(layout.createParallelGroup(Alignment.LEADING)
                                         .addComponent(optionUnmaintainedUnitsNag)
@@ -1348,7 +1356,8 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
                                         .addComponent(optionBeginTransitConfirmation)
                                         .addComponent(optionStratConBatchallBreachConfirmation)
                                         .addComponent(optionStratConDeployConfirmation)
-                                        .addComponent(optionAbandonUnitsConfirmation));
+                                        .addComponent(optionAbandonUnitsConfirmation)
+                                        .addComponent(optionAssignTechsConfirmation));
 
         return panel;
     }
@@ -1712,6 +1721,9 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         options
               .setNagDialogIgnore(MHQConstants.CONFIRMATION_ABANDON_UNITS,
                     optionAbandonUnitsConfirmation.isSelected());
+        options
+              .setNagDialogIgnore(MHQConstants.CONFIRMATION_ASSIGN_TECHS,
+                    optionAssignTechsConfirmation.isSelected());
 
         PreferenceManager.getClientPreferences().setUserDir(txtUserDir.getText());
         PreferenceManager.getInstance().save();
@@ -1908,6 +1920,8 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
                                                            .getNagDialogIgnore(MHQConstants.CONFIRMATION_STRATCON_DEPLOY));
         optionAbandonUnitsConfirmation.setSelected(options
                                                          .getNagDialogIgnore(MHQConstants.CONFIRMATION_ABANDON_UNITS));
+        optionAssignTechsConfirmation.setSelected(options
+                                                         .getNagDialogIgnore(MHQConstants.CONFIRMATION_ASSIGN_TECHS));
         txtUserDir.setText(PreferenceManager.getClientPreferences().getUserDir());
         spnStartGameDelay.setValue(options.getStartGameDelay());
         spnStartGameClientDelay.setValue(options.getStartGameClientDelay());


### PR DESCRIPTION
Recently we opened a dialog with the user base to try and identify pain points and areas of friction.

One of the requested features was the ability to more easily assign techs to unassigned units. That technology was implemented earlier in the year but wasn't well advertised. Now we add a nice shiny ui button in the hangar for the user to mash which will not only assign techs, but also inform the user of the automated option in MekHQ Options.


https://github.com/user-attachments/assets/2beb6dc2-069a-4eaf-953e-38386cdb0a89


