### PR TITLE
Fix #9052: Fixed a Handful of Additional Bugs with Stress Leave

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/Fatigue.java
+++ b/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/Fatigue.java
@@ -179,7 +179,8 @@ public class Fatigue {
         int effectiveFatigue = getEffectiveFatigue(person.getAdjustedFatigue(), person.getPermanentFatigue(),
               person.isClanPersonnel(), person.getSkillLevel(campaign, false, true));
 
-        if (!campaign.getCampaignOptions().isUseFatigue()) {
+        CampaignOptions campaignOptions = campaign.getCampaignOptions();
+        if (!campaignOptions.isUseFatigue()) {
             return;
         }
 
@@ -213,9 +214,15 @@ public class Fatigue {
             person.setIsRecoveringFromFatigue(true);
         }
 
-        if ((!person.getStatus().isCampFollower()) &&
-                  (campaign.getCampaignOptions().getFatigueLeaveThreshold() != 0) &&
-                  (effectiveFatigue >= campaign.getCampaignOptions().getFatigueLeaveThreshold())) {
+        int fatigueThreshold = campaignOptions.getFatigueLeaveThreshold();
+        boolean isFatigued = effectiveFatigue >= fatigueThreshold;
+        boolean isCampFollower = person.getStatus().isCampFollower();
+
+        int nonPermanentInjuryCount = person.getNonPermanentInjuries().size();
+        int hits = person.getHits();
+        boolean isInjured = nonPermanentInjuryCount > 0 || hits > 0;
+
+        if (isFatigued && !isInjured && !isCampFollower) {
             person.changeStatus(campaign, campaign.getLocalDate(), PersonnelStatus.ON_LEAVE);
         }
     }

--- a/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/Fatigue.java
+++ b/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/Fatigue.java
@@ -215,6 +215,8 @@ public class Fatigue {
         }
 
         int fatigueThreshold = campaignOptions.getFatigueLeaveThreshold();
+        boolean hasThreshold = fatigueThreshold != 0;
+
         boolean isFatigued = effectiveFatigue >= fatigueThreshold;
         boolean isCampFollower = person.getStatus().isCampFollower();
         boolean isFree = !person.isBusy();
@@ -223,7 +225,11 @@ public class Fatigue {
         int hits = person.getHits();
         boolean isInjured = nonPermanentInjuryCount > 0 || hits > 0;
 
-        if (isFatigued && isFree && !isInjured && !isCampFollower) {
+        if (hasThreshold &&
+                  isFatigued &&
+                  isFree &&
+                  !isInjured &&
+                  !isCampFollower) {
             person.changeStatus(campaign, campaign.getLocalDate(), PersonnelStatus.ON_LEAVE);
         }
     }

--- a/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/Fatigue.java
+++ b/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/Fatigue.java
@@ -217,12 +217,13 @@ public class Fatigue {
         int fatigueThreshold = campaignOptions.getFatigueLeaveThreshold();
         boolean isFatigued = effectiveFatigue >= fatigueThreshold;
         boolean isCampFollower = person.getStatus().isCampFollower();
+        boolean isFree = !person.isBusy();
 
         int nonPermanentInjuryCount = person.getNonPermanentInjuries().size();
         int hits = person.getHits();
         boolean isInjured = nonPermanentInjuryCount > 0 || hits > 0;
 
-        if (isFatigued && !isInjured && !isCampFollower) {
+        if (isFatigued && isFree && !isInjured && !isCampFollower) {
             person.changeStatus(campaign, campaign.getLocalDate(), PersonnelStatus.ON_LEAVE);
         }
     }

--- a/MekHQ/unittests/mekhq/campaign/randomEvents/prisoners/EventEffectsManagerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/randomEvents/prisoners/EventEffectsManagerTest.java
@@ -60,6 +60,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import mekhq.campaign.Campaign;
+import mekhq.campaign.Hangar;
+import mekhq.campaign.Warehouse;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.personnel.Person;
@@ -545,6 +547,11 @@ class EventEffectsManagerTest {
         when(mockCampaignOptions.isUseFatigue()).thenReturn(true);
         when(mockCampaignOptions.getFatigueRate()).thenReturn(1);
 
+        Hangar mockHangar = mock(Hangar.class);
+        when(mockCampaign.getHangar()).thenReturn(mockHangar);
+        Warehouse mockWarehouse = mock(Warehouse.class);
+        when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
+
         EventResult eventResult = new EventResult(FATIGUE_ONE, false, MAGNITUDE, "");
         PrisonerResponseEntry responseEntry = new PrisonerResponseEntry(RESPONSE_NEUTRAL,
               List.of(eventResult),
@@ -580,6 +587,11 @@ class EventEffectsManagerTest {
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         when(mockCampaignOptions.isUseFatigue()).thenReturn(true);
         when(mockCampaignOptions.getFatigueRate()).thenReturn(1);
+
+        Hangar mockHangar = mock(Hangar.class);
+        when(mockCampaign.getHangar()).thenReturn(mockHangar);
+        Warehouse mockWarehouse = mock(Warehouse.class);
+        when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
 
         EventResult eventResult = new EventResult(FATIGUE_ALL, false, MAGNITUDE, "");
         PrisonerResponseEntry responseEntry = new PrisonerResponseEntry(RESPONSE_NEUTRAL,
@@ -782,6 +794,11 @@ class EventEffectsManagerTest {
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         when(mockCampaignOptions.isUseFatigue()).thenReturn(true);
         when(mockCampaignOptions.getFatigueRate()).thenReturn(1);
+
+        Hangar mockHangar = mock(Hangar.class);
+        when(mockCampaign.getHangar()).thenReturn(mockHangar);
+        Warehouse mockWarehouse = mock(Warehouse.class);
+        when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
 
         EventResult eventResult = new EventResult(UNIQUE, false, MAGNITUDE, "");
         PrisonerResponseEntry responseEntry = new PrisonerResponseEntry(RESPONSE_NEUTRAL,


### PR DESCRIPTION
Fix #9052

- Characters will no longer go on stress leave if they're in the middle of something, such as a deployment or maintenance task.
- Characters will no longer go on stress leave if they're actively injured, to stop a situation where players cannot heal injured characters

Neither bug exists for Maternity Leave.