### PR TITLE
Fix #8773: Fixed Misc Skill Bonus Not Displaying in Personnel Tab Character Sheets

### DIFF
--- a/MekHQ/resources/mekhq/resources/Skill.properties
+++ b/MekHQ/resources/mekhq/resources/Skill.properties
@@ -29,6 +29,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 tooltip.format.age=<b>Aging Modifier:</b> {0}<br>
+tooltip.format.bonus=<b>Misc Bonus:</b> {0}<br>
 tooltip.format.spa=<b>SPA & Trait Modifier:</b> {0}<br>
 tooltip.format.injury=<b>Injury Modifier:</b> {0}<br>
 tooltip.format.linkedAttribute=<b>{0}:</b> {1}<br>

--- a/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
@@ -839,6 +839,12 @@ public class Skill {
             tooltip.append(flavorText).append("<br><br>");
         }
 
+        if (bonus != 0) {
+            tooltip.append(getFormattedTextAt(RESOURCE_BUNDLE,
+                  "tooltip.format.bonus",
+                  (bonus > 0 ? "+" : "") + bonus));
+        }
+
         int spaModifier = getSPAModifiers(skillModifierData.characterOptions(), skillModifierData.adjustedReputation());
         if (spaModifier != 0) {
             tooltip.append(getFormattedTextAt(RESOURCE_BUNDLE,

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -1998,7 +1998,8 @@ public class PersonViewPanel extends JScrollablePanel {
                   characterAge);
             int spaModifier = skill.getSPAModifiers(options, adjustedReputation);
             int injuryModifier = Skill.getTotalInjuryModifier(skillModifierData, skill.getType());
-            String adjustment = getSkillAdjustment(attributeModifier, spaModifier, injuryModifier);
+            int bonus = skill.getBonus();
+            String adjustment = getSkillAdjustment(attributeModifier, spaModifier, injuryModifier, bonus);
 
             JLabel lblValue = new JLabel(String.format("<html>%s%s</html>",
                   skill.toString(skillModifierData),
@@ -2029,8 +2030,8 @@ public class PersonViewPanel extends JScrollablePanel {
         return pnlSkills;
     }
 
-    private static String getSkillAdjustment(int attributeModifier, int spaModifier, int injuryModifier) {
-        int totalModifier = attributeModifier + spaModifier + injuryModifier;
+    private static String getSkillAdjustment(int attributeModifier, int spaModifier, int injuryModifier, int bonus) {
+        int totalModifier = attributeModifier + spaModifier + injuryModifier + bonus;
 
         String color = "";
         String icon = "";


### PR DESCRIPTION
Fix #8773

When displaying skills in `PersonView` (the character sheet seen in Personnel Tab, among other places) we show an infographic so illustrate whether the skill has an overall bonus or mallus.

Misc Modifiers (gained from the Edit Person dialog or Education) were not included. Now they are. :)