### PR TITLE
RFE #9061: Improved Temp Pools UI

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignGUI.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignGUI.properties
@@ -184,6 +184,11 @@ miFireVesselCrew.text=Release Vessel Crew
 popupFireVesselCrewNum.text=Release How Many Vessel Crew?
 miFullStrengthVesselCrew.text=Bring All Vessels to Full Crew Strength
 miFireAllVesselCrew.text=Release All Vessel Crew from Pool
+# Menu Temp Pool
+menuTempPool.text=Temp Pool
+miTempPoolFullStrength.text=Bring All Temps to Full Strength
+miTempPoolReleaseAll.text=Release All Temps
+miTempPoolReleaseSurplus.text=Release Surplus Temps
 # Reports Menu
 menuReports.text=Reports
 miDragoonsRating.text=Unit Rating...

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7069,6 +7069,35 @@ public class Campaign implements ITechManager {
 
 
     /**
+     * Releases surplus AsTechs from the pool, keeping only what is currently needed.
+     * If the pool already has fewer than needed, no change is made.
+     */
+    public void releaseSurplusAsTechPool() {
+        humanResources.releaseSurplusAsTechPool(this);
+    }
+
+    /**
+     * Releases surplus Medics from the pool, keeping only what is currently needed.
+     * If the pool already has fewer than needed, no change is made.
+     */
+    public void releaseSurplusMedicPool() {
+        humanResources.releaseSurplusMedicPool(this);
+    }
+
+    /**
+     * Releases surplus temp crew for a specific blob crew role.
+     *
+     * <p>For each unit, any assigned temp crew beyond what the unit needs (i.e., where real crew
+     * already fills or exceeds {@code fullCrewSize}) is removed. The unassigned pool is then
+     * emptied.</p>
+     *
+     * @param role the personnel role to trim
+     */
+    public void releaseSurplusBlobCrewForRole(PersonnelRole role) {
+        humanResources.releaseSurplusBlobCrewForRole(this, role);
+    }
+
+    /**
      * Clears blob crew for a specific personnel role from units and empties the campaign pool. Should be called when a
      * specific blob crew option is disabled.
      *

--- a/MekHQ/src/mekhq/campaign/HumanResources.java
+++ b/MekHQ/src/mekhq/campaign/HumanResources.java
@@ -893,6 +893,57 @@ public class HumanResources {
         }
     }
 
+    /**
+     * Releases surplus AsTechs from the pool, keeping only what is currently needed.
+     * If the pool is at or below the required amount, no change is made.
+     *
+     * @param campaign the campaign
+     */
+    public void releaseSurplusAsTechPool(Campaign campaign) {
+        int surplus = Math.max(0, -getAsTechNeed(campaign.getCampaignOptions()));
+        if (surplus > 0) {
+            decreaseAsTechPool(campaign, surplus);
+        }
+    }
+
+    /**
+     * Releases surplus Medics from the pool, keeping only what is currently needed.
+     * If the pool is at or below the required amount, no change is made.
+     *
+     * @param campaign the campaign
+     */
+    public void releaseSurplusMedicPool(Campaign campaign) {
+        int surplus = Math.max(0, -getMedicsNeed());
+        if (surplus > 0) {
+            decreaseMedicPool(campaign, surplus);
+        }
+    }
+
+    /**
+     * Releases surplus temp crew for a specific blob crew role.
+     *
+     * <p>For each unit, any assigned temp crew beyond what the unit needs (i.e., where real crew
+     * already fills or exceeds {@code fullCrewSize}) is removed. The unassigned pool is then
+     * emptied.</p>
+     *
+     * @param campaign the campaign
+     * @param role     the personnel role to trim
+     */
+    public void releaseSurplusBlobCrewForRole(Campaign campaign, PersonnelRole role) {
+        for (Unit unit : campaign.getUnits()) {
+            int currentTemp = unit.getTempCrewByPersonnelRole(role);
+            if (currentTemp > 0) {
+                int realCrew = unit.getActiveCrew().size();
+                int fullCrew = unit.getFullCrewSize();
+                int excess = Math.max(0, (realCrew + currentTemp) - fullCrew);
+                if (excess > 0) {
+                    unit.setTempCrew(role, currentTemp - excess);
+                }
+            }
+        }
+        emptyTempCrewPoolForRole(campaign, role);
+    }
+
 
     @Deprecated(since = "0.50.06")
     public PersonnelMarket getPersonnelMarket() {

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -853,104 +853,15 @@ public class CampaignGUI extends JPanel {
         JMenu menuTempPool = new JMenu(resourceMap.getString("menuTempPool.text"));
 
         JMenuItem miTempPoolFullStrength = new JMenuItem(resourceMap.getString("miTempPoolFullStrength.text"));
-        miTempPoolFullStrength.addActionListener(evt -> {
-            getCampaign().resetAsTechPool();
-            getCampaign().resetMedicPool();
-            if (getCampaign().getCampaignOptions().isUseBlobInfantry()) {
-                getCampaign().resetTempCrewPoolForRole(PersonnelRole.SOLDIER);
-                getCampaign().distributeTempCrewPoolToUnits(PersonnelRole.SOLDIER);
-            }
-            if (getCampaign().getCampaignOptions().isUseBlobBattleArmor()) {
-                getCampaign().resetTempCrewPoolForRole(PersonnelRole.BATTLE_ARMOUR);
-                getCampaign().distributeTempCrewPoolToUnits(PersonnelRole.BATTLE_ARMOUR);
-            }
-            if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewGround()) {
-                getCampaign().resetTempCrewPoolForRole(PersonnelRole.VEHICLE_CREW_GROUND);
-                getCampaign().distributeTempCrewPoolToUnits(PersonnelRole.VEHICLE_CREW_GROUND);
-            }
-            if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewVTOL()) {
-                getCampaign().resetTempCrewPoolForRole(PersonnelRole.VEHICLE_CREW_VTOL);
-                getCampaign().distributeTempCrewPoolToUnits(PersonnelRole.VEHICLE_CREW_VTOL);
-            }
-            if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewNaval()) {
-                getCampaign().resetTempCrewPoolForRole(PersonnelRole.VEHICLE_CREW_NAVAL);
-                getCampaign().distributeTempCrewPoolToUnits(PersonnelRole.VEHICLE_CREW_NAVAL);
-            }
-            if (getCampaign().getCampaignOptions().isUseBlobVesselPilot()) {
-                getCampaign().resetTempCrewPoolForRole(PersonnelRole.VESSEL_PILOT);
-                getCampaign().distributeTempCrewPoolToUnits(PersonnelRole.VESSEL_PILOT);
-            }
-            if (getCampaign().getCampaignOptions().isUseBlobVesselGunner()) {
-                getCampaign().resetTempCrewPoolForRole(PersonnelRole.VESSEL_GUNNER);
-                getCampaign().distributeTempCrewPoolToUnits(PersonnelRole.VESSEL_GUNNER);
-            }
-            if (getCampaign().getCampaignOptions().isUseBlobVesselCrew()) {
-                getCampaign().resetTempCrewPoolForRole(PersonnelRole.VESSEL_CREW);
-                getCampaign().distributeTempCrewPoolToUnits(PersonnelRole.VESSEL_CREW);
-            }
-        });
+        miTempPoolFullStrength.addActionListener(evt -> bringAllTempCrewsToFullStrength());
         menuTempPool.add(miTempPoolFullStrength);
 
         JMenuItem miTempPoolReleaseAll = new JMenuItem(resourceMap.getString("miTempPoolReleaseAll.text"));
-        miTempPoolReleaseAll.addActionListener(evt -> {
-            getCampaign().emptyAsTechPool();
-            getCampaign().emptyMedicPool();
-            if (getCampaign().getCampaignOptions().isUseBlobInfantry()) {
-                getCampaign().clearBlobCrewForRole(PersonnelRole.SOLDIER);
-            }
-            if (getCampaign().getCampaignOptions().isUseBlobBattleArmor()) {
-                getCampaign().clearBlobCrewForRole(PersonnelRole.BATTLE_ARMOUR);
-            }
-            if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewGround()) {
-                getCampaign().clearBlobCrewForRole(PersonnelRole.VEHICLE_CREW_GROUND);
-            }
-            if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewVTOL()) {
-                getCampaign().clearBlobCrewForRole(PersonnelRole.VEHICLE_CREW_VTOL);
-            }
-            if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewNaval()) {
-                getCampaign().clearBlobCrewForRole(PersonnelRole.VEHICLE_CREW_NAVAL);
-            }
-            if (getCampaign().getCampaignOptions().isUseBlobVesselPilot()) {
-                getCampaign().clearBlobCrewForRole(PersonnelRole.VESSEL_PILOT);
-            }
-            if (getCampaign().getCampaignOptions().isUseBlobVesselGunner()) {
-                getCampaign().clearBlobCrewForRole(PersonnelRole.VESSEL_GUNNER);
-            }
-            if (getCampaign().getCampaignOptions().isUseBlobVesselCrew()) {
-                getCampaign().clearBlobCrewForRole(PersonnelRole.VESSEL_CREW);
-            }
-        });
+        miTempPoolReleaseAll.addActionListener(evt -> releaseAllTempCrews());
         menuTempPool.add(miTempPoolReleaseAll);
 
         JMenuItem miTempPoolReleaseSurplus = new JMenuItem(resourceMap.getString("miTempPoolReleaseSurplus.text"));
-        miTempPoolReleaseSurplus.addActionListener(evt -> {
-            getCampaign().releaseSurplusAsTechPool();
-            getCampaign().releaseSurplusMedicPool();
-            if (getCampaign().getCampaignOptions().isUseBlobInfantry()) {
-                getCampaign().releaseSurplusBlobCrewForRole(PersonnelRole.SOLDIER);
-            }
-            if (getCampaign().getCampaignOptions().isUseBlobBattleArmor()) {
-                getCampaign().releaseSurplusBlobCrewForRole(PersonnelRole.BATTLE_ARMOUR);
-            }
-            if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewGround()) {
-                getCampaign().releaseSurplusBlobCrewForRole(PersonnelRole.VEHICLE_CREW_GROUND);
-            }
-            if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewVTOL()) {
-                getCampaign().releaseSurplusBlobCrewForRole(PersonnelRole.VEHICLE_CREW_VTOL);
-            }
-            if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewNaval()) {
-                getCampaign().releaseSurplusBlobCrewForRole(PersonnelRole.VEHICLE_CREW_NAVAL);
-            }
-            if (getCampaign().getCampaignOptions().isUseBlobVesselPilot()) {
-                getCampaign().releaseSurplusBlobCrewForRole(PersonnelRole.VESSEL_PILOT);
-            }
-            if (getCampaign().getCampaignOptions().isUseBlobVesselGunner()) {
-                getCampaign().releaseSurplusBlobCrewForRole(PersonnelRole.VESSEL_GUNNER);
-            }
-            if (getCampaign().getCampaignOptions().isUseBlobVesselCrew()) {
-                getCampaign().releaseSurplusBlobCrewForRole(PersonnelRole.VESSEL_CREW);
-            }
-        });
+        miTempPoolReleaseSurplus.addActionListener(evt -> releaseSurplusTempCrews());
         menuTempPool.add(miTempPoolReleaseSurplus);
 
         menuTempPool.addSeparator();
@@ -2269,6 +2180,101 @@ public class CampaignGUI extends JPanel {
     private void hireBulkPersonnel() {
         HireBulkPersonnelDialog hireBulkPersonnelDialog = new HireBulkPersonnelDialog(getFrame(), true, getCampaign());
         hireBulkPersonnelDialog.setVisible(true);
+    }
+
+    private void bringAllTempCrewsToFullStrength() {
+        getCampaign().resetAsTechPool();
+        getCampaign().resetMedicPool();
+        if (getCampaign().getCampaignOptions().isUseBlobInfantry()) {
+            getCampaign().resetTempCrewPoolForRole(PersonnelRole.SOLDIER);
+            getCampaign().distributeTempCrewPoolToUnits(PersonnelRole.SOLDIER);
+        }
+        if (getCampaign().getCampaignOptions().isUseBlobBattleArmor()) {
+            getCampaign().resetTempCrewPoolForRole(PersonnelRole.BATTLE_ARMOUR);
+            getCampaign().distributeTempCrewPoolToUnits(PersonnelRole.BATTLE_ARMOUR);
+        }
+        if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewGround()) {
+            getCampaign().resetTempCrewPoolForRole(PersonnelRole.VEHICLE_CREW_GROUND);
+            getCampaign().distributeTempCrewPoolToUnits(PersonnelRole.VEHICLE_CREW_GROUND);
+        }
+        if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewVTOL()) {
+            getCampaign().resetTempCrewPoolForRole(PersonnelRole.VEHICLE_CREW_VTOL);
+            getCampaign().distributeTempCrewPoolToUnits(PersonnelRole.VEHICLE_CREW_VTOL);
+        }
+        if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewNaval()) {
+            getCampaign().resetTempCrewPoolForRole(PersonnelRole.VEHICLE_CREW_NAVAL);
+            getCampaign().distributeTempCrewPoolToUnits(PersonnelRole.VEHICLE_CREW_NAVAL);
+        }
+        if (getCampaign().getCampaignOptions().isUseBlobVesselPilot()) {
+            getCampaign().resetTempCrewPoolForRole(PersonnelRole.VESSEL_PILOT);
+            getCampaign().distributeTempCrewPoolToUnits(PersonnelRole.VESSEL_PILOT);
+        }
+        if (getCampaign().getCampaignOptions().isUseBlobVesselGunner()) {
+            getCampaign().resetTempCrewPoolForRole(PersonnelRole.VESSEL_GUNNER);
+            getCampaign().distributeTempCrewPoolToUnits(PersonnelRole.VESSEL_GUNNER);
+        }
+        if (getCampaign().getCampaignOptions().isUseBlobVesselCrew()) {
+            getCampaign().resetTempCrewPoolForRole(PersonnelRole.VESSEL_CREW);
+            getCampaign().distributeTempCrewPoolToUnits(PersonnelRole.VESSEL_CREW);
+        }
+    }
+
+    private void releaseAllTempCrews() {
+        getCampaign().emptyAsTechPool();
+        getCampaign().emptyMedicPool();
+        if (getCampaign().getCampaignOptions().isUseBlobInfantry()) {
+            getCampaign().clearBlobCrewForRole(PersonnelRole.SOLDIER);
+        }
+        if (getCampaign().getCampaignOptions().isUseBlobBattleArmor()) {
+            getCampaign().clearBlobCrewForRole(PersonnelRole.BATTLE_ARMOUR);
+        }
+        if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewGround()) {
+            getCampaign().clearBlobCrewForRole(PersonnelRole.VEHICLE_CREW_GROUND);
+        }
+        if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewVTOL()) {
+            getCampaign().clearBlobCrewForRole(PersonnelRole.VEHICLE_CREW_VTOL);
+        }
+        if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewNaval()) {
+            getCampaign().clearBlobCrewForRole(PersonnelRole.VEHICLE_CREW_NAVAL);
+        }
+        if (getCampaign().getCampaignOptions().isUseBlobVesselPilot()) {
+            getCampaign().clearBlobCrewForRole(PersonnelRole.VESSEL_PILOT);
+        }
+        if (getCampaign().getCampaignOptions().isUseBlobVesselGunner()) {
+            getCampaign().clearBlobCrewForRole(PersonnelRole.VESSEL_GUNNER);
+        }
+        if (getCampaign().getCampaignOptions().isUseBlobVesselCrew()) {
+            getCampaign().clearBlobCrewForRole(PersonnelRole.VESSEL_CREW);
+        }
+    }
+
+    private void releaseSurplusTempCrews() {
+        getCampaign().releaseSurplusAsTechPool();
+        getCampaign().releaseSurplusMedicPool();
+        if (getCampaign().getCampaignOptions().isUseBlobInfantry()) {
+            getCampaign().releaseSurplusBlobCrewForRole(PersonnelRole.SOLDIER);
+        }
+        if (getCampaign().getCampaignOptions().isUseBlobBattleArmor()) {
+            getCampaign().releaseSurplusBlobCrewForRole(PersonnelRole.BATTLE_ARMOUR);
+        }
+        if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewGround()) {
+            getCampaign().releaseSurplusBlobCrewForRole(PersonnelRole.VEHICLE_CREW_GROUND);
+        }
+        if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewVTOL()) {
+            getCampaign().releaseSurplusBlobCrewForRole(PersonnelRole.VEHICLE_CREW_VTOL);
+        }
+        if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewNaval()) {
+            getCampaign().releaseSurplusBlobCrewForRole(PersonnelRole.VEHICLE_CREW_NAVAL);
+        }
+        if (getCampaign().getCampaignOptions().isUseBlobVesselPilot()) {
+            getCampaign().releaseSurplusBlobCrewForRole(PersonnelRole.VESSEL_PILOT);
+        }
+        if (getCampaign().getCampaignOptions().isUseBlobVesselGunner()) {
+            getCampaign().releaseSurplusBlobCrewForRole(PersonnelRole.VESSEL_GUNNER);
+        }
+        if (getCampaign().getCampaignOptions().isUseBlobVesselCrew()) {
+            getCampaign().releaseSurplusBlobCrewForRole(PersonnelRole.VESSEL_CREW);
+        }
     }
 
     public void showContractMarket() {

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -64,8 +64,8 @@ import javax.swing.UIManager.LookAndFeelInfo;
 import javax.xml.parsers.DocumentBuilder;
 
 import megamek.Version;
-import megamek.client.ui.CopySystemDataAction;
 import megamek.client.generator.RandomUnitGenerator;
+import megamek.client.ui.CopySystemDataAction;
 import megamek.client.ui.clientGUI.GUIPreferences;
 import megamek.client.ui.dialogs.UnitLoadingDialog;
 import megamek.client.ui.dialogs.buttonDialogs.CommonSettingsDialog;
@@ -849,6 +849,112 @@ public class CampaignGUI extends JPanel {
         menuHire.add(menuHireCivilian);
         menuMarket.add(menuHire);
 
+        // region Temp Pool
+        JMenu menuTempPool = new JMenu(resourceMap.getString("menuTempPool.text"));
+
+        JMenuItem miTempPoolFullStrength = new JMenuItem(resourceMap.getString("miTempPoolFullStrength.text"));
+        miTempPoolFullStrength.addActionListener(evt -> {
+            getCampaign().resetAsTechPool();
+            getCampaign().resetMedicPool();
+            if (getCampaign().getCampaignOptions().isUseBlobInfantry()) {
+                getCampaign().resetTempCrewPoolForRole(PersonnelRole.SOLDIER);
+                getCampaign().distributeTempCrewPoolToUnits(PersonnelRole.SOLDIER);
+            }
+            if (getCampaign().getCampaignOptions().isUseBlobBattleArmor()) {
+                getCampaign().resetTempCrewPoolForRole(PersonnelRole.BATTLE_ARMOUR);
+                getCampaign().distributeTempCrewPoolToUnits(PersonnelRole.BATTLE_ARMOUR);
+            }
+            if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewGround()) {
+                getCampaign().resetTempCrewPoolForRole(PersonnelRole.VEHICLE_CREW_GROUND);
+                getCampaign().distributeTempCrewPoolToUnits(PersonnelRole.VEHICLE_CREW_GROUND);
+            }
+            if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewVTOL()) {
+                getCampaign().resetTempCrewPoolForRole(PersonnelRole.VEHICLE_CREW_VTOL);
+                getCampaign().distributeTempCrewPoolToUnits(PersonnelRole.VEHICLE_CREW_VTOL);
+            }
+            if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewNaval()) {
+                getCampaign().resetTempCrewPoolForRole(PersonnelRole.VEHICLE_CREW_NAVAL);
+                getCampaign().distributeTempCrewPoolToUnits(PersonnelRole.VEHICLE_CREW_NAVAL);
+            }
+            if (getCampaign().getCampaignOptions().isUseBlobVesselPilot()) {
+                getCampaign().resetTempCrewPoolForRole(PersonnelRole.VESSEL_PILOT);
+                getCampaign().distributeTempCrewPoolToUnits(PersonnelRole.VESSEL_PILOT);
+            }
+            if (getCampaign().getCampaignOptions().isUseBlobVesselGunner()) {
+                getCampaign().resetTempCrewPoolForRole(PersonnelRole.VESSEL_GUNNER);
+                getCampaign().distributeTempCrewPoolToUnits(PersonnelRole.VESSEL_GUNNER);
+            }
+            if (getCampaign().getCampaignOptions().isUseBlobVesselCrew()) {
+                getCampaign().resetTempCrewPoolForRole(PersonnelRole.VESSEL_CREW);
+                getCampaign().distributeTempCrewPoolToUnits(PersonnelRole.VESSEL_CREW);
+            }
+        });
+        menuTempPool.add(miTempPoolFullStrength);
+
+        JMenuItem miTempPoolReleaseAll = new JMenuItem(resourceMap.getString("miTempPoolReleaseAll.text"));
+        miTempPoolReleaseAll.addActionListener(evt -> {
+            getCampaign().emptyAsTechPool();
+            getCampaign().emptyMedicPool();
+            if (getCampaign().getCampaignOptions().isUseBlobInfantry()) {
+                getCampaign().clearBlobCrewForRole(PersonnelRole.SOLDIER);
+            }
+            if (getCampaign().getCampaignOptions().isUseBlobBattleArmor()) {
+                getCampaign().clearBlobCrewForRole(PersonnelRole.BATTLE_ARMOUR);
+            }
+            if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewGround()) {
+                getCampaign().clearBlobCrewForRole(PersonnelRole.VEHICLE_CREW_GROUND);
+            }
+            if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewVTOL()) {
+                getCampaign().clearBlobCrewForRole(PersonnelRole.VEHICLE_CREW_VTOL);
+            }
+            if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewNaval()) {
+                getCampaign().clearBlobCrewForRole(PersonnelRole.VEHICLE_CREW_NAVAL);
+            }
+            if (getCampaign().getCampaignOptions().isUseBlobVesselPilot()) {
+                getCampaign().clearBlobCrewForRole(PersonnelRole.VESSEL_PILOT);
+            }
+            if (getCampaign().getCampaignOptions().isUseBlobVesselGunner()) {
+                getCampaign().clearBlobCrewForRole(PersonnelRole.VESSEL_GUNNER);
+            }
+            if (getCampaign().getCampaignOptions().isUseBlobVesselCrew()) {
+                getCampaign().clearBlobCrewForRole(PersonnelRole.VESSEL_CREW);
+            }
+        });
+        menuTempPool.add(miTempPoolReleaseAll);
+
+        JMenuItem miTempPoolReleaseSurplus = new JMenuItem(resourceMap.getString("miTempPoolReleaseSurplus.text"));
+        miTempPoolReleaseSurplus.addActionListener(evt -> {
+            getCampaign().releaseSurplusAsTechPool();
+            getCampaign().releaseSurplusMedicPool();
+            if (getCampaign().getCampaignOptions().isUseBlobInfantry()) {
+                getCampaign().releaseSurplusBlobCrewForRole(PersonnelRole.SOLDIER);
+            }
+            if (getCampaign().getCampaignOptions().isUseBlobBattleArmor()) {
+                getCampaign().releaseSurplusBlobCrewForRole(PersonnelRole.BATTLE_ARMOUR);
+            }
+            if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewGround()) {
+                getCampaign().releaseSurplusBlobCrewForRole(PersonnelRole.VEHICLE_CREW_GROUND);
+            }
+            if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewVTOL()) {
+                getCampaign().releaseSurplusBlobCrewForRole(PersonnelRole.VEHICLE_CREW_VTOL);
+            }
+            if (getCampaign().getCampaignOptions().isUseBlobVehicleCrewNaval()) {
+                getCampaign().releaseSurplusBlobCrewForRole(PersonnelRole.VEHICLE_CREW_NAVAL);
+            }
+            if (getCampaign().getCampaignOptions().isUseBlobVesselPilot()) {
+                getCampaign().releaseSurplusBlobCrewForRole(PersonnelRole.VESSEL_PILOT);
+            }
+            if (getCampaign().getCampaignOptions().isUseBlobVesselGunner()) {
+                getCampaign().releaseSurplusBlobCrewForRole(PersonnelRole.VESSEL_GUNNER);
+            }
+            if (getCampaign().getCampaignOptions().isUseBlobVesselCrew()) {
+                getCampaign().releaseSurplusBlobCrewForRole(PersonnelRole.VESSEL_CREW);
+            }
+        });
+        menuTempPool.add(miTempPoolReleaseSurplus);
+
+        menuTempPool.addSeparator();
+
         // region Astech Pool
         // The Astech Pool menu uses the following Mnemonic keys as of 19-March-2020:
         // B, E, F, H
@@ -896,7 +1002,7 @@ public class CampaignGUI extends JPanel {
         miFireAllAsTechs.setMnemonic(KeyEvent.VK_R);
         miFireAllAsTechs.addActionListener(evt -> getCampaign().emptyAsTechPool());
         menuAsTechPool.add(miFireAllAsTechs);
-        menuMarket.add(menuAsTechPool);
+        menuTempPool.add(menuAsTechPool);
         // endregion Astech Pool
 
         // region Medic Pool
@@ -946,7 +1052,7 @@ public class CampaignGUI extends JPanel {
         miFireAllMedics.setMnemonic(KeyEvent.VK_R);
         miFireAllMedics.addActionListener(evt -> getCampaign().emptyMedicPool());
         menuMedicPool.add(miFireAllMedics);
-        menuMarket.add(menuMedicPool);
+        menuTempPool.add(menuMedicPool);
         // endregion Medic Pool
 
         // region Soldier Pool
@@ -998,7 +1104,7 @@ public class CampaignGUI extends JPanel {
         miFireAllSoldiers.setMnemonic(KeyEvent.VK_R);
         miFireAllSoldiers.addActionListener(evt -> getCampaign().emptyTempCrewPoolForRole(PersonnelRole.SOLDIER));
         menuSoldierPool.add(miFireAllSoldiers);
-        menuMarket.add(menuSoldierPool);
+        menuTempPool.add(menuSoldierPool);
         // endregion Soldier Pool
 
         // region Battle Armor Pool
@@ -1048,7 +1154,7 @@ public class CampaignGUI extends JPanel {
         miFireAllBattleArmor.setMnemonic(KeyEvent.VK_R);
         miFireAllBattleArmor.addActionListener(evt -> getCampaign().emptyTempCrewPoolForRole(PersonnelRole.BATTLE_ARMOUR));
         menuBattleArmorPool.add(miFireAllBattleArmor);
-        menuMarket.add(menuBattleArmorPool);
+        menuTempPool.add(menuBattleArmorPool);
         // endregion Battle Armor Pool
 
         // region Vehicle Crew Ground Pool
@@ -1099,7 +1205,7 @@ public class CampaignGUI extends JPanel {
         miFireAllVehicleCrewGround.addActionListener(evt -> getCampaign().setTempCrewPool(PersonnelRole.VEHICLE_CREW_GROUND,
               0));
         menuVehicleCrewGroundPool.add(miFireAllVehicleCrewGround);
-        menuMarket.add(menuVehicleCrewGroundPool);
+        menuTempPool.add(menuVehicleCrewGroundPool);
         // endregion Vehicle Crew Ground Pool
 
         // region Vehicle Crew VTOL Pool
@@ -1148,7 +1254,7 @@ public class CampaignGUI extends JPanel {
         miFireAllVehicleCrewVTOL.addActionListener(evt -> getCampaign().setTempCrewPool(PersonnelRole.VEHICLE_CREW_VTOL,
               0));
         menuVehicleCrewVTOLPool.add(miFireAllVehicleCrewVTOL);
-        menuMarket.add(menuVehicleCrewVTOLPool);
+        menuTempPool.add(menuVehicleCrewVTOLPool);
         // endregion Vehicle Crew VTOL Pool
 
         // region Vehicle Crew Naval Pool
@@ -1197,7 +1303,7 @@ public class CampaignGUI extends JPanel {
         miFireAllVehicleCrewNaval.addActionListener(evt -> getCampaign().setTempCrewPool(PersonnelRole.VEHICLE_CREW_NAVAL,
               0));
         menuVehicleCrewNavalPool.add(miFireAllVehicleCrewNaval);
-        menuMarket.add(menuVehicleCrewNavalPool);
+        menuTempPool.add(menuVehicleCrewNavalPool);
         // endregion Vehicle Crew Naval Pool
 
         // region Vessel Pilot Pool
@@ -1244,7 +1350,7 @@ public class CampaignGUI extends JPanel {
         JMenuItem miFireAllVesselPilot = new JMenuItem(resourceMap.getString("miFireAllVesselPilot.text"));
         miFireAllVesselPilot.addActionListener(evt -> getCampaign().setTempCrewPool(PersonnelRole.VESSEL_PILOT, 0));
         menuVesselPilotPool.add(miFireAllVesselPilot);
-        menuMarket.add(menuVesselPilotPool);
+        menuTempPool.add(menuVesselPilotPool);
         // endregion Vessel Pilot Pool
 
         // region Vessel Gunner Pool
@@ -1291,7 +1397,7 @@ public class CampaignGUI extends JPanel {
         JMenuItem miFireAllVesselGunner = new JMenuItem(resourceMap.getString("miFireAllVesselGunner.text"));
         miFireAllVesselGunner.addActionListener(evt -> getCampaign().setTempCrewPool(PersonnelRole.VESSEL_GUNNER, 0));
         menuVesselGunnerPool.add(miFireAllVesselGunner);
-        menuMarket.add(menuVesselGunnerPool);
+        menuTempPool.add(menuVesselGunnerPool);
         // endregion Vessel Gunner Pool
 
         // region Vessel Crew Pool
@@ -1338,8 +1444,11 @@ public class CampaignGUI extends JPanel {
         JMenuItem miFireAllVesselCrew = new JMenuItem(resourceMap.getString("miFireAllVesselCrew.text"));
         miFireAllVesselCrew.addActionListener(evt -> getCampaign().setTempCrewPool(PersonnelRole.VESSEL_CREW, 0));
         menuVesselCrewPool.add(miFireAllVesselCrew);
-        menuMarket.add(menuVesselCrewPool);
+        menuTempPool.add(menuVesselCrewPool);
         // endregion Vessel Crew Pool
+
+        menuMarket.add(menuTempPool);
+        // endregion Temp Pool
 
         menuBar.add(menuMarket);
         // endregion Marketplace Menu

--- a/MekHQ/unittests/mekhq/campaign/CampaignTest.java
+++ b/MekHQ/unittests/mekhq/campaign/CampaignTest.java
@@ -48,9 +48,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static testUtilities.MHQTestUtilities.TEST_CANON_SYSTEMS_DIR;
 
@@ -71,7 +69,6 @@ import megamek.common.units.Crew;
 import megamek.common.units.Dropship;
 import megamek.common.units.EntityMovementMode;
 import megamek.common.units.UnitType;
-import mekhq.campaign.HumanResources;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.enums.CampaignTransportType;
 import mekhq.campaign.personnel.Person;
@@ -937,6 +934,162 @@ public class CampaignTest {
             // Assert
             assertEquals(0, testCampaign.getTempCrewPool(PersonnelRole.SOLDIER));
             assertEquals(8, testCampaign.getTempCrewPool(PersonnelRole.BATTLE_ARMOUR));
+        }
+
+        /**
+         * Tests {@link Campaign#releaseSurplusBlobCrewForRole(PersonnelRole)}: when a unit has more temp crew than
+         * needed to fill the gap left by real crew, the excess is trimmed.
+         *
+         * <p>SOLDIER units have fullCrewSize=5 and 1 real crew member, so they need 4 temp crew.
+         * Setting 6 temp crew gives an excess of 2, which should be removed.</p>
+         */
+        @Test
+        void testReleaseSurplusTrimsExcessTempCrewFromUnit() {
+            // Arrange
+            PersonnelRole role = PersonnelRole.SOLDIER;
+            enableBlobCrewForRole(role);
+            Unit unit = createMockUnitForRole(role, true); // 1 real crew, fullSize=5
+            unit.setTempCrew(role, 6); // 1 real + 6 temp = 7 total; need 5, excess = 2
+            testCampaign.importUnit(unit);
+
+            // Act
+            testCampaign.releaseSurplusBlobCrewForRole(role);
+
+            // Assert
+            assertEquals(4, unit.getTempCrewByPersonnelRole(role),
+                  "Excess temp crew should be trimmed so real + temp equals fullCrewSize");
+        }
+
+        /**
+         * Tests {@link Campaign#releaseSurplusBlobCrewForRole(PersonnelRole)}: when temp crew exactly covers the gap
+         * between real crew and full crew size, nothing is changed.
+         */
+        @Test
+        void testReleaseSurplusDoesNotRemoveTempCrewWhenExactFit() {
+            // Arrange
+            PersonnelRole role = PersonnelRole.SOLDIER;
+            enableBlobCrewForRole(role);
+            Unit unit = createMockUnitForRole(role, true); // 1 real crew, fullSize=5
+            unit.setTempCrew(role, 4); // 1 real + 4 temp = 5 = fullSize; no excess
+            testCampaign.importUnit(unit);
+
+            // Act
+            testCampaign.releaseSurplusBlobCrewForRole(role);
+
+            // Assert
+            assertEquals(4, unit.getTempCrewByPersonnelRole(role),
+                  "Temp crew should be unchanged when it exactly fills the crew gap");
+        }
+
+        /**
+         * Tests {@link Campaign#releaseSurplusBlobCrewForRole(PersonnelRole)}: when real crew already meets or exceeds
+         * fullCrewSize, all temp crew are removed from the unit.
+         *
+         * <p>VESSEL_PILOT units have fullCrewSize=2. By providing 2 real crew members the unit is fully staffed,
+         * so any temp crew assigned is pure surplus.</p>
+         */
+        @Test
+        void testReleaseSurplusRemovesAllTempWhenRealCrewFull() {
+            // Arrange
+            PersonnelRole role = PersonnelRole.VESSEL_PILOT;
+            enableBlobCrewForRole(role);
+            Unit unit = createMockUnitForRole(role, false); // fullSize=2
+            doReturn(List.of(mock(Person.class), mock(Person.class))).when(unit).getActiveCrew();
+            unit.setTempCrew(role, 1); // 2 real + 1 temp = 3 total; need 2, excess = 1
+            testCampaign.importUnit(unit);
+
+            // Act
+            testCampaign.releaseSurplusBlobCrewForRole(role);
+
+            // Assert
+            assertEquals(0, unit.getTempCrewByPersonnelRole(role),
+                  "All temp crew should be removed when real crew already fills the unit");
+        }
+
+        /**
+         * Tests {@link Campaign#releaseSurplusBlobCrewForRole(PersonnelRole)}: any temp crew sitting in the unassigned
+         * pool (not yet distributed to units) is also cleared.
+         */
+        @Test
+        void testReleaseSurplusClearsUnassignedPool() {
+            // Arrange
+            PersonnelRole role = PersonnelRole.SOLDIER;
+            enableBlobCrewForRole(role);
+            Unit unit = createMockUnitForRole(role, true); // 1 real crew, fullSize=5
+            unit.setTempCrew(role, 4); // unit exactly staffed: 1 + 4 = 5
+            testCampaign.importUnit(unit);
+            testCampaign.setTempCrewPool(role, 10); // 4 in-use, 6 unassigned in pool
+
+            // Act
+            testCampaign.releaseSurplusBlobCrewForRole(role);
+
+            // Assert — pool reduced to just the in-use count
+            assertEquals(4, testCampaign.getTempCrewPool(role),
+                  "Unassigned pool should be cleared; only assigned (in-use) temp crew remain");
+        }
+
+        /**
+         * Tests {@link Campaign#releaseSurplusAsTechPool()}: in a campaign with no tech personnel all pooled AsTechs
+         * are surplus and should be released.
+         */
+        @Test
+        void testReleaseSurplusAsTechPoolReleasesAllWhenNoTechs() {
+            // Arrange — no techs in campaign, so entire pool is surplus
+            testCampaign.getHumanResources().setAsTechPool(5);
+
+            // Act
+            testCampaign.releaseSurplusAsTechPool();
+
+            // Assert
+            assertEquals(0, testCampaign.getTemporaryAsTechPool(),
+                  "All AsTechs should be released when there are no tech teams requiring support");
+        }
+
+        /**
+         * Tests {@link Campaign#releaseSurplusAsTechPool()}: when the pool is already empty, nothing changes.
+         */
+        @Test
+        void testReleaseSurplusAsTechPoolDoesNothingWhenEmpty() {
+            // Arrange — pool already at 0
+            assertEquals(0, testCampaign.getTemporaryAsTechPool());
+
+            // Act
+            testCampaign.releaseSurplusAsTechPool();
+
+            // Assert
+            assertEquals(0, testCampaign.getTemporaryAsTechPool());
+        }
+
+        /**
+         * Tests {@link Campaign#releaseSurplusMedicPool()}: in a campaign with no doctors all pooled Medics are surplus
+         * and should be released.
+         */
+        @Test
+        void testReleaseSurplusMedicPoolReleasesAllWhenNoDoctors() {
+            // Arrange — no doctors in campaign, so entire pool is surplus
+            testCampaign.getHumanResources().setMedicPool(3);
+
+            // Act
+            testCampaign.releaseSurplusMedicPool();
+
+            // Assert
+            assertEquals(0, testCampaign.getTemporaryMedicPool(),
+                  "All Medics should be released when there are no doctors requiring support");
+        }
+
+        /**
+         * Tests {@link Campaign#releaseSurplusMedicPool()}: when the pool is already empty, nothing changes.
+         */
+        @Test
+        void testReleaseSurplusMedicPoolDoesNothingWhenEmpty() {
+            // Arrange — pool already at 0
+            assertEquals(0, testCampaign.getTemporaryMedicPool());
+
+            // Act
+            testCampaign.releaseSurplusMedicPool();
+
+            // Assert
+            assertEquals(0, testCampaign.getTemporaryMedicPool());
         }
     }
     // endregion Nested Test Classes for Temp Crew


### PR DESCRIPTION
Fixes #9061 

Temp Pools are now in a tested "Temp Pool" submenu under market. The first three options let the player bring all teams to full strength, let go of every temp, or release just the excess temps. Then below that, for each enabled temp type (including medic and as tech) there will be a submenu with its options for hiring/firing just that crew type.