### PR TITLE
Random Civilian Removal Fix

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/RandomDependents.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RandomDependents.java
@@ -151,8 +151,8 @@ public class RandomDependents {
     int prepareData() {
         int activeNonDependents = 0;
 
-        for (Person person : campaign.getActivePersonnel(false, false)) {
-            if (!person.isEmployed()) {
+        for (Person person : campaign.getActivePersonnel(false, true)) {
+            if (!person.isEmployed() && person.isCivilian()) {
                 activeDependents.add(person);
                 continue;
             }

--- a/MekHQ/unittests/mekhq/campaign/personnel/RandomDependentsTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/RandomDependentsTest.java
@@ -94,7 +94,7 @@ class RandomDependentsTest {
             activeNonDependent.add(nonDependent);
         }
         activeNonDependent.addAll(activeDependents);
-        when(mockCampaign.getActivePersonnel(false, false)).thenReturn(activeNonDependent);
+        when(mockCampaign.getActivePersonnel(false, true)).thenReturn(activeNonDependent);
 
         // Act
         RandomDependents randomDependents = new RandomDependents(mockCampaign);


### PR DESCRIPTION
At some point in the distant past we introduced implicit filters to the method that fetches personnel. This was done to filter out unnecessary personnel, specifically Camp Followers. However, this was incorrectly propagated to the Random Civilian Removal system, so that all Camp Followers were filtered out and thus never considered eligible for random removal.

Addendum: we may see an uptick in player contract regarding civilians leaving their campaign. This will be working as intended, if players want to keep their civilians they should employ them. At which point they'll be covered by normal Retention systems.