### PR TITLE
Close #8813: Arriving at Your Destination or Completing a Contract With Now Populate the Personnel Market Instantly

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -4337,13 +4337,14 @@ public class Campaign implements ITechManager, ILocation {
     /**
      * Refreshes the personnel markets based on the current market style and the current date.
      *
-     * @param isCampaignStart {@code true} if campaign method is being called at the start of the campaign
+     * @param bypassDateRestrictions {@code true} if we want the market to refresh at an unusual time, such as campaign
+     *                               start
      *
      * @author Illiani
      * @since 0.50.06
      */
-    public void refreshPersonnelMarkets(boolean isCampaignStart) {
-        humanResources.refreshPersonnelMarkets(this, isCampaignStart);
+    public void refreshPersonnelMarkets(boolean bypassDateRestrictions) {
+        humanResources.refreshPersonnelMarkets(this, bypassDateRestrictions);
     }
 
     public int getInitiativeBonus() {

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -2202,7 +2202,7 @@ public class CampaignNewDayManager {
         }
     }
 
-    private void showRarePersonnelDialog(Campaign campaign, boolean isCampaignStart) {
+    public static void showRarePersonnelDialog(Campaign campaign, boolean isCampaignStart) {
         if (!campaign.getNewPersonnelMarket().getHasRarePersonnel()) {
             return;
         }

--- a/MekHQ/src/mekhq/campaign/CurrentLocation.java
+++ b/MekHQ/src/mekhq/campaign/CurrentLocation.java
@@ -34,6 +34,7 @@
 package mekhq.campaign;
 
 import static megamek.common.compute.Compute.randomInt;
+import static mekhq.campaign.HumanResources.isUsingLegacyPersonnelMarket;
 import static mekhq.campaign.enums.DailyReportType.GENERAL;
 import static mekhq.campaign.market.contractMarket.ContractAutomation.performAutomatedActivation;
 
@@ -295,6 +296,12 @@ public class CurrentLocation extends AbstractLocation {
             }
 
             testForEarlyArrival(campaign);
+
+            // We've just stopped traveling, so we should see if there are any local applicants.
+            if (!isUsingLegacyPersonnelMarket(campaignOptions)) {
+                campaign.refreshPersonnelMarkets(true);
+                CampaignNewDayManager.showRarePersonnelDialog(campaign, false);
+            }
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/HumanResources.java
+++ b/MekHQ/src/mekhq/campaign/HumanResources.java
@@ -926,7 +926,7 @@ public class HumanResources {
      * and causes the legacy market to run instead — the name is counterintuitive, so this predicate makes the intent
      * explicit at every call site.</p>
      */
-    private static boolean isUsingLegacyPersonnelMarket(CampaignOptions options) {
+    public static boolean isUsingLegacyPersonnelMarket(CampaignOptions options) {
         return options.getPersonnelMarketStyle() == PERSONNEL_MARKET_DISABLED;
     }
 
@@ -942,10 +942,11 @@ public class HumanResources {
     /**
      * Refreshes the personnel markets based on the current market style and the current date.
      *
-     * @param campaign        the campaign
-     * @param isCampaignStart {@code true} if called at the start of the campaign
+     * @param campaign               the campaign
+     * @param bypassDateRestrictions {@code true} if we want the market to refresh at an unusual time, such as campaign
+     *                               start
      */
-    public void refreshPersonnelMarkets(Campaign campaign, boolean isCampaignStart) {
+    public void refreshPersonnelMarkets(Campaign campaign, boolean bypassDateRestrictions) {
         CampaignOptions campaignOptions = campaign.getCampaignOptions();
         LocalDate currentDay = campaign.getLocalDate();
 
@@ -954,7 +955,7 @@ public class HumanResources {
                 personnelMarket.generatePersonnelForDay(campaign);
             }
         } else {
-            if (currentDay.getDayOfMonth() == 1 || isCampaignStart) {
+            if (currentDay.getDayOfMonth() == 1 || bypassDateRestrictions) {
                 newPersonnelMarket.gatherApplications();
             }
         }

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -33,6 +33,7 @@
 package mekhq.gui;
 
 import static megamek.client.ratgenerator.ForceDescriptor.RATING_5;
+import static mekhq.campaign.HumanResources.isUsingLegacyPersonnelMarket;
 import static mekhq.campaign.enums.DailyReportType.GENERAL;
 import static mekhq.campaign.enums.DailyReportType.PERSONNEL;
 import static mekhq.campaign.force.Formation.NO_ASSIGNED_SCENARIO;
@@ -87,6 +88,7 @@ import megamek.logging.MMLogger;
 import megameklab.util.UnitPrintManager;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.CampaignNewDayManager;
 import mekhq.campaign.Hangar;
 import mekhq.campaign.autoResolve.AutoResolveMethod;
 import mekhq.campaign.campaignOptions.CampaignOptions;
@@ -103,6 +105,7 @@ import mekhq.campaign.events.scenarios.ScenarioRemovedEvent;
 import mekhq.campaign.events.scenarios.ScenarioResolvedEvent;
 import mekhq.campaign.force.CombatTeam;
 import mekhq.campaign.force.Formation;
+import mekhq.campaign.market.personnelMarket.markets.NewPersonnelMarket;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.AtBDynamicScenario;
 import mekhq.campaign.mission.AtBDynamicScenarioFactory;
@@ -472,6 +475,10 @@ public final class BriefingTab extends CampaignGuiTab {
             }
         }
 
+        // Set up some variables we'll be using later
+        NewPersonnelMarket newPersonnelMarket = getCampaign().getNewPersonnelMarket();
+        boolean marketPreviouslyDisabled = !newPersonnelMarket.getAvailabilityMessage().isBlank();
+
         getCampaign().completeMission(mission, status);
         MekHQ.triggerEvent(new MissionCompletedEvent(mission));
 
@@ -588,6 +595,12 @@ public final class BriefingTab extends CampaignGuiTab {
                     getCampaign().addReport(GENERAL, report);
                 }
             }
+        }
+
+        // Refresh personnel market if it was previously disabled
+        if (!isUsingLegacyPersonnelMarket(campaignOptions) && marketPreviouslyDisabled) {
+            getCampaign().refreshPersonnelMarkets(true);
+            CampaignNewDayManager.showRarePersonnelDialog(getCampaign(), false);
         }
 
         // Undeploy forces & units


### PR DESCRIPTION
Close #8813

Previously the market would only populate at the start of the campaign, or on the first of each new month.

Has no effect on the old, deprecated, personnel markets.