### PR TITLE
Fix #9039: Fixed Scenarios Not Starting When Salvage is Skipped

### DIFF
--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -944,7 +944,7 @@ public final class BriefingTab extends CampaignGuiTab {
 
             // If we didn't pick any salvage units, there's no point assigning techs
             if (scenario.getSalvageFormations().isEmpty()) {
-                return true;
+                return false;
             }
 
             return !displaySalvageTechPicker(scenario);


### PR DESCRIPTION
Fix #9039

Scenarios were not starting if salvage was skipped. This was due to a wonky conditional.

This PR fixes it.