### PR TITLE
Fix #8760: Fix Campaigns failing to load on Java 25

### DIFF
--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -62,7 +62,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
-import javax.xml.parsers.DocumentBuilder;
 
 import megamek.Version;
 import megamek.client.bot.princess.BehaviorSettingsFactory;
@@ -185,11 +184,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
         Document xmlDoc;
 
         try {
-            // Using factory get an instance of document builder
-            DocumentBuilder db = MHQXMLUtility.newSafeDocumentBuilder();
-
-            // Parse using builder to get DOM representation of the XML file
-            xmlDoc = db.parse(is);
+            xmlDoc = MHQXMLUtility.parseDocument(is);
         } catch (Exception ex) {
             LOGGER.error("", ex);
             throw new CampaignXmlParseException(ex);

--- a/MekHQ/src/mekhq/utilities/MHQXMLUtility.java
+++ b/MekHQ/src/mekhq/utilities/MHQXMLUtility.java
@@ -642,9 +642,6 @@ public class MHQXMLUtility extends MMXMLUtility {
      * Parses an XML {@link Document} from {@code is}, automatically retrying with a doubled
      * {@code maxGeneralEntitySizeLimit} if Java 24+'s tightened default limit is exceeded.
      *
-     * <p>The last limit that succeeded is remembered for the rest of the session so that
-     * subsequent large-file loads skip the retry cycle entirely.</p>
-     *
      * @param is the input stream to read from (consumed and closed by this method is <em>not</em> the caller's
      *           responsibility to reset)
      *

--- a/MekHQ/src/mekhq/utilities/MHQXMLUtility.java
+++ b/MekHQ/src/mekhq/utilities/MHQXMLUtility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2013-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -32,6 +32,9 @@
  */
 package mekhq.utilities;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintWriter;
 import java.util.List;
 import java.util.Map;
@@ -50,14 +53,20 @@ import megamek.logging.MMLogger;
 import megamek.utilities.xml.MMXMLUtility;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
+import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
+import org.xml.sax.SAXParseException;
 
 public class MHQXMLUtility extends MMXMLUtility {
     private static final MMLogger LOGGER = MMLogger.create(MHQXMLUtility.class);
 
     private static DocumentBuilderFactory UNSAFE_DOCUMENT_BUILDER_FACTORY;
+
+    private static final String JAXP_MAX_GENERAL_ENTITY_SIZE = "jdk.xml.maxGeneralEntitySizeLimit";
+    private static final String JAXP_TOTAL_ENTITY_SIZE = "jdk.xml.totalEntitySizeLimit";
+    private static final String FEATURE_DISALLOW_DOCTYPE = "http://apache.org/xml/features/disallow-doctype-decl";
 
     /**
      * USE WITH CARE. Creates a DocumentBuilder safe from XML external entities attacks, but unsafe from XML entity
@@ -628,4 +637,89 @@ public class MHQXMLUtility extends MMXMLUtility {
         }
     }
     // endregion Simple XML Tag
+
+    /**
+     * Parses an XML {@link Document} from {@code is}, automatically retrying with a doubled
+     * {@code maxGeneralEntitySizeLimit} if Java 24+'s tightened default limit is exceeded.
+     *
+     * <p>The last limit that succeeded is remembered for the rest of the session so that
+     * subsequent large-file loads skip the retry cycle entirely.</p>
+     *
+     * @param is the input stream to read from (consumed and closed by this method is <em>not</em> the caller's
+     *           responsibility to reset)
+     *
+     * @return the parsed {@link Document}
+     *
+     * @throws IOException                  if the stream cannot be read
+     * @throws ParserConfigurationException if a suitable XML parser cannot be configured
+     * @throws SAXParseException            if the XML is malformed or the limit cannot be raised further
+     * @throws Exception                    for any other parse-related failure
+     */
+    public static Document parseDocument(InputStream is) throws Exception {
+        byte[] data = is.readAllBytes();
+        long initialLimit = readCurrentEntitySizeLimit();
+        long limit = initialLimit;
+
+        while (true) {
+            try {
+                DocumentBuilder db = buildDocumentBuilderWithLimit(limit);
+                Document doc = db.parse(new ByteArrayInputStream(data));
+                LOGGER.info("Parsed XML document ({} nodes){}", doc.getElementsByTagName("*").getLength(),
+                      limit == initialLimit ? "" : " after raising JAXP entity size limit from "
+                                                         + initialLimit + " to " + limit + " characters");
+                return doc;
+            } catch (SAXParseException ex) {
+                // JAXP00010003 = maxGeneralEntitySizeLimit (single entity too large)
+                // JAXP00010004 = totalEntitySizeLimit (accumulated entity size exceeded)
+                // Both have been observed on Java 25 with large campaign files.
+                String msg = ex.getMessage();
+                boolean isKnownLimit = msg != null &&
+                                             (msg.contains("JAXP00010003") || msg.contains("JAXP00010004"));
+                if (!isKnownLimit) {
+                    throw ex;
+                }
+                long next = limit * 2L;
+                if (next < 0 || next > Integer.MAX_VALUE) {
+                    LOGGER.error(
+                          "XML document exceeds JAXP entity size limits even at maximum ({} characters); giving up",
+                          limit);
+                    throw ex;
+                }
+                LOGGER.warn("XML parse hit JAXP entity size limit ({} characters); retrying with limit={} characters",
+                      limit, next);
+                limit = next;
+            }
+        }
+    }
+
+    private static long readCurrentEntitySizeLimit() {
+        try {
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            Object val = dbf.getAttribute(JAXP_TOTAL_ENTITY_SIZE);
+            if (val instanceof Integer i) {return i.longValue();}
+            if (val instanceof Long l) {return l;}
+            if (val instanceof String s && !s.isEmpty()) {return Long.parseLong(s);}
+        } catch (Exception ignored) {}
+        return 100_000L; // fallback: Java 25 default
+    }
+
+    private static DocumentBuilder buildDocumentBuilderWithLimit(long entitySizeLimit)
+          throws ParserConfigurationException {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setXIncludeAware(false);
+        dbf.setExpandEntityReferences(false);
+        dbf.setFeature(FEATURE_DISALLOW_DOCTYPE, true);
+        int limit = (int) entitySizeLimit;
+        try {
+            dbf.setAttribute(JAXP_MAX_GENERAL_ENTITY_SIZE, limit);
+        } catch (IllegalArgumentException e) {
+            LOGGER.warn("XML processor does not support maxGeneralEntitySizeLimit; limit not applied", e);
+        }
+        try {
+            dbf.setAttribute(JAXP_TOTAL_ENTITY_SIZE, limit);
+        } catch (IllegalArgumentException e) {
+            LOGGER.warn("XML processor does not support totalEntitySizeLimit; limit not applied", e);
+        }
+        return dbf.newDocumentBuilder();
+    }
 }


### PR DESCRIPTION
Fixes #8760
Fixes #8973 
Fixes #8983

Dynamically increases the limit instead of erroring out.