### PR TITLE
Fixed 0 Edge Incorrectly Displaying as 1

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/skills/Attributes.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Attributes.java
@@ -248,7 +248,8 @@ public class Attributes {
         int abilityModifier = getAbilityAdjustment(attribute, options);
 
         int total = attributeScore + injuryModifier + agingModifier + abilityModifier;
-        return Math.clamp(total, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
+        int minimumValue = attribute == SkillAttribute.EDGE ? MINIMUM_EDGE_SCORE : MINIMUM_ATTRIBUTE_SCORE;
+        return Math.clamp(total, minimumValue, MAXIMUM_ATTRIBUTE_SCORE);
     }
 
     public int getAbilityAdjustment(SkillAttribute attribute, PersonnelOptions options) {

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/AttributesTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/AttributesTest.java
@@ -51,6 +51,9 @@ import mekhq.campaign.personnel.enums.Phenotype;
 import mekhq.campaign.personnel.skills.enums.SkillAttribute;
 import org.junit.jupiter.api.Test;
 
+import javax.swing.text.AttributeSet;
+import java.util.List;
+
 public class AttributesTest {
     @Test
     public void testDefaultConstructor() {
@@ -269,5 +272,27 @@ public class AttributesTest {
                 assertEquals(expected, newValue);
             }
         }
+    }
+
+    @Test
+    public void testGetAdjustedAttributeScore_MinimumScore_Edge() {
+        Attributes attributes = new Attributes();
+        PersonnelOptions personnelOptions = new PersonnelOptions();
+        attributes.setAttributeScore(Phenotype.GENERAL, personnelOptions, SkillAttribute.EDGE, 0);
+
+        int actualScore = attributes.getAdjustedAttributeScore(SkillAttribute.EDGE, List.of(), personnelOptions,
+              21);
+        assertEquals(MINIMUM_EDGE_SCORE, actualScore);
+    }
+
+    @Test
+    public void testGetAdjustedAttributeScore_MinimumScore_NotEdge() {
+        Attributes attributes = new Attributes();
+        PersonnelOptions personnelOptions = new PersonnelOptions();
+        attributes.setAttributeScore(Phenotype.GENERAL, personnelOptions, BODY, 0);
+
+        int actualScore = attributes.getAdjustedAttributeScore(SkillAttribute.BODY, List.of(), personnelOptions,
+              21);
+        assertEquals(MINIMUM_ATTRIBUTE_SCORE, actualScore);
     }
 }


### PR DESCRIPTION
In certain GUI instances a characters' Edge score was displaying as `1` when actually the score was `0`. This was due to a missing conditional that should have determined whether to display the minimum _Edge_ score or the minimum _Attribute_ score, the former being `0` the latter `1`.

Edge scores will now display correctly.