### PR TITLE
Added Deployment Disclaimer to Scenario Description to Reduce Confusion

### DIFF
--- a/MekHQ/resources/mekhq/resources/AtBScenarioViewPanel.properties
+++ b/MekHQ/resources/mekhq/resources/AtBScenarioViewPanel.properties
@@ -49,3 +49,5 @@ lblVictory=Victory Conditions
 lblObservations=Observations
 lblDescription=Description
 lblSpecialConditions=Special Conditions
+AtBScenarioViewPanel.scenarioDescription.disclaimer=Any mention of your own forces in the scenario objectives can be \
+  ignored. The scenario will automatically update to use whatever forces you choose to deploy.

--- a/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
@@ -36,6 +36,7 @@ package mekhq.gui.view;
 import static megamek.common.options.OptionsConstants.BASE_BLIND_DROP;
 import static megamek.common.options.OptionsConstants.BASE_REAL_BLIND_DROP;
 import static megamek.common.units.Entity.getEntityMajorTypeName;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import java.awt.Component;
 import java.awt.GridBagConstraints;
@@ -144,6 +145,8 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
     private JTextArea txtDesc;
 
     private final StubTreeModel playerForceModel;
+
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.AtBScenarioViewPanel";
 
     public AtBScenarioViewPanel(AtBScenario s, Campaign c, JFrame frame) {
         super();
@@ -440,6 +443,11 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
         panStats.add(txtDesc, gridBagConstraints);
 
         StringBuilder objectiveBuilder = new StringBuilder();
+
+        String disclaimer = getTextAt(RESOURCE_BUNDLE, "AtBScenarioViewPanel.scenarioDescription.disclaimer");
+        objectiveBuilder.append(disclaimer);
+        objectiveBuilder.append("\n\n");
+
         objectiveBuilder.append(scenario.getDeploymentInstructions());
 
         for (ScenarioObjective objective : scenario.getScenarioObjectives()) {


### PR DESCRIPTION
Close #8692

Back in the olden days, when a scenario generated it would tie the scenario to a specific force. Ostensibly the player was then expected to deploy that force.

That hasn't been the case for well over a year now, if not longer. However, this change was relatively easy to miss. Not just because it wasn't well advertised, but because the scenario description still shows the force that spawned the scenario. This necessary due to legacy reasons - we need the force to generate objectives.

However, _now_ in modern MekHQ those objectives will automatically update to reflect whatever force you deploy to the scenario.

To try and help reduce this confusion the following notice has been added to the scenario briefing:

<img width="424" height="155" alt="image" src="https://github.com/user-attachments/assets/e130988d-5c79-42da-8181-85a83a68d982" />

## Why Don't We Just Hide the Spawning Force?
In short, it would upset people. Again, back in the olden days, the force that spawned the scenario would be the scenario's Seed Force (see the in-game Glossary). Many players preferred to deploy this seed force to the scenario to ensure a relatively balanced engagement.

Nowadays, we have the option (on by default) to not use Seed Forces. However, there is no guarantee the player is using it. And the last time we tried to obfuscate the Seed Force players complained.

Instead, the approach used here was picked as a way to make everyone happy.