### PR TITLE
Fix #8657: Fixed Negative Extra Income Causing Campaign Commanders to Incorrectly Embezzle Campaign Funds, Adding Funds Instead of Deducting

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/enums/ExtraIncome.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/ExtraIncome.java
@@ -296,11 +296,9 @@ public enum ExtraIncome {
 
         String transactionMessage = getFormattedTextAt(RESOURCE_BUNDLE, transactionMessageKey, personTitle);
 
-        if (financialChange.isPositiveOrZero()) {
-            finances.credit(TransactionType.WEALTH, today, financialChange, transactionMessage);
-        } else {
-            finances.debit(TransactionType.WEALTH, today, financialChange, transactionMessage);
-        }
+        // We always use credit here as negative extra income returns a negative value. If we debited that value we'd
+        // actually be adding funds to the campaign.
+        finances.credit(TransactionType.WEALTH, today, financialChange, transactionMessage);
 
         campaignReport = getFormattedTextAt(
               RESOURCE_BUNDLE,

--- a/MekHQ/unittests/mekhq/campaign/personnel/ExtraIncomeTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/ExtraIncomeTest.java
@@ -401,4 +401,34 @@ class ExtraIncomeTest {
         assertEquals(campaignFinancesExpected, campaignFinancesAfter);
         assertEquals(personalFinancesExpected, personalFinancesAfter);
     }
+
+    @Test
+    void testProcessExtraIncome_isAdult_isCommander_negativeExtraIncome() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Faction mockFaction = mock(Faction.class);
+        Finances finances = new Finances();
+
+        when(mockCampaign.getFinances()).thenReturn(finances);
+        when(mockCampaign.getFaction()).thenReturn(mockFaction);
+        when(mockFaction.getShortName()).thenReturn("MERC");
+
+        Person person = new Person(mockCampaign);
+        person.setExtraIncomeDirect(NEGATIVE_TEN);
+        person.setDateOfBirth(TODAY.minusYears(30));
+        person.setCommander(true);
+
+        Money campaignFinancesBefore = mockCampaign.getFinances().getBalance();
+        Money personalFinancesBefore = person.getTotalEarnings();
+
+        ExtraIncome.processExtraIncome(finances, person, TODAY, false);
+
+        Money campaignFinancesAfter = mockCampaign.getFinances().getBalance();
+        Money personalFinancesAfter = person.getTotalEarnings();
+
+        Money campaignFinancesExpected = campaignFinancesBefore.plus(NEGATIVE_TEN.getMonthlyIncomeDirect());
+        Money personalFinancesExpected = personalFinancesBefore.plus(Money.of(0));
+
+        assertEquals(campaignFinancesExpected, campaignFinancesAfter);
+        assertEquals(personalFinancesExpected, personalFinancesAfter);
+    }
 }


### PR DESCRIPTION
Pesky double-negatives. We were deducting `-n` from campaign funds, which due to the nebulous powers of mathomancy meant we were _adding_ funds to the campaign. Now we're embezzling correctly.

I opted not to update the report text as while "deducting -whatever C-Bills" suggests a double negative, I do think the meaning is clear.