### PR TITLE
Fix #9064: Stopped 'Rare Personnel' Dialog Spamming Player on New Day

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -412,7 +412,9 @@ public class CampaignNewDayManager {
 
         // Manage the Markets
         campaign.refreshPersonnelMarkets(false);
-        showRarePersonnelDialog(campaign, false);
+        if (isFirstOfMonth) {
+            showRarePersonnelDialog(campaign, false);
+        }
 
         // TODO : AbstractContractMarket : Uncomment
         // getContractMarket().processNewDay(campaign);
@@ -1759,7 +1761,7 @@ public class CampaignNewDayManager {
      * Determines if a willpower check has failed for the given person with the specified modifier.
      *
      * @param campaign The campaign context, needed for reporting skill check results.
-     * @param person The person for whom the willpower check is being performed.
+     * @param person   The person for whom the willpower check is being performed.
      * @param modifier An integer value representing the modification to the willpower check.
      *
      * @return {@code true} if the willpower check has failed; {@code false} otherwise.


### PR DESCRIPTION
Fix #9064

Added missing conditional, resulting in the dialog triggering any time there was a rare profession in the pool, not just when the market refreshed.