### PR TITLE
Fix #9045: Enabled CamOps Salvage Steps When Player Manually Resolves Scenario

### DIFF
--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -1323,10 +1323,17 @@ public final class BriefingTab extends CampaignGuiTab {
      * Resolve the selected scenario by proving a MUL file
      */
     private void resolveScenario() {
+
+
         Scenario scenario = getSelectedScenario();
         if (null == scenario) {
             return;
         }
+
+        if (handleSalvageAssignments(scenario)) {
+            return;
+        }
+
         getCampaign().getApp().resolveScenario(scenario);
     }
 


### PR DESCRIPTION
Fix #9045

The steps needed for CamOps Salvage to function were missed if the player chose to manually resolve a scenario, now they're not.