### PR TITLE
Fix StratCon ghost objectives when scenario stubs disappear (Fixes #5218)

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratCon/StratConContractInitializer.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConContractInitializer.java
@@ -533,11 +533,13 @@ public class StratConContractInitializer {
             }
 
             // facility
+            boolean addedFacility = false;
             if (template.isFacilityScenario()) {
                 StratConFacility facility = template.isHostileFacility() ?
                                                   StratConFacilityFactory.getRandomHostileFacility() :
                                                   StratConFacilityFactory.getRandomAlliedFacility();
                 trackState.addFacility(coords, facility);
+                addedFacility = true;
             }
 
             // create scenario - don't assign a force yet
@@ -572,6 +574,8 @@ public class StratConContractInitializer {
                 sso.setObjectiveType(StrategicObjectiveType.SpecificScenarioVictory);
                 sso.setDesiredObjectiveCount(1);
                 trackState.addStrategicObjective(sso);
+            } else if (addedFacility) {
+                trackState.removeFacility(coords);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConContractInitializer.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConContractInitializer.java
@@ -518,6 +518,12 @@ public class StratConContractInitializer {
             ScenarioTemplate template = StratConScenarioFactory.getSpecificScenario(objectiveScenarios.get(Compute.randomInt(
                   objectiveScenarios.size())));
 
+            if (template == null) {
+                LOGGER.error("Unable to place objective scenario on track {}, as no scenario template was available.",
+                    trackState.getDisplayableName());
+                continue;
+            }
+
             StratConCoords coords = getUnoccupiedCoords(trackState);
 
             if (coords == null) {
@@ -560,13 +566,13 @@ public class StratConContractInitializer {
                 }
 
                 trackState.addScenario(scenario);
-            }
 
-            StratConStrategicObjective sso = new StratConStrategicObjective();
-            sso.setObjectiveCoords(coords);
-            sso.setObjectiveType(StrategicObjectiveType.SpecificScenarioVictory);
-            sso.setDesiredObjectiveCount(1);
-            trackState.addStrategicObjective(sso);
+                StratConStrategicObjective sso = new StratConStrategicObjective();
+                sso.setObjectiveCoords(coords);
+                sso.setObjectiveType(StrategicObjectiveType.SpecificScenarioVictory);
+                sso.setDesiredObjectiveCount(1);
+                trackState.addStrategicObjective(sso);
+            }
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -1417,7 +1417,15 @@ public class StratConRulesManager {
             StratConFacility facility = track.getFacility(coords);
             boolean alliedFacility = facility.getOwner() == Allied;
             template = StratConScenarioFactory.getFacilityScenario(alliedFacility);
+            if (template == null) {
+                return null;
+            }
+
             scenario = generateScenario(campaign, contract, track, forceID, coords, template, daysTilDeployment);
+            if (scenario == null) {
+                return null;
+            }
+
             setupFacilityScenario(scenario, facility);
         } else {
             if (template != null) {
@@ -2503,8 +2511,8 @@ public class StratConRulesManager {
      * @return the generated {@link StratConScenario}, or {@code null} if scenario generation failed
      */
     static @Nullable StratConScenario generateScenario(Campaign campaign, AtBContract contract,
-          StratConTrackState track, @Nullable Integer forceID, StratConCoords coords, ScenarioTemplate template,
-          @Nullable Integer daysTilDeployment) {
+          StratConTrackState track, @Nullable Integer forceID, StratConCoords coords,
+          @Nullable ScenarioTemplate template, @Nullable Integer daysTilDeployment) {
         StratConScenario scenario = new StratConScenario();
 
         if (forceID == null) {
@@ -3612,8 +3620,8 @@ public class StratConRulesManager {
      *         <li>If a facility exists at the scenario's location and is owned by allied forces, ownership is flipped
      *         to the opposing forces.</li>
      *       </ul>
-     *       This must happen before the scenario is removed so that any objective linked to the scenario's coordinates
-     *       can still be looked up.</li>
+     *       These ignored-scenario consequences are applied before removal so {@code removeScenario} only has to unlink
+     *       scenario state.</li>
      *   <li><b>Scenario Removal:</b>
      *       The ignored scenario is removed from its associated track.</li>
      * </ol>

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -3595,18 +3595,16 @@ public class StratConRulesManager {
     }
 
     /**
-     * Processes an ignored StratCon scenario by removing it from the campaign state and updating related state
-     * variables, including victory points, facility ownership, and objectives.
+     * Processes an ignored StratCon scenario by updating related state variables (victory points, facility ownership,
+     * and objectives) and then removing it from the campaign state.
      *
      * <p>This method is called when a StratCon scenario is ignored, and it ensures that the state of the campaign is
-     * updated accordingly. The following operations are performed:</p>
+     * updated accordingly. The following operations are performed, in order:</p>
      *
-     * <ul>
+     * <ol>
      *   <li><b>Victory Points Adjustment:</b>
      *       If the scenario is marked as "special" or a "turning point," the campaign's victory points are reduced by 1
-     *       to reflect a penalty before the scenario is removed.</li>
-     *   <li><b>Scenario Removal:</b>
-     *       The ignored scenario is removed from its associated track.</li>
+     *       to reflect a penalty.</li>
      *   <li><b>Facility Ownership and Objective Status:</b>
      *       <ul>
      *         <li>If no facility is associated with the scenario's coordinates, the objective tied to the scenario's
@@ -3614,8 +3612,11 @@ public class StratConRulesManager {
      *         <li>If a facility exists at the scenario's location and is owned by allied forces, ownership is flipped
      *         to the opposing forces.</li>
      *       </ul>
-     *   </li>
-     * </ul>
+     *       This must happen before the scenario is removed so that any objective linked to the scenario's coordinates
+     *       can still be looked up.</li>
+     *   <li><b>Scenario Removal:</b>
+     *       The ignored scenario is removed from its associated track.</li>
+     * </ol>
      *
      * @param scenario      The {@link StratConScenario} that is being ignored and processed for removal. This includes
      *                      information such as the scenario type and coordinates.
@@ -3634,9 +3635,6 @@ public class StratConRulesManager {
             campaignState.updateVictoryPoints(-1);
         }
 
-        // Remove the scenario from the track
-        track.removeScenario(scenario);
-
         // Check the facility associated with the scenario, if any
         StratConFacility localFacility = track.getFacility(scenario.getCoords());
         if (localFacility == null) {
@@ -3646,6 +3644,9 @@ public class StratConRulesManager {
             // Update the facility's ownership if it belongs to allies
             localFacility.setOwner(Opposing);
         }
+
+        // Remove the scenario from the track
+        track.removeScenario(scenario);
     }
 
     public void startup() {

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConScenarioFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2019-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConScenarioFactory.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 
 import megamek.codeUtilities.ObjectUtility;
+import megamek.common.annotations.Nullable;
 import megamek.common.units.UnitType;
 import megamek.logging.MMLogger;
 import mekhq.MHQConstants;
@@ -146,8 +147,14 @@ public class StratConScenarioFactory {
     /**
      * Retrieves a specific scenario given the key (file name)
      */
-    public static ScenarioTemplate getSpecificScenario(String name) {
-        return dynamicScenarioNameMap.get(name).clone();
+    public static @Nullable ScenarioTemplate getSpecificScenario(String name) {
+        ScenarioTemplate template = dynamicScenarioNameMap.get(name);
+        if (template == null) {
+            logger.error("Scenario template {} not found.", name);
+            return null;
+        }
+
+        return template.clone();
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConScenarioFactory.java
@@ -195,7 +195,7 @@ public class StratConScenarioFactory {
     /**
      * Get an allied or hostile facility scenario, depending on passed on parameter.
      */
-    public static ScenarioTemplate getFacilityScenario(boolean allied) {
+    public static @Nullable ScenarioTemplate getFacilityScenario(boolean allied) {
         if (allied) {
             return getSpecificScenario(MHQConstants.ALLIED_FACILITY_SCENARIO);
         } else {

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConTrackState.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConTrackState.java
@@ -46,7 +46,6 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import megamek.common.annotations.Nullable;
 import mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment;
-import mekhq.campaign.stratCon.StratConContractDefinition.StrategicObjectiveType;
 import mekhq.utilities.MHQXMLUtility;
 
 /**
@@ -192,19 +191,6 @@ public class StratConTrackState {
     public void removeScenario(StratConScenario scenario) {
         scenarios.remove(scenario.getCoords());
         getBackingScenariosMap().remove(scenario.getBackingScenarioID());
-        Map<StratConCoords, StratConStrategicObjective> objectives = getObjectivesByCoords();
-        if (objectives.containsKey(scenario.getCoords())) {
-            StrategicObjectiveType objectiveType = objectives.get(scenario.getCoords()).getObjectiveType();
-
-            switch (objectiveType) {
-                case RequiredScenarioVictory:
-                case SpecificScenarioVictory:
-                    objectives.remove(scenario.getCoords());
-                    break;
-                default:
-                    break;
-            }
-        }
 
         // any assigned forces get cleared out here as well.
         for (int forceID : scenario.getAssignedForces()) {
@@ -436,7 +422,10 @@ public class StratConTrackState {
         if (specificStrategicObjectives == null) {
             specificStrategicObjectives = new HashMap<>();
             for (StratConStrategicObjective objective : strategicObjectives) {
-                specificStrategicObjectives.put(objective.getObjectiveCoords(), objective);
+                StratConCoords coords = objective.getObjectiveCoords();
+                if (coords != null) {
+                    specificStrategicObjectives.put(coords, objective);
+                }
             }
         }
 
@@ -554,10 +543,17 @@ public class StratConTrackState {
     @Deprecated(since = "0.51.0", forRemoval = true)
     public void setStrategicObjectives(List<StratConStrategicObjective> strategicObjectives) {
         this.strategicObjectives = strategicObjectives;
+        specificStrategicObjectives = null;
     }
 
     public void addStrategicObjective(StratConStrategicObjective strategicObjective) {
         getStrategicObjectives().add(strategicObjective);
+        if (specificStrategicObjectives != null) {
+            StratConCoords coords = strategicObjective.getObjectiveCoords();
+            if (coords != null) {
+                specificStrategicObjectives.put(coords, strategicObjective);
+            }
+        }
     }
 
     public int getTemperature() {

--- a/MekHQ/unittests/mekhq/campaign/stratCon/StratConRulesManagerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/stratCon/StratConRulesManagerTest.java
@@ -35,6 +35,7 @@ package mekhq.campaign.stratCon;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -160,12 +161,17 @@ class StratConRulesManagerTest {
         track.setWidth(1);
         track.setHeight(1);
         ScenarioTemplate template = mock(ScenarioTemplate.class);
+        StratConFacility facility = new StratConFacility();
 
         try (MockedStatic<StratConScenarioFactory> scenarioFactory = Mockito.mockStatic(StratConScenarioFactory.class);
+              MockedStatic<StratConFacilityFactory> facilityFactory = Mockito.mockStatic(StratConFacilityFactory.class);
               MockedStatic<StratConRulesManager> rulesManager = Mockito.mockStatic(StratConRulesManager.class,
                     CALLS_REAL_METHODS)) {
             scenarioFactory.when(() -> StratConScenarioFactory.getSpecificScenario("objective-template.xml"))
                   .thenReturn(template);
+            when(template.isFacilityScenario()).thenReturn(true);
+            when(template.isHostileFacility()).thenReturn(true);
+            facilityFactory.when(StratConFacilityFactory::getRandomHostileFacility).thenReturn(facility);
             rulesManager.when(() -> StratConRulesManager.generateScenario(any(Campaign.class),
                         any(AtBContract.class),
                         any(StratConTrackState.class),
@@ -179,6 +185,7 @@ class StratConRulesManagerTest {
         }
 
         assertTrue(track.getScenarios().isEmpty());
+            assertTrue(track.getFacilities().isEmpty());
         assertTrue(track.getStrategicObjectives().isEmpty());
     }
 
@@ -207,6 +214,42 @@ class StratConRulesManagerTest {
         assertFalse(track.getScenarios().containsKey(coords));
         assertSame(objective, track.getObjectivesByCoords().get(coords));
         assertEquals(StratConStrategicObjective.OBJECTIVE_FAILED, objective.getCurrentObjectiveCount());
+    }
+
+    @Test
+    void setupScenario_existingFacilitySkipsGenerationWhenFacilityTemplateMissing() {
+        Campaign campaign = mock(Campaign.class);
+        AtBContract contract = mock(AtBContract.class);
+        StratConTrackState track = new StratConTrackState();
+        StratConCoords coords = new StratConCoords(2, 6);
+
+        StratConFacility facility = new StratConFacility();
+        facility.setOwner(ScenarioForceTemplate.ForceAlignment.Allied);
+        track.addFacility(coords, facility);
+
+        try (MockedStatic<StratConScenarioFactory> scenarioFactory = Mockito.mockStatic(StratConScenarioFactory.class);
+              MockedStatic<StratConRulesManager> rulesManager = Mockito.mockStatic(StratConRulesManager.class,
+                    CALLS_REAL_METHODS)) {
+            scenarioFactory.when(() -> StratConScenarioFactory.getFacilityScenario(true)).thenReturn(null);
+
+            StratConScenario scenario = StratConRulesManager.setupScenario(coords,
+                  null,
+                  campaign,
+                  contract,
+                  track,
+                  null,
+                  false,
+                  null);
+
+            assertNull(scenario);
+            rulesManager.verify(() -> StratConRulesManager.generateScenario(any(Campaign.class),
+                  any(AtBContract.class),
+                  any(StratConTrackState.class),
+                  any(),
+                  any(StratConCoords.class),
+                  any(ScenarioTemplate.class),
+                  any()), never());
+        }
     }
 
     /**

--- a/MekHQ/unittests/mekhq/campaign/stratCon/StratConRulesManagerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/stratCon/StratConRulesManagerTest.java
@@ -32,8 +32,10 @@
  */
 package mekhq.campaign.stratCon;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -44,7 +46,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Method;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
@@ -68,9 +72,11 @@ import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.AtBDynamicScenario;
 import mekhq.campaign.mission.ScenarioForceTemplate;
 import mekhq.campaign.mission.ScenarioMapParameters.MapLocation;
+import mekhq.campaign.mission.ScenarioTemplate;
 import mekhq.campaign.mission.enums.CombatRole;
 import mekhq.campaign.mission.enums.ScenarioType;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.stratCon.StratConContractDefinition.StrategicObjectiveType;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Atmosphere;
 import mekhq.campaign.universe.Planet;
@@ -83,6 +89,125 @@ import megamek.common.units.UnitType;
  * Tests for {@link StratConRulesManager}
  */
 class StratConRulesManagerTest {
+
+    private static void initializeObjectiveScenarios(Campaign campaign, AtBContract contract,
+          StratConTrackState track, List<String> objectiveScenarios) throws Exception {
+        Method method = StratConContractInitializer.class.getDeclaredMethod("initializeObjectiveScenarios",
+              Campaign.class,
+              AtBContract.class,
+              StratConTrackState.class,
+              int.class,
+              List.class,
+              List.class);
+        method.setAccessible(true);
+        method.invoke(null, campaign, contract, track, 1, objectiveScenarios, null);
+    }
+
+    @Test
+    void addStrategicObjective_updatesLookupAfterCacheWasBuilt() {
+        StratConTrackState track = new StratConTrackState();
+        StratConCoords coords = new StratConCoords(2, 6);
+
+        assertTrue(track.getObjectivesByCoords().isEmpty());
+
+        StratConStrategicObjective objective = new StratConStrategicObjective();
+        objective.setObjectiveCoords(coords);
+        objective.setObjectiveType(StrategicObjectiveType.SpecificScenarioVictory);
+
+        track.addStrategicObjective(objective);
+
+        assertSame(objective, track.getObjectivesByCoords().get(coords));
+    }
+
+    @Test
+    void addStrategicObjective_doesNotCacheCoordinateLessObjectives() {
+        StratConTrackState track = new StratConTrackState();
+
+        StratConStrategicObjective objective = new StratConStrategicObjective();
+        objective.setObjectiveType(StrategicObjectiveType.AnyScenarioVictory);
+
+        track.addStrategicObjective(objective);
+
+        assertFalse(track.getObjectivesByCoords().containsKey(null));
+
+        StratConStrategicObjective laterObjective = new StratConStrategicObjective();
+        laterObjective.setObjectiveType(StrategicObjectiveType.AnyScenarioVictory);
+
+        track.addStrategicObjective(laterObjective);
+
+        assertFalse(track.getObjectivesByCoords().containsKey(null));
+    }
+
+    @Test
+    void initializeObjectiveScenarios_skipsMissingTemplateWithoutAddingObjective() throws Exception {
+        Campaign campaign = mock(Campaign.class);
+        AtBContract contract = mock(AtBContract.class);
+        StratConTrackState track = new StratConTrackState();
+        track.setWidth(1);
+        track.setHeight(1);
+
+        initializeObjectiveScenarios(campaign, contract, track, List.of("missing-objective-template.xml"));
+
+        assertTrue(track.getScenarios().isEmpty());
+        assertTrue(track.getStrategicObjectives().isEmpty());
+    }
+
+    @Test
+    void initializeObjectiveScenarios_doesNotAddObjectiveWhenScenarioGenerationFails() throws Exception {
+        Campaign campaign = mock(Campaign.class);
+        AtBContract contract = mock(AtBContract.class);
+        StratConTrackState track = new StratConTrackState();
+        track.setWidth(1);
+        track.setHeight(1);
+        ScenarioTemplate template = mock(ScenarioTemplate.class);
+
+        try (MockedStatic<StratConScenarioFactory> scenarioFactory = Mockito.mockStatic(StratConScenarioFactory.class);
+              MockedStatic<StratConRulesManager> rulesManager = Mockito.mockStatic(StratConRulesManager.class,
+                    CALLS_REAL_METHODS)) {
+            scenarioFactory.when(() -> StratConScenarioFactory.getSpecificScenario("objective-template.xml"))
+                  .thenReturn(template);
+            rulesManager.when(() -> StratConRulesManager.generateScenario(any(Campaign.class),
+                        any(AtBContract.class),
+                        any(StratConTrackState.class),
+                        any(),
+                        any(StratConCoords.class),
+                        any(ScenarioTemplate.class),
+                        any()))
+                  .thenReturn(null);
+
+            initializeObjectiveScenarios(campaign, contract, track, List.of("objective-template.xml"));
+        }
+
+        assertTrue(track.getScenarios().isEmpty());
+        assertTrue(track.getStrategicObjectives().isEmpty());
+    }
+
+    @Test
+    void processIgnoredStratConScenario_failsObjectiveBeforeScenarioRemoval() {
+        StratConTrackState track = new StratConTrackState();
+        StratConCoords coords = new StratConCoords(2, 6);
+
+        AtBDynamicScenario backingScenario = mock(AtBDynamicScenario.class);
+        when(backingScenario.getId()).thenReturn(231);
+        when(backingScenario.getForceIDs()).thenReturn(new ArrayList<>());
+
+        StratConScenario scenario = new StratConScenario();
+        scenario.setCoords(coords);
+        scenario.setBackingScenario(backingScenario);
+        track.addScenario(scenario);
+
+        StratConStrategicObjective objective = new StratConStrategicObjective();
+        objective.setObjectiveCoords(coords);
+        objective.setObjectiveType(StrategicObjectiveType.SpecificScenarioVictory);
+        objective.setDesiredObjectiveCount(1);
+        track.addStrategicObjective(objective);
+
+        StratConRulesManager.processIgnoredStratConScenario(scenario, track, new StratConCampaignState());
+
+        assertFalse(track.getScenarios().containsKey(coords));
+        assertSame(objective, track.getObjectivesByCoords().get(coords));
+        assertEquals(StratConStrategicObjective.OBJECTIVE_FAILED, objective.getCurrentObjectiveCount());
+    }
 
     /**
      * Creates the common mock infrastructure needed for deployForceToCoords tests.


### PR DESCRIPTION
## Problem

StratCon specific scenario objectives are represented in two linked pieces of state:

- a `StratConScenario` placed on a track at the objective coordinates
- a `StratConStrategicObjective` entry that tracks whether that specific scenario objective is unresolved, completed, or failed

Issue #5218 exposed a case where those two pieces could become disconnected. The objective remained in the contract objective list, but the matching scenario stub was no longer present on the StratCon track. When the player later revealed the objective hex, the UI correctly revealed the objective coordinates, but there was no scenario at that location to uncloak or assign a mission date to. From the player’s perspective, the objective updated but no mission appeared.

The root cause seems to be inconsistent bookkeeping around track scenario removal and objective lookup state. `removeScenario(...)` removes coordinate-bound objectives from the transient `objectivesByCoords` cache, but not from the serialized `strategicObjectives` list. Later logic that attempts to fail the objective by coordinate could miss it because the cache entry had already been removed, leaving an unresolved objective serialized without a matching track scenario.

There is also a related initialization edge case: `SpecificScenarioVictory` objectives can be added even when the objective scenario stub is not successfully created, allowing the same “objective without scenario” state to be created up front.

## Summary

- Fail linked specific objectives before removing ignored StratCon scenarios from their track.
- Stop `removeScenario(...)` from mutating the strategic objective coordinate cache.
- Keep the coordinate-objective cache synchronized when objectives are added or reset.
- Avoid caching coordinate-less objectives such as `AnyScenarioVictory`.
- Skip objective creation when the objective scenario template cannot be resolved or scenario generation fails.
- Add regression coverage for ignored objective scenarios, missing templates, failed scenario generation, coordinate-less objectives, and objective cache synchronization.


Fixes #5218