### PR TITLE
Fix #8801: Stopped Characters From Being Given Gunnery/ProtoMek as a Random Skill

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/generator/DefaultSkillGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/generator/DefaultSkillGenerator.java
@@ -156,6 +156,14 @@ public class DefaultSkillGenerator extends AbstractSkillGenerator {
             List<String> possibleSkills = new ArrayList<>();
             for (String skillType : SkillType.skillList) {
                 SkillType type = SkillType.getType(skillType);
+
+                // We're removing protomek from the pool as only actual protomek pilots should have access to this
+                // skill. Adding it randomly creates some lore inconsistencies. ProtoMek pilots will already have the
+                // skill at this stage
+                if (skillType.equalsIgnoreCase(SkillType.S_GUN_PROTO)) {
+                    continue;
+                }
+
                 if (!person.getSkills().hasSkill(skillType)
                           && !DEPRECATED_SKILLS.contains(type)
                           // The next lines are to prevent double-dipping


### PR DESCRIPTION
Fix #8801

This created lore inconsistencies, blocking the skill was the easiest implementation.