### PR TITLE
Close #8818: Added Disease Warning to Begin Transit Confirmation Dialog

### DIFF
--- a/MekHQ/resources/mekhq/resources/ImmersiveDialogConfirmation.properties
+++ b/MekHQ/resources/mekhq/resources/ImmersiveDialogConfirmation.properties
@@ -37,7 +37,9 @@ ImmersiveDialogConfirmation.button.yes=Confirm
 ImmersiveDialogConfirmation.confirmationContractRental.text.primary=You will not get another chance to tell your \
   employer what facilities you want to rent.
 ImmersiveDialogConfirmation.confirmationBeginTransit.text.primary=If you select 'confirm,' the funds for the entire \
-  journey will be deducted from your account.
+  journey will be deducted from your account.\
+  <p><b>Warning:</b> if you are experiencing an ongoing outbreak of disease, it will spread like wildfire during \
+  transit. Vaccines will not help. Permanent diseases will not spread in this fashion.</p>
 ImmersiveDialogConfirmation.confirmationResolveScenario.text.primary=This is a point of no return.\
   <p>If you select 'confirm,' the scenario will be resolved. It will not be possible to undo this action.</p>
 ImmersiveDialogConfirmation.confirmationStratConBatchallBreach.text.primary=If you select 'confirm,' the terms of \


### PR DESCRIPTION
Close #8818

Expanded the enter transit confirmation dialog to ensure the player is warned that traveling during an active disease outbreak may have adverse effects.