### PR TITLE
Fix #9093: Fixed Support Units Being Automatically Assigned to TO&E

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/companyGeneration/AddSupportUnitsToTOE.java
+++ b/MekHQ/src/mekhq/campaign/universe/companyGeneration/AddSupportUnitsToTOE.java
@@ -107,14 +107,14 @@ public class AddSupportUnitsToTOE {
     private static void createSubFormation(Campaign campaign, String label, FormationType type,
           List<Unit> units, Formation hqFormation) {
         Formation subFormation = new Formation(label);
-        subFormation.setFormationType(type, true); // Largely irrelevant
+        campaign.addFormation(subFormation, hqFormation); // needs to be before we add units
+
+        subFormation.setFormationType(type, true); //subtype propagation is largely irrelevant
 
         int subFormationId = subFormation.getId();
         for (Unit unit : units) {
             campaign.addUnitToFormation(unit, subFormationId);
         }
-
-        campaign.addFormation(subFormation, hqFormation);
     }
 
     /**


### PR DESCRIPTION
Fix #9093

Fixed a merge error that caused all support units to be dumped into the HQ formation, not an appropriate sub formation.