### PR TITLE
fix children still having portraits

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
+++ b/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
@@ -55,6 +55,7 @@ import java.util.UUID;
 import megamek.common.annotations.Nullable;
 import megamek.common.compute.Compute;
 import megamek.common.enums.Gender;
+import megamek.common.icons.Portrait;
 import megamek.common.options.IOption;
 import mekhq.MHQConstants;
 import mekhq.campaign.Campaign;
@@ -445,6 +446,11 @@ public abstract class AbstractProcreation {
             baby.setPreNominal(""); // Stop babies being born with doctorates
             baby.setPostNominal(""); // Stop babies being born with post-nominal titles
 
+            if (campaign.getCampaignOptions().isNoRandomPortraitsForChildren() &&
+                      baby.isChild(campaign.getLocalDate(), false)) {
+                baby.setPortrait(new Portrait());
+            }
+
             baby.setBloodGroup(getInheritedBloodGroup(mother.getBloodGroup(),
                   father == null ? getRandomBloodGroup() : father.getBloodGroup()));
 
@@ -605,6 +611,11 @@ public abstract class AbstractProcreation {
             baby.setDateOfBirth(mother.getDueDate());
             baby.removeAllSkills(); // Limit skills by age for children and adolescents
             baby.setPrimaryRole(campaign, PersonnelRole.DEPENDENT); // Babies can't have jobs
+
+            if (campaign.getCampaignOptions().isNoRandomPortraitsForChildren() &&
+                      baby.isChild(campaign.getLocalDate(), false)) {
+                baby.setPortrait(new Portrait());
+            }
 
             // re-roll SPAs to include in any age and skill adjustments
             Enumeration<IOption> options = new PersonnelOptions().getOptions(PersonnelOptions.LVL3_ADVANTAGES);


### PR DESCRIPTION
The campaign option to have a default portrait for children that was introduced in PR #9007 does not work properly.

The underlying reason is that a call to isChild() is used to determine if a New Person is a child. However, at birth the Person is created first (including a portrait) and only then is the birthdate set for the new person.

This PR fixes this issue by checking if the new option is active after the birthdate is set. There is still a check for isChild(), since with historic births the baby may have been born many years earlier than the current date in the campaign and could now be at the age where a portrait should be added.

If the campaign option is used and the person is still a child, a default Portrait will be set.