### PR TITLE
Fix getting multiple injuries for twins/triplets/etc and remove all injuries from generated personnel

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
+++ b/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
@@ -478,21 +478,23 @@ public abstract class AbstractProcreation {
                 baby.changeStatus(campaign, today, PersonnelStatus.ON_LEAVE);
             }
 
-            // Apply postpartum effects
-            if (campaignOptions.isUseAdvancedMedical()) {
-                Injury injury;
-                if (campaignOptions.isUseAlternativeAdvancedMedical() &&
-                          // These injury types don't stack
-                          !AdvancedMedicalAlternate.hasInjuryOfType(mother.getInjuries(),
-                                AlternateInjuries.POSTPARTUM_RECOVERY)) {
-                    injury = AlternateInjuries.POSTPARTUM_RECOVERY.newInjury(campaign, mother, GENERIC, 1);
+            // Apply postpartum effects (first baby only)
+            if (i == 0) {
+                if (campaignOptions.isUseAdvancedMedical()) {
+                    Injury injury;
+                    if (campaignOptions.isUseAlternativeAdvancedMedical() &&
+                              // These injury types don't stack
+                              !AdvancedMedicalAlternate.hasInjuryOfType(mother.getInjuries(),
+                                    AlternateInjuries.POSTPARTUM_RECOVERY)) {
+                        injury = AlternateInjuries.POSTPARTUM_RECOVERY.newInjury(campaign, mother, GENERIC, 1);
+                    } else {
+                        injury = InjuryTypes.POSTPARTUM_RECOVERY.newInjury(campaign, mother, INTERNAL, 1);
+                    }
+                    mother.addInjury(injury);
                 } else {
-                    injury = InjuryTypes.POSTPARTUM_RECOVERY.newInjury(campaign, mother, INTERNAL, 1);
+                    int currentHits = mother.getHits();
+                    mother.setHits(currentHits + 1);
                 }
-                mother.addInjury(injury);
-            } else {
-                int currentHits = mother.getHits();
-                mother.setHits(currentHits + 1);
             }
 
             // Check for hereditary diseases

--- a/MekHQ/src/mekhq/campaign/universe/generators/companyGenerators/AbstractCompanyGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/generators/companyGenerators/AbstractCompanyGenerator.java
@@ -65,6 +65,7 @@ import mekhq.MHQStaticDirectoryManager;
 import mekhq.MekHQ;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.finances.Loan;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.enums.FinancialTerm;
@@ -708,6 +709,20 @@ public abstract class AbstractCompanyGenerator {
 
                     if (getOptions().isSimulateRandomProcreation()) {
                         campaign.getProcreation().processNewWeek(campaign, date, tracker.getPerson());
+                    }
+                }
+            }
+            //remove any post-partum injuries/hits that may have been applied due to giving birth
+            for (final CompanyGenerationPersonTracker tracker : trackers) {
+                CampaignOptions campaignOptions = campaign.getCampaignOptions();
+                Person person = tracker.getPerson();
+                if (person.needsFixing()) {
+                    if (campaignOptions.isUseAdvancedMedical()) {
+                        person.clearInjuriesExcludingProsthetics(campaign.getLocalDate());
+                    } else {
+                        while (person.needsFixing()) {
+                            person.heal();
+                        }
                     }
                 }
             }


### PR DESCRIPTION
If a person gives birth to multiple children, a post-partum injury (or a hit) would be added for each baby. This is unintended, it should be a single injury (or hit).

Also, when using the option to run a simulation for a few years in the Company Generator, the generated personnel would also give birth. The post-partum injuries (or hits) from that would still be present on the person, even if the birth occurred years ago. This PR fixes that by removing all injuries (or hits) from the generated personnel.