### PR TITLE
Close #8904: Added Field Control Statement to Salvage Formation & Tech Pickers

### DIFF
--- a/MekHQ/resources/mekhq/resources/SalvageFormationPicker.properties
+++ b/MekHQ/resources/mekhq/resources/SalvageFormationPicker.properties
@@ -29,15 +29,16 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 # suppress inspection "UnusedProperty" for whole file
-SalvageFormationPicker.instructions=Under CamOps salvage rules a salvage team cannot partake in the fighting. They sit\
-  \ on\
-  \ the sidelines until the OpFor has been routed.\n\n\
+SalvageFormationPicker.instructions=Under CamOps salvage rules a salvage team cannot partake in the fighting. They \
+  sit on the sidelines until the OpFor has been routed.\n\n\
   Only 'Meks and vehicles can participate in ground salvage. Only DropShips and WarShips can participate in space \
   salvage. Units that are not fully crewed cannot salvage.\n\n\
-  This is an early implementation of the Rules as Written salvage rules. You cannot field strip salvage, and salvage \
+  This is a basic implementation of the Rules as Written salvage rules. You cannot field strip salvage, and salvage \
   quality weapon effects are not implemented. For an overview of the full salvage rules, please see Campaign \
   Operations.\n\n\
-  Each item in the below table has detailed tooltips, make sure to check them.
+  Each item in the below table has detailed tooltips, make sure to check them.\n\n\
+  Field Control:
+SalvageFormationPicker.instructions.fieldControlUnknown=Unknown
 SalvageFormationPicker.column.select=Select
 SalvageFormationPicker.column.formation=Formation
 SalvageFormationPicker.column.type=Type

--- a/MekHQ/resources/mekhq/resources/SalvageTechPicker.properties
+++ b/MekHQ/resources/mekhq/resources/SalvageTechPicker.properties
@@ -32,7 +32,9 @@ SalvageTechPicker.instructions=Under CamOps salvage rules each recovery task dep
   the 'Risky Salvage' campaign option is enabled, each recovery task will require a 2d6 roll, with a random tech \
   being injured (possibly killed) on a roll of 2. The same tech can be injured multiple times, but the task will \
   always be successful. Clearly Astechs learn by example.\n\n\
-  Assigning a tech to salvage operations will consume all of their remaining work minutes.
+  Assigning a tech to salvage operations will consume all of their remaining work minutes.\n\n\
+  Field Control:
+SalvageTechPicker.instructions.fieldControlUnknown=Unknown
 SalvageTechPicker.column.select=Select
 SalvageTechPicker.column.rank=Rank
 SalvageTechPicker.column.firstName=Name

--- a/MekHQ/src/mekhq/campaign/mission/ScenarioTemplate.java
+++ b/MekHQ/src/mekhq/campaign/mission/ScenarioTemplate.java
@@ -112,7 +112,12 @@ public class ScenarioTemplate implements Cloneable {
         /**
          * Battlefield control is always assigned to the enemy.
          */
-        ENEMY
+        ENEMY,
+
+        /**
+         * Battlefield control has not been defined
+         */
+        UNDEFINED
     }
 
     @Override

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -111,6 +111,7 @@ import mekhq.campaign.mission.BotForce;
 import mekhq.campaign.mission.Contract;
 import mekhq.campaign.mission.Mission;
 import mekhq.campaign.mission.Scenario;
+import mekhq.campaign.mission.ScenarioTemplate;
 import mekhq.campaign.mission.camOpsSalvage.CamOpsSalvageUtilities;
 import mekhq.campaign.mission.camOpsSalvage.SalvageFormationData;
 import mekhq.campaign.mission.camOpsSalvage.SalvageTechData;
@@ -997,7 +998,8 @@ public final class BriefingTab extends CampaignGuiTab {
               scenario.getSalvageFormations());
 
         SalvageFormationPicker forcePicker = new SalvageFormationPicker(getCampaign(), salvageFormationOptions, isSpace,
-              scenario.getSalvageFormations());
+              scenario.getSalvageFormations(), getBattlefieldControlType(scenario));
+
         boolean wasConfirmed = forcePicker.wasConfirmed();
         if (wasConfirmed) {
             scenario.clearSalvageFormations();
@@ -1034,6 +1036,20 @@ public final class BriefingTab extends CampaignGuiTab {
         }
 
         return forcePicker.wasConfirmed();
+    }
+
+    private static @Nullable ScenarioTemplate.BattlefieldControlType getBattlefieldControlType(Scenario scenario) {
+        if (scenario instanceof AtBDynamicScenario dynamicScenario) {
+            ScenarioTemplate template = dynamicScenario.getTemplate();
+
+            if (template != null) {
+                return template.getBattlefieldControl();
+            }
+
+            return ScenarioTemplate.BattlefieldControlType.VICTOR;
+        }
+
+        return null;
     }
 
 
@@ -1097,7 +1113,7 @@ public final class BriefingTab extends CampaignGuiTab {
         }
 
         SalvageTechPicker techPicker = new SalvageTechPicker(techData, priorSelectedTechs,
-              getCampaign().isClanCampaign());
+              getCampaign().isClanCampaign(), getBattlefieldControlType(scenario));
         boolean wasConfirmed = techPicker.wasConfirmed();
         if (wasConfirmed) {
             scenario.clearSalvageTechs();

--- a/MekHQ/src/mekhq/gui/dialog/camOpsSalvage/SalvageFormationPicker.java
+++ b/MekHQ/src/mekhq/gui/dialog/camOpsSalvage/SalvageFormationPicker.java
@@ -59,6 +59,7 @@ import javax.swing.table.TableRowSorter;
 
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
+import megamek.common.annotations.Nullable;
 import megamek.common.util.sorter.NaturalOrderComparator;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
@@ -66,19 +67,20 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.Hangar;
 import mekhq.campaign.force.Formation;
 import mekhq.campaign.force.FormationType;
+import mekhq.campaign.mission.ScenarioTemplate;
 import mekhq.campaign.mission.camOpsSalvage.SalvageFormationData;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
 
 /**
- * Modal dialog that lists available formations capable of participating in salvage operations and lets the user select one
- * or more for the current task.
+ * Modal dialog that lists available formations capable of participating in salvage operations and lets the user select
+ * one or more for the current task.
  *
  * <p>The center of the dialog is a sortable {@link JTable} backed by
- * {@link SalvageFormationTableModel}. Columns include formation name/type, assigned tech (with
- * experience/rank-aware sort), cargo/tow capacities, salvage-capable unit count, and a tug availability flag. Tooltips
- * provide detailed capacity reasoning and tech status.</p>
+ * {@link SalvageFormationTableModel}. Columns include formation name/type, assigned tech (with experience/rank-aware
+ * sort), cargo/tow capacities, salvage-capable unit count, and a tug availability flag. Tooltips provide detailed
+ * capacity reasoning and tech status.</p>
  *
  * <p>Use {@link #wasConfirmed()} to check whether the user confirmed and {@link #getSelectedFormations()} to retrieve
  * the chosen formations after the dialog closes.</p>
@@ -112,8 +114,8 @@ public class SalvageFormationPicker extends JDialog {
     }
 
     /**
-     * Returns all selected {@link Formation}s from the table. If the table was never constructed (e.g., no formations were
-     * provided), returns an empty list.
+     * Returns all selected {@link Formation}s from the table. If the table was never constructed (e.g., no formations
+     * were provided), returns an empty list.
      *
      * @return a list of selected formations (never {@code null})
      *
@@ -134,26 +136,27 @@ public class SalvageFormationPicker extends JDialog {
      * operations. A read-only instruction panel is shown at the top, and Confirm/Cancel controls are placed at the
      * bottom.</p>
      *
-     * @param campaign            current campaign context; used for tech labels, experience, tooltips, and hangar
-     *                            lookups
-     * @param formations              the candidate salvage-capable formations with precomputed stats; may be {@code null} or
-     *                            empty
-     * @param isSpaceOperation    {@code true} to show space-specific columns (e.g., tug availability); {@code false} to
-     *                            hide them
+     * @param campaign                current campaign context; used for tech labels, experience, tooltips, and hangar
+     *                                lookups
+     * @param formations              the candidate salvage-capable formations with precomputed stats; may be
+     *                                {@code null} or empty
+     * @param isSpaceOperation        {@code true} to show space-specific columns (e.g., tug availability);
+     *                                {@code false} to hide them
      * @param priorSelectedFormations a list of formations that were previously selected
+     * @param fieldControl            who controls the field at the end of the scenario
      *
      * @author Illiani
      * @since 0.50.10
      */
     public SalvageFormationPicker(Campaign campaign, List<SalvageFormationData> formations, boolean isSpaceOperation,
-                                  List<Integer> priorSelectedFormations) {
+          List<Integer> priorSelectedFormations, @Nullable ScenarioTemplate.BattlefieldControlType fieldControl) {
         setTitle(getText("accessingTerminal.title"));
         setModal(true);
         setLayout(new BorderLayout());
 
         // Instructions at the top
         JPanel instructionsPanel = new JPanel(new BorderLayout());
-        JTextArea instructionsLabel = new JTextArea(getInstructions());
+        JTextArea instructionsLabel = new JTextArea(getInstructions(fieldControl));
         instructionsLabel.setLineWrap(true);
         instructionsLabel.setWrapStyleWord(true);
         instructionsLabel.setEditable(false);
@@ -276,8 +279,8 @@ public class SalvageFormationPicker extends JDialog {
 
             // Table sorting
             sorter.setComparator(SalvageFormationTableModel.COL_SELECT, (b1, b2) ->
-                                                                          Boolean.compare(((Boolean) b1),
-                                                                                ((Boolean) b2)));
+                                                                              Boolean.compare(((Boolean) b1),
+                                                                                    ((Boolean) b2)));
             sorter.setComparator(SalvageFormationTableModel.COL_FORMATION_NAME,
                   new NaturalOrderComparator());
             sorter.setComparator(SalvageFormationTableModel.COL_FORMATION_TYPE,
@@ -314,8 +317,8 @@ public class SalvageFormationPicker extends JDialog {
             sorter.setComparator(SalvageFormationTableModel.COL_CREW_TECHS,
                   Comparator.comparingInt(i -> ((int) i)));
             sorter.setComparator(SalvageFormationTableModel.COL_HAS_TUG, (b1, b2) ->
-                                                                           Boolean.compare(((Boolean) b1),
-                                                                                 ((Boolean) b2)));
+                                                                               Boolean.compare(((Boolean) b1),
+                                                                                     ((Boolean) b2)));
         } catch (ClassCastException e) {
             // There's a lot of class casting so we want to catch anything that is malformed. For example, if the
             // underlying data structure in the table changes.
@@ -375,7 +378,8 @@ public class SalvageFormationPicker extends JDialog {
 
     /**
      * Comparator used for the Formation Type column. Ensures types with the display name containing
-     * {@link FormationType#SALVAGE} sort before others, then falls back to natural-order comparison of the type labels.
+     * {@link FormationType#SALVAGE} sort before others, then falls back to natural-order comparison of the type
+     * labels.
      *
      * @param s1 first type display string
      * @param s2 second type display string
@@ -396,18 +400,30 @@ public class SalvageFormationPicker extends JDialog {
     /**
      * Loads the localized instruction string shown at the top of the dialog.
      *
+     * @param fieldControl the field control type to use for the instructions text
+     *
      * @return localized instructions text
      *
      * @author Illiani
      * @since 0.50.10
      */
-    private static String getInstructions() {
-        return getTextAt(RESOURCE_BUNDLE, "SalvageFormationPicker.instructions");
+    private static String getInstructions(@Nullable ScenarioTemplate.BattlefieldControlType fieldControl) {
+        String instructions = getTextAt(RESOURCE_BUNDLE, "SalvageFormationPicker.instructions");
+
+        if (fieldControl != null) {
+            String controlText = getText("ResolveDialog.control." + fieldControl.name());
+
+            return instructions + ' ' + controlText;
+        }
+
+        String unknownFieldControlText = getTextAt(RESOURCE_BUNDLE,
+              "SalvageFormationPicker.instructions.fieldControlUnknown");
+        return instructions + ' ' + unknownFieldControlText;
     }
 
     /**
-     * Adds Cancel (always) and Confirm (only if formations exist) buttons to the provided panel and wires up their actions
-     * to close the dialog and set {@link #wasConfirmed}.
+     * Adds Cancel (always) and Confirm (only if formations exist) buttons to the provided panel and wires up their
+     * actions to close the dialog and set {@link #wasConfirmed}.
      *
      * @param buttonPanel panel to populate
      *
@@ -432,8 +448,8 @@ public class SalvageFormationPicker extends JDialog {
     }
 
     /**
-     * Table model that exposes {@link SalvageFormationData} properties to the UI and tracks which rows are selected. Also
-     * formats tech labels (experience and injury highlighting).
+     * Table model that exposes {@link SalvageFormationData} properties to the UI and tracks which rows are selected.
+     * Also formats tech labels (experience and injury highlighting).
      *
      * @author Illiani
      * @since 0.50.10
@@ -477,7 +493,7 @@ public class SalvageFormationPicker extends JDialog {
         /**
          * Creates a new table model over the provided data.
          *
-         * @param campaign            campaign context for skill/experience labels and tooltips
+         * @param campaign                campaign context for skill/experience labels and tooltips
          * @param formations              row data; one entry per formation
          * @param priorSelectedFormations a list of formations that were previously selected
          *
@@ -680,7 +696,8 @@ public class SalvageFormationPicker extends JDialog {
             if (component instanceof JComponent jComponent) {
                 String tooltip = switch (modelColumn) {
                     case SalvageFormationTableModel.COL_FORMATION_NAME -> wordWrap(data.formation().getFullName());
-                    case SalvageFormationTableModel.COL_TOE_TECH -> wordWrap(data.getTechTooltip(campaign, data.tech()));
+                    case SalvageFormationTableModel.COL_TOE_TECH ->
+                          wordWrap(data.getTechTooltip(campaign, data.tech()));
                     case SalvageFormationTableModel.COL_CREW_TECHS ->
                           wordWrap(data.getAllCrewTechTooltip(campaign, data.formation()));
                     case SalvageFormationTableModel.COL_CARGO_CAPACITY ->

--- a/MekHQ/src/mekhq/gui/dialog/camOpsSalvage/SalvageTechPicker.java
+++ b/MekHQ/src/mekhq/gui/dialog/camOpsSalvage/SalvageTechPicker.java
@@ -60,9 +60,11 @@ import javax.swing.table.TableRowSorter;
 
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
+import megamek.common.annotations.Nullable;
 import megamek.common.util.sorter.NaturalOrderComparator;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
+import mekhq.campaign.mission.ScenarioTemplate;
 import mekhq.campaign.mission.camOpsSalvage.SalvageTechData;
 import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
 import mekhq.gui.sorter.LevelSorter;
@@ -127,18 +129,20 @@ public class SalvageTechPicker extends JDialog {
      *                             instructions and a Cancel button are shown.
      * @param alreadySelectedTechs list of tech UUIDs that should start as pre-selected.
      * @param isClanCampaign       {@code true} if the campaign is Clan affiliated
+     * @param fieldControl         who controls the field at the end of the scenario
      *
      * @author Illiani
      * @since 0.50.10
      */
-    public SalvageTechPicker(List<SalvageTechData> techs, List<UUID> alreadySelectedTechs, boolean isClanCampaign) {
+    public SalvageTechPicker(List<SalvageTechData> techs, List<UUID> alreadySelectedTechs, boolean isClanCampaign,
+          ScenarioTemplate.BattlefieldControlType fieldControl) {
         setTitle(getText("accessingTerminal.title"));
         setModal(true);
         setLayout(new BorderLayout());
 
         // Instructions at the top
         JPanel instructionsPanel = new JPanel(new BorderLayout());
-        JTextArea instructionsLabel = new JTextArea(getInstructions());
+        JTextArea instructionsLabel = new JTextArea(getInstructions(fieldControl));
         instructionsLabel.setLineWrap(true);
         instructionsLabel.setWrapStyleWord(true);
         instructionsLabel.setEditable(false);
@@ -325,13 +329,25 @@ public class SalvageTechPicker extends JDialog {
     /**
      * Localized instructional text for the dialog header.
      *
+     * @param fieldControl the field control type to use for the instructions text
+     *
      * @return the localized instructions string
      *
      * @author Illiani
      * @since 0.50.10
      */
-    private static String getInstructions() {
-        return getTextAt(RESOURCE_BUNDLE, "SalvageTechPicker.instructions");
+    private static String getInstructions(@Nullable ScenarioTemplate.BattlefieldControlType fieldControl) {
+        String instructions = getTextAt(RESOURCE_BUNDLE, "SalvageTechPicker.instructions");
+
+        if (fieldControl != null) {
+            String controlText = getText("ResolveDialog.control." + fieldControl.name());
+
+            return instructions + ' ' + controlText;
+        }
+
+        String unknownFieldControlText = getTextAt(RESOURCE_BUNDLE,
+              "SalvageTechPicker.instructions.fieldControlUnknown");
+        return instructions + ' ' + unknownFieldControlText;
     }
 
     /**


### PR DESCRIPTION
Close #8904

Now the salvage formation and tech pickers will show who will control the field below the instructions.

For non-AtBDynamicScenarios (i.e. scenarios without FieldControl) we display 'Unknown'.