### PR TITLE
Fix #8737: Added Safeguard for Missing Game Options When Saving Older Campaigns

### DIFF
--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -238,6 +238,5 @@ stratCon.earlyContractEnd.objectives=You have resolved all outstanding objective
   <p>The contract will end tomorrow. If the contract was successful, any outstanding payments will be rendered once \
   the contract has concluded.</p>
 gameOptions.save.failure.title=Broken Game Options
-gameOptions.save.failure.body=MegaMek's game options failed to save.n\n\
-  All options have been reset to their default values.n\n\
-  If this keeps happening, please report to the MekHQ team.
+gameOptions.save.failure.body=MegaMek's game options failed to save.n\n\All options have been reset to their default \
+  values.n\n\If this keeps happening, please report to the MekHQ team.

--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -237,3 +237,7 @@ atbScenarioTodayWithForce.format=Scenario "{0}" is today, {1} has been deployed!
 stratCon.earlyContractEnd.objectives=You have resolved all outstanding objectives for <b>%s</b>.\
   <p>The contract will end tomorrow. If the contract was successful, any outstanding payments will be rendered once \
   the contract has concluded.</p>
+gameOptions.save.failure.title=Broken Game Options
+gameOptions.save.failure.body=MegaMek's game options failed to save.n\n\
+  All options have been reset to their default values.n\n\
+  If this keeps happening, please report to the MekHQ team.

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -70,6 +70,7 @@ import static mekhq.campaign.unit.Unit.TECH_WORK_DAY;
 import static mekhq.campaign.universe.Faction.MERCENARY_FACTION_CODE;
 import static mekhq.campaign.universe.Faction.PIRATE_FACTION_CODE;
 import static mekhq.campaign.universe.Factions.getFactionLogo;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import java.io.File;
 import java.io.IOException;
@@ -460,8 +461,11 @@ public class Campaign implements ITechManager, ILocation {
         COMMAND, LOGISTICS, TRANSPORT, HR
     }
 
+    @Deprecated(since = "0.51.0")
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Campaign",
           MekHQ.getMHQOptions().getLocale());
+
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.Campaign";
 
     private HumanResources humanResources = new HumanResources();
 
@@ -5419,9 +5423,11 @@ public class Campaign implements ITechManager, ILocation {
 
         // We've had instances where game options isn't loaded correctly from player campaigns, potentially due to
         // age. This safeguards.
-        if (gameOptions == null) {
+        if (true) {
             gameOptions = new GameOptions();
-            LOGGER.error("null gameOptions, resetting to default.");
+            LOGGER.errorDialog(new NullPointerException(),
+                  getTextAt(RESOURCE_BUNDLE, "gameOptions.save.failure.body"),
+                  getTextAt(RESOURCE_BUNDLE, "gameOptions.save.failure.title"));
         }
 
         getGameOptions().writeToXML(writer, indent);

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5421,6 +5421,7 @@ public class Campaign implements ITechManager, ILocation {
         // age. This safeguards.
         if (gameOptions == null) {
             gameOptions = new GameOptions();
+            LOGGER.error("null gameOptions, resetting to default.");
         }
 
         getGameOptions().writeToXML(writer, indent);

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5416,6 +5416,13 @@ public class Campaign implements ITechManager, ILocation {
         if (getCampaignOptions() != null) {
             CampaignOptionsMarshaller.writeCampaignOptionsToXML(getCampaignOptions(), writer, indent);
         }
+
+        // We've had instances where game options isn't loaded correctly from player campaigns, potentially due to
+        // age. This safeguards.
+        if (gameOptions == null) {
+            gameOptions = new GameOptions();
+        }
+
         getGameOptions().writeToXML(writer, indent);
         // endregion Options
 


### PR DESCRIPTION
Fix #8737

Under rare circumstances it seems that a campaign can end up with malformed MegaMek Game Options. `null` to be precise. This then prevents saving, because the saving process assumes `GameOptions` has been substantiated.

I've explored the campaign creation process and I cannot find any explanation why campaigns are instantiating with `null GameOptions`. It _shouldn't_ be possible.

Clearly that isn't the case, so what I've gone ahead and done is added a catch that will self-correct in the event a `null GameOption` is detected during the save process. The player will be notified when this occurs.