### PR TITLE
[improvement] Remove zeroed out lines from Finance Tab Summary

### DIFF
--- a/MekHQ/src/mekhq/gui/FinancesTab.java
+++ b/MekHQ/src/mekhq/gui/FinancesTab.java
@@ -616,12 +616,16 @@ public final class FinancesTab extends CampaignGuiTab {
                       .append('\n');
             }
         }
-        sb.append(formattingFinancialReport(resourceMap.getString("liabilities.text"), 2,
-              String.format(formatted, liabilities.toAmountAndSymbolString())));
+        if (!liabilities.isZero()) {
+            sb.append(formattingFinancialReport(resourceMap.getString("liabilities.text"), 2,
+                  String.format(formatted, liabilities.toAmountAndSymbolString())));
+        }
 
-        sb.append(formattingFinancialReport(resourceMap.getString("loans.text"), 3,
-              String.format(formatted, r.getLoans().toAmountAndSymbolString())));
-        sb.append("\n\n");
+        if (!r.getLoans().isZero()) {
+            sb.append(formattingFinancialReport(resourceMap.getString("loans.text"), 3,
+                  String.format(formatted, r.getLoans().toAmountAndSymbolString())));
+            sb.append("\n\n");
+        }
 
         sb.append(formattingFinancialReport(resourceMap.getString("monthlyProfit.text"), 1,
               String.format(formatted, r.getMonthlyIncome().minus(r.getMonthlyExpenses()).toAmountAndSymbolString())));
@@ -640,11 +644,15 @@ public final class FinancesTab extends CampaignGuiTab {
         sb.append(formattingFinancialReport(resourceMap.getString("salaries.text"), 2,
               String.format(formatted, r.getSalaries().toAmountAndSymbolString())));
 
-        sb.append(formattingFinancialReport(resourceMap.getString("maintenance.text"), 2,
-              String.format(formatted, r.getMaintenance().toAmountAndSymbolString())));
+        if (!r.getMaintenance().isZero()) {
+            sb.append(formattingFinancialReport(resourceMap.getString("maintenance.text"), 2,
+                  String.format(formatted, r.getMaintenance().toAmountAndSymbolString())));
+        }
 
-        sb.append(formattingFinancialReport(resourceMap.getString("overhead.text"), 2,
-              String.format(formatted, r.getOverheadCosts().toAmountAndSymbolString())));
+        if (!r.getOverheadCosts().isZero()) {
+            sb.append(formattingFinancialReport(resourceMap.getString("overhead.text"), 2,
+                  String.format(formatted, r.getOverheadCosts().toAmountAndSymbolString())));
+        }
 
         Money rentals = r.getRentals();
         if (!rentals.isZero()) {

--- a/MekHQ/src/mekhq/gui/FinancesTab.java
+++ b/MekHQ/src/mekhq/gui/FinancesTab.java
@@ -537,67 +537,67 @@ public final class FinancesTab extends CampaignGuiTab {
     }
 
     public String getFormattedFinancialReport() {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder financialLine = new StringBuilder();
 
-        FinancialReport r = FinancialReport.calculate(getCampaign());
+        FinancialReport report = FinancialReport.calculate(getCampaign());
 
-        Money liabilities = r.getTotalLiabilities();
-        Money assets = r.getTotalAssets();
-        Money netWorth = r.getNetWorth();
+        Money liabilities = report.getTotalLiabilities();
+        Money assets = report.getTotalAssets();
+        Money netWorth = report.getNetWorth();
 
         int longest = Math.max(liabilities.toAmountAndSymbolString().length(),
               assets.toAmountAndSymbolString().length());
         longest = Math.max(netWorth.toAmountAndSymbolString().length(), longest);
         String formatted = "%1$" + longest + 's';
 
-        sb.append(formattingFinancialReport(resourceMap.getString("netWorth.text"), 1,
+        financialLine.append(formattingFinancialReport(resourceMap.getString("netWorth.text"), 1,
               String.format(formatted, netWorth.toAmountAndSymbolString())));
-        sb.append('\n');
+        financialLine.append('\n');
 
-        sb.append(formattingFinancialReport(resourceMap.getString("assets.text"), 2,
+        financialLine.append(formattingFinancialReport(resourceMap.getString("assets.text"), 2,
               String.format(formatted, assets.toAmountAndSymbolString())));
 
-        sb.append(formattingFinancialReport(resourceMap.getString("cash.text"), 3,
-              String.format(formatted, r.getCash().toAmountAndSymbolString())));
+        financialLine.append(formattingFinancialReport(resourceMap.getString("cash.text"), 3,
+              String.format(formatted, report.getCash().toAmountAndSymbolString())));
 
-        if (r.getMekValue().isPositive()) {
-            sb.append(formattingFinancialReport(resourceMap.getString("meks.text"), 3,
-                  String.format(formatted, r.getMekValue().toAmountAndSymbolString())));
+        if (report.getMekValue().isPositive()) {
+            financialLine.append(formattingFinancialReport(resourceMap.getString("meks.text"), 3,
+                  String.format(formatted, report.getMekValue().toAmountAndSymbolString())));
         }
 
-        if (r.getVeeValue().isPositive()) {
-            sb.append(formattingFinancialReport(resourceMap.getString("vehicles.text"), 3,
-                  String.format(formatted, r.getVeeValue().toAmountAndSymbolString())));
+        if (report.getVeeValue().isPositive()) {
+            financialLine.append(formattingFinancialReport(resourceMap.getString("vehicles.text"), 3,
+                  String.format(formatted, report.getVeeValue().toAmountAndSymbolString())));
         }
 
-        if (r.getBattleArmorValue().isPositive()) {
-            sb.append(formattingFinancialReport(resourceMap.getString("battleArmor.text"), 3,
-                  String.format(formatted, r.getBattleArmorValue().toAmountAndSymbolString())));
+        if (report.getBattleArmorValue().isPositive()) {
+            financialLine.append(formattingFinancialReport(resourceMap.getString("battleArmor.text"), 3,
+                  String.format(formatted, report.getBattleArmorValue().toAmountAndSymbolString())));
         }
 
-        if (r.getInfantryValue().isPositive()) {
-            sb.append(formattingFinancialReport(resourceMap.getString("infantry.text"), 3,
-                  String.format(formatted, r.getInfantryValue().toAmountAndSymbolString())));
+        if (report.getInfantryValue().isPositive()) {
+            financialLine.append(formattingFinancialReport(resourceMap.getString("infantry.text"), 3,
+                  String.format(formatted, report.getInfantryValue().toAmountAndSymbolString())));
         }
 
-        if (r.getProtoMekValue().isPositive()) {
-            sb.append(formattingFinancialReport(resourceMap.getString("protoMeks.text"), 3,
-                  String.format(formatted, r.getProtoMekValue().toAmountAndSymbolString())));
+        if (report.getProtoMekValue().isPositive()) {
+            financialLine.append(formattingFinancialReport(resourceMap.getString("protoMeks.text"), 3,
+                  String.format(formatted, report.getProtoMekValue().toAmountAndSymbolString())));
         }
 
-        if (r.getSmallCraftValue().isPositive()) {
-            sb.append(formattingFinancialReport(resourceMap.getString("smallCraft.text"), 3,
-                  String.format(formatted, r.getSmallCraftValue().toAmountAndSymbolString())));
+        if (report.getSmallCraftValue().isPositive()) {
+            financialLine.append(formattingFinancialReport(resourceMap.getString("smallCraft.text"), 3,
+                  String.format(formatted, report.getSmallCraftValue().toAmountAndSymbolString())));
         }
 
-        if (r.getLargeCraftValue().isPositive()) {
-            sb.append(formattingFinancialReport(resourceMap.getString("largeCraft.text"), 3,
-                  String.format(formatted, r.getLargeCraftValue().toAmountAndSymbolString())));
+        if (report.getLargeCraftValue().isPositive()) {
+            financialLine.append(formattingFinancialReport(resourceMap.getString("largeCraft.text"), 3,
+                  String.format(formatted, report.getLargeCraftValue().toAmountAndSymbolString())));
         }
 
-        sb.append(formattingFinancialReport(resourceMap.getString("spareParts.text"), 3,
-              String.format(formatted, r.getSparePartsValue().toAmountAndSymbolString())));
-        sb.append('\n');
+        financialLine.append(formattingFinancialReport(resourceMap.getString("spareParts.text"), 3,
+              String.format(formatted, report.getSparePartsValue().toAmountAndSymbolString())));
+        financialLine.append('\n');
 
 
         if (!getCampaign().getFinances().getAssets().isEmpty()) {
@@ -610,66 +610,67 @@ public final class FinancesTab extends CampaignGuiTab {
                     assetName.repeat(".", Math.max(0, numPeriods));
                 }
                 assetName.append(" ");
-                sb.append("       ")
+                financialLine.append("       ")
                       .append(assetName)
                       .append(String.format(formatted, asset.getValue().toAmountAndSymbolString()))
                       .append('\n');
             }
         }
         if (!liabilities.isZero()) {
-            sb.append(formattingFinancialReport(resourceMap.getString("liabilities.text"), 2,
+            financialLine.append(formattingFinancialReport(resourceMap.getString("liabilities.text"), 2,
                   String.format(formatted, liabilities.toAmountAndSymbolString())));
         }
 
-        if (!r.getLoans().isZero()) {
-            sb.append(formattingFinancialReport(resourceMap.getString("loans.text"), 3,
-                  String.format(formatted, r.getLoans().toAmountAndSymbolString())));
-            sb.append("\n\n");
+        if (!report.getLoans().isZero()) {
+            financialLine.append(formattingFinancialReport(resourceMap.getString("loans.text"), 3,
+                  String.format(formatted, report.getLoans().toAmountAndSymbolString())));
+            financialLine.append("\n\n");
         }
 
-        sb.append(formattingFinancialReport(resourceMap.getString("monthlyProfit.text"), 1,
-              String.format(formatted, r.getMonthlyIncome().minus(r.getMonthlyExpenses()).toAmountAndSymbolString())));
-        sb.append("\n");
+        financialLine.append(formattingFinancialReport(resourceMap.getString("monthlyProfit.text"), 1,
+              String.format(formatted,
+                    report.getMonthlyIncome().minus(report.getMonthlyExpenses()).toAmountAndSymbolString())));
+        financialLine.append("\n");
 
-        sb.append(formattingFinancialReport(resourceMap.getString("monthlyIncome.text"), 1,
-              String.format(formatted, r.getMonthlyIncome().toAmountAndSymbolString())));
+        financialLine.append(formattingFinancialReport(resourceMap.getString("monthlyIncome.text"), 1,
+              String.format(formatted, report.getMonthlyIncome().toAmountAndSymbolString())));
 
-        sb.append(formattingFinancialReport(resourceMap.getString("contractPayments.text"), 2,
-              String.format(formatted, r.getContracts().toAmountAndSymbolString())));
-        sb.append('\n');
+        financialLine.append(formattingFinancialReport(resourceMap.getString("contractPayments.text"), 2,
+              String.format(formatted, report.getContracts().toAmountAndSymbolString())));
+        financialLine.append('\n');
 
-        sb.append(formattingFinancialReport(resourceMap.getString("monthlyExpenses.text"), 1,
-              String.format(formatted, r.getMonthlyExpenses().toAmountAndSymbolString())));
+        financialLine.append(formattingFinancialReport(resourceMap.getString("monthlyExpenses.text"), 1,
+              String.format(formatted, report.getMonthlyExpenses().toAmountAndSymbolString())));
 
-        sb.append(formattingFinancialReport(resourceMap.getString("salaries.text"), 2,
-              String.format(formatted, r.getSalaries().toAmountAndSymbolString())));
+        financialLine.append(formattingFinancialReport(resourceMap.getString("salaries.text"), 2,
+              String.format(formatted, report.getSalaries().toAmountAndSymbolString())));
 
-        if (!r.getMaintenance().isZero()) {
-            sb.append(formattingFinancialReport(resourceMap.getString("maintenance.text"), 2,
-                  String.format(formatted, r.getMaintenance().toAmountAndSymbolString())));
+        if (!report.getMaintenance().isZero()) {
+            financialLine.append(formattingFinancialReport(resourceMap.getString("maintenance.text"), 2,
+                  String.format(formatted, report.getMaintenance().toAmountAndSymbolString())));
         }
 
-        if (!r.getOverheadCosts().isZero()) {
-            sb.append(formattingFinancialReport(resourceMap.getString("overhead.text"), 2,
-                  String.format(formatted, r.getOverheadCosts().toAmountAndSymbolString())));
+        if (!report.getOverheadCosts().isZero()) {
+            financialLine.append(formattingFinancialReport(resourceMap.getString("overhead.text"), 2,
+                  String.format(formatted, report.getOverheadCosts().toAmountAndSymbolString())));
         }
 
-        Money rentals = r.getRentals();
+        Money rentals = report.getRentals();
         if (!rentals.isZero()) {
-            sb.append(formattingFinancialReport(resourceMap.getString("rentalFacilities.text"), 2,
+            financialLine.append(formattingFinancialReport(resourceMap.getString("rentalFacilities.text"), 2,
                   String.format(formatted, rentals.toAmountAndSymbolString())));
         }
 
         if (getCampaign().getCampaignOptions().isUsePeacetimeCost()) {
-            sb.append(formattingFinancialReport(resourceMap.getString("spareParts.text"), 2,
-                  String.format(formatted, r.getMonthlySparePartCosts().toAmountAndSymbolString())));
-            sb.append(formattingFinancialReport(resourceMap.getString("trainingMunitions.text"), 2,
-                  String.format(formatted, r.getMonthlyAmmoCosts().toAmountAndSymbolString())));
-            sb.append(formattingFinancialReport(resourceMap.getString("fuel.text"), 2,
-                  String.format(formatted, r.getMonthlyFuelCosts().toAmountAndSymbolString())));
+            financialLine.append(formattingFinancialReport(resourceMap.getString("spareParts.text"), 2,
+                  String.format(formatted, report.getMonthlySparePartCosts().toAmountAndSymbolString())));
+            financialLine.append(formattingFinancialReport(resourceMap.getString("trainingMunitions.text"), 2,
+                  String.format(formatted, report.getMonthlyAmmoCosts().toAmountAndSymbolString())));
+            financialLine.append(formattingFinancialReport(resourceMap.getString("fuel.text"), 2,
+                  String.format(formatted, report.getMonthlyFuelCosts().toAmountAndSymbolString())));
         }
 
-        return sb.toString();
+        return financialLine.toString();
     }
 
     ActionScheduler financialTransactionsScheduler = new ActionScheduler(this::refreshFinancialTransactions);


### PR DESCRIPTION
Partially addresses #8889 

Depending on the settings that a player has, they may not have to pay any overhead or maintenance costs. When this happens they have two lines in their monthly costs that will persistently be zero. Additionally, a large number of player will not have loans, and they will have lines on their finance tab which will always be zero. In order to decrease clutter and improve readability, I just added `if` statements for each line that can be zeroed out in settings that I'm aware of. 

