### PR TITLE
Added Confirmation Dialog to the End of Scenario Resolution to Prevent Player Unwittingly Hitting a Point of No Return

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -1127,6 +1127,9 @@ optionAbandonUnitsConfirmation.toolTipText=This allows you to skip the confirmat
 optionAssignTechsConfirmation.text=Hide Quick Assign Techs Confirmation Dialog
 optionAssignTechsConfirmation.toolTipText=This allows you to skip the confirmation dialog which confirms whether \
   you are happy assigning techs to unmaintained units
+optionResolveScenarioConfirmation.text=Hide Scenario Resolution Confirmation Dialog
+optionResolveScenarioConfirmation.toolTipText=This allows you to skip the confirmation dialog which confirms whether \
+  you are happy to resolve a scenario.
 ## Miscellaneous Tab
 miscellaneousTab.title=Miscellaneous Options
 lblUserDir.text=User Files Directory:

--- a/MekHQ/resources/mekhq/resources/ImmersiveDialogConfirmation.properties
+++ b/MekHQ/resources/mekhq/resources/ImmersiveDialogConfirmation.properties
@@ -38,6 +38,8 @@ ImmersiveDialogConfirmation.confirmationContractRental.text.primary=You will not
   employer what facilities you want to rent.
 ImmersiveDialogConfirmation.confirmationBeginTransit.text.primary=If you select 'confirm,' the funds for the entire \
   journey will be deducted from your account.
+ImmersiveDialogConfirmation.confirmationResolveScenario.text.primary=This is a point of no return.\
+  <p>If you select 'confirm,' the scenario will be resolved. It will not be possible to undo this action.</p>
 ImmersiveDialogConfirmation.confirmationStratConBatchallBreach.text.primary=If you select 'confirm,' the terms of \
   your batchall will be broken. The Clan OpFor will no longer bid for the duration of the contract. If you have \
   Faction Standings enabled, your standing with the Clan will be negatively affected.

--- a/MekHQ/src/mekhq/MHQConstants.java
+++ b/MekHQ/src/mekhq/MHQConstants.java
@@ -238,6 +238,7 @@ public final class MHQConstants extends SuiteConstants {
     public static final String CONFIRMATION_CONTRACT_RENTAL = "confirmationContractRental";
     public static final String CONFIRMATION_FACTION_STANDINGS_ULTIMATUM = "confirmationFactionStandingsUltimatum";
     public static final String CONFIRMATION_BEGIN_TRANSIT = "confirmationBeginTransit";
+    public static final String CONFIRMATION_RESOLVE_SCENARIO = "confirmationResolveScenario";
     public static final String CONFIRMATION_STRATCON_BATCHALL_BREACH = "confirmationStratConBatchallBreach";
     public static final String CONFIRMATION_STRATCON_DEPLOY = "confirmationStratConDeploy";
     public static final String CONFIRMATION_ABANDON_UNITS = "confirmationAbandonUnits";

--- a/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
@@ -237,6 +237,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
     private JCheckBox optionBeginTransitConfirmation;
     private JCheckBox optionStratConBatchallBreachConfirmation;
     private JCheckBox optionStratConDeployConfirmation;
+    private JCheckBox optionResolveScenarioConfirmation;
     private JCheckBox optionAbandonUnitsConfirmation;
     private JCheckBox optionAssignTechsConfirmation;
 
@@ -973,15 +974,18 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         chkNewDayBattleArmorPoolFill.setName("chkNewDayBattleArmorPoolFill");
 
         chkNewDayVehicleCrewGroundPoolFill = new JCheckBox(resources.getString("chkNewDayVehicleCrewGroundPoolFill.text"));
-        chkNewDayVehicleCrewGroundPoolFill.setToolTipText(resources.getString("chkNewDayVehicleCrewGroundPoolFill.toolTipText"));
+        chkNewDayVehicleCrewGroundPoolFill.setToolTipText(resources.getString(
+              "chkNewDayVehicleCrewGroundPoolFill.toolTipText"));
         chkNewDayVehicleCrewGroundPoolFill.setName("chkNewDayVehicleCrewGroundPoolFill");
 
         chkNewDayVehicleCrewVTOLPoolFill = new JCheckBox(resources.getString("chkNewDayVehicleCrewVTOLPoolFill.text"));
-        chkNewDayVehicleCrewVTOLPoolFill.setToolTipText(resources.getString("chkNewDayVehicleCrewVTOLPoolFill.toolTipText"));
+        chkNewDayVehicleCrewVTOLPoolFill.setToolTipText(resources.getString(
+              "chkNewDayVehicleCrewVTOLPoolFill.toolTipText"));
         chkNewDayVehicleCrewVTOLPoolFill.setName("chkNewDayVehicleCrewVTOLPoolFill");
 
         chkNewDayVehicleCrewNavalPoolFill = new JCheckBox(resources.getString("chkNewDayVehicleCrewNavalPoolFill.text"));
-        chkNewDayVehicleCrewNavalPoolFill.setToolTipText(resources.getString("chkNewDayVehicleCrewNavalPoolFill.toolTipText"));
+        chkNewDayVehicleCrewNavalPoolFill.setToolTipText(resources.getString(
+              "chkNewDayVehicleCrewNavalPoolFill.toolTipText"));
         chkNewDayVehicleCrewNavalPoolFill.setName("chkNewDayVehicleCrewNavalPoolFill");
 
         chkNewDayVesselPilotPoolFill = new JCheckBox(resources.getString("chkNewDayVesselPilotPoolFill.text"));
@@ -1039,7 +1043,8 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
               "lblNewDayFormationIconOperationalStatusStyle.toolTipText"));
         lblNewDayFormationIconOperationalStatusStyle.setName("lblNewDayFormationIconOperationalStatusStyle");
 
-        comboNewDayFormationIconOperationalStatusStyle = new MMComboBox<>("comboNewDayFormationIconOperationalStatusStyle",
+        comboNewDayFormationIconOperationalStatusStyle = new MMComboBox<>(
+              "comboNewDayFormationIconOperationalStatusStyle",
               FormationIconOperationalStatusStyle.values());
         comboNewDayFormationIconOperationalStatusStyle.setToolTipText(resources.getString(
               "lblNewDayFormationIconOperationalStatusStyle.toolTipText"));
@@ -1278,6 +1283,12 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
               "optionStratConDeployConfirmation.toolTipText"));
         optionStratConDeployConfirmation.setName("optionStratConDeployConfirmation");
 
+        optionResolveScenarioConfirmation = new JCheckBox(resources.getString(
+              "optionResolveScenarioConfirmation.text"));
+        optionResolveScenarioConfirmation.setToolTipText(resources.getString(
+              "optionResolveScenarioConfirmation.toolTipText"));
+        optionResolveScenarioConfirmation.setName("optionResolveScenarioConfirmation");
+
         optionAbandonUnitsConfirmation = new JCheckBox(resources.getString(
               "optionAbandonUnitsConfirmation.text"));
         optionAbandonUnitsConfirmation.setToolTipText(resources.getString(
@@ -1326,6 +1337,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
                                       .addComponent(optionBeginTransitConfirmation)
                                       .addComponent(optionStratConBatchallBreachConfirmation)
                                       .addComponent(optionStratConDeployConfirmation)
+                                      .addComponent(optionResolveScenarioConfirmation)
                                       .addComponent(optionAbandonUnitsConfirmation)
                                       .addComponent(optionAssignTechsConfirmation));
 
@@ -1356,6 +1368,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
                                         .addComponent(optionBeginTransitConfirmation)
                                         .addComponent(optionStratConBatchallBreachConfirmation)
                                         .addComponent(optionStratConDeployConfirmation)
+                                        .addComponent(optionResolveScenarioConfirmation)
                                         .addComponent(optionAbandonUnitsConfirmation)
                                         .addComponent(optionAssignTechsConfirmation));
 
@@ -1719,6 +1732,9 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
               .setNagDialogIgnore(MHQConstants.CONFIRMATION_STRATCON_DEPLOY,
                     optionStratConDeployConfirmation.isSelected());
         options
+              .setNagDialogIgnore(MHQConstants.CONFIRMATION_RESOLVE_SCENARIO,
+                    optionResolveScenarioConfirmation.isSelected());
+        options
               .setNagDialogIgnore(MHQConstants.CONFIRMATION_ABANDON_UNITS,
                     optionAbandonUnitsConfirmation.isSelected());
         options
@@ -1861,7 +1877,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
             chkNewDayFormationIconOperationalStatus.doClick();
         }
         comboNewDayFormationIconOperationalStatusStyle.setSelectedItem(options
-                                                                         .getNewDayFormationIconOperationalStatusStyle());
+                                                                             .getNewDayFormationIconOperationalStatusStyle());
 
         optionPreferGzippedOutput.setSelected(options.getPreferGzippedOutput());
         optionWriteCustomsToXML.setSelected(options.getWriteCustomsToXML());
@@ -1918,10 +1934,13 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
 
         optionStratConDeployConfirmation.setSelected(options
                                                            .getNagDialogIgnore(MHQConstants.CONFIRMATION_STRATCON_DEPLOY));
+
+        optionResolveScenarioConfirmation.setSelected(options
+                                                            .getNagDialogIgnore(MHQConstants.CONFIRMATION_RESOLVE_SCENARIO));
         optionAbandonUnitsConfirmation.setSelected(options
                                                          .getNagDialogIgnore(MHQConstants.CONFIRMATION_ABANDON_UNITS));
         optionAssignTechsConfirmation.setSelected(options
-                                                         .getNagDialogIgnore(MHQConstants.CONFIRMATION_ASSIGN_TECHS));
+                                                        .getNagDialogIgnore(MHQConstants.CONFIRMATION_ASSIGN_TECHS));
         txtUserDir.setText(PreferenceManager.getClientPreferences().getUserDir());
         spnStartGameDelay.setValue(options.getStartGameDelay());
         spnStartGameClientDelay.setValue(options.getStartGameClientDelay());

--- a/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
@@ -34,6 +34,7 @@
 package mekhq.gui.dialog;
 
 import static megamek.client.ui.util.UIUtil.scaleForGUI;
+import static mekhq.MHQConstants.CONFIRMATION_RESOLVE_SCENARIO;
 import static mekhq.campaign.enums.DailyReportType.FINANCES;
 import static mekhq.campaign.enums.DailyReportType.GENERAL;
 import static mekhq.campaign.mission.resupplyAndCaches.PerformResupply.RESUPPLY_LOOT_BOX_NAME;
@@ -94,6 +95,7 @@ import mekhq.campaign.stratCon.StratConRulesManager;
 import mekhq.campaign.unit.TestUnit;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.baseComponents.DefaultMHQScrollablePanel;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogConfirmation;
 import mekhq.gui.utilities.MarkdownEditorPanel;
 import mekhq.gui.view.PersonViewPanel;
 import mekhq.utilities.ReportingUtilities;
@@ -343,7 +345,17 @@ public class ResolveScenarioWizardDialog extends JDialog {
         btnFinish = new JButton(resourceMap.getString("btnFinish.text"));
         btnFinish.setName("btnFinish");
         btnFinish.setMnemonic(KeyEvent.VK_F);
-        btnFinish.addActionListener(evt -> finish());
+        btnFinish.addActionListener(evt -> {
+            if (!MekHQ.getMHQOptions().getNagDialogIgnore(CONFIRMATION_RESOLVE_SCENARIO)) {
+                ImmersiveDialogConfirmation dialog = new ImmersiveDialogConfirmation(campaign,
+                      CONFIRMATION_RESOLVE_SCENARIO);
+                if (!dialog.wasConfirmed()) {
+                    return;
+                }
+            }
+
+            finish();
+        });
         gridBagConstraints.gridx = 3;
         panButtons.add(btnFinish, gridBagConstraints);
 


### PR DESCRIPTION
We received feedback that it was a poor play experience that there isn't a way to back out of the salvage dialog post-scenario. The root cause is that the scenario salvage dialog _stuff_ occurs after MekHQ has already resolved the scenario, therefore it's not possible to return to scenario resolution at that time.

I chewed the issue for a bit and what I ended up doing was adding a confirmation dialog to the 'Finish' button (in the resolve scenario dialog). This informs the player that they're hitting a point of no return.\

As with other nag dialogs, this can be set to ignore, at which point it will stop displaying.