### PR TITLE
Fixed Several Tooltips in Campaign Options IIC Market Tab

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/MarketsTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/MarketsTab.java
@@ -762,14 +762,12 @@ public class MarketsTab {
         // Contents
         btnContractEquipment = new JRadioButton(getTextAt(getCampaignOptionsResourceBundle(),
               "lblContractEquipment.text"));
-        btnContractEquipment.addMouseListener(createTipPanelUpdater(contractMarketHeader, "ContractEquipment"));
         btnContractEquipment.setToolTipText(getTextAt(getCampaignOptionsResourceBundle(),
               "lblContractEquipment.tooltip"));
         btnContractEquipment.addMouseListener(createTipPanelUpdater(contractMarketHeader, "ContractEquipment"));
 
         btnContractPersonnel = new JRadioButton(getTextAt(getCampaignOptionsResourceBundle(),
               "lblContractPersonnel.text"));
-        btnContractPersonnel.addMouseListener(createTipPanelUpdater(contractMarketHeader, "ContractPersonnel"));
         btnContractPersonnel.setToolTipText(getTextAt(getCampaignOptionsResourceBundle(),
               "lblContractPersonnel.tooltip"));
         btnContractPersonnel.addMouseListener(createTipPanelUpdater(contractMarketHeader, "ContractPersonnel"));

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/MarketsTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/MarketsTab.java
@@ -762,17 +762,17 @@ public class MarketsTab {
         // Contents
         btnContractEquipment = new JRadioButton(getTextAt(getCampaignOptionsResourceBundle(),
               "lblContractEquipment.text"));
-        spnDropShipBonusPercentage.addMouseListener(createTipPanelUpdater(contractMarketHeader, "ContractEquipment"));
+        btnContractEquipment.addMouseListener(createTipPanelUpdater(contractMarketHeader, "ContractEquipment"));
         btnContractEquipment.setToolTipText(getTextAt(getCampaignOptionsResourceBundle(),
               "lblContractEquipment.tooltip"));
-        spnDropShipBonusPercentage.addMouseListener(createTipPanelUpdater(contractMarketHeader, "ContractEquipment"));
+        btnContractEquipment.addMouseListener(createTipPanelUpdater(contractMarketHeader, "ContractEquipment"));
 
         btnContractPersonnel = new JRadioButton(getTextAt(getCampaignOptionsResourceBundle(),
               "lblContractPersonnel.text"));
-        spnDropShipBonusPercentage.addMouseListener(createTipPanelUpdater(contractMarketHeader, "ContractPersonnel"));
+        btnContractPersonnel.addMouseListener(createTipPanelUpdater(contractMarketHeader, "ContractPersonnel"));
         btnContractPersonnel.setToolTipText(getTextAt(getCampaignOptionsResourceBundle(),
               "lblContractPersonnel.tooltip"));
-        spnDropShipBonusPercentage.addMouseListener(createTipPanelUpdater(contractMarketHeader, "ContractPersonnel"));
+        btnContractPersonnel.addMouseListener(createTipPanelUpdater(contractMarketHeader, "ContractPersonnel"));
 
         ButtonGroup contractGroup = new ButtonGroup();
         contractGroup.add(btnContractEquipment);


### PR DESCRIPTION
A pair of buttons in the Markets tab of CO-IIC were incorrectly attaching mouse listeners to the wrong component. This appears to be a copy-paste error.