### PR TITLE
Fix #8812: Untethered Individual Initiative Modifiers in Campaign Options from Individual Initiative in MegaMek

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -405,7 +405,9 @@ lblUseTactics.tooltip=All initiative rolls are modified by the commander's Tacti
 lblUseInitiativeBonus.text=Use Individual Initiative Bonus
 lblUseInitiativeBonus.tooltip=Each unit has their initiative rolls modified by their Tactics skill.\
   <br>\
-  <br><b>Warning:</b> Should not be combined with 'Use Commander Initiative Bonus.'
+  <br><b>Warning:</b> Should not be combined with 'Use Commander Initiative Bonus.\
+  <br>\
+  <br><b>Requirement:</b> The individual initiative option must be enabled in MegaMek.
 lblUseToughness.text=Use Toughness
 lblUseToughness.tooltip=A character's Toughness score acts as a modifier to all consciousness checks.
 lblUseRandomToughness.text=Randomize Toughness

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
@@ -34,7 +34,15 @@
 package mekhq.campaign.campaignOptions;
 
 import static megamek.common.TechConstants.getSimpleLevel;
-import static megamek.common.options.OptionsConstants.*;
+import static megamek.common.options.OptionsConstants.ADVANCED_STRATOPS_QUIRKS;
+import static megamek.common.options.OptionsConstants.ALLOWED_CANON_ONLY;
+import static megamek.common.options.OptionsConstants.ALLOWED_TECH_LEVEL;
+import static megamek.common.options.OptionsConstants.EDGE;
+import static megamek.common.options.OptionsConstants.RPG_ARTILLERY_SKILL;
+import static megamek.common.options.OptionsConstants.RPG_COMMAND_INIT;
+import static megamek.common.options.OptionsConstants.RPG_MANEI_DOMINI;
+import static megamek.common.options.OptionsConstants.RPG_PILOT_ADVANTAGES;
+import static megamek.common.options.OptionsConstants.RPG_TOUGHNESS;
 import static mekhq.campaign.market.personnelMarket.enums.PersonnelMarketStyle.PERSONNEL_MARKET_DISABLED;
 import static mekhq.gui.campaignOptions.enums.ProcurementPersonnelPick.SUPPORT;
 
@@ -5771,7 +5779,6 @@ public class CampaignOptions {
      */
     public void updateCampaignOptionsFromGameOptions(GameOptions gameOptions) {
         useTactics = gameOptions.getOption(RPG_COMMAND_INIT).booleanValue();
-        useInitiativeBonus = gameOptions.getOption(RPG_INDIVIDUAL_INITIATIVE).booleanValue();
         useToughness = gameOptions.getOption(RPG_TOUGHNESS).booleanValue();
         useArtillery = gameOptions.getOption(RPG_ARTILLERY_SKILL).booleanValue();
         useAbilities = gameOptions.getOption(RPG_PILOT_ADVANTAGES).booleanValue();
@@ -5795,7 +5802,6 @@ public class CampaignOptions {
      * @param gameOptions the {@link GameOptions} to update based on the current campaign options.
      */
     public void updateGameOptionsFromCampaignOptions(GameOptions gameOptions) {
-        gameOptions.getOption(RPG_INDIVIDUAL_INITIATIVE).setValue(useInitiativeBonus);
         gameOptions.getOption(RPG_COMMAND_INIT).setValue(useTactics || useInitiativeBonus);
         gameOptions.getOption(RPG_TOUGHNESS).setValue(useToughness);
         gameOptions.getOption(RPG_ARTILLERY_SKILL).setValue(useArtillery);


### PR DESCRIPTION
Fix #8812

Turning on individual initiative modifiers in CO IIC would turn on individual initiative in megamek. Similarly, having individual initiative on in megamek would turn on individual initiative modifiers.

This PR breaks that tethering, allowing for individual initiative to be used without the player also being forced to use individual initiative modifiers (despite such being RAW).