### PR TITLE
Updated Default Options for Mass Repair Dialog

### DIFF
--- a/MekHQ/src/mekhq/service/mrms/MRMSOption.java
+++ b/MekHQ/src/mekhq/service/mrms/MRMSOption.java
@@ -64,7 +64,7 @@ public class MRMSOption {
     // region Constructors
     public MRMSOption(PartRepairType type) {
         this(type,
-              false,
+              true,
               SkillType.EXP_ULTRA_GREEN,
               SkillType.EXP_LEGENDARY,
               TARGET_NUMBER_PREFERRED,


### PR DESCRIPTION
MRMS is a fantastic tool - now that it works reliably - that all players should be using. However, it has a learning curve specifically because when you first launch it, it won't actually repair anything. Similarly, clicking 'instance repair' won't do anything.

This is because, by default, MRMS has all repair tasks disabled. If the player doesn't know that, they won't know to go in and manually set it up.

Furthermore, if you make changes you need to actually hit 'set as default' - which only applies to the current campaign.

This results in the following use-experience:

- Player attempts to use MRMS, it doesn't do anything
- Player sets up MRMS
- Player exists and advances day or whatever
- Player attempts to use MRMS, it doesn't do anything again, because they forgot to hit 'set as default'.

This PR addresses the above by setting the following options to 'on' by default:

<img width="777" height="238" alt="image" src="https://github.com/user-attachments/assets/302a6080-9bc8-4ee6-a171-661589e6ff04" />

It is not possible to only have some of these enabled by default, it's all or nothing, so I went with the option (all on) that will be the best experience for players who just want to fire MRMS without setting everything up. Power users already know how MRMS works so can editing the settings to match their needs.
