### PR TITLE
PR: Refactor Campaign::getLocation to Campaign::getCurrentLocation to avoid conflict with Part::getLocation

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -166,7 +166,6 @@ import mekhq.campaign.market.PartsStore;
 import mekhq.campaign.market.PersonnelMarket;
 import mekhq.campaign.market.ShoppingList;
 import mekhq.campaign.market.contractMarket.AbstractContractMarket;
-import mekhq.campaign.market.personnelMarket.enums.PersonnelMarketStyle;
 import mekhq.campaign.market.personnelMarket.markets.NewPersonnelMarket;
 import mekhq.campaign.market.unitMarket.AbstractUnitMarket;
 import mekhq.campaign.mission.AtBContract;
@@ -1738,7 +1737,7 @@ public class Campaign implements ITechManager {
      */
     public void moveToPlanetarySystem(PlanetarySystem planetarySystem) {
         setLocation(new CurrentLocation(planetarySystem, 0.0));
-        MekHQ.triggerEvent(new LocationChangedEvent(getLocation(), false));
+        MekHQ.triggerEvent(new LocationChangedEvent(getCurrentLocation(), false));
 
         if (getAutomatedMothballUnits().isEmpty()) {
             performAutomatedActivation(this);
@@ -1749,7 +1748,7 @@ public class Campaign implements ITechManager {
         }
     }
 
-    public CurrentLocation getLocation() {
+    public CurrentLocation getCurrentLocation() {
         return location;
     }
 

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -69,7 +69,6 @@ import static mekhq.campaign.personnel.medical.advancedMedicalAlternate.Canonica
 import static mekhq.campaign.personnel.medical.advancedMedicalAlternate.CanonicalDiseaseType.getNewDiseaseOutbreaks;
 import static mekhq.campaign.personnel.skills.Aging.applyAgingSPA;
 import static mekhq.campaign.personnel.skills.Aging.getMilestone;
-import static mekhq.campaign.personnel.skills.AttributeCheckUtility.performQuickAttributeCheck;
 import static mekhq.campaign.personnel.skills.SkillModifierData.IGNORE_AGE;
 import static mekhq.campaign.personnel.turnoverAndRetention.Fatigue.areFieldKitchensWithinCapacity;
 import static mekhq.campaign.personnel.turnoverAndRetention.Fatigue.checkFieldKitchenCapacity;
@@ -386,8 +385,8 @@ public class CampaignNewDayManager {
 
         campaign.readNews();
 
-        campaign.getLocation().newDay(campaign);
-        updatedLocation = campaign.getLocation();
+        campaign.getCurrentLocation().newDay(campaign);
+        updatedLocation = campaign.getCurrentLocation();
 
         updateFacilities();
 
@@ -1214,7 +1213,7 @@ public class CampaignNewDayManager {
                 // If we're in transit and we don't allow deliveries while in transit the part will remain fixed with
                 // a delivery time of 1 day until we arrive at our destination.
                 if (campaignOptions.isNoDeliveriesInTransit() &&
-                          !campaign.getLocation().isOnPlanet() &&
+                          !campaign.getCurrentLocation().isOnPlanet() &&
                           newDaysToArrival <= 0) {
                     return;
                 }
@@ -1289,7 +1288,8 @@ public class CampaignNewDayManager {
                 campaign.workOnMothballingOrActivation(unit);
             }
             if (!unit.isPresent()) {
-                unit.checkArrival(!campaign.getLocation().isOnPlanet() && campaignOptions.isNoDeliveriesInTransit());
+                unit.checkArrival(!campaign.getCurrentLocation().isOnPlanet() &&
+                                        campaignOptions.isNoDeliveriesInTransit());
 
                 // Has unit just been delivered?
                 if (unit.isPresent()) {

--- a/MekHQ/src/mekhq/campaign/HumanResources.java
+++ b/MekHQ/src/mekhq/campaign/HumanResources.java
@@ -1942,7 +1942,7 @@ public class HumanResources {
                         add));
         }
 
-        CurrentLocation location = campaign.getLocation();
+        CurrentLocation location = campaign.getCurrentLocation();
         if (location.isOnPlanet()) {
             Planet planet = location.getPlanet();
             String planetId = planet.getId();

--- a/MekHQ/src/mekhq/campaign/finances/Accountant.java
+++ b/MekHQ/src/mekhq/campaign/finances/Accountant.java
@@ -162,7 +162,7 @@ public record Accountant(Campaign campaign) {
      */
     public Money getMonthlyFoodAndHousingExpenses() {
         boolean payForFood = getCampaignOptions().isPayForFood();
-        CurrentLocation location = campaign.getLocation();
+        CurrentLocation location = campaign.getCurrentLocation();
         boolean isOnPlanet = location.isOnPlanet();
         boolean payForHousing = getCampaignOptions().isPayForHousing() && isOnPlanet;
 

--- a/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2013 Dylan Myers <dylan at dylanspcs.com>. All rights reserved.
- * Copyright (C) 2013-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2013-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
@@ -145,11 +145,11 @@ public class PersonnelMarket {
      *                 current planetary system, date, settings, factions, and more.
      */
     public void generatePersonnelForDay(Campaign campaign) {
-        PlanetarySystem location = campaign.getLocation().getCurrentSystem();
+        PlanetarySystem location = campaign.getCurrentLocation().getCurrentSystem();
         LocalDate today = campaign.getLocalDate();
 
         // Determine conditions
-        boolean isOnPlanet = campaign.getLocation().isOnPlanet();
+        boolean isOnPlanet = campaign.getCurrentLocation().isOnPlanet();
         boolean useCapitalsHiringHallsOnly = campaign.getCampaignOptions().isUsePersonnelHireHiringHallOnly();
         boolean isHiringHall = location.isHiringHall(today);
         boolean isCapital = location.getFactionSet(today)

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/ContractAutomation.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/ContractAutomation.java
@@ -82,7 +82,7 @@ public class ContractAutomation {
      */
     public static void contractStartPrompt(Campaign campaign, Contract contract) {
         // If we're already in the right system, there is no need to automate these actions
-        if (Objects.equals(campaign.getLocation().getCurrentSystem(), contract.getSystem())) {
+        if (Objects.equals(campaign.getCurrentLocation().getCurrentSystem(), contract.getSystem())) {
             return;
         }
 
@@ -147,7 +147,7 @@ public class ContractAutomation {
                 return;
             }
 
-            campaign.getLocation().setJumpPath(jumpPath);
+            campaign.getCurrentLocation().setJumpPath(jumpPath);
             campaign.getUnits().forEach(unit -> unit.setSite(Unit.SITE_FACILITY_BASIC));
             campaign.getApp().getCampaigngui().refreshAllTabs();
             campaign.getApp().getCampaigngui().refreshLocation();

--- a/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketMekHQ.java
+++ b/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketMekHQ.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketMekHQ.java
+++ b/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketMekHQ.java
@@ -199,7 +199,7 @@ public class PersonnelMarketMekHQ extends NewPersonnelMarket {
      */
     @Override
     public String getAvailabilityMessage() {
-        CurrentLocation location = getCampaign().getLocation();
+        CurrentLocation location = getCampaign().getCurrentLocation();
         String color;
         String closingBrace = CLOSING_SPAN_TAG;
 
@@ -373,7 +373,7 @@ public class PersonnelMarketMekHQ extends NewPersonnelMarket {
     private double getFactionStandingsRecruitmentModifier() {
         FactionStandings factionStandings = getCampaign().getFactionStandings();
 
-        CurrentLocation location = getCampaign().getLocation();
+        CurrentLocation location = getCampaign().getCurrentLocation();
         PlanetarySystem currentSystem = location.getCurrentSystem();
         double multiplier = 0;
 
@@ -399,7 +399,7 @@ public class PersonnelMarketMekHQ extends NewPersonnelMarket {
      * @since 0.50.06
      */
     public int getSystemStatusRecruitmentMultiplier() {
-        CurrentLocation location = getCampaign().getLocation();
+        CurrentLocation location = getCampaign().getCurrentLocation();
         PlanetarySystem currentSystem = location.getCurrentSystem();
 
         LocalDate today = getCampaign().getLocalDate();

--- a/MekHQ/src/mekhq/campaign/mission/Contract.java
+++ b/MekHQ/src/mekhq/campaign/mission/Contract.java
@@ -566,7 +566,7 @@ public class Contract extends Mission {
 
             JumpPath jumpPath = getJumpPath(campaign);
             double days = Math.round(jumpPath.getTotalTime(campaign.getLocalDate(),
-                  campaign.getLocation().getTransitTime(), isUseCommandCircuit) * 100.0)
+                  campaign.getCurrentLocation().getTransitTime(), isUseCommandCircuit) * 100.0)
                                 / 100.0;
             return (int) ceil(days);
         }
@@ -827,7 +827,7 @@ public class Contract extends Mission {
                         campaign.getFactionStandings(), campaign.getFutureAtBContracts());
 
             int days = (int) ceil(getJumpPath(campaign).getTotalTime(campaign.getLocalDate(),
-                  campaign.getLocation().getTransitTime(), isUseCommandCircuit));
+                  campaign.getCurrentLocation().getTransitTime(), isUseCommandCircuit));
             startDate = startDate.plusDays(days);
         }
 
@@ -862,7 +862,7 @@ public class Contract extends Mission {
         boolean useTwoWayPay = campaign.getCampaignOptions().isUseTwoWayPay();
         boolean isUseCommandCircuits = campaign.isUseCommandCircuitForContract(this);
         int duration = (int) ceil(jumpPath.getTotalTime(campaign.getLocalDate(),
-              campaign.getLocation().getTransitTime(), isUseCommandCircuits));
+              campaign.getCurrentLocation().getTransitTime(), isUseCommandCircuits));
         Money transportCost = transportCostCalculations.calculateJumpCostForEntireJourney(duration,
               jumpPath.getJumps());
 

--- a/MekHQ/src/mekhq/campaign/mission/rentals/FacilityRentals.java
+++ b/MekHQ/src/mekhq/campaign/mission/rentals/FacilityRentals.java
@@ -482,7 +482,7 @@ public class FacilityRentals {
             }
         }
 
-        if (!isBayRentalAllowed || !campaign.getLocation().isOnPlanet()) {
+        if (!isBayRentalAllowed || !campaign.getCurrentLocation().isOnPlanet()) {
             BayRentalDialog.showNoFacilitiesAvailableDialog(campaign);
             return false;
         }

--- a/MekHQ/src/mekhq/campaign/personnel/death/RandomDeath.java
+++ b/MekHQ/src/mekhq/campaign/personnel/death/RandomDeath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2022-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/campaign/personnel/death/RandomDeath.java
+++ b/MekHQ/src/mekhq/campaign/personnel/death/RandomDeath.java
@@ -539,7 +539,7 @@ public class RandomDeath {
      * @return the HPG access multiplier, or 0 if no modifier is required.
      */
     private double getHpgAccessMultiplier() {
-        HPGRating hpgRating = campaign.getLocation().getPlanet().getHPG(campaign.getLocalDate());
+        HPGRating hpgRating = campaign.getCurrentLocation().getPlanet().getHPG(campaign.getLocalDate());
         if (hpgRating != null && hpgRating.compareTo(HPGRating.B) >= 0) {
             return MEDICAL_MULTIPLIER_HPG_ACCESS;
         }

--- a/MekHQ/src/mekhq/campaign/personnel/lifeEvents/WinterHolidayAnnouncement.java
+++ b/MekHQ/src/mekhq/campaign/personnel/lifeEvents/WinterHolidayAnnouncement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/campaign/personnel/lifeEvents/WinterHolidayAnnouncement.java
+++ b/MekHQ/src/mekhq/campaign/personnel/lifeEvents/WinterHolidayAnnouncement.java
@@ -132,7 +132,7 @@ public record WinterHolidayAnnouncement(Campaign campaign) {
         String commanderAddress = campaign.getCommanderAddress();
 
         // Determine the location context
-        String location = campaign.getLocation().isOnPlanet() ? "planetside" : "transit";
+        String location = campaign.getCurrentLocation().isOnPlanet() ? "planetside" : "transit";
 
         // Generate each paragraph and concatenate the full message
         StringBuilder messageBuilder = new StringBuilder();

--- a/MekHQ/src/mekhq/campaign/personnel/marriage/AbstractMarriage.java
+++ b/MekHQ/src/mekhq/campaign/personnel/marriage/AbstractMarriage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2021-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/campaign/personnel/marriage/AbstractMarriage.java
+++ b/MekHQ/src/mekhq/campaign/personnel/marriage/AbstractMarriage.java
@@ -374,7 +374,7 @@ public abstract class AbstractMarriage {
             }
         }
 
-        if (!isInterUnit && campaign.getLocation().isOnPlanet()) {
+        if (!isInterUnit && campaign.getCurrentLocation().isOnPlanet()) {
             List<Gender> possibleGenders = new ArrayList<>();
             if (prefersMen) {
                 possibleGenders.add(Gender.MALE);

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/Inoculations.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/Inoculations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/Inoculations.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/Inoculations.java
@@ -118,7 +118,7 @@ public class Inoculations {
      * @since 0.50.10
      */
     public static void triggerInoculationPrompt(Campaign campaign, boolean isAdHoc) {
-        CurrentLocation location = campaign.getLocation();
+        CurrentLocation location = campaign.getCurrentLocation();
         if (!location.isOnPlanet()) {
             new ImmersiveDialogNotification(campaign, getTextAt(RESOURCE_BUNDLE, "Inoculations.inTransit"), true);
             return;
@@ -491,7 +491,7 @@ public class Inoculations {
      * @since 0.50.10
      */
     public static void performDiseaseChecks(Campaign campaign) {
-        CurrentLocation location = campaign.getLocation();
+        CurrentLocation location = campaign.getCurrentLocation();
         LocalDate today = campaign.getLocalDate();
 
         String planetCode = location.isOnPlanet() ? location.getPlanet().getId() : null;

--- a/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
+++ b/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
@@ -432,7 +432,7 @@ public abstract class AbstractProcreation {
             // Create a baby
             final Person baby = campaign.newDependent(Gender.RANDOMIZE,
                   mother.getOriginFaction(),
-                  campaign.getLocation().getPlanet());
+                  campaign.getCurrentLocation().getPlanet());
             baby.setSurname(campaignOptions.getBabySurnameStyle()
                                   .generateBabySurname(mother, father, baby.getGender()));
 

--- a/MekHQ/src/mekhq/campaign/storyArc/storypoint/TravelStoryPoint.java
+++ b/MekHQ/src/mekhq/campaign/storyArc/storypoint/TravelStoryPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/campaign/storyArc/storypoint/TravelStoryPoint.java
+++ b/MekHQ/src/mekhq/campaign/storyArc/storypoint/TravelStoryPoint.java
@@ -110,10 +110,10 @@ public class TravelStoryPoint extends StoryPoint {
             // if we don't have a valid destination, then complete the story point
             complete();
         } else if (autoStart) {
-            CurrentLocation location = getStoryArc().getCampaign().getLocation();
+            CurrentLocation location = getStoryArc().getCampaign().getCurrentLocation();
             JumpPath path = getStoryArc().getCampaign().calculateJumpPath(location.getCurrentSystem(),
                   getDestination());
-            getStoryArc().getCampaign().getLocation().setJumpPath(path);
+            getStoryArc().getCampaign().getCurrentLocation().setJumpPath(path);
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -1046,7 +1046,7 @@ public class StratConRulesManager {
         // Unstreamlined units (e.g. Behemoth) cannot operate in atmosphere or on the ground,
         // but they can operate on airless worlds (vacuum)
         if (isAtmospheric && entity.hasQuirk(OptionsConstants.QUIRK_NEG_UNSTREAMLINED)) {
-            Planet planet = campaign.getLocation().getPlanet();
+            Planet planet = campaign.getCurrentLocation().getPlanet();
             if (planet == null || !planet.getAtmosphere(campaign.getLocalDate()).isNone()) {
                 return false;
             }

--- a/MekHQ/src/mekhq/campaign/unit/Maintenance.java
+++ b/MekHQ/src/mekhq/campaign/unit/Maintenance.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2009 - Jay Lawson (jaylawson39 at yahoo.com). All Rights Reserved.
- * Copyright (C) 2013-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2013-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/campaign/unit/Maintenance.java
+++ b/MekHQ/src/mekhq/campaign/unit/Maintenance.java
@@ -425,8 +425,8 @@ public class Maintenance {
         }
 
         if (partWork.getUnit().getSite() < SITE_FACILITY_BASIC) {
-            if (campaign.getLocation().isOnPlanet() && campaignOptions.isUsePlanetaryModifiers()) {
-                Planet planet = campaign.getLocation().getPlanet();
+            if (campaign.getCurrentLocation().isOnPlanet() && campaignOptions.isUsePlanetaryModifiers()) {
+                Planet planet = campaign.getCurrentLocation().getPlanet();
                 Atmosphere atmosphere = planet.getAtmosphere(campaign.getLocalDate());
                 megamek.common.planetaryConditions.Atmosphere planetaryConditions = planet.getPressure(campaign.getLocalDate());
                 int temperature = planet.getTemperature(campaign.getLocalDate());

--- a/MekHQ/src/mekhq/campaign/universe/FactionBorderTracker.java
+++ b/MekHQ/src/mekhq/campaign/universe/FactionBorderTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2018-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/campaign/universe/FactionBorderTracker.java
+++ b/MekHQ/src/mekhq/campaign/universe/FactionBorderTracker.java
@@ -495,7 +495,7 @@ public class FactionBorderTracker {
         invalid |= now.minusDays(dayThreshold).isAfter(lastUpdate)
                          || now.plusDays(dayThreshold).isBefore(lastUpdate);
 
-        PlanetarySystem loc = event.getCampaign().getLocation().getCurrentSystem();
+        PlanetarySystem loc = event.getCampaign().getCurrentLocation().getCurrentSystem();
         if (!regionHex.isCenter(loc.getX(), loc.getY())) {
             invalid |= (distanceThreshold > 0)
                              && (regionHex.distanceTo(loc.getX(), loc.getY()) > distanceThreshold);

--- a/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
@@ -111,7 +111,7 @@ public class RandomFactionGenerator {
 
     public void startup(Campaign c) {
         borderTracker.setDate(c.getLocalDate());
-        final PlanetarySystem location = c.getLocation().getCurrentSystem();
+        final PlanetarySystem location = c.getCurrentLocation().getCurrentSystem();
         borderTracker.setRegionCenter(location.getX(), location.getY());
         borderTracker.setRegionRadius(c.getCampaignOptions().getContractSearchRadius());
         MekHQ.registerHandler(borderTracker);

--- a/MekHQ/src/mekhq/campaign/universe/generators/companyGenerators/AbstractCompanyGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/generators/companyGenerators/AbstractCompanyGenerator.java
@@ -1615,7 +1615,7 @@ public abstract class AbstractCompanyGenerator {
         }
 
         if (getOptions().isStartCourseToContractPlanet()) {
-            campaign.getLocation().setJumpPath(contract.getJumpPath(campaign));
+            campaign.getCurrentLocation().setJumpPath(contract.getJumpPath(campaign));
         }
     }
     // endregion Contract

--- a/MekHQ/src/mekhq/campaign/universe/selectors/planetSelectors/DefaultPlanetSelector.java
+++ b/MekHQ/src/mekhq/campaign/universe/selectors/planetSelectors/DefaultPlanetSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2019-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/campaign/universe/selectors/planetSelectors/DefaultPlanetSelector.java
+++ b/MekHQ/src/mekhq/campaign/universe/selectors/planetSelectors/DefaultPlanetSelector.java
@@ -78,7 +78,9 @@ public class DefaultPlanetSelector extends AbstractPlanetSelector {
 
     @Override
     public @Nullable Planet selectPlanet(final Campaign campaign) {
-        return (getPlanet() == null) ? getOptions().determinePlanet(campaign.getLocation().getPlanet()) : getPlanet();
+        return (getPlanet() == null) ?
+                     getOptions().determinePlanet(campaign.getCurrentLocation().getPlanet()) :
+                     getPlanet();
     }
 
     @Override

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -1602,7 +1602,7 @@ public class CampaignGUI extends JPanel {
                     getCampaign().isGM(), getCampaign().getCampaignOptions().isUseFactionStandingCommandCircuitSafe(),
                     getCampaign().getFactionStandings(), getCampaign().getFutureAtBContracts());
 
-        lblLocation = new JLabel(getCampaign().getLocation()
+        lblLocation = new JLabel(getCampaign().getCurrentLocation()
                                        .getReport(getCampaign().getLocalDate(),
                                              isUseCommandCircuit,
                                              getCampaign().getTransportCostCalculation(EXP_REGULAR)));
@@ -3366,7 +3366,7 @@ public class CampaignGUI extends JPanel {
                     getCampaign().isGM(), getCampaign().getCampaignOptions().isUseFactionStandingCommandCircuitSafe(),
                     getCampaign().getFactionStandings(), getCampaign().getFutureAtBContracts());
 
-        lblLocation.setText(getCampaign().getLocation()
+        lblLocation.setText(getCampaign().getCurrentLocation()
                                   .getReport(getCampaign().getLocalDate(),
                                         isUseCommandCircuit,
                                         getCampaign().getTransportCostCalculation(EXP_REGULAR)));

--- a/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
+++ b/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
@@ -275,9 +275,9 @@ public class InterstellarMapPanel extends JPanel {
                     centerM.add(item);
                     popup.add(centerM);
                     item = new JMenuItem("Cancel Current Trip");
-                    item.setEnabled(null != InterstellarMapPanel.this.campaign.getLocation().getJumpPath());
+                    item.setEnabled(null != InterstellarMapPanel.this.campaign.getCurrentLocation().getJumpPath());
                     item.addActionListener(evt -> {
-                        InterstellarMapPanel.this.campaign.getLocation().setJumpPath(null);
+                        InterstellarMapPanel.this.campaign.getCurrentLocation().setJumpPath(null);
                         repaint();
                     });
                     popup.add(item);
@@ -349,11 +349,11 @@ public class InterstellarMapPanel extends JPanel {
                     menuGM.add(item);
 
                     item = new JMenuItem("Recharge Jumpdrive");
-                    item.setEnabled(InterstellarMapPanel.this.campaign.getLocation()
+                    item.setEnabled(InterstellarMapPanel.this.campaign.getCurrentLocation()
                                           .isRecharging(InterstellarMapPanel.this.campaign) &&
                                           InterstellarMapPanel.this.campaign.isGM());
                     item.addActionListener(evt -> {
-                        InterstellarMapPanel.this.campaign.getLocation()
+                        InterstellarMapPanel.this.campaign.getCurrentLocation()
                               .setRecharged(InterstellarMapPanel.this.campaign);
                         InterstellarMapPanel.this.campaign.addReport(GENERAL, "GM: Jumpship drives fully charged");
                         hqView.refreshLocation();
@@ -713,9 +713,13 @@ public class InterstellarMapPanel extends JPanel {
 
                 // check to see if the unit is traveling on a jump path currently and if so
                 // draw this one too, in a different color
-                if (null != InterstellarMapPanel.this.campaign.getLocation().getJumpPath()) {
-                    for (int i = 0; i < InterstellarMapPanel.this.campaign.getLocation().getJumpPath().size(); i++) {
-                        PlanetarySystem systemB = InterstellarMapPanel.this.campaign.getLocation().getJumpPath().get(i);
+                if (null != InterstellarMapPanel.this.campaign.getCurrentLocation().getJumpPath()) {
+                    for (int i = 0;
+                          i < InterstellarMapPanel.this.campaign.getCurrentLocation().getJumpPath().size();
+                          i++) {
+                        PlanetarySystem systemB = InterstellarMapPanel.this.campaign.getCurrentLocation()
+                                                        .getJumpPath()
+                                                        .get(i);
                         double x = map2scrX(systemB.getX());
                         double y = map2scrY(systemB.getY());
                         // lest try rings
@@ -732,7 +736,7 @@ public class InterstellarMapPanel extends JPanel {
                         arc.setArcByCenter(x, y, size * 1.2, 0, 360, Arc2D.OPEN);
                         g2.fill(arc);
                         if (i > 0) {
-                            PlanetarySystem systemA = InterstellarMapPanel.this.campaign.getLocation()
+                            PlanetarySystem systemA = InterstellarMapPanel.this.campaign.getCurrentLocation()
                                                             .getJumpPath()
                                                             .get(i - 1);
                             g2.setPaint(Color.YELLOW);
@@ -878,9 +882,9 @@ public class InterstellarMapPanel extends JPanel {
                         double y = map2scrY(system.getY());
                         if ((conf.showPlanetNamesThreshold == 0) || (conf.scale > conf.showPlanetNamesThreshold)
                                   || jumpPath.contains(system)
-                                  || ((InterstellarMapPanel.this.campaign.getLocation().getJumpPath() != null)
+                                  || ((InterstellarMapPanel.this.campaign.getCurrentLocation().getJumpPath() != null)
                                             &&
-                                            InterstellarMapPanel.this.campaign.getLocation()
+                                            InterstellarMapPanel.this.campaign.getCurrentLocation()
                                                   .getJumpPath()
                                                   .contains(system))) {
                             final String planetName = system.getPrintableName(InterstellarMapPanel.this.campaign.getLocalDate());

--- a/MekHQ/src/mekhq/gui/MapTab.java
+++ b/MekHQ/src/mekhq/gui/MapTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2017-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/gui/MapTab.java
+++ b/MekHQ/src/mekhq/gui/MapTab.java
@@ -220,7 +220,7 @@ public final class MapTab extends CampaignGuiTab implements ActionListener {
         //the actual map
         panMap = new InterstellarMapPanel(getCampaign(), getCampaignGui());
         // let's go ahead and zoom in on the current location
-        panMap.setSelectedSystem(getCampaign().getLocation().getCurrentSystem());
+        panMap.setSelectedSystem(getCampaign().getCurrentLocation().getCurrentSystem());
         panMapView.add(panMap, BorderLayout.CENTER);
 
         JPanel pnlTutorial = new TutorialHyperlinkPanel("mapTab");
@@ -295,7 +295,7 @@ public final class MapTab extends CampaignGuiTab implements ActionListener {
 
         boolean isUseCommandCircuits = getCampaign().isUseCommandCircuit();
         int duration = (int) ceil(jumpPath.getTotalTime(getCampaign().getLocalDate(),
-              getCampaign().getLocation().getTransitTime(), isUseCommandCircuits));
+              getCampaign().getCurrentLocation().getTransitTime(), isUseCommandCircuits));
 
         TransportCostCalculations transportCostCalculations = getCampaign().getTransportCostCalculation(EXP_REGULAR);
         Money journeyCost = transportCostCalculations.calculateJumpCostForEntireJourney(duration, jumpPath.getJumps());
@@ -307,7 +307,7 @@ public final class MapTab extends CampaignGuiTab implements ActionListener {
             getCampaign().addReport(GENERAL, jumpReport);
         }
 
-        getCampaign().getLocation().setJumpPath(panMap.getJumpPath());
+        getCampaign().getCurrentLocation().setJumpPath(panMap.getJumpPath());
 
         refreshPlanetView();
         getCampaignGui().refreshLocation();

--- a/MekHQ/src/mekhq/gui/PlanetarySystemMapPanel.java
+++ b/MekHQ/src/mekhq/gui/PlanetarySystemMapPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2019-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/gui/PlanetarySystemMapPanel.java
+++ b/MekHQ/src/mekhq/gui/PlanetarySystemMapPanel.java
@@ -206,7 +206,7 @@ public class PlanetarySystemMapPanel extends JPanel {
                 // where is the JumpShip
                 int jumpshipX = zenithX + jumpPointImgWidth + 8;
                 int jumpshipY = zenithY + (jumpPointImgHeight / 2) - (shipImgSize / 2);
-                if (!PlanetarySystemMapPanel.this.campaign.getLocation().isJumpZenith()) {
+                if (!PlanetarySystemMapPanel.this.campaign.getCurrentLocation().isJumpZenith()) {
                     jumpshipX = nadirX + jumpPointImgWidth + 8;
                     jumpshipY = nadirY + (jumpPointImgHeight / 2) - (shipImgSize / 2);
                 }
@@ -272,21 +272,21 @@ public class PlanetarySystemMapPanel extends JPanel {
                         int radius = diameter / 2;
 
                         // check for current location - we assume you are on primary planet for now
-                        if (PlanetarySystemMapPanel.this.campaign.getLocation().getCurrentSystem().equals(system)
+                        if (PlanetarySystemMapPanel.this.campaign.getCurrentLocation().getCurrentSystem().equals(system)
                                   && i == system.getPrimaryPlanetPosition()) {
                             updateShipImages();
 
-                            JumpPath jp = PlanetarySystemMapPanel.this.campaign.getLocation().getJumpPath();
+                            JumpPath jp = PlanetarySystemMapPanel.this.campaign.getCurrentLocation().getJumpPath();
                             int lineX1 = x;
                             int lineY1 = y - radius;
                             int lineX2 = jumpshipX + shipImgSize;
                             int lineY2 = jumpshipY + shipImgSize;
-                            if (!PlanetarySystemMapPanel.this.campaign.getLocation().isJumpZenith()) {
+                            if (!PlanetarySystemMapPanel.this.campaign.getCurrentLocation().isJumpZenith()) {
                                 lineY2 = jumpshipY - shipImgSize;
                             }
                             if (null != jp
                                       &&
-                                      (!PlanetarySystemMapPanel.this.campaign.getLocation().isAtJumpPoint() ||
+                                      (!PlanetarySystemMapPanel.this.campaign.getCurrentLocation().isAtJumpPoint() ||
                                              jp.getLastSystem().equals(system))) {
                                 // the unit has a flight plan in this system so draw the line
                                 // in transit so draw a path
@@ -296,7 +296,7 @@ public class PlanetarySystemMapPanel extends JPanel {
                                 g2.setStroke(dashed);
                                 g2.drawLine(lineX1, lineY1, lineX2, lineY2);
                             }
-                            if (PlanetarySystemMapPanel.this.campaign.getLocation().isAtJumpPoint()) {
+                            if (PlanetarySystemMapPanel.this.campaign.getCurrentLocation().isAtJumpPoint()) {
                                 // draw a ring around jumpship
                                 drawRing(g2, jumpshipX + (shipImgSize / 2), jumpshipY + (shipImgSize / 2),
                                       shipImgSize / 2, Color.ORANGE);
@@ -304,7 +304,7 @@ public class PlanetarySystemMapPanel extends JPanel {
                                     drawRotatedImage(g2, imgJumpshipFleet, 90, jumpshipX, jumpshipY, shipImgSize,
                                           shipImgSize);
                                 }
-                            } else if (PlanetarySystemMapPanel.this.campaign.getLocation().isOnPlanet()) {
+                            } else if (PlanetarySystemMapPanel.this.campaign.getCurrentLocation().isOnPlanet()) {
                                 drawRing(g2, x, y, radius, Color.ORANGE);
                                 if (null != imgDropshipFleet) {
                                     g2.drawImage(imgDropshipFleet, x - radius - shipImgSize, y - radius - shipImgSize,
@@ -321,16 +321,16 @@ public class PlanetarySystemMapPanel extends JPanel {
                                     int lengthY = lineY1 - lineY2;
                                     double rotationRequired = getFlightRotation(lengthX, lengthY,
                                           null != jp && jp.getLastSystem().equals(system),
-                                          PlanetarySystemMapPanel.this.campaign.getLocation().isJumpZenith());
+                                          PlanetarySystemMapPanel.this.campaign.getCurrentLocation().isJumpZenith());
                                     int partialX = lineX2
                                                          +
                                                          (int) Math.round(lengthX *
-                                                                                PlanetarySystemMapPanel.this.campaign.getLocation()
+                                                                                PlanetarySystemMapPanel.this.campaign.getCurrentLocation()
                                                                                       .getPercentageTransit());
                                     int partialY = lineY2
                                                          +
                                                          (int) Math.round(lengthY *
-                                                                                PlanetarySystemMapPanel.this.campaign.getLocation()
+                                                                                PlanetarySystemMapPanel.this.campaign.getCurrentLocation()
                                                                                       .getPercentageTransit());
                                     drawRing(g2, partialX, partialY, shipImgSize / 2, Color.ORANGE);
                                     drawRotatedImage(g2, imgDropshipFleet, rotationRequired,

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -1633,7 +1633,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
             case CMD_ADD_RANDOM_DISEASE: {
                 InjuryType disease = DiseaseService.catchRandomDisease();
-                Inoculations.triggerDiseaseSpreadMessages(getCampaign(), !getCampaign().getLocation().isOnPlanet(),
+                Inoculations.triggerDiseaseSpreadMessages(getCampaign(),
+                      !getCampaign().getCurrentLocation().isOnPlanet(),
                       Set.of(disease.getSimpleName()));
                 for (Person person : people) {
                     Inoculations.applyDisease(getCampaign(), person, disease);
@@ -2257,7 +2258,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
         popup.add(menu);
 
         if (!StaticChecks.areAnyFree(selected)) {
-            if (getCampaign().getLocation().isOnPlanet()) {
+            if (getCampaign().getCurrentLocation().isOnPlanet()) {
                 popup.add(newMenuItem(resources.getString("free.text"), CMD_FREE));
                 popup.add(newMenuItem(resources.getString("execute.text"), CMD_EXECUTE));
             } else {

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2024-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
@@ -710,7 +710,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
      * @since 0.50.10
      */
     private static void inoculateAllCharacters(Campaign campaign) {
-        final CurrentLocation location = campaign.getLocation();
+        final CurrentLocation location = campaign.getCurrentLocation();
         final LocalDate currentDay = campaign.getLocalDate();
 
         final Map<String, Set<InjuryType>> curesBySystem = new HashMap<>();

--- a/MekHQ/src/mekhq/gui/campaignOptions/CreateCampaignPreset.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CreateCampaignPreset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2021-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/gui/campaignOptions/CreateCampaignPreset.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CreateCampaignPreset.java
@@ -680,11 +680,11 @@ public class CreateCampaignPreset extends AbstractMHQValidationButtonDialog {
         getComboFaction().setSelectedItem(new FactionDisplay(faction, getDate()));
         getComboStartingSystem().setSelectedItem((getPreset() == null) || (getPreset().getPlanet() == null)
                                                        ?
-                                                       getCampaign().getLocation().getCurrentSystem() :
+                                                       getCampaign().getCurrentLocation().getCurrentSystem() :
                                                        getPreset().getPlanet().getParentSystem());
         getComboStartingPlanet().setSelectedItem((getPreset() == null) || (getPreset().getPlanet() == null)
                                                        ?
-                                                       getCampaign().getLocation()
+                                                       getCampaign().getCurrentLocation()
                                                              .getCurrentSystem()
                                                              .getPrimaryPlanet() :
                                                        getPreset().getPlanet());

--- a/MekHQ/src/mekhq/gui/dialog/AdvancedReplacementLimbDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AdvancedReplacementLimbDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/gui/dialog/AdvancedReplacementLimbDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AdvancedReplacementLimbDialog.java
@@ -405,7 +405,7 @@ public class AdvancedReplacementLimbDialog extends JDialog {
     private JComboBox<ProstheticType> createTreatmentComboBox(List<ProstheticType> options) {
         Faction campaignFaction = campaign.getFaction();
         int currentYear = campaign.getGameYear();
-        boolean isOnPlanet = campaign.getLocation().isOnPlanet();
+        boolean isOnPlanet = campaign.getCurrentLocation().isOnPlanet();
         boolean isUseKinderMode = campaign.getCampaignOptions().isUseKinderAlternativeAdvancedMedical();
 
         JComboBox<ProstheticType> comboBox = new JComboBox<>();
@@ -514,7 +514,7 @@ public class AdvancedReplacementLimbDialog extends JDialog {
                   surgeryLevelNeeded));
 
             if (isUseLocalSurgeon) {
-                if (campaign.getLocation().isOnPlanet()) {
+                if (campaign.getCurrentLocation().isOnPlanet()) {
                     summary.add(getTextAt(RESOURCE_BUNDLE,
                           "AdvancedReplacementLimbDialog.status.localSurgeon"));
                 } else {
@@ -663,7 +663,7 @@ public class AdvancedReplacementLimbDialog extends JDialog {
                 }
             }
 
-            if (!selected.isAvailableInCurrentLocation(campaign.getLocation(), campaign.getLocalDate())) {
+            if (!selected.isAvailableInCurrentLocation(campaign.getCurrentLocation(), campaign.getLocalDate())) {
                 tooltip += getFormattedTextAt(RESOURCE_BUNDLE,
                       "AdvancedReplacementLimbDialog.exclusions.tech", warningColor, CLOSING_SPAN_TAG);
             }
@@ -1208,7 +1208,7 @@ public class AdvancedReplacementLimbDialog extends JDialog {
      */
     public Map<BodyLocation, ProstheticType> getSelectedTreatments() {
         Map<BodyLocation, ProstheticType> selections = new HashMap<>();
-        boolean isPlanetside = campaign.getLocation().isOnPlanet();
+        boolean isPlanetside = campaign.getCurrentLocation().isOnPlanet();
         Faction campaignFaction = campaign.getFaction();
         int currentYear = campaign.getGameYear();
         for (Map.Entry<BodyLocation, JComboBox<ProstheticType>> entry :

--- a/MekHQ/src/mekhq/gui/dialog/BayRentalDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BayRentalDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/gui/dialog/BayRentalDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BayRentalDialog.java
@@ -94,7 +94,7 @@ public class BayRentalDialog extends ImmersiveDialogSimple {
     }
 
     public static void showNoFacilitiesAvailableDialog(Campaign campaign) {
-        boolean isInSpace = !campaign.getLocation().isOnPlanet();
+        boolean isInSpace = !campaign.getCurrentLocation().isOnPlanet();
 
         String message;
         if (isInSpace) {

--- a/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
@@ -534,7 +534,7 @@ public class CampaignExportWizard extends JDialog {
             destinationCampaign.setFaction(sourceCampaign.getFaction());
             destinationCampaign.setCamouflage(sourceCampaign.getCamouflage().clone());
             destinationCampaign.setLocalDate(sourceCampaign.getLocalDate());
-            destinationCampaign.setLocation(sourceCampaign.getLocation());
+            destinationCampaign.setLocation(sourceCampaign.getCurrentLocation());
         }
 
         if (chkExportContractOffers.isSelected()) {

--- a/MekHQ/src/mekhq/gui/dialog/ContractMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ContractMarketDialog.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2014 Carl Spain. All rights reserved.
- * Copyright (C) 2014-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2014-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/gui/dialog/ContractMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ContractMarketDialog.java
@@ -350,7 +350,7 @@ public class ContractMarketDialog extends JDialog {
 
             final JumpPath path = campaign.calculateJumpPath(campaign.getCurrentSystem(), contract.getSystem());
             final int days = (int) Math.ceil(path.getTotalTime(contract.getStartDate(),
-                  campaign.getLocation().getTransitTime(), isUseCommandCircuit));
+                  campaign.getCurrentLocation().getTransitTime(), isUseCommandCircuit));
             row.add(Integer.toString(days));
             row.add(String.valueOf(contract.getLength()));
             row.add(contract.getTransportCompString());
@@ -519,7 +519,7 @@ public class ContractMarketDialog extends JDialog {
             row.add(contract.getContractType().toString());
             final JumpPath path = campaign.calculateJumpPath(campaign.getCurrentSystem(), contract.getSystem());
             final int days = (int) Math.ceil(path.getTotalTime(contract.getStartDate(),
-                  campaign.getLocation().getTransitTime(), finalIsUseCommandCircuit));
+                  campaign.getCurrentLocation().getTransitTime(), finalIsUseCommandCircuit));
             row.add(Integer.toString(days));
             row.add(String.valueOf(contract.getLength()));
             row.add(contract.getTransportCompString());

--- a/MekHQ/src/mekhq/gui/dialog/ReplacementLimbDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ReplacementLimbDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/gui/dialog/ReplacementLimbDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ReplacementLimbDialog.java
@@ -72,7 +72,7 @@ public class ReplacementLimbDialog {
     public ReplacementLimbDialog(Campaign campaign, List<Person> suitableDoctors, Person patient, Money cost) {
         this.campaign = campaign;
 
-        final boolean isPlanetside = campaign.getLocation().isOnPlanet();
+        final boolean isPlanetside = campaign.getCurrentLocation().isOnPlanet();
         final boolean hasQualifiedDoctors = !suitableDoctors.isEmpty();
         final boolean hasSufficientFunds = campaign.getFunds().isGreaterOrEqualThan(cost);
 

--- a/MekHQ/src/mekhq/gui/dialog/camOpsSalvage/SalvagePostScenarioPicker.java
+++ b/MekHQ/src/mekhq/gui/dialog/camOpsSalvage/SalvagePostScenarioPicker.java
@@ -328,7 +328,7 @@ public class SalvagePostScenarioPicker {
             }
 
             RecoveryTimeData data = RecoveryTimeCalculations.calculateRecoveryTimeForEntity(entity.getDisplayName(),
-                  entity.getRecoveryTime(), scenario, campaign.getLocation().getPlanet());
+                  entity.getRecoveryTime(), scenario, campaign.getCurrentLocation().getPlanet());
             recoveryTimeData.put(unit.getId(), data);
         }
     }

--- a/MekHQ/src/mekhq/gui/dialog/factionStanding/factionJudgment/FactionJudgmentDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/factionStanding/factionJudgment/FactionJudgmentDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/gui/dialog/factionStanding/factionJudgment/FactionJudgmentDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/factionStanding/factionJudgment/FactionJudgmentDialog.java
@@ -133,7 +133,7 @@ public class FactionJudgmentDialog {
         String factionName = getFactionName(judgingFaction, campaign.getGameYear());
 
         LocalDate today = campaign.getLocalDate();
-        CurrentLocation location = campaign.getLocation();
+        CurrentLocation location = campaign.getCurrentLocation();
         boolean isPlanetside = location.isOnPlanet();
         String locationName = isPlanetside
                                     ? location.getPlanet().getName(today)

--- a/MekHQ/src/mekhq/gui/dialog/factionStanding/factionJudgment/FactionJudgmentNewsArticle.java
+++ b/MekHQ/src/mekhq/gui/dialog/factionStanding/factionJudgment/FactionJudgmentNewsArticle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/gui/dialog/factionStanding/factionJudgment/FactionJudgmentNewsArticle.java
+++ b/MekHQ/src/mekhq/gui/dialog/factionStanding/factionJudgment/FactionJudgmentNewsArticle.java
@@ -155,7 +155,7 @@ public class FactionJudgmentNewsArticle {
         String dialogKey = getDialogKey(judgmentType, judgmentLookupName, censuringFaction);
 
         LocalDate today = campaign.getLocalDate();
-        CurrentLocation location = campaign.getLocation();
+        CurrentLocation location = campaign.getCurrentLocation();
 
         String locationName;
         if (useFactionCapitalAsLocation) {

--- a/MekHQ/src/mekhq/gui/dialog/factionStanding/factionJudgment/FactionJudgmentSceneDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/factionStanding/factionJudgment/FactionJudgmentSceneDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/gui/dialog/factionStanding/factionJudgment/FactionJudgmentSceneDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/factionStanding/factionJudgment/FactionJudgmentSceneDialog.java
@@ -88,7 +88,7 @@ public class FactionJudgmentSceneDialog {
         LocalDate today = campaign.getLocalDate();
         String factionName = judgingFaction.getFullName(today.getYear());
         String campaignName = campaign.getName();
-        CurrentLocation location = campaign.getLocation();
+        CurrentLocation location = campaign.getCurrentLocation();
         boolean isPlanetside = location.isOnPlanet();
         String locationName = isPlanetside
                                     ? location.getPlanet().getName(today)

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/nagLogic/DeploymentShortfallNagLogic.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/nagLogic/DeploymentShortfallNagLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2024-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/nagLogic/DeploymentShortfallNagLogic.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/nagLogic/DeploymentShortfallNagLogic.java
@@ -53,7 +53,7 @@ public class DeploymentShortfallNagLogic {
      * @return {@code true} if there are unmet deployment requirements; otherwise, {@code false}.
      */
     public static boolean hasDeploymentShortfall(Campaign campaign) {
-        if (!campaign.getLocation().isOnPlanet()) {
+        if (!campaign.getCurrentLocation().isOnPlanet()) {
             return false;
         }
 

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/nagLogic/UnableToAffordJumpNagLogic.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/nagLogic/UnableToAffordJumpNagLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2024-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/nagLogic/UnableToAffordJumpNagLogic.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/nagLogic/UnableToAffordJumpNagLogic.java
@@ -69,7 +69,7 @@ public class UnableToAffordJumpNagLogic {
      * </p>
      */
     public static Money getNextJumpCost(Campaign campaign) {
-        CurrentLocation location = campaign.getLocation();
+        CurrentLocation location = campaign.getCurrentLocation();
         JumpPath jumpPath = location.getJumpPath();
 
         if (jumpPath == null) {

--- a/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2014 Carl Spain. All rights reserved.
- * Copyright (C) 2014-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2014-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
@@ -292,10 +292,10 @@ public class ContractSummaryPanel extends JPanel {
                         campaign.getFactionStandings(), List.of(atBContract));
 
             int days = (int) Math.ceil(path.getTotalTime(contract.getStartDate(),
-                  campaign.getLocation().getTransitTime(), isUseCommandCircuit));
+                  campaign.getCurrentLocation().getTransitTime(), isUseCommandCircuit));
             int jumps = path.getJumps();
             if (campaign.getCurrentSystem().getId().equals(contract.getSystemId()) &&
-                      campaign.getLocation().isOnPlanet()) {
+                      campaign.getCurrentLocation().isOnPlanet()) {
                 days = 0;
                 jumps = 0;
             }

--- a/MekHQ/src/mekhq/gui/view/JumpPathViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/JumpPathViewPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2009-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/gui/view/JumpPathViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/JumpPathViewPanel.java
@@ -196,7 +196,8 @@ public class JumpPathViewPanel extends JScrollablePanel {
 
         txtTimeStart.setName("lblTimeStart2");
         txtTimeStart.setText("<html>" +
-                                   Math.round(path.getStartTime(campaign.getLocation().getTransitTime()) * 100.0) /
+                                   Math.round(path.getStartTime(campaign.getCurrentLocation().getTransitTime()) *
+                                                    100.0) /
                                          100.0 +
                                    " days from " +
                                    startName +
@@ -274,7 +275,9 @@ public class JumpPathViewPanel extends JScrollablePanel {
 
         txtTotalTime.setName("lblTotalTime2");
         txtTotalTime.setText("<html>" + Math.round(path.getTotalTime(currentDate,
-              campaign.getLocation().getTransitTime(), isUseCommandCircuit) * 100.0) / 100.0 + " days" + "</html>");
+              campaign.getCurrentLocation().getTransitTime(), isUseCommandCircuit) * 100.0) / 100.0 +
+                                   " days" +
+                                   "</html>");
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 5;
@@ -295,7 +298,7 @@ public class JumpPathViewPanel extends JScrollablePanel {
             pnlStats.add(lblCost, gridBagConstraints);
 
             TransportCostCalculations transportCostCalculations = campaign.getTransportCostCalculation(EXP_REGULAR);
-            int duration = (int) ceil(path.getTotalTime(currentDate, campaign.getLocation().getTransitTime(),
+            int duration = (int) ceil(path.getTotalTime(currentDate, campaign.getCurrentLocation().getTransitTime(),
                   isUseCommandCircuit));
             Money journeyCost = transportCostCalculations.calculateJumpCostForEntireJourney(duration, path.getJumps());
 

--- a/MekHQ/unittests/mekhq/campaign/finances/AccountantTest.java
+++ b/MekHQ/unittests/mekhq/campaign/finances/AccountantTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/unittests/mekhq/campaign/finances/AccountantTest.java
+++ b/MekHQ/unittests/mekhq/campaign/finances/AccountantTest.java
@@ -74,7 +74,7 @@ public class AccountantTest {
         Accountant accountant = new Accountant(mockCampaign);
 
         CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getLocation()).thenReturn(location);
+        when(mockCampaign.getCurrentLocation()).thenReturn(location);
 
         // Act
         Money expected = Money.zero();
@@ -97,7 +97,7 @@ public class AccountantTest {
         Accountant accountant = new Accountant(mockCampaign);
 
         CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getLocation()).thenReturn(location);
+        when(mockCampaign.getCurrentLocation()).thenReturn(location);
 
         when(mockCampaign.getPersonnel()).thenReturn(new ArrayList<>());
 
@@ -122,7 +122,7 @@ public class AccountantTest {
         Accountant accountant = new Accountant(mockCampaign);
 
         CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getLocation()).thenReturn(location);
+        when(mockCampaign.getCurrentLocation()).thenReturn(location);
 
         Faction faction = new Faction();
         when(mockCampaign.getFaction()).thenReturn(faction);
@@ -156,7 +156,7 @@ public class AccountantTest {
         Accountant accountant = new Accountant(mockCampaign);
 
         CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getLocation()).thenReturn(location);
+        when(mockCampaign.getCurrentLocation()).thenReturn(location);
 
         Faction faction = new Faction();
         when(mockCampaign.getFaction()).thenReturn(faction);
@@ -189,7 +189,7 @@ public class AccountantTest {
         Accountant accountant = new Accountant(mockCampaign);
 
         CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getLocation()).thenReturn(location);
+        when(mockCampaign.getCurrentLocation()).thenReturn(location);
 
         Faction faction = new Faction();
         when(mockCampaign.getFaction()).thenReturn(faction);
@@ -222,7 +222,7 @@ public class AccountantTest {
         Accountant accountant = new Accountant(mockCampaign);
 
         CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getLocation()).thenReturn(location);
+        when(mockCampaign.getCurrentLocation()).thenReturn(location);
 
         Faction faction = new Faction();
         when(mockCampaign.getFaction()).thenReturn(faction);
@@ -256,7 +256,7 @@ public class AccountantTest {
         Accountant accountant = new Accountant(mockCampaign);
 
         CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getLocation()).thenReturn(location);
+        when(mockCampaign.getCurrentLocation()).thenReturn(location);
 
         Faction faction = new Faction();
         when(mockCampaign.getFaction()).thenReturn(faction);
@@ -289,7 +289,7 @@ public class AccountantTest {
         Accountant accountant = new Accountant(mockCampaign);
 
         CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getLocation()).thenReturn(location);
+        when(mockCampaign.getCurrentLocation()).thenReturn(location);
 
         Faction faction = new Faction();
         when(mockCampaign.getFaction()).thenReturn(faction);
@@ -322,7 +322,7 @@ public class AccountantTest {
         Accountant accountant = new Accountant(mockCampaign);
 
         CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getLocation()).thenReturn(location);
+        when(mockCampaign.getCurrentLocation()).thenReturn(location);
 
         Faction faction = new Faction();
         when(mockCampaign.getFaction()).thenReturn(faction);
@@ -357,7 +357,7 @@ public class AccountantTest {
         Accountant accountant = new Accountant(mockCampaign);
 
         CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getLocation()).thenReturn(location);
+        when(mockCampaign.getCurrentLocation()).thenReturn(location);
 
         Faction faction = new Faction();
         when(mockCampaign.getFaction()).thenReturn(faction);
@@ -391,7 +391,7 @@ public class AccountantTest {
         Accountant accountant = new Accountant(mockCampaign);
 
         CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getLocation()).thenReturn(location);
+        when(mockCampaign.getCurrentLocation()).thenReturn(location);
 
         Faction faction = new Faction();
         when(mockCampaign.getFaction()).thenReturn(faction);
@@ -425,7 +425,7 @@ public class AccountantTest {
         Accountant accountant = new Accountant(mockCampaign);
 
         CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getLocation()).thenReturn(location);
+        when(mockCampaign.getCurrentLocation()).thenReturn(location);
 
         Faction faction = new Faction();
         when(mockCampaign.getFaction()).thenReturn(faction);
@@ -460,7 +460,7 @@ public class AccountantTest {
         Accountant accountant = new Accountant(mockCampaign);
 
         CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getLocation()).thenReturn(location);
+        when(mockCampaign.getCurrentLocation()).thenReturn(location);
 
         Faction faction = new Faction();
         when(mockCampaign.getFaction()).thenReturn(faction);
@@ -494,7 +494,7 @@ public class AccountantTest {
         Accountant accountant = new Accountant(mockCampaign);
 
         CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getLocation()).thenReturn(location);
+        when(mockCampaign.getCurrentLocation()).thenReturn(location);
 
         Faction faction = new Faction();
         when(mockCampaign.getFaction()).thenReturn(faction);
@@ -528,7 +528,7 @@ public class AccountantTest {
         Accountant accountant = new Accountant(mockCampaign);
 
         CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getLocation()).thenReturn(location);
+        when(mockCampaign.getCurrentLocation()).thenReturn(location);
 
         Faction faction = new Faction();
         when(mockCampaign.getFaction()).thenReturn(faction);
@@ -588,7 +588,7 @@ public class AccountantTest {
         Accountant accountant = new Accountant(mockCampaign);
 
         CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getLocation()).thenReturn(location);
+        when(mockCampaign.getCurrentLocation()).thenReturn(location);
 
         Faction faction = new Faction();
         when(mockCampaign.getFaction()).thenReturn(faction);
@@ -644,7 +644,7 @@ public class AccountantTest {
         Accountant accountant = new Accountant(mockCampaign);
 
         CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getLocation()).thenReturn(location);
+        when(mockCampaign.getCurrentLocation()).thenReturn(location);
 
         Faction faction = new Faction();
         when(mockCampaign.getFaction()).thenReturn(faction);
@@ -701,7 +701,7 @@ public class AccountantTest {
 
         CurrentLocation location = new CurrentLocation();
         location.setTransitTime(1);
-        when(mockCampaign.getLocation()).thenReturn(location);
+        when(mockCampaign.getCurrentLocation()).thenReturn(location);
 
         Faction faction = new Faction();
         when(mockCampaign.getFaction()).thenReturn(faction);
@@ -759,7 +759,7 @@ public class AccountantTest {
         Accountant accountant = new Accountant(mockCampaign);
 
         CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getLocation()).thenReturn(location);
+        when(mockCampaign.getCurrentLocation()).thenReturn(location);
 
         Faction faction = new Faction();
         when(mockCampaign.getFaction()).thenReturn(faction);

--- a/MekHQ/unittests/mekhq/campaign/market/ContractMarketAtBGenerationTests.java
+++ b/MekHQ/unittests/mekhq/campaign/market/ContractMarketAtBGenerationTests.java
@@ -164,7 +164,7 @@ public class ContractMarketAtBGenerationTests {
         doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
 
         CurrentLocation currentLocation = mock(CurrentLocation.class);
-        when(campaign.getLocation()).thenReturn(currentLocation);
+        when(campaign.getCurrentLocation()).thenReturn(currentLocation);
 
         String missionTarget = "TARGET";
         PlanetarySystem targetSystem = mock(PlanetarySystem.class);
@@ -269,7 +269,7 @@ public class ContractMarketAtBGenerationTests {
         doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
 
         CurrentLocation currentLocation = mock(CurrentLocation.class);
-        when(campaign.getLocation()).thenReturn(currentLocation);
+        when(campaign.getCurrentLocation()).thenReturn(currentLocation);
 
         String missionTarget = "TARGET";
         PlanetarySystem targetSystem = mock(PlanetarySystem.class);
@@ -377,7 +377,7 @@ public class ContractMarketAtBGenerationTests {
         doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
 
         CurrentLocation currentLocation = mock(CurrentLocation.class);
-        when(campaign.getLocation()).thenReturn(currentLocation);
+        when(campaign.getCurrentLocation()).thenReturn(currentLocation);
 
         String missionTarget = "TARGET";
         PlanetarySystem targetSystem = mock(PlanetarySystem.class);
@@ -485,7 +485,7 @@ public class ContractMarketAtBGenerationTests {
         doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
 
         CurrentLocation currentLocation = mock(CurrentLocation.class);
-        when(campaign.getLocation()).thenReturn(currentLocation);
+        when(campaign.getCurrentLocation()).thenReturn(currentLocation);
 
         String missionTarget = "TARGET";
         PlanetarySystem targetSystem = mock(PlanetarySystem.class);
@@ -606,7 +606,7 @@ public class ContractMarketAtBGenerationTests {
         doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
 
         CurrentLocation currentLocation = mock(CurrentLocation.class);
-        when(campaign.getLocation()).thenReturn(currentLocation);
+        when(campaign.getCurrentLocation()).thenReturn(currentLocation);
 
         String missionTarget = "TARGET";
         PlanetarySystem targetSystem = mock(PlanetarySystem.class);
@@ -754,7 +754,7 @@ public class ContractMarketAtBGenerationTests {
         doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
 
         CurrentLocation currentLocation = mock(CurrentLocation.class);
-        when(campaign.getLocation()).thenReturn(currentLocation);
+        when(campaign.getCurrentLocation()).thenReturn(currentLocation);
 
         String missionTarget = "TARGET";
         PlanetarySystem targetSystem = mock(PlanetarySystem.class);
@@ -862,7 +862,7 @@ public class ContractMarketAtBGenerationTests {
         doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
 
         CurrentLocation currentLocation = mock(CurrentLocation.class);
-        when(campaign.getLocation()).thenReturn(currentLocation);
+        when(campaign.getCurrentLocation()).thenReturn(currentLocation);
 
         String missionTarget = "TARGET";
         PlanetarySystem targetSystem = mock(PlanetarySystem.class);
@@ -962,7 +962,7 @@ public class ContractMarketAtBGenerationTests {
         doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
 
         CurrentLocation currentLocation = mock(CurrentLocation.class);
-        when(campaign.getLocation()).thenReturn(currentLocation);
+        when(campaign.getCurrentLocation()).thenReturn(currentLocation);
 
         String missionTarget = "TARGET";
         PlanetarySystem targetSystem = mock(PlanetarySystem.class);
@@ -1070,7 +1070,7 @@ public class ContractMarketAtBGenerationTests {
         doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
 
         CurrentLocation currentLocation = mock(CurrentLocation.class);
-        when(campaign.getLocation()).thenReturn(currentLocation);
+        when(campaign.getCurrentLocation()).thenReturn(currentLocation);
 
         String missionTarget = "TARGET";
         PlanetarySystem targetSystem = mock(PlanetarySystem.class);
@@ -1173,7 +1173,7 @@ public class ContractMarketAtBGenerationTests {
         doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
 
         CurrentLocation currentLocation = mock(CurrentLocation.class);
-        when(campaign.getLocation()).thenReturn(currentLocation);
+        when(campaign.getCurrentLocation()).thenReturn(currentLocation);
 
         String missionTarget = "TARGET";
         PlanetarySystem targetSystem = mock(PlanetarySystem.class);
@@ -1281,7 +1281,7 @@ public class ContractMarketAtBGenerationTests {
         doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
 
         CurrentLocation currentLocation = mock(CurrentLocation.class);
-        when(campaign.getLocation()).thenReturn(currentLocation);
+        when(campaign.getCurrentLocation()).thenReturn(currentLocation);
 
         String missionTarget = "TARGET";
         PlanetarySystem targetSystem = mock(PlanetarySystem.class);
@@ -1389,7 +1389,7 @@ public class ContractMarketAtBGenerationTests {
         doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
 
         CurrentLocation currentLocation = mock(CurrentLocation.class);
-        when(campaign.getLocation()).thenReturn(currentLocation);
+        when(campaign.getCurrentLocation()).thenReturn(currentLocation);
 
         String missionTarget = "TARGET";
         PlanetarySystem targetSystem = mock(PlanetarySystem.class);
@@ -1497,7 +1497,7 @@ public class ContractMarketAtBGenerationTests {
         doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
 
         CurrentLocation currentLocation = mock(CurrentLocation.class);
-        when(campaign.getLocation()).thenReturn(currentLocation);
+        when(campaign.getCurrentLocation()).thenReturn(currentLocation);
 
         String missionTarget = "TARGET";
         PlanetarySystem targetSystem = mock(PlanetarySystem.class);
@@ -1604,7 +1604,7 @@ public class ContractMarketAtBGenerationTests {
         doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
 
         CurrentLocation currentLocation = mock(CurrentLocation.class);
-        when(campaign.getLocation()).thenReturn(currentLocation);
+        when(campaign.getCurrentLocation()).thenReturn(currentLocation);
 
         String missionTarget = "TARGET";
         PlanetarySystem targetSystem = mock(PlanetarySystem.class);
@@ -1713,7 +1713,7 @@ public class ContractMarketAtBGenerationTests {
         doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
 
         CurrentLocation currentLocation = mock(CurrentLocation.class);
-        when(campaign.getLocation()).thenReturn(currentLocation);
+        when(campaign.getCurrentLocation()).thenReturn(currentLocation);
 
         String missionTarget = "TARGET";
         PlanetarySystem targetSystem = mock(PlanetarySystem.class);
@@ -1821,7 +1821,7 @@ public class ContractMarketAtBGenerationTests {
         doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
 
         CurrentLocation currentLocation = mock(CurrentLocation.class);
-        when(campaign.getLocation()).thenReturn(currentLocation);
+        when(campaign.getCurrentLocation()).thenReturn(currentLocation);
 
         String missionTarget = "TARGET";
         PlanetarySystem targetSystem = mock(PlanetarySystem.class);
@@ -1930,7 +1930,7 @@ public class ContractMarketAtBGenerationTests {
         doReturn(currentSystem).when(campaign).getSystemByName(eq(current));
 
         CurrentLocation currentLocation = mock(CurrentLocation.class);
-        when(campaign.getLocation()).thenReturn(currentLocation);
+        when(campaign.getCurrentLocation()).thenReturn(currentLocation);
 
         String missionTarget = "TARGET";
         PlanetarySystem targetSystem = mock(PlanetarySystem.class);

--- a/MekHQ/unittests/mekhq/campaign/mission/ContractTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/ContractTest.java
@@ -299,7 +299,7 @@ public class ContractTest {
         when(mockCampaign.getLocalDate()).thenReturn(LocalDate.of(3067, 1, 1));
 
         CurrentLocation mockCurrentLocation = mock(CurrentLocation.class);
-        when(mockCampaign.getLocation()).thenReturn(mockCurrentLocation);
+        when(mockCampaign.getCurrentLocation()).thenReturn(mockCurrentLocation);
 
         TransportCostCalculations mockTransportCostCalculation = mock(TransportCostCalculations.class);
         when(mockCampaign.getTransportCostCalculation(EXP_REGULAR)).thenReturn(mockTransportCostCalculation);

--- a/MekHQ/unittests/mekhq/campaign/stratCon/StratConRulesManagerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/stratCon/StratConRulesManagerTest.java
@@ -553,7 +553,7 @@ class StratConRulesManagerTest {
         when(campaign.getLocalDate()).thenReturn(LocalDate.of(3025, 1, 15));
 
         CurrentLocation location = mock(CurrentLocation.class);
-        when(campaign.getLocation()).thenReturn(location);
+        when(campaign.getCurrentLocation()).thenReturn(location);
 
         if (atmosphere != null) {
             Planet planet = mock(Planet.class);

--- a/MekHQ/unittests/mekhq/gui/dialog/nagDialogs/nagLogic/ShortDeploymentNagLogicTest.java
+++ b/MekHQ/unittests/mekhq/gui/dialog/nagDialogs/nagLogic/ShortDeploymentNagLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2024-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/unittests/mekhq/gui/dialog/nagDialogs/nagLogic/ShortDeploymentNagLogicTest.java
+++ b/MekHQ/unittests/mekhq/gui/dialog/nagDialogs/nagLogic/ShortDeploymentNagLogicTest.java
@@ -75,19 +75,19 @@ public class ShortDeploymentNagLogicTest {
         contract = mock(AtBContract.class);
 
         // Stubs
-        when(campaign.getLocation()).thenReturn(location);
+        when(campaign.getCurrentLocation()).thenReturn(location);
     }
 
     @Test
     void notOnPlanet() {
-        when(campaign.getLocation().isOnPlanet()).thenReturn(false);
+        when(campaign.getCurrentLocation().isOnPlanet()).thenReturn(false);
 
         assertFalse(hasDeploymentShortfall(campaign));
     }
 
     @Test
     void notSunday() {
-        when(campaign.getLocation().isOnPlanet()).thenReturn(true);
+        when(campaign.getCurrentLocation().isOnPlanet()).thenReturn(true);
         when(campaign.getLocalDate()).thenReturn(monday);
 
         assertFalse(hasDeploymentShortfall(campaign));
@@ -95,7 +95,7 @@ public class ShortDeploymentNagLogicTest {
 
     @Test
     void noContract() {
-        when(campaign.getLocation().isOnPlanet()).thenReturn(true);
+        when(campaign.getCurrentLocation().isOnPlanet()).thenReturn(true);
         when(campaign.getLocalDate()).thenReturn(sunday);
 
         when(campaign.getActiveAtBContracts()).thenReturn(new ArrayList<>());
@@ -105,7 +105,7 @@ public class ShortDeploymentNagLogicTest {
 
     @Test
     void noDeploymentDeficit() {
-        when(campaign.getLocation().isOnPlanet()).thenReturn(true);
+        when(campaign.getCurrentLocation().isOnPlanet()).thenReturn(true);
         when(campaign.getLocalDate()).thenReturn(sunday);
 
         when(campaign.getActiveAtBContracts()).thenReturn(List.of(contract));
@@ -116,7 +116,7 @@ public class ShortDeploymentNagLogicTest {
 
     @Test
     void negativeDeploymentDeficit() {
-        when(campaign.getLocation().isOnPlanet()).thenReturn(true);
+        when(campaign.getCurrentLocation().isOnPlanet()).thenReturn(true);
         when(campaign.getLocalDate()).thenReturn(sunday);
 
         when(campaign.getActiveAtBContracts()).thenReturn(List.of(contract));
@@ -127,7 +127,7 @@ public class ShortDeploymentNagLogicTest {
 
     @Test
     void positiveDeploymentDeficit() {
-        when(campaign.getLocation().isOnPlanet()).thenReturn(true);
+        when(campaign.getCurrentLocation().isOnPlanet()).thenReturn(true);
         when(campaign.getLocalDate()).thenReturn(sunday);
 
         when(campaign.getActiveAtBContracts()).thenReturn(List.of(contract));


### PR DESCRIPTION
While working on #1099 I came across a blocker:

Both `ILocation` and `IPartWork` have a method `getLocation()` that return different types, so one of these methods needs renamed. I've opted to rename `ILocation`'s `getLocation()`. This is the same method that `Campaign` currently has and is utilized across the project, so I'm refactoring this as a standalone PR to not clutter the other PRs.