### PR TITLE
fix execution report showing placeholders

### DIFF
--- a/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonerEventManager.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonerEventManager.java
@@ -705,8 +705,8 @@ public class PrisonerEventManager {
                                           CLOSING_SPAN_TAG);
 
         // Add the report
-        campaign.addReport(GENERAL, getFormattedTextAt(RESOURCE_BUNDLE, key), messageColor, CLOSING_SPAN_TAG,
-              crimeMessage);
+        campaign.addReport(GENERAL, getFormattedTextAt(RESOURCE_BUNDLE, key, messageColor, CLOSING_SPAN_TAG,
+              crimeMessage));
     }
 
     /**


### PR DESCRIPTION
When resolving a prisoner event that involved the execution of prisoners, the report in the daily log showed placeholders.

This PR fixes that by supplying all required parameters.

Example text of wrong report:

_Fear is keeping our prisoners in line. Our prisoner capacity has been temporarily {0}increased{1}. {2}_