### PR TITLE
Added Campaign Option to Improve Relevance of Veterancy Awards

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -2106,6 +2106,12 @@ lblVeterancySPAs.tooltip=If checked, a character will receive an SPA or Flaw upo
   <br>\
   <br><b>Recommendation:</b> This was balanced around the inclusion of Flaws and ATOW SPAs. If you are working with a \
   smaller SPA pool due to disabling those SPAs or have Flaws disabled, you might want to leave this off.
+lblAwardRelevantVeterancySPAs.text=Filter Veterancy Awards
+lblAwardRelevantVeterancySPAs.tooltip=If checked, when a character is awarded a Veterancy SPA, only those SPAs that \
+  the character is eligible to purchase be awarded. This reduces the likelihood a character will be issued an SPA \
+  irrelevant to their profession.\
+  <br>\
+  <br><b>Requirement:</b> 'Award Veterancy Awards' must be enabled.
 lblComingOfAgeAbilities.text=Award Coming of Age SPAs
 lblComingOfAgeAbilities.tooltip=If checked, all characters will be awarded a single SPA when they turn 16.\
   <br>\

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
@@ -242,6 +242,7 @@ public class CampaignOptions {
     private boolean displayAssignmentRecord;
     private boolean displayPerformanceRecord;
     private boolean awardVeterancySPAs;
+    private boolean awardRelevantVeterancySPAs;
 
     // Expanded Personnel Information
     private boolean useTimeInService;
@@ -1807,6 +1808,14 @@ public class CampaignOptions {
 
     public void setAwardVeterancySPAs(final boolean awardVeterancySPAs) {
         this.awardVeterancySPAs = awardVeterancySPAs;
+    }
+
+    public boolean isAwardRelevantVeterancySPAs() {
+        return awardRelevantVeterancySPAs;
+    }
+
+    public void setAwardRelevantVeterancySPAs(final boolean awardRelevantVeterancySPAs) {
+        this.awardRelevantVeterancySPAs = awardRelevantVeterancySPAs;
     }
 
     public boolean isRewardComingOfAgeAbilities() {

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
@@ -313,6 +313,10 @@ public class CampaignOptionsMarshaller {
               campaignOptions.isAwardVeterancySPAs());
         MHQXMLUtility.writeSimpleXMLTag(pw,
               indent,
+              "awardRelevantVeterancySPAs",
+              campaignOptions.isAwardRelevantVeterancySPAs());
+        MHQXMLUtility.writeSimpleXMLTag(pw,
+              indent,
               "rewardComingOfAgeAbilities",
               campaignOptions.isRewardComingOfAgeAbilities());
         MHQXMLUtility.writeSimpleXMLTag(pw,

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
@@ -350,6 +350,8 @@ public class CampaignOptionsUnmarshaller {
                   nodeContents));
             case "awardVeterancySPAs" -> campaignOptions.setAwardVeterancySPAs(parseBoolean(
                   nodeContents));
+            case "awardRelevantVeterancySPAs" -> campaignOptions.setAwardRelevantVeterancySPAs(parseBoolean(
+                  nodeContents));
             case "rewardComingOfAgeAbilities" -> campaignOptions.setRewardComingOfAgeAbilities(parseBoolean(
                   nodeContents));
             case "rewardComingOfAgeRPSkills" -> campaignOptions.setRewardComingOfAgeRPSkills(parseBoolean(

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -2523,8 +2523,9 @@ public class Person {
             return;
         }
 
+        boolean isIgnoreSPAEligibility = !campaignOptions.isAwardRelevantVeterancySPAs();
         SingleSpecialAbilityGenerator singleSpecialAbilityGenerator = new SingleSpecialAbilityGenerator();
-        String spaGained = singleSpecialAbilityGenerator.rollSPA(campaign, this, true, true, true);
+        String spaGained = singleSpecialAbilityGenerator.rollSPA(campaign, this, true, isIgnoreSPAEligibility, true);
         if (spaGained == null) {
             return;
         } else {
@@ -7076,8 +7077,9 @@ public class Person {
     /**
      * Retrieves the modifier value for a specified skill attribute.
      *
-     * @param attribute the skill attribute for which the modifier is to be calculated;
-     *                  if the attribute is null or represents "none", a warning is logged and the method returns 0
+     * @param attribute the skill attribute for which the modifier is to be calculated; if the attribute is null or
+     *                  represents "none", a warning is logged and the method returns 0
+     *
      * @return the calculated modifier value for the provided skill attribute, or 0 if the attribute is null or "none"
      *
      * @author Illiani

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyTab.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import javax.swing.*;
 
+import megamek.Version;
 import megamek.client.generator.RandomGenderGenerator;
 import megamek.client.generator.RandomNameGenerator;
 import megamek.client.ui.comboBoxes.MMComboBox;
@@ -120,6 +121,7 @@ public class BiographyTab {
     private JCheckBox chkShowLifeEventDialogCelebrations;
     private JPanel pnlComingOfAge;
     private JCheckBox chkVeterancySPAs;
+    private JCheckBox chkAwardRelevantVeterancySPAs;
     private JCheckBox chkComingOfAgeSPAs;
     private JCheckBox chkRewardComingOfAgeRPSkills;
     //end General Tab
@@ -399,6 +401,7 @@ public class BiographyTab {
 
         pnlComingOfAge = new JPanel();
         chkVeterancySPAs = new JCheckBox();
+        chkAwardRelevantVeterancySPAs = new JCheckBox();
         chkComingOfAgeSPAs = new JCheckBox();
         chkRewardComingOfAgeRPSkills = new JCheckBox();
     }
@@ -592,6 +595,11 @@ public class BiographyTab {
               getMetadata(MILESTONE_BEFORE_METADATA, CampaignOptionFlag.RECOMMENDED));
         chkVeterancySPAs.addMouseListener(createTipPanelUpdater(generalHeader, "VeterancySPAs"));
 
+        chkAwardRelevantVeterancySPAs = new CampaignOptionsCheckBox("AwardRelevantVeterancySPAs",
+              getMetadata(new Version(0, 51, 0), CampaignOptionFlag.IMPORTANT));
+        chkAwardRelevantVeterancySPAs.addMouseListener(createTipPanelUpdater(generalHeader,
+              "AwardRelevantVeterancySPAs"));
+
         chkComingOfAgeSPAs = new CampaignOptionsCheckBox("ComingOfAgeAbilities",
               getMetadata(null, CampaignOptionFlag.RECOMMENDED));
         chkComingOfAgeSPAs.addMouseListener(createTipPanelUpdater(generalHeader, "ComingOfAgeAbilities"));
@@ -609,6 +617,9 @@ public class BiographyTab {
         layoutParent.gridx = 0;
         layoutParent.gridy = 0;
         panel.add(chkVeterancySPAs, layoutParent);
+
+        layoutParent.gridy++;
+        panel.add(chkAwardRelevantVeterancySPAs, layoutParent);
 
         layoutParent.gridy++;
         panel.add(chkComingOfAgeSPAs, layoutParent);
@@ -1557,6 +1568,7 @@ public class BiographyTab {
         chkShowLifeEventDialogComingOfAge.setSelected(options.isShowLifeEventDialogComingOfAge());
         chkShowLifeEventDialogCelebrations.setSelected(options.isShowLifeEventDialogCelebrations());
         chkVeterancySPAs.setSelected(options.isAwardVeterancySPAs());
+        chkAwardRelevantVeterancySPAs.setSelected(options.isAwardRelevantVeterancySPAs());
         chkComingOfAgeSPAs.setSelected(options.isRewardComingOfAgeAbilities());
         chkRewardComingOfAgeRPSkills.setSelected(options.isRewardComingOfAgeRPSkills());
 
@@ -1652,6 +1664,7 @@ public class BiographyTab {
         options.setShowLifeEventDialogComingOfAge(chkShowLifeEventDialogComingOfAge.isSelected());
         options.setShowLifeEventDialogCelebrations(chkShowLifeEventDialogCelebrations.isSelected());
         options.setAwardVeterancySPAs(chkVeterancySPAs.isSelected());
+        options.setAwardRelevantVeterancySPAs(chkAwardRelevantVeterancySPAs.isSelected());
         options.setRewardComingOfAgeAbilities(chkComingOfAgeSPAs.isSelected());
         options.setRewardComingOfAgeRPSkills(chkRewardComingOfAgeRPSkills.isSelected());
 


### PR DESCRIPTION
When Veterancy Awards were implemented I made the decision to make the SPA award largely random. In my mind this would create memorable situations where a character in one profession might get an amazing SPA, prompting users to cross-train. Or a character might get an otherwise impossible combination.

This approach was also done to reduce the 'power' of these free SPAs.

Over time, based on player feedback, I have softened on this somewhat. Especially with just how many RP SPAs there are.

With all this in mind, I've added a new campaign option. If selected characters will only be given Veterancy Awards that they would be eligible to take had the player purchased the SPA. So no more NatApt on Administrators.