### PR TITLE
Close #9047: Increased Personnel Market Applicants (Most Noticeable for Low Population Systems)

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketMekHQ.java
+++ b/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketMekHQ.java
@@ -105,7 +105,7 @@ public class PersonnelMarketMekHQ extends NewPersonnelMarket {
 
         setAssociatedPersonnelMarketStyle(MEKHQ);
 
-        setLowPopulationRecruitmentDivider(10000000);
+        setLowPopulationRecruitmentDivider(7500000);
         setUnitReputationRecruitmentCutoff(-25);
 
         PersonnelMarketLibraries personnelMarketLibraries = new PersonnelMarketLibraries();


### PR DESCRIPTION
Close #9047

Reduced the divider used to determine population multiplier from `10,000,000` to `7,500,000`. This will result in more applicants, most noticeably in less populated locations. Highly populated locations likely won't notice any significant changes.