### PR TITLE
Fix #8848: Fix Large Vessel Temp Crew Issues

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7084,26 +7084,7 @@ public class Campaign implements ITechManager, ILocation {
      * @param role the personnel role to fill
      */
     public void fillTempCrewPoolForRole(PersonnelRole role) {
-        if (!isBlobCrewEnabled(role)) {
-            return;
-        }
-
-        int need = 0;
-        for (Unit unit : getUnits()) {
-            if (unitCanUseTempCrewRole(unit, role)) {
-                int currentCrew = unit.getActiveCrew().size();
-                int currentTempCrew = unit.getTempCrewByPersonnelRole(role);
-                int fullCrew = unit.getFullCrewSize();
-                int totalCurrentCrew = currentCrew + currentTempCrew;
-                if (fullCrew > totalCurrentCrew) {
-                    need += (fullCrew - totalCurrentCrew);
-                }
-            }
-        }
-
-        if (need > 0) {
-            increaseTempCrewPool(role, need);
-        }
+        humanResources.fillTempCrewPoolForRole(this, getCampaignOptions(), role);
     }
 
     /**
@@ -7153,17 +7134,7 @@ public class Campaign implements ITechManager, ILocation {
      * @param role the personnel role to clear
      */
     public void clearBlobCrewForRole(PersonnelRole role) {
-        // Clear temp crew from all units for this specific role
-        for (Unit unit : getUnits()) {
-            if (unit.getTempCrewByPersonnelRole(role) > 0) {
-                unit.setTempCrew(role, 0);
-            }
-        }
-
-        // Empty the campaign pool for this specific role
-        if (getTempCrewPool(role) > 0) {
-            setTempCrewPool(role, 0);
-        }
+        humanResources.clearBlobCrewForRole(this, role);
     }
 
     /**
@@ -7174,85 +7145,18 @@ public class Campaign implements ITechManager, ILocation {
      */
     @Deprecated
     public void clearBlobCrew() {
-        // Clear temp crew from all units
-        for (Unit unit : getUnits()) {
-            for (PersonnelRole role : PersonnelRole.values()) {
-                if (unit.getTempCrewByPersonnelRole(role) > 0) {
-                    unit.setTempCrew(role, 0);
-                }
-            }
-        }
-
-        // Empty all campaign pools
         for (PersonnelRole role : PersonnelRole.values()) {
-            if (getTempCrewPool(role) > 0) {
-                setTempCrewPool(role, 0);
-            }
+            clearBlobCrewForRole(role);
         }
     }
 
     /**
-     * Checks if a unit can use temp crew of a specific personnel role. A unit must have at least one person to use temp
-     * crew - checks if the commander is null
-     *
-     * @param unit the unit to check
-     * @param role the personnel role
-     *
-     * @return true if the unit can use this type of temp crew
-     */
-    private boolean unitCanUseTempCrewRole(Unit unit, PersonnelRole role) {
-        if (unit.getCommander() == null || unit.getEntity() == null) {
-            return false;
-        }
-
-        return switch (role) {
-            case SOLDIER,
-                 BATTLE_ARMOUR,
-                 VEHICLE_CREW_GROUND,
-                 VEHICLE_CREW_VTOL,
-                 VEHICLE_CREW_NAVAL,
-                 VESSEL_PILOT -> unit.getDriverRole() == role;
-            case VESSEL_GUNNER -> unit.getGunnerRole() == role;
-            case VESSEL_CREW -> (unit.getEntity() instanceof Aero aero && !(aero instanceof ConvFighter)) &&
-                                      unit.canTakeMoreVesselCrew();
-            default -> false;
-        };
-    }
-
-    /**
-     * Distributes temp crew from the pool to units that need crew for a specific personnel role. Each unit can be
-     * filled up to (fullCrewSize - 1) with temp crew, ensuring at least one real Person.
+     * Distributes temp crew from the pool to units that need crew for a specific personnel role.
      *
      * @param role the personnel role to distribute
      */
     public void distributeTempCrewPoolToUnits(PersonnelRole role) {
-        if (!isBlobCrewEnabled(role)) {
-            return;
-        }
-
-        int availablePool = getAvailableTempCrewPool(role);
-        for (Unit unit : getUnits()) {
-            if (availablePool <= 0) {
-                break;
-            }
-
-            if (unitCanUseTempCrewRole(unit, role)) {
-                int currentCrew = unit.getActiveCrew().size();
-                int currentTempCrew = unit.getTempCrewByPersonnelRole(role);
-                int fullCrew = unit.getFullCrewSize();
-
-                int totalCurrentCrew = currentCrew + unit.getTotalTempCrew();
-                int needed = fullCrew - totalCurrentCrew;
-
-                if (needed > 0) {
-                    int toAssign = Math.min(needed, availablePool);
-                    unit.setTempCrew(role, currentTempCrew + toAssign);
-                    availablePool -= toAssign;
-                }
-            }
-        }
-        // Note: No need to decrease the total pool - it's tracked by units automatically
-        // The pool represents the TOTAL, and "in use" is calculated from units
+        humanResources.distributeTempCrewPoolToUnits(this, getCampaignOptions(), role);
     }
 
 

--- a/MekHQ/src/mekhq/campaign/HumanResources.java
+++ b/MekHQ/src/mekhq/campaign/HumanResources.java
@@ -61,6 +61,8 @@ import megamek.common.enums.Gender;
 import megamek.common.icons.Portrait;
 import megamek.common.options.IOption;
 import megamek.common.rolls.TargetRoll;
+import megamek.common.units.Aero;
+import megamek.common.units.ConvFighter;
 import megamek.common.units.Infantry;
 import megamek.logging.MMLogger;
 import mekhq.MHQConstants;
@@ -780,12 +782,9 @@ public class HumanResources {
         int need = 0;
         for (Unit unit : campaign.getUnits()) {
             if (unitCanUseTempCrewRole(unit, role)) {
-                int currentCrew = unit.getActiveCrew().size();
-                int currentTempCrew = unit.getTempCrewByPersonnelRole(role);
-                int fullCrew = unit.getFullCrewSize();
-                int totalCurrentCrew = currentCrew + currentTempCrew;
-                if (fullCrew > totalCurrentCrew) {
-                    need += (fullCrew - totalCurrentCrew);
+                int roleSpecificNeed = getRoleSpecificNeeds(unit, role);
+                if (roleSpecificNeed > 0) {
+                    need += roleSpecificNeed;
                 }
             }
         }
@@ -842,8 +841,37 @@ public class HumanResources {
                  VEHICLE_CREW_NAVAL,
                  VESSEL_PILOT -> unit.getDriverRole() == role;
             case VESSEL_GUNNER -> unit.getGunnerRole() == role;
-            case VESSEL_CREW -> unit.canTakeMoreVesselCrew();
+            case VESSEL_CREW -> (unit.getEntity() instanceof Aero aero && !(aero instanceof ConvFighter))
+                    && unit.canTakeMoreVesselCrew();
             default -> false;
+        };
+    }
+
+    /**
+     * Returns the number of temp crew slots still available for the given role on the given unit. A negative value
+     * means the role is over-allocated. For vessel roles (pilot, gunner, crew), the calculation uses role-specific slot
+     * counts so that each role's budget is tracked independently. For all other roles the unit's total crew size is
+     * used (correct for single-role units such as infantry).
+     *
+     * @param unit the unit
+     * @param role the personnel role
+     *
+     * @return available slots (negative = surplus temp crew)
+     */
+    private int getRoleSpecificNeeds(Unit unit, PersonnelRole role) {
+        return switch (role) {
+            case VESSEL_PILOT -> unit.getTotalDriverNeeds()
+                                       - unit.getDrivers().size()
+                                       - unit.getTempCrewByPersonnelRole(PersonnelRole.VESSEL_PILOT);
+            case VESSEL_GUNNER -> unit.getTotalGunnerNeeds()
+                                        - unit.getGunners().size()
+                                        - unit.getTempCrewByPersonnelRole(PersonnelRole.VESSEL_GUNNER);
+            case VESSEL_CREW -> unit.getTotalCrewNeeds()
+                                      - unit.getVesselCrew().size()
+                                      - unit.getTempCrewByPersonnelRole(PersonnelRole.VESSEL_CREW);
+            default -> unit.getFullCrewSize()
+                             - unit.getActiveCrew().size()
+                             - unit.getTempCrewByPersonnelRole(role);
         };
     }
 
@@ -866,16 +894,11 @@ public class HumanResources {
             }
 
             if (unitCanUseTempCrewRole(unit, role)) {
-                int currentCrew = unit.getActiveCrew().size();
-                int currentTempCrew = unit.getTempCrewByPersonnelRole(role);
-                int fullCrew = unit.getFullCrewSize();
-
-                int totalCurrentCrew = currentCrew + unit.getTotalTempCrew();
-                int needed = fullCrew - totalCurrentCrew;
+                int needed = getRoleSpecificNeeds(unit, role);
 
                 if (needed > 0) {
                     int toAssign = Math.min(needed, availablePool);
-                    unit.setTempCrew(role, currentTempCrew + toAssign);
+                    unit.setTempCrew(role, unit.getTempCrewByPersonnelRole(role) + toAssign);
                     availablePool -= toAssign;
                 }
             }
@@ -940,9 +963,7 @@ public class HumanResources {
         for (Unit unit : campaign.getUnits()) {
             int currentTemp = unit.getTempCrewByPersonnelRole(role);
             if (currentTemp > 0) {
-                int realCrew = unit.getActiveCrew().size();
-                int fullCrew = unit.getFullCrewSize();
-                int excess = Math.max(0, (realCrew + currentTemp) - fullCrew);
+                int excess = Math.max(0, -getRoleSpecificNeeds(unit, role));
                 if (excess > 0) {
                     unit.setTempCrew(role, currentTemp - excess);
                 }

--- a/MekHQ/unittests/mekhq/campaign/CampaignTest.java
+++ b/MekHQ/unittests/mekhq/campaign/CampaignTest.java
@@ -567,6 +567,23 @@ public class CampaignTest {
             when(unit.getActiveCrew()).thenReturn(activeCrew);
             when(unit.getFullCrewSize()).thenReturn(crewSize);
 
+            // Mock vessel-specific role methods for getRoleSpecificNeeds
+            switch (role) {
+                case VESSEL_PILOT -> {
+                    doReturn(activeCrew).when(unit).getDrivers();
+                    doReturn(crewSize).when(unit).getTotalDriverNeeds();
+                }
+                case VESSEL_GUNNER -> {
+                    doReturn(new HashSet<>(activeCrew)).when(unit).getGunners();
+                    doReturn(crewSize).when(unit).getTotalGunnerNeeds();
+                }
+                case VESSEL_CREW -> {
+                    doReturn(activeCrew).when(unit).getVesselCrew();
+                    doReturn(crewSize).when(unit).getTotalCrewNeeds();
+                }
+                default -> { /* non-vessel: getActiveCrew() + getFullCrewSize() covers default case */ }
+            }
+
             // Mock role methods so unitCanUseTempCrewRole returns true
             switch (role) {
                 case SOLDIER, BATTLE_ARMOUR, VEHICLE_CREW_GROUND,
@@ -994,7 +1011,9 @@ public class CampaignTest {
             PersonnelRole role = PersonnelRole.VESSEL_PILOT;
             enableBlobCrewForRole(role);
             Unit unit = createMockUnitForRole(role, false); // fullSize=2
-            doReturn(List.of(mock(Person.class), mock(Person.class))).when(unit).getActiveCrew();
+            List<Person> fullPilotCrew = List.of(mock(Person.class), mock(Person.class));
+            doReturn(fullPilotCrew).when(unit).getActiveCrew();
+            doReturn(fullPilotCrew).when(unit).getDrivers();
             unit.setTempCrew(role, 1); // 2 real + 1 temp = 3 total; need 2, excess = 1
             testCampaign.importUnit(unit);
 


### PR DESCRIPTION
Fixes #8848

Temp Crew is now more role-aware when determining how many more crew members a unit needs to ensure it is filled with the correct temp crew and not just pilots. 

Also consolidates some code from Campaign to use HumanResources instead.