### PR TITLE
Close #8625, #8804: Added Options to Quick Train (Both Manual & Automatically Run) to Allow Players to Adjust What Skills are Trained and to What Level

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -1025,8 +1025,29 @@ chkNewDayAutomaticallyAssignUnmaintainedUnits.toolTipText=Automatically assign t
   tiebreaker (lowest to highest). The highest BV units are assigned first. Characters with two units already assigned\
   \ will not be assigned additional units in this manner. The 'Never Assign to Maintenance' flag can be used to mark \
   personnel you want this system to ignore.
-chkNewMonthQuickTrain.text=Quick Train on First Day of Each Month
+chkNewMonthQuickTrain.text=Quick Train on First Day of Each Month.
 chkNewMonthQuickTrain.toolTipText=On the first day of a new month, automatically run Quick Training on all characters.
+lblQuickTrainTarget.text=Quick Train Target
+lblQuickTrainTarget.toolTipText=If 'Quick Train on First Day of Each Month', this is the highest skill level Quick \
+  Train will increase skills to. Has no effect when Quick Train is manually run from the Personnel tab.
+chkLevelArtillery.text=Quick Train Artillery
+chkLevelArtillery.toolTipText=If 'Quick Train on First Day of Each Month', the Artillery skill will be trained on \
+  characters who have that skill. Has no effect when Quick Train is manually run from the Personnel tab.
+chkLevelScoutingSkills.text=Quick Train Scouting Skills
+chkLevelScoutingSkills.toolTipText=If 'Quick Train on First Day of Each Month', a character's best Scouting skill \
+  will be trained. Has no effect when Quick Train is manually run from the Personnel tab.
+chkLevelEscapeSkills.text=Quick Train Escape Skills
+chkLevelEscapeSkills.toolTipText=If 'Quick Train on First Day of Each Month', a character's best Escape skill \
+  will be trained. Has no effect when Quick Train is manually run from the Personnel tab.
+chkLevelLeadership.text=Quick Train Leadership
+chkLevelLeadership.toolTipText=If 'Quick Train on First Day of Each Month', the Leadership skill will be trained on \
+  characters who have that skill. Has no effect when Quick Train is manually run from the Personnel tab.
+chkLevelTraining.text=Quick Train Training
+chkLevelTraining.toolTipText=If 'Quick Train on First Day of Each Month', the Training skill will be trained on \
+  characters who have that skill. Has no effect when Quick Train is manually run from the Personnel tab.
+chkLevelOtherCommandSkills.text=Quick Train Other Command Skills
+chkLevelOtherCommandSkills.toolTipText=If 'Quick Train on First Day of Each Month', the Strategy and Tactics skills \
+  will be trained on characters who have those skills. Has no effect when Quick Train is manually run from the Personnel tab.
 chkSelfCorrectMaintenance.text=Automatically Adjust Maintenance Schedules
 chkSelfCorrectMaintenance.toolTipText=MekHQ will evaluate each tech's maintenance schedule, making adjustments to \
   ensure all units can be maintained, where possible.

--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -1025,9 +1025,8 @@ chkNewDayAutomaticallyAssignUnmaintainedUnits.toolTipText=Automatically assign t
   tiebreaker (lowest to highest). The highest BV units are assigned first. Characters with two units already assigned\
   \ will not be assigned additional units in this manner. The 'Never Assign to Maintenance' flag can be used to mark \
   personnel you want this system to ignore.
-chkNewMonthQuickTrain.text=Quick Train to Level 5
-chkNewMonthQuickTrain.toolTipText=On the first day of a new month, automatically run Quick Training on all characters\
-  \ with a target skill level of 5.
+chkNewMonthQuickTrain.text=Quick Train on First Day of Each Month
+chkNewMonthQuickTrain.toolTipText=On the first day of a new month, automatically run Quick Training on all characters.
 chkSelfCorrectMaintenance.text=Automatically Adjust Maintenance Schedules
 chkSelfCorrectMaintenance.toolTipText=MekHQ will evaluate each tech's maintenance schedule, making adjustments to \
   ensure all units can be maintained, where possible.

--- a/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
+++ b/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
@@ -1198,21 +1198,8 @@ QUICK_TRAIN.definition=<b>Quick Train</b> is designed to supplement Mass Trainin
   Characters will train their lowest profession skills first. Skills won't be upgraded if they exceed the \
   character's available XP, at the max level, or push them past the selected skill milestone (e.g., Green, Regular, \
   Veteran). For Infantry Gunnery skills, only the highest relevant skill will be improved (or Small Arms if 'only use\
-  \ Small Arms' is enabled in campaign options). If the 'use artillery skill' campaign option is enabled, only \
-  characters who already have the Artillery skill will be trained in Artillery gunnery. Only Soldiers with the \
-  Anti-Mek (Climbing) skill will be trained in Anti-Mek.\
-  <h2>Utility Skills</h2>\
-  Certain skills are flagged as 'utility,' these are skills that are not strictly required by a characters' profession \
-  but offer some benefits. A utility skill will only be added if the character already possesses the relevant skill \
-  and the following criteria is met:\
-  <blockquote><b>- StratCon Enabled:</b> Training, Tactics, Leadership, and Strategy will be considered.\
-  <br><b>- Advanced Scouting Enabled:</b> If the character is assigned to a combat profession, their best scouting \
-  skill (if any) will be considered.\
-  <br><b>- Escape Skills Enabled:</b> If the character is assigned to a combat profession, their best escape skill \
-  (if any) will be considered.\
-  <br><p>- Functional Appraisal Enabled:</b> If the character is assigned a profession that can perform procurement, \
-  the Appraisal skill will be considered.\
-  <br><b>- Management Skill Enabled:</b> The Leadership skill will be considered.</blockquote>
+  \ Small Arms' is enabled in campaign options). Only Soldiers with the Anti-Mek (Climbing) skill will be trained in \
+  Anti-Mek.
 ### R
 RELEASE_TYPE_DEVELOPMENT.title=Development Releases
 RELEASE_TYPE_DEVELOPMENT.definition=Development builds are the regular releases that come out frequently as part of the\

--- a/MekHQ/resources/mekhq/resources/QuickTrainDialog.properties
+++ b/MekHQ/resources/mekhq/resources/QuickTrainDialog.properties
@@ -30,7 +30,8 @@
 # affiliated with Microsoft.
 # suppress inspection "UnusedProperty" for the whole file
 QuickTrainDialog.centerMessage.normal=Hey {0}, I agree our folks could use some training.\
-  <p>I''ve drawn up a list of suitable courses.</p>
+  <p>I''ve drawn up a list of suitable courses. We''ve also got the option of some supplemental HoloVids. These will \
+  be run alongside the usual profession-based curriculums.</p>
 QuickTrainDialog.centerMessage.empty=I''m happy to arrange some training, but you haven''t told me who you want trained.
 QuickTrainDialog.button.whoops=(Cancel) Whoops, I forgot to select anyone
 QuickTrainDialog.button.cancel=(Cancel) I've changed my mind

--- a/MekHQ/resources/mekhq/resources/QuickTrainDialog.properties
+++ b/MekHQ/resources/mekhq/resources/QuickTrainDialog.properties
@@ -43,8 +43,16 @@ QuickTrainDialog.outOfCharacterMessage=<b>Quick Train</b> is designed to supplem
   <br><b>Continuous</b>: Skills are improved repeatedly until no XP remains.</p>\
   <p>- Skills won't be upgraded if they exceed the character's available XP, at the max level, or push them past the \
   selected skill milestone (e.g., Green, Regular, Veteran).\
+  <br>- The various checkboxes allow you to control which skills are improved. Only those skills the character \
+  already possesses at level 0+ will be improved, even if the checkboxes are ticked. Furthermore, for Scouting and \
+  Escape skills only the best skill will be improved, even if the character has multiple Scouting or Escape skills.\
   <br>- You can tell MekHQ to run <b>Quick Train</b> at the end of each month automatically in MekHQ Options.\
   <br>- You can tell <b>Quick Train</b> to ignore a character by right-clicking on the character, heading to \
   <b>Flags</b> and enabling the Quick Train Ignore flag.
 QuickTrainDialog.spinner=Target Level
 improved.format={0} improved {1}!
+QuickTrainDialog.chkLevelArtillery=Improve Artillery Skills
+QuickTrainDialog.chkLevelScoutingSkills=Improve Scouting Skills
+QuickTrainDialog.chkLevelEscapeSkills=Improve Escape Skills
+QuickTrainDialog.chkLevelLeadership=Improve Leadership
+QuickTrainDialog.chkLevelOtherCommandSkills=Improve Other Command Skills

--- a/MekHQ/resources/mekhq/resources/QuickTrainDialog.properties
+++ b/MekHQ/resources/mekhq/resources/QuickTrainDialog.properties
@@ -55,4 +55,5 @@ QuickTrainDialog.chkLevelArtillery=Improve Artillery Skills
 QuickTrainDialog.chkLevelScoutingSkills=Improve Scouting Skills
 QuickTrainDialog.chkLevelEscapeSkills=Improve Escape Skills
 QuickTrainDialog.chkLevelLeadership=Improve Leadership
+QuickTrainDialog.chkLevelTraining=Improve Training
 QuickTrainDialog.chkLevelOtherCommandSkills=Improve Other Command Skills

--- a/MekHQ/src/mekhq/MHQConstants.java
+++ b/MekHQ/src/mekhq/MHQConstants.java
@@ -185,6 +185,12 @@ public final class MHQConstants extends SuiteConstants {
     public static final String NEW_DAY_OPTIMIZE_MEDICAL_ASSIGNMENTS = "NewDayOptimizeMedicalAssignments";
     public static final String NEW_DAY_AUTOMATE_MAINTENANCE_ASSIGNMENTS = "NewDayAutomateMaintenanceAssignments";
     public static final String NEW_DAY_QUICK_TRAIN = "NewDayQuickTrain";
+    public static final String NEW_DAY_ARTILLERY = "NewDayArtillery";
+    public static final String NEW_DAY_SCOUTING = "NewDayScouting";
+    public static final String NEW_DAY_ESCAPE = "NewDayEscape";
+    public static final String NEW_DAY_LEADERSHIP = "NewDayLeadership";
+    public static final String NEW_DAY_TRAINING = "NewDayTraining";
+    public static final String NEW_DAY_OTHER_COMMAND = "NewDayOtherCommand";
     public static final String SELF_CORRECT_MAINTENANCE = "SelfCorrectMaintenance";
     public static final String NEW_DAY_FORCE_ICON_OPERATIONAL_STATUS = "newDayFormationIconOperationalStatus";
     public static final String NEW_DAY_FORCE_ICON_OPERATIONAL_STATUS_STYLE = "newDayFormationIconOperationalStatusStyle";

--- a/MekHQ/src/mekhq/MHQConstants.java
+++ b/MekHQ/src/mekhq/MHQConstants.java
@@ -185,6 +185,7 @@ public final class MHQConstants extends SuiteConstants {
     public static final String NEW_DAY_OPTIMIZE_MEDICAL_ASSIGNMENTS = "NewDayOptimizeMedicalAssignments";
     public static final String NEW_DAY_AUTOMATE_MAINTENANCE_ASSIGNMENTS = "NewDayAutomateMaintenanceAssignments";
     public static final String NEW_DAY_QUICK_TRAIN = "NewDayQuickTrain";
+    public static final String NEW_DAY_QUICK_TRAIN_TARGET = "QuickTrainTarget";
     public static final String NEW_DAY_ARTILLERY = "NewDayArtillery";
     public static final String NEW_DAY_SCOUTING = "NewDayScouting";
     public static final String NEW_DAY_ESCAPE = "NewDayEscape";

--- a/MekHQ/src/mekhq/MHQOptions.java
+++ b/MekHQ/src/mekhq/MHQOptions.java
@@ -964,6 +964,14 @@ public final class MHQOptions extends SuiteOptions {
               .putBoolean(MHQConstants.NEW_DAY_QUICK_TRAIN, value);
     }
 
+    public int getQuickTrainTarget() {
+        return userPreferences.node(MHQConstants.NEW_DAY_NODE).getInt(MHQConstants.NEW_DAY_QUICK_TRAIN_TARGET, 5);
+    }
+
+    public void setQuickTrainTarget(final int value) {
+        userPreferences.node(MHQConstants.NEW_DAY_NODE).putInt(MHQConstants.NEW_DAY_QUICK_TRAIN_TARGET, value);
+    }
+
     public boolean getLevelArtillery() {
         return userPreferences.node(MHQConstants.NEW_DAY_NODE)
                      .getBoolean(MHQConstants.NEW_DAY_ARTILLERY, false);

--- a/MekHQ/src/mekhq/MHQOptions.java
+++ b/MekHQ/src/mekhq/MHQOptions.java
@@ -852,7 +852,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public boolean getNewDaySoldierPoolFill() {
-        return userPreferences.node(MHQConstants.NEW_DAY_NODE).getBoolean(MHQConstants.NEW_DAY_SOLDIER_POOL_FILL, false);
+        return userPreferences.node(MHQConstants.NEW_DAY_NODE)
+                     .getBoolean(MHQConstants.NEW_DAY_SOLDIER_POOL_FILL, false);
     }
 
     public void setNewDaySoldierPoolFill(final boolean value) {
@@ -860,7 +861,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public boolean getNewDayBattleArmorPoolFill() {
-        return userPreferences.node(MHQConstants.NEW_DAY_NODE).getBoolean(MHQConstants.NEW_DAY_BATTLE_ARMOR_POOL_FILL, false);
+        return userPreferences.node(MHQConstants.NEW_DAY_NODE)
+                     .getBoolean(MHQConstants.NEW_DAY_BATTLE_ARMOR_POOL_FILL, false);
     }
 
     public void setNewDayBattleArmorPoolFill(final boolean value) {
@@ -868,31 +870,38 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public boolean getNewDayVehicleCrewGroundPoolFill() {
-        return userPreferences.node(MHQConstants.NEW_DAY_NODE).getBoolean(MHQConstants.NEW_DAY_VEHICLE_CREW_GROUND_POOL_FILL, false);
+        return userPreferences.node(MHQConstants.NEW_DAY_NODE)
+                     .getBoolean(MHQConstants.NEW_DAY_VEHICLE_CREW_GROUND_POOL_FILL, false);
     }
 
     public void setNewDayVehicleCrewGroundPoolFill(final boolean value) {
-        userPreferences.node(MHQConstants.NEW_DAY_NODE).putBoolean(MHQConstants.NEW_DAY_VEHICLE_CREW_GROUND_POOL_FILL, value);
+        userPreferences.node(MHQConstants.NEW_DAY_NODE)
+              .putBoolean(MHQConstants.NEW_DAY_VEHICLE_CREW_GROUND_POOL_FILL, value);
     }
 
     public boolean getNewDayVehicleCrewVTOLPoolFill() {
-        return userPreferences.node(MHQConstants.NEW_DAY_NODE).getBoolean(MHQConstants.NEW_DAY_VEHICLE_CREW_VTOL_POOL_FILL, false);
+        return userPreferences.node(MHQConstants.NEW_DAY_NODE)
+                     .getBoolean(MHQConstants.NEW_DAY_VEHICLE_CREW_VTOL_POOL_FILL, false);
     }
 
     public void setNewDayVehicleCrewVTOLPoolFill(final boolean value) {
-        userPreferences.node(MHQConstants.NEW_DAY_NODE).putBoolean(MHQConstants.NEW_DAY_VEHICLE_CREW_VTOL_POOL_FILL, value);
+        userPreferences.node(MHQConstants.NEW_DAY_NODE)
+              .putBoolean(MHQConstants.NEW_DAY_VEHICLE_CREW_VTOL_POOL_FILL, value);
     }
 
     public boolean getNewDayVehicleCrewNavalPoolFill() {
-        return userPreferences.node(MHQConstants.NEW_DAY_NODE).getBoolean(MHQConstants.NEW_DAY_VEHICLE_CREW_NAVAL_POOL_FILL, false);
+        return userPreferences.node(MHQConstants.NEW_DAY_NODE)
+                     .getBoolean(MHQConstants.NEW_DAY_VEHICLE_CREW_NAVAL_POOL_FILL, false);
     }
 
     public void setNewDayVehicleCrewNavalPoolFill(final boolean value) {
-        userPreferences.node(MHQConstants.NEW_DAY_NODE).putBoolean(MHQConstants.NEW_DAY_VEHICLE_CREW_NAVAL_POOL_FILL, value);
+        userPreferences.node(MHQConstants.NEW_DAY_NODE)
+              .putBoolean(MHQConstants.NEW_DAY_VEHICLE_CREW_NAVAL_POOL_FILL, value);
     }
 
     public boolean getNewDayVesselPilotPoolFill() {
-        return userPreferences.node(MHQConstants.NEW_DAY_NODE).getBoolean(MHQConstants.NEW_DAY_VESSEL_PILOT_POOL_FILL, false);
+        return userPreferences.node(MHQConstants.NEW_DAY_NODE)
+                     .getBoolean(MHQConstants.NEW_DAY_VESSEL_PILOT_POOL_FILL, false);
     }
 
     public void setNewDayVesselPilotPoolFill(final boolean value) {
@@ -900,7 +909,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public boolean getNewDayVesselGunnerPoolFill() {
-        return userPreferences.node(MHQConstants.NEW_DAY_NODE).getBoolean(MHQConstants.NEW_DAY_VESSEL_GUNNER_POOL_FILL, false);
+        return userPreferences.node(MHQConstants.NEW_DAY_NODE)
+                     .getBoolean(MHQConstants.NEW_DAY_VESSEL_GUNNER_POOL_FILL, false);
     }
 
     public void setNewDayVesselGunnerPoolFill(final boolean value) {
@@ -908,7 +918,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public boolean getNewDayVesselCrewPoolFill() {
-        return userPreferences.node(MHQConstants.NEW_DAY_NODE).getBoolean(MHQConstants.NEW_DAY_VESSEL_CREW_POOL_FILL, false);
+        return userPreferences.node(MHQConstants.NEW_DAY_NODE)
+                     .getBoolean(MHQConstants.NEW_DAY_VESSEL_CREW_POOL_FILL, false);
     }
 
     public void setNewDayVesselCrewPoolFill(final boolean value) {
@@ -953,6 +964,66 @@ public final class MHQOptions extends SuiteOptions {
               .putBoolean(MHQConstants.NEW_DAY_QUICK_TRAIN, value);
     }
 
+    public boolean getLevelArtillery() {
+        return userPreferences.node(MHQConstants.NEW_DAY_NODE)
+                     .getBoolean(MHQConstants.NEW_DAY_ARTILLERY, false);
+    }
+
+    public void setLevelArtillery(final boolean value) {
+        userPreferences.node(MHQConstants.NEW_DAY_NODE)
+              .putBoolean(MHQConstants.NEW_DAY_ARTILLERY, value);
+    }
+
+    public boolean getLevelScouting() {
+        return userPreferences.node(MHQConstants.NEW_DAY_NODE)
+                     .getBoolean(MHQConstants.NEW_DAY_SCOUTING, false);
+    }
+
+    public void setLevelScouting(final boolean value) {
+        userPreferences.node(MHQConstants.NEW_DAY_NODE)
+              .putBoolean(MHQConstants.NEW_DAY_SCOUTING, value);
+    }
+
+    public boolean getLevelEscape() {
+        return userPreferences.node(MHQConstants.NEW_DAY_NODE)
+                     .getBoolean(MHQConstants.NEW_DAY_ESCAPE, false);
+    }
+
+    public void setLevelEscape(final boolean value) {
+        userPreferences.node(MHQConstants.NEW_DAY_NODE)
+              .putBoolean(MHQConstants.NEW_DAY_ESCAPE, value);
+    }
+
+    public boolean getLevelLeadership() {
+        return userPreferences.node(MHQConstants.NEW_DAY_NODE)
+                     .getBoolean(MHQConstants.NEW_DAY_LEADERSHIP, false);
+    }
+
+    public void setLevelLeadership(final boolean value) {
+        userPreferences.node(MHQConstants.NEW_DAY_NODE)
+              .putBoolean(MHQConstants.NEW_DAY_LEADERSHIP, value);
+    }
+
+    public boolean getLevelTraining() {
+        return userPreferences.node(MHQConstants.NEW_DAY_NODE)
+                     .getBoolean(MHQConstants.NEW_DAY_TRAINING, false);
+    }
+
+    public void setLevelTraining(final boolean value) {
+        userPreferences.node(MHQConstants.NEW_DAY_NODE)
+              .putBoolean(MHQConstants.NEW_DAY_TRAINING, value);
+    }
+
+    public boolean getLevelOtherCommand() {
+        return userPreferences.node(MHQConstants.NEW_DAY_NODE)
+                     .getBoolean(MHQConstants.NEW_DAY_OTHER_COMMAND, false);
+    }
+
+    public void setLevelOtherCommand(final boolean value) {
+        userPreferences.node(MHQConstants.NEW_DAY_NODE)
+              .putBoolean(MHQConstants.NEW_DAY_OTHER_COMMAND, value);
+    }
+
     public boolean getSelfCorrectMaintenance() {
         return userPreferences.node(MHQConstants.NEW_DAY_NODE)
                      .getBoolean(MHQConstants.SELF_CORRECT_MAINTENANCE, true);
@@ -975,8 +1046,8 @@ public final class MHQOptions extends SuiteOptions {
 
     public FormationIconOperationalStatusStyle getNewDayFormationIconOperationalStatusStyle() {
         return FormationIconOperationalStatusStyle.valueOf(userPreferences.node(MHQConstants.NEW_DAY_NODE)
-                                                             .get(MHQConstants.NEW_DAY_FORCE_ICON_OPERATIONAL_STATUS_STYLE,
-                                                                   FormationIconOperationalStatusStyle.BORDER.name()));
+                                                                 .get(MHQConstants.NEW_DAY_FORCE_ICON_OPERATIONAL_STATUS_STYLE,
+                                                                       FormationIconOperationalStatusStyle.BORDER.name()));
     }
 
     public void setNewDayFormationIconOperationalStatusStyle(final FormationIconOperationalStatusStyle value) {
@@ -1096,8 +1167,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     /**
-     * This sets the path where one saves their layered formation icon during export, as this is not required for any data
-     * but improves UX.
+     * This sets the path where one saves their layered formation icon during export, as this is not required for any
+     * data but improves UX.
      *
      * @param value the path where the person saved their last layered formation icon export
      */

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -907,6 +907,7 @@ public class CampaignNewDayManager {
 
         if (MekHQ.getMHQOptions().getNewMonthQuickTrain()) {
             final int newMonthQuickTrainTargetLevel = 5;
+            QuickTrain.QuickTrainOptions options = QuickTrain.QuickTrainOptions.buildQuickTrainOptions(campaignOptions);
             QuickTrain.processQuickTraining(personnel, newMonthQuickTrainTargetLevel, campaign, options, true);
         }
     }

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -912,7 +912,6 @@ public class CampaignNewDayManager {
         }
     }
 
-
     /**
      * Checks if the commander has any burned contacts, and if so, generates and records a report.
      *

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -907,7 +907,7 @@ public class CampaignNewDayManager {
 
         if (MekHQ.getMHQOptions().getNewMonthQuickTrain()) {
             final int newMonthQuickTrainTargetLevel = 5;
-            QuickTrain.processQuickTraining(personnel, newMonthQuickTrainTargetLevel, campaign, true);
+            QuickTrain.processQuickTraining(personnel, newMonthQuickTrainTargetLevel, campaign, options, true);
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -69,6 +69,7 @@ import static mekhq.campaign.personnel.medical.advancedMedicalAlternate.Canonica
 import static mekhq.campaign.personnel.medical.advancedMedicalAlternate.CanonicalDiseaseType.getNewDiseaseOutbreaks;
 import static mekhq.campaign.personnel.skills.Aging.applyAgingSPA;
 import static mekhq.campaign.personnel.skills.Aging.getMilestone;
+import static mekhq.campaign.personnel.skills.QuickTrain.QuickTrainOptions.getQuickTrainOptionsForNewDay;
 import static mekhq.campaign.personnel.skills.SkillModifierData.IGNORE_AGE;
 import static mekhq.campaign.personnel.turnoverAndRetention.Fatigue.areFieldKitchensWithinCapacity;
 import static mekhq.campaign.personnel.turnoverAndRetention.Fatigue.checkFieldKitchenCapacity;
@@ -105,6 +106,7 @@ import javax.swing.JOptionPane;
 import megamek.codeUtilities.StringUtility;
 import megamek.common.options.OptionsConstants;
 import megamek.logging.MMLogger;
+import mekhq.MHQOptions;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign.AdministratorSpecialization;
 import mekhq.campaign.campaignOptions.CampaignOptions;
@@ -905,10 +907,17 @@ public class CampaignNewDayManager {
             new OptimizeInfirmaryAssignments(campaign);
         }
 
+        MHQOptions mekhqOptions = MekHQ.getMHQOptions();
         if (MekHQ.getMHQOptions().getNewMonthQuickTrain()) {
-            final int newMonthQuickTrainTargetLevel = 5;
-            QuickTrain.QuickTrainOptions options = QuickTrain.QuickTrainOptions.buildQuickTrainOptions(campaignOptions);
-            QuickTrain.processQuickTraining(personnel, newMonthQuickTrainTargetLevel, campaign, options, true);
+
+            final int newMonthQuickTrainTargetLevel = mekhqOptions.getQuickTrainTarget();
+
+            QuickTrain.QuickTrainOptions quickTrainOptions = getQuickTrainOptionsForNewDay(mekhqOptions);
+            QuickTrain.processQuickTraining(personnel,
+                  newMonthQuickTrainTargetLevel,
+                  campaign,
+                  quickTrainOptions,
+                  true);
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/personnel/skills/QuickTrain.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/QuickTrain.java
@@ -49,6 +49,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import megamek.logging.MMLogger;
+import mekhq.MHQOptions;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.log.PerformanceLogger;
@@ -56,6 +57,7 @@ import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
 import mekhq.gui.campaignOptions.enums.ProcurementPersonnelPick;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Utility class for performing Quick Training on personnel in a campaign.
@@ -494,6 +496,22 @@ public class QuickTrain {
             boolean isLevelLeadership = true;
             boolean isLevelTraining = true;
             boolean isLevelOtherCommandSkills = true;
+
+            return new QuickTrainOptions(isLevelArtillery,
+                  isLevelScoutingSkills,
+                  isLevelEscapeSkills,
+                  isLevelLeadership,
+                  isLevelTraining,
+                  isLevelOtherCommandSkills);
+        }
+
+        public static QuickTrain.@NonNull QuickTrainOptions getQuickTrainOptionsForNewDay(MHQOptions mekhqOptions) {
+            final boolean isLevelArtillery = mekhqOptions.getLevelArtillery();
+            final boolean isLevelScoutingSkills = mekhqOptions.getLevelScouting();
+            final boolean isLevelEscapeSkills = mekhqOptions.getLevelEscape();
+            final boolean isLevelLeadership = mekhqOptions.getLevelLeadership();
+            final boolean isLevelTraining = mekhqOptions.getLevelTraining();
+            final boolean isLevelOtherCommandSkills = mekhqOptions.getLevelOtherCommand();
 
             return new QuickTrainOptions(isLevelArtillery,
                   isLevelScoutingSkills,

--- a/MekHQ/src/mekhq/campaign/personnel/skills/QuickTrain.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/QuickTrain.java
@@ -469,4 +469,33 @@ public class QuickTrain {
         }
         return highestSkillName;
     }
+
+    public record QuickTrainOptions(
+          boolean isLevelArtillery,
+          boolean isLevelScoutingSkills,
+          boolean isLevelEscapeSkills,
+          boolean isLevelLeadership,
+          boolean isLevelOtherCommandSkills
+    ) {
+        // Additional logic to provide defaults for missing properties
+        public static QuickTrainOptions buildQuickTrainOptions(CampaignOptions campaignOptions) {
+            boolean isLevelArtillery = campaignOptions.isUseArtillery();
+
+            boolean isUseStratCon = campaignOptions.isUseStratCon();
+            boolean isLevelScoutingSkills = isUseStratCon && campaignOptions.isUseAdvancedScouting();
+
+            boolean isLevelEscapeSkills = campaignOptions.isUseFunctionalEscapeArtist();
+
+            // These values are purposefully always true, as we always want the options enabled.
+            // We added them here anyway, in case that assumption ever changed.
+            boolean isLevelLeadership = true;
+            boolean isLevelOtherCommandSkills = true;
+
+            return new QuickTrainOptions(isLevelArtillery,
+                  isLevelScoutingSkills,
+                  isLevelEscapeSkills,
+                  isLevelLeadership,
+                  isLevelOtherCommandSkills);
+        }
+    }
 }

--- a/MekHQ/src/mekhq/campaign/personnel/skills/QuickTrain.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/QuickTrain.java
@@ -39,7 +39,6 @@ import static mekhq.campaign.personnel.skills.SkillType.S_LEADER;
 import static mekhq.campaign.personnel.skills.SkillType.S_SMALL_ARMS;
 import static mekhq.campaign.personnel.skills.SkillType.S_STRATEGY;
 import static mekhq.campaign.personnel.skills.SkillType.S_TACTICS;
-import static mekhq.campaign.personnel.skills.SkillType.S_TRAINING;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 import java.time.LocalDate;
@@ -78,6 +77,7 @@ public class QuickTrain {
      * @param targetPersonnel      the list of personnel (characters) to be trained
      * @param targetLevel          the minimum skill level to reach in each skill
      * @param campaign             the campaign context providing configuration and reporting support
+     * @param options
      * @param isContinuousTraining if {@code true}, training will be repeated for each person as long as improvements
      *                             are possible and XP is available
      *
@@ -85,7 +85,7 @@ public class QuickTrain {
      * @since 0.50.10
      */
     public static void processQuickTraining(List<Person> targetPersonnel, int targetLevel,
-          Campaign campaign, boolean isContinuousTraining) {
+          Campaign campaign, QuickTrainOptions options, boolean isContinuousTraining) {
         CampaignOptions campaignOptions = campaign.getCampaignOptions();
         // Should we train Negotiation for Admins?
         boolean isAdminsHaveNegotiation = campaignOptions.isAdminsHaveNegotiation();
@@ -93,21 +93,21 @@ public class QuickTrain {
         boolean isDoctorsUseAdministration = campaignOptions.isDoctorsUseAdministration();
         boolean isTechsUseAdministration = campaignOptions.isTechsUseAdministration();
         // Should we train Artillery on combat personnel characters who already have it?
-        boolean isUseArtillery = campaignOptions.isUseArtillery();
+        boolean isLevelArtillery = options.isLevelArtillery();
         // Should soldiers only train Small Arms?
         boolean isUseSmallArmsOnly = campaignOptions.isUseSmallArmsOnly();
         // Should we train command utility & training skills?
         boolean isUseStratCon = campaignOptions.isUseStratCon();
         // Should we train scouting skills on combat personnel who already have them?
-        boolean isUseAdvancedScouting = isUseStratCon && campaignOptions.isUseAdvancedScouting();
+        boolean isLevelScoutingSkills = isUseStratCon && options.isLevelScoutingSkills();
         // Should we train escape skills on personnel who already have them?
-        boolean isUseEscapeSkills = campaignOptions.isUseFunctionalEscapeArtist();
+        boolean isLevelEscapeSkills = options.isLevelEscapeSkills();
         // Should we train appraisal on procurement personnel?
         boolean isUseAppraisal = campaignOptions.isUseFunctionalAppraisal();
         ProcurementPersonnelPick procurementPersonnel = campaignOptions.getAcquisitionPersonnelCategory();
         // Should we train Leadership?
-        boolean isUseManagementSkill = campaignOptions.isUseRandomRetirement() &&
-                                             campaignOptions.isUseManagementSkill();
+        boolean isLevelLeadership = options.isLevelLeadership();
+        boolean isLevelOtherCommandSkills = options.isLevelOtherCommandSkills();
 
         // Do XP costs need to be adjusted?
         boolean isUseReasoningMultiplier = campaignOptions.isUseReasoningXpMultiplier();
@@ -137,8 +137,9 @@ public class QuickTrain {
             SkillModifierData skillModifierData = person.getSkillModifierData(isUseAgingEffects, isClanCampaign,
                   today, true);
             processSkills(person, isAdminsHaveNegotiation, isDoctorsUseAdministration, isTechsUseAdministration,
-                  isUseArtillery, isUseSmallArmsOnly, isUseStratCon, isUseAdvancedScouting, isUseEscapeSkills,
-                  isUseAppraisal, procurementPersonnel, isUseManagementSkill, targetSkills, skillModifierData);
+                  isLevelArtillery, isUseSmallArmsOnly, isUseStratCon, isLevelScoutingSkills, isLevelEscapeSkills,
+                  isUseAppraisal, procurementPersonnel, isLevelLeadership, isLevelOtherCommandSkills, targetSkills,
+                  skillModifierData);
 
             if (targetSkills.isEmpty()) {
                 continue;
@@ -270,19 +271,20 @@ public class QuickTrain {
      *                                   skills for their profession-based picks
      * @param isTechsUseAdministration   {@code true} if technicians should use administration instead of
      *                                   technical-specific skills for their profession-based picks
-     * @param isUseArtillery             {@code true} if artillery skills should be considered when building the target
+     * @param isLevelArtillery           {@code true} if artillery skills should be considered when building the target
      *                                   skill list
      * @param isUseSmallArmsOnly         {@code true} if only small-arms combat skills should be considered for combat
      *                                   roles instead of heavier weapon skills
      * @param isUseStratCon              {@code true} to add StratCon-related skills (training, tactics, leadership,
      *                                   strategy) for combat personnel
-     * @param isUseAdvancedScouting      {@code true} to consider and add the best scouting skill for combat personnel
-     * @param isUseEscapeSkills          {@code true} to consider and add the best escape skill for combat personnel
+     * @param isLevelScoutingSkills      {@code true} to consider and add the best scouting skill for combat personnel
+     * @param isLevelEscapeSkills        {@code true} to consider and add the best escape skill for combat personnel
      * @param isUseAppraisal             {@code true} to consider adding the appraisal skill based on the
      *                                   {@code procurementPersonnel} policy
      * @param procurementPersonnel       the policy that determines which personnel (none, all, support, or logistics)
      *                                   are eligible to receive appraisal training
-     * @param isUseManagementSkill       {@code true} to consider and add the leadership skill
+     * @param isLevelLeadership          {@code true} to consider and add the leadership skill
+     * @param isLevelOtherCommandSkills
      * @param targetSkills               the mutable list of skill IDs to populate and then sort
      * @param skillModifierData          the modifier data used to compute each skill's total effective level when
      *                                   ordering {@code targetSkills}
@@ -291,49 +293,32 @@ public class QuickTrain {
      * @since 0.50.10
      */
     private static void processSkills(Person person, boolean isAdminsHaveNegotiation,
-          boolean isDoctorsUseAdministration, boolean isTechsUseAdministration, boolean isUseArtillery,
-          boolean isUseSmallArmsOnly, boolean isUseStratCon, boolean isUseAdvancedScouting, boolean isUseEscapeSkills,
-          boolean isUseAppraisal, ProcurementPersonnelPick procurementPersonnel, boolean isUseManagementSkill,
-          List<String> targetSkills, SkillModifierData skillModifierData) {
+          boolean isDoctorsUseAdministration, boolean isTechsUseAdministration, boolean isLevelArtillery,
+          boolean isUseSmallArmsOnly, boolean isUseStratCon, boolean isLevelScoutingSkills, boolean isLevelEscapeSkills,
+          boolean isUseAppraisal, ProcurementPersonnelPick procurementPersonnel, boolean isLevelLeadership,
+          boolean isLevelOtherCommandSkills, List<String> targetSkills, SkillModifierData skillModifierData) {
         Skills personSkills = person.getSkills();
         boolean isCombatPersonnel = person.isCombat();
 
         fetchSkillsForProfession(isAdminsHaveNegotiation, isDoctorsUseAdministration,
-              isTechsUseAdministration, isUseArtillery, isUseSmallArmsOnly, person, targetSkills,
+              isTechsUseAdministration, isLevelArtillery, isUseSmallArmsOnly, person, targetSkills,
               person.getPrimaryRole(), skillModifierData);
         fetchSkillsForProfession(isAdminsHaveNegotiation, isDoctorsUseAdministration,
-              isTechsUseAdministration, isUseArtillery, isUseSmallArmsOnly, person, targetSkills,
+              isTechsUseAdministration, isLevelArtillery, isUseSmallArmsOnly, person, targetSkills,
               person.getSecondaryRole(), skillModifierData);
 
         if (!personSkills.hasSkill(SkillType.S_ARTILLERY)) {
             targetSkills.remove(SkillType.S_ARTILLERY);
         }
 
-        if (isUseStratCon) {
-            if (isCombatPersonnel) {
-                if (shouldAddSkill(personSkills, S_TRAINING, targetSkills)) {
-                    targetSkills.add(S_TRAINING);
-                }
-                if (shouldAddSkill(personSkills, S_TACTICS, targetSkills)) {
-                    targetSkills.add(S_TACTICS);
-                }
-                if (shouldAddSkill(personSkills, S_LEADER, targetSkills)) {
-                    targetSkills.add(S_LEADER);
-                }
-                if (shouldAddSkill(personSkills, S_STRATEGY, targetSkills)) {
-                    targetSkills.add(S_STRATEGY);
-                }
-            }
-        }
-
-        if (isCombatPersonnel && isUseAdvancedScouting) {
+        if (isCombatPersonnel && isLevelScoutingSkills) {
             String bestSkill = ScoutingSkills.getBestScoutingSkill(person);
             if (shouldAddSkill(personSkills, bestSkill, targetSkills)) {
                 targetSkills.add(bestSkill);
             }
         }
 
-        if (isCombatPersonnel && isUseEscapeSkills) {
+        if (isCombatPersonnel && isLevelEscapeSkills) {
             String bestSkill = EscapeSkills.getHighestEscapeSkill(person);
             if (shouldAddSkill(personSkills, bestSkill, targetSkills)) {
                 targetSkills.add(bestSkill);
@@ -363,9 +348,19 @@ public class QuickTrain {
             }
         }
 
-        if (isUseManagementSkill) {
+        if (isLevelLeadership) {
             if (shouldAddSkill(personSkills, S_LEADER, targetSkills)) {
                 targetSkills.add(S_LEADER);
+            }
+        }
+
+        if (isLevelOtherCommandSkills) {
+            if (shouldAddSkill(personSkills, S_TACTICS, targetSkills)) {
+                targetSkills.add(S_TACTICS);
+            }
+
+            if (shouldAddSkill(personSkills, S_TACTICS, targetSkills)) {
+                targetSkills.add(S_STRATEGY);
             }
         }
 

--- a/MekHQ/src/mekhq/campaign/personnel/skills/QuickTrain.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/QuickTrain.java
@@ -368,7 +368,7 @@ public class QuickTrain {
                 targetSkills.add(S_TACTICS);
             }
 
-            if (shouldAddSkill(personSkills, S_TACTICS, targetSkills)) {
+            if (shouldAddSkill(personSkills, S_STRATEGY, targetSkills)) {
                 targetSkills.add(S_STRATEGY);
             }
         }

--- a/MekHQ/src/mekhq/campaign/personnel/skills/QuickTrain.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/QuickTrain.java
@@ -39,6 +39,7 @@ import static mekhq.campaign.personnel.skills.SkillType.S_LEADER;
 import static mekhq.campaign.personnel.skills.SkillType.S_SMALL_ARMS;
 import static mekhq.campaign.personnel.skills.SkillType.S_STRATEGY;
 import static mekhq.campaign.personnel.skills.SkillType.S_TACTICS;
+import static mekhq.campaign.personnel.skills.SkillType.S_TRAINING;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 import java.time.LocalDate;
@@ -89,24 +90,25 @@ public class QuickTrain {
         CampaignOptions campaignOptions = campaign.getCampaignOptions();
         // Should we train Negotiation for Admins?
         boolean isAdminsHaveNegotiation = campaignOptions.isAdminsHaveNegotiation();
+
         // Should we train Administration for Techs and Doctors?
         boolean isDoctorsUseAdministration = campaignOptions.isDoctorsUseAdministration();
         boolean isTechsUseAdministration = campaignOptions.isTechsUseAdministration();
-        // Should we train Artillery on combat personnel characters who already have it?
-        boolean isLevelArtillery = options.isLevelArtillery();
+
         // Should soldiers only train Small Arms?
         boolean isUseSmallArmsOnly = campaignOptions.isUseSmallArmsOnly();
+
         // Should we train command utility & training skills?
         boolean isUseStratCon = campaignOptions.isUseStratCon();
-        // Should we train scouting skills on combat personnel who already have them?
-        boolean isLevelScoutingSkills = isUseStratCon && options.isLevelScoutingSkills();
-        // Should we train escape skills on personnel who already have them?
-        boolean isLevelEscapeSkills = options.isLevelEscapeSkills();
         // Should we train appraisal on procurement personnel?
         boolean isUseAppraisal = campaignOptions.isUseFunctionalAppraisal();
         ProcurementPersonnelPick procurementPersonnel = campaignOptions.getAcquisitionPersonnelCategory();
-        // Should we train Leadership?
+
+        boolean isLevelScoutingSkills = isUseStratCon && options.isLevelScoutingSkills();
+        boolean isLevelArtillery = options.isLevelArtillery();
+        boolean isLevelEscapeSkills = options.isLevelEscapeSkills();
         boolean isLevelLeadership = options.isLevelLeadership();
+        boolean isLevelTraining = options.isLevelTraining();
         boolean isLevelOtherCommandSkills = options.isLevelOtherCommandSkills();
 
         // Do XP costs need to be adjusted?
@@ -137,9 +139,9 @@ public class QuickTrain {
             SkillModifierData skillModifierData = person.getSkillModifierData(isUseAgingEffects, isClanCampaign,
                   today, true);
             processSkills(person, isAdminsHaveNegotiation, isDoctorsUseAdministration, isTechsUseAdministration,
-                  isLevelArtillery, isUseSmallArmsOnly, isUseStratCon, isLevelScoutingSkills, isLevelEscapeSkills,
-                  isUseAppraisal, procurementPersonnel, isLevelLeadership, isLevelOtherCommandSkills, targetSkills,
-                  skillModifierData);
+                  isLevelArtillery, isUseSmallArmsOnly, isLevelScoutingSkills, isLevelEscapeSkills,
+                  isUseAppraisal, procurementPersonnel, isLevelLeadership, isLevelTraining, isLevelOtherCommandSkills,
+                  targetSkills, skillModifierData);
 
             if (targetSkills.isEmpty()) {
                 continue;
@@ -275,8 +277,6 @@ public class QuickTrain {
      *                                   skill list
      * @param isUseSmallArmsOnly         {@code true} if only small-arms combat skills should be considered for combat
      *                                   roles instead of heavier weapon skills
-     * @param isUseStratCon              {@code true} to add StratCon-related skills (training, tactics, leadership,
-     *                                   strategy) for combat personnel
      * @param isLevelScoutingSkills      {@code true} to consider and add the best scouting skill for combat personnel
      * @param isLevelEscapeSkills        {@code true} to consider and add the best escape skill for combat personnel
      * @param isUseAppraisal             {@code true} to consider adding the appraisal skill based on the
@@ -284,7 +284,8 @@ public class QuickTrain {
      * @param procurementPersonnel       the policy that determines which personnel (none, all, support, or logistics)
      *                                   are eligible to receive appraisal training
      * @param isLevelLeadership          {@code true} to consider and add the leadership skill
-     * @param isLevelOtherCommandSkills
+     * @param isLevelTraining            {@code true} to consider and add the training skill
+     * @param isLevelOtherCommandSkills  {@code true} to consider and add the tactics and strategy skills
      * @param targetSkills               the mutable list of skill IDs to populate and then sort
      * @param skillModifierData          the modifier data used to compute each skill's total effective level when
      *                                   ordering {@code targetSkills}
@@ -294,11 +295,11 @@ public class QuickTrain {
      */
     private static void processSkills(Person person, boolean isAdminsHaveNegotiation,
           boolean isDoctorsUseAdministration, boolean isTechsUseAdministration, boolean isLevelArtillery,
-          boolean isUseSmallArmsOnly, boolean isUseStratCon, boolean isLevelScoutingSkills, boolean isLevelEscapeSkills,
+          boolean isUseSmallArmsOnly, boolean isLevelScoutingSkills, boolean isLevelEscapeSkills,
           boolean isUseAppraisal, ProcurementPersonnelPick procurementPersonnel, boolean isLevelLeadership,
-          boolean isLevelOtherCommandSkills, List<String> targetSkills, SkillModifierData skillModifierData) {
+          boolean isLevelTraining, boolean isLevelOtherCommandSkills, List<String> targetSkills,
+          SkillModifierData skillModifierData) {
         Skills personSkills = person.getSkills();
-        boolean isCombatPersonnel = person.isCombat();
 
         fetchSkillsForProfession(isAdminsHaveNegotiation, isDoctorsUseAdministration,
               isTechsUseAdministration, isLevelArtillery, isUseSmallArmsOnly, person, targetSkills,
@@ -311,14 +312,14 @@ public class QuickTrain {
             targetSkills.remove(SkillType.S_ARTILLERY);
         }
 
-        if (isCombatPersonnel && isLevelScoutingSkills) {
+        if (isLevelScoutingSkills) {
             String bestSkill = ScoutingSkills.getBestScoutingSkill(person);
             if (shouldAddSkill(personSkills, bestSkill, targetSkills)) {
                 targetSkills.add(bestSkill);
             }
         }
 
-        if (isCombatPersonnel && isLevelEscapeSkills) {
+        if (isLevelEscapeSkills) {
             String bestSkill = EscapeSkills.getHighestEscapeSkill(person);
             if (shouldAddSkill(personSkills, bestSkill, targetSkills)) {
                 targetSkills.add(bestSkill);
@@ -351,6 +352,12 @@ public class QuickTrain {
         if (isLevelLeadership) {
             if (shouldAddSkill(personSkills, S_LEADER, targetSkills)) {
                 targetSkills.add(S_LEADER);
+            }
+        }
+
+        if (isLevelTraining) {
+            if (shouldAddSkill(personSkills, S_TRAINING, targetSkills)) {
+                targetSkills.add(S_TRAINING);
             }
         }
 
@@ -470,6 +477,7 @@ public class QuickTrain {
           boolean isLevelScoutingSkills,
           boolean isLevelEscapeSkills,
           boolean isLevelLeadership,
+          boolean isLevelTraining,
           boolean isLevelOtherCommandSkills
     ) {
         // Additional logic to provide defaults for missing properties
@@ -484,12 +492,14 @@ public class QuickTrain {
             // These values are purposefully always true, as we always want the options enabled.
             // We added them here anyway, in case that assumption ever changed.
             boolean isLevelLeadership = true;
+            boolean isLevelTraining = true;
             boolean isLevelOtherCommandSkills = true;
 
             return new QuickTrainOptions(isLevelArtillery,
                   isLevelScoutingSkills,
                   isLevelEscapeSkills,
                   isLevelLeadership,
+                  isLevelTraining,
                   isLevelOtherCommandSkills);
         }
     }

--- a/MekHQ/src/mekhq/campaign/personnel/skills/QuickTrain.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/QuickTrain.java
@@ -78,7 +78,7 @@ public class QuickTrain {
      * @param targetPersonnel      the list of personnel (characters) to be trained
      * @param targetLevel          the minimum skill level to reach in each skill
      * @param campaign             the campaign context providing configuration and reporting support
-     * @param options
+     * @param options              A record storing which checkboxes were checked in the Quick Train dialog
      * @param isContinuousTraining if {@code true}, training will be repeated for each person as long as improvements
      *                             are possible and XP is available
      *

--- a/MekHQ/src/mekhq/campaign/utilities/glossary/GlossaryEntry.java
+++ b/MekHQ/src/mekhq/campaign/utilities/glossary/GlossaryEntry.java
@@ -123,7 +123,7 @@ public enum GlossaryEntry {
     PRISONER_CAPACITY("PRISONER_CAPACITY", new Version("0.50.06")),
     PROFESSIONS("PROFESSIONS", new Version("0.50.06")),
     PROSTHETICS("PROSTHETICS", new Version("0.50.10")),
-    QUICK_TRAIN("QUICK_TRAIN", new Version("0.50.11")),
+    QUICK_TRAIN("QUICK_TRAIN", new Version("0.51.0")),
     RANDOM_PERSONALITIES("RANDOM_PERSONALITIES", new Version("0.50.06")),
     RELEASE_TYPES("RELEASE_TYPES", new Version("0.50.06")),
     RELEASE_TYPE_DEVELOPMENT("RELEASE_TYPE_DEVELOPMENT", new Version("0.50.06")),

--- a/MekHQ/src/mekhq/gui/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/PersonnelTab.java
@@ -221,7 +221,9 @@ public final class PersonnelTab extends CampaignGuiTab {
         btnQuickTrain.setToolTipText(resourceMap.getString("btnQuickTrain.toolTipText"));
         btnQuickTrain.addActionListener(e -> {
             List<Person> selectedPersons = getSelectedPersons();
-            QuickTrainDialog dialog = new QuickTrainDialog(getCampaign(), selectedPersons.isEmpty());
+            QuickTrain.QuickTrainOptions options = QuickTrain.QuickTrainOptions.buildQuickTrainOptions(
+                  getCampaignOptions());
+            QuickTrainDialog dialog = new QuickTrainDialog(getCampaign(), selectedPersons.isEmpty(), options);
             if (!dialog.isCancel()) {
                 int targetSkillLevel = dialog.getSpinnerValue();
                 QuickTrain.processQuickTraining(selectedPersons,

--- a/MekHQ/src/mekhq/gui/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/PersonnelTab.java
@@ -226,9 +226,12 @@ public final class PersonnelTab extends CampaignGuiTab {
             QuickTrainDialog dialog = new QuickTrainDialog(getCampaign(), selectedPersons.isEmpty(), options);
             if (!dialog.isCancel()) {
                 int targetSkillLevel = dialog.getSpinnerValue();
+                options = dialog.getSelectedOptions();
+
                 QuickTrain.processQuickTraining(selectedPersons,
                       targetSkillLevel,
                       getCampaign(),
+                      options,
                       dialog.isContinuousTraining());
             }
         });

--- a/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
@@ -198,12 +198,13 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
     private JCheckBox chkNewDayOptimizeMedicalAssignments;
     private JCheckBox chkNewDayAutomaticallyAssignUnmaintainedUnits;
     private JCheckBox chkNewMonthQuickTrain;
+    private JSpinner spnQuickTrainTarget;
     private JCheckBox chkLevelArtillery;
     private JCheckBox chkLevelEscapeSkills;
     private JCheckBox chkLevelScoutingSkills;
     private JCheckBox chkLevelLeadership;
     private JCheckBox chkLevelTraining;
-    private JCheckBox isLevelOtherCommandSkills;
+    private JCheckBox chkLevelOtherCommandSkills;
     private JCheckBox chkSelfCorrectMaintenance;
     private JCheckBox chkNewDayFormationIconOperationalStatus;
     private MMComboBox<FormationIconOperationalStatusStyle> comboNewDayFormationIconOperationalStatusStyle;
@@ -1027,32 +1028,40 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         chkNewMonthQuickTrain.setToolTipText(getText("chkNewMonthQuickTrain.toolTipText"));
         chkNewMonthQuickTrain.setName("chkNewMonthQuickTrain.text");
 
+        final JLabel lblQuickTrainTarget = new JLabel(getText("lblQuickTrainTarget.text"));
+        lblQuickTrainTarget.setToolTipText(wordWrap(getText("lblQuickTrainTarget.toolTipText")));
+        lblQuickTrainTarget.setName("lblQuickTrainTarget");
+
+        spnQuickTrainTarget = new JSpinner(new SpinnerNumberModel(5, 1, 10, 1));
+        spnQuickTrainTarget.setToolTipText(wordWrap(getText("lblQuickTrainTarget.toolTipText")));
+        spnQuickTrainTarget.setName("spnQuickTrainTarget");
+
         chkLevelArtillery = new JCheckBox(getText("chkLevelArtillery.text"));
-        chkLevelArtillery.setToolTipText(getText("chkLevelArtillery.toolTipText"));
+        chkLevelArtillery.setToolTipText(wordWrap(getText("chkLevelArtillery.toolTipText")));
         chkLevelArtillery.setName("chkLevelArtillery.text");
 
         chkLevelScoutingSkills = new JCheckBox(getText("chkLevelScoutingSkills.text"));
-        chkLevelScoutingSkills.setToolTipText(getText("chkLevelScoutingSkills.toolTipText"));
+        chkLevelScoutingSkills.setToolTipText(wordWrap(getText("chkLevelScoutingSkills.toolTipText")));
         chkLevelScoutingSkills.setName("chkLevelScoutingSkills.text");
 
         chkLevelEscapeSkills = new JCheckBox(getText("chkLevelEscapeSkills.text"));
-        chkLevelEscapeSkills.setToolTipText(getText("chkLevelEscapeSkills.toolTipText"));
+        chkLevelEscapeSkills.setToolTipText(wordWrap(getText("chkLevelEscapeSkills.toolTipText")));
         chkLevelEscapeSkills.setName("chkLevelEscapeSkills.text");
 
         chkLevelLeadership = new JCheckBox(getText("chkLevelLeadership.text"));
-        chkLevelLeadership.setToolTipText(getText("chkLevelLeadership.toolTipText"));
+        chkLevelLeadership.setToolTipText(wordWrap(getText("chkLevelLeadership.toolTipText")));
         chkLevelLeadership.setName("chkLevelLeadership.text");
 
         chkLevelTraining = new JCheckBox(getText("chkLevelTraining.text"));
-        chkLevelTraining.setToolTipText(getText("chkLevelTraining.toolTipText"));
+        chkLevelTraining.setToolTipText(wordWrap(getText("chkLevelTraining.toolTipText")));
         chkLevelTraining.setName("chkLevelTraining.text");
 
-        isLevelOtherCommandSkills = new JCheckBox(getText("isLevelOtherCommandSkills.text"));
-        isLevelOtherCommandSkills.setToolTipText(getText("isLevelOtherCommandSkills.toolTipText"));
-        isLevelOtherCommandSkills.setName("isLevelOtherCommandSkills.text");
+        chkLevelOtherCommandSkills = new JCheckBox(getText("chkLevelOtherCommandSkills.text"));
+        chkLevelOtherCommandSkills.setToolTipText(wordWrap(getText("chkLevelOtherCommandSkills.toolTipText")));
+        chkLevelOtherCommandSkills.setName("chkLevelOtherCommandSkills.text");
 
         chkSelfCorrectMaintenance = new JCheckBox(getText("chkSelfCorrectMaintenance.text"));
-        chkSelfCorrectMaintenance.setToolTipText(resources.getString("chkSelfCorrectMaintenance.toolTipText"));
+        chkSelfCorrectMaintenance.setToolTipText(wordWrap(resources.getString("chkSelfCorrectMaintenance.toolTipText")));
         chkSelfCorrectMaintenance.setName("chkSelfCorrectMaintenance.text");
 
         chkNewDayFormationIconOperationalStatus = new JCheckBox(resources.getString(
@@ -1118,12 +1127,15 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
                                       .addComponent(chkNewDayOptimizeMedicalAssignments)
                                       .addComponent(chkNewDayAutomaticallyAssignUnmaintainedUnits)
                                       .addComponent(chkNewMonthQuickTrain)
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(lblQuickTrainTarget)
+                                                      .addComponent(spnQuickTrainTarget, Alignment.TRAILING))
                                       .addComponent(chkLevelArtillery)
                                       .addComponent(chkLevelScoutingSkills)
                                       .addComponent(chkLevelEscapeSkills)
                                       .addComponent(chkLevelLeadership)
                                       .addComponent(chkLevelTraining)
-                                      .addComponent(isLevelOtherCommandSkills)
+                                      .addComponent(chkLevelOtherCommandSkills)
                                       .addComponent(chkSelfCorrectMaintenance)
                                       .addComponent(chkNewDayFormationIconOperationalStatus)
                                       .addGroup(layout.createParallelGroup(Alignment.LEADING)
@@ -1148,12 +1160,15 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
                                         .addComponent(chkNewDayOptimizeMedicalAssignments)
                                         .addComponent(chkNewDayAutomaticallyAssignUnmaintainedUnits)
                                         .addComponent(chkNewMonthQuickTrain)
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(lblQuickTrainTarget)
+                                                        .addComponent(spnQuickTrainTarget))
                                         .addComponent(chkLevelArtillery)
                                         .addComponent(chkLevelScoutingSkills)
                                         .addComponent(chkLevelEscapeSkills)
                                         .addComponent(chkLevelLeadership)
                                         .addComponent(chkLevelTraining)
-                                        .addComponent(isLevelOtherCommandSkills)
+                                        .addComponent(chkLevelOtherCommandSkills)
                                         .addComponent(chkSelfCorrectMaintenance)
                                         .addComponent(chkNewDayFormationIconOperationalStatus)
                                         .addGroup(layout.createSequentialGroup()
@@ -1701,12 +1716,13 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         options
               .setNewDayAutomaticallyAssignUnmaintainedUnits(chkNewDayAutomaticallyAssignUnmaintainedUnits.isSelected());
         options.setNewMonthQuickTrain(chkNewMonthQuickTrain.isSelected());
+        options.setQuickTrainTarget((int) spnQuickTrainTarget.getValue());
         options.setLevelArtillery(chkLevelArtillery.isSelected());
         options.setLevelScouting(chkLevelScoutingSkills.isSelected());
         options.setLevelEscape(chkLevelEscapeSkills.isSelected());
         options.setLevelLeadership(chkLevelLeadership.isSelected());
         options.setLevelTraining(chkLevelTraining.isSelected());
-        options.setLevelOtherCommand(isLevelOtherCommandSkills.isSelected());
+        options.setLevelOtherCommand(chkLevelOtherCommandSkills.isSelected());
         options.setSelfCorrectMaintenance(chkSelfCorrectMaintenance.isSelected());
         options.setNewDayFormationIconOperationalStatus(chkNewDayFormationIconOperationalStatus.isSelected());
         options
@@ -1916,12 +1932,13 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         chkNewDayAutomaticallyAssignUnmaintainedUnits.setSelected(options
                                                                         .getNewDayAutomaticallyAssignUnmaintainedUnits());
         chkNewMonthQuickTrain.setSelected(options.getNewMonthQuickTrain());
+        spnQuickTrainTarget.setValue(options.getQuickTrainTarget());
         chkLevelArtillery.setSelected(options.getLevelArtillery());
         chkLevelScoutingSkills.setSelected(options.getLevelScouting());
         chkLevelEscapeSkills.setSelected(options.getLevelEscape());
         chkLevelLeadership.setSelected(options.getLevelLeadership());
         chkLevelTraining.setSelected(options.getLevelTraining());
-        isLevelOtherCommandSkills.setSelected(options.getLevelOtherCommand());
+        chkLevelOtherCommandSkills.setSelected(options.getLevelOtherCommand());
         chkSelfCorrectMaintenance.setSelected(options.getSelfCorrectMaintenance());
         if (chkNewDayFormationIconOperationalStatus.isSelected() !=
                   options.getNewDayFormationIconOperationalStatus()) {

--- a/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
@@ -33,6 +33,7 @@
 package mekhq.gui.dialog;
 
 import static megamek.client.ui.WrapLayout.wordWrap;
+import static mekhq.utilities.MHQInternationalization.getText;
 
 import java.awt.Component;
 import java.awt.Container;
@@ -197,6 +198,12 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
     private JCheckBox chkNewDayOptimizeMedicalAssignments;
     private JCheckBox chkNewDayAutomaticallyAssignUnmaintainedUnits;
     private JCheckBox chkNewMonthQuickTrain;
+    private JCheckBox chkLevelArtillery;
+    private JCheckBox chkLevelEscapeSkills;
+    private JCheckBox chkLevelScoutingSkills;
+    private JCheckBox chkLevelLeadership;
+    private JCheckBox chkLevelTraining;
+    private JCheckBox isLevelOtherCommandSkills;
     private JCheckBox chkSelfCorrectMaintenance;
     private JCheckBox chkNewDayFormationIconOperationalStatus;
     private MMComboBox<FormationIconOperationalStatusStyle> comboNewDayFormationIconOperationalStatusStyle;
@@ -1016,16 +1023,36 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
               "chkNewDayAutomaticallyAssignUnmaintainedUnits.toolTipText")));
         chkNewDayAutomaticallyAssignUnmaintainedUnits.setName("chkNewDayAutomaticallyAssignUnmaintainedUnits.text");
 
-        chkNewMonthQuickTrain = new JCheckBox(resources.getString(
-              "chkNewMonthQuickTrain.text"));
-        chkNewMonthQuickTrain.setToolTipText(resources.getString(
-              "chkNewMonthQuickTrain.toolTipText"));
+        chkNewMonthQuickTrain = new JCheckBox(getText("chkNewMonthQuickTrain.text"));
+        chkNewMonthQuickTrain.setToolTipText(getText("chkNewMonthQuickTrain.toolTipText"));
         chkNewMonthQuickTrain.setName("chkNewMonthQuickTrain.text");
 
-        chkSelfCorrectMaintenance = new JCheckBox(resources.getString(
-              "chkSelfCorrectMaintenance.text"));
-        chkSelfCorrectMaintenance.setToolTipText(resources.getString(
-              "chkSelfCorrectMaintenance.toolTipText"));
+        chkLevelArtillery = new JCheckBox(getText("chkLevelArtillery.text"));
+        chkLevelArtillery.setToolTipText(getText("chkLevelArtillery.toolTipText"));
+        chkLevelArtillery.setName("chkLevelArtillery.text");
+
+        chkLevelScoutingSkills = new JCheckBox(getText("chkLevelScoutingSkills.text"));
+        chkLevelScoutingSkills.setToolTipText(getText("chkLevelScoutingSkills.toolTipText"));
+        chkLevelScoutingSkills.setName("chkLevelScoutingSkills.text");
+
+        chkLevelEscapeSkills = new JCheckBox(getText("chkLevelEscapeSkills.text"));
+        chkLevelEscapeSkills.setToolTipText(getText("chkLevelEscapeSkills.toolTipText"));
+        chkLevelEscapeSkills.setName("chkLevelEscapeSkills.text");
+
+        chkLevelLeadership = new JCheckBox(getText("chkLevelLeadership.text"));
+        chkLevelLeadership.setToolTipText(getText("chkLevelLeadership.toolTipText"));
+        chkLevelLeadership.setName("chkLevelLeadership.text");
+
+        chkLevelTraining = new JCheckBox(getText("chkLevelTraining.text"));
+        chkLevelTraining.setToolTipText(getText("chkLevelTraining.toolTipText"));
+        chkLevelTraining.setName("chkLevelTraining.text");
+
+        isLevelOtherCommandSkills = new JCheckBox(getText("isLevelOtherCommandSkills.text"));
+        isLevelOtherCommandSkills.setToolTipText(getText("isLevelOtherCommandSkills.toolTipText"));
+        isLevelOtherCommandSkills.setName("isLevelOtherCommandSkills.text");
+
+        chkSelfCorrectMaintenance = new JCheckBox(getText("chkSelfCorrectMaintenance.text"));
+        chkSelfCorrectMaintenance.setToolTipText(resources.getString("chkSelfCorrectMaintenance.toolTipText"));
         chkSelfCorrectMaintenance.setName("chkSelfCorrectMaintenance.text");
 
         chkNewDayFormationIconOperationalStatus = new JCheckBox(resources.getString(
@@ -1091,6 +1118,12 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
                                       .addComponent(chkNewDayOptimizeMedicalAssignments)
                                       .addComponent(chkNewDayAutomaticallyAssignUnmaintainedUnits)
                                       .addComponent(chkNewMonthQuickTrain)
+                                      .addComponent(chkLevelArtillery)
+                                      .addComponent(chkLevelScoutingSkills)
+                                      .addComponent(chkLevelEscapeSkills)
+                                      .addComponent(chkLevelLeadership)
+                                      .addComponent(chkLevelTraining)
+                                      .addComponent(isLevelOtherCommandSkills)
                                       .addComponent(chkSelfCorrectMaintenance)
                                       .addComponent(chkNewDayFormationIconOperationalStatus)
                                       .addGroup(layout.createParallelGroup(Alignment.LEADING)
@@ -1115,6 +1148,12 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
                                         .addComponent(chkNewDayOptimizeMedicalAssignments)
                                         .addComponent(chkNewDayAutomaticallyAssignUnmaintainedUnits)
                                         .addComponent(chkNewMonthQuickTrain)
+                                        .addComponent(chkLevelArtillery)
+                                        .addComponent(chkLevelScoutingSkills)
+                                        .addComponent(chkLevelEscapeSkills)
+                                        .addComponent(chkLevelLeadership)
+                                        .addComponent(chkLevelTraining)
+                                        .addComponent(isLevelOtherCommandSkills)
                                         .addComponent(chkSelfCorrectMaintenance)
                                         .addComponent(chkNewDayFormationIconOperationalStatus)
                                         .addGroup(layout.createSequentialGroup()
@@ -1662,6 +1701,12 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         options
               .setNewDayAutomaticallyAssignUnmaintainedUnits(chkNewDayAutomaticallyAssignUnmaintainedUnits.isSelected());
         options.setNewMonthQuickTrain(chkNewMonthQuickTrain.isSelected());
+        options.setLevelArtillery(chkLevelArtillery.isSelected());
+        options.setLevelScouting(chkLevelScoutingSkills.isSelected());
+        options.setLevelEscape(chkLevelEscapeSkills.isSelected());
+        options.setLevelLeadership(chkLevelLeadership.isSelected());
+        options.setLevelTraining(chkLevelTraining.isSelected());
+        options.setLevelOtherCommand(isLevelOtherCommandSkills.isSelected());
         options.setSelfCorrectMaintenance(chkSelfCorrectMaintenance.isSelected());
         options.setNewDayFormationIconOperationalStatus(chkNewDayFormationIconOperationalStatus.isSelected());
         options
@@ -1871,6 +1916,12 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         chkNewDayAutomaticallyAssignUnmaintainedUnits.setSelected(options
                                                                         .getNewDayAutomaticallyAssignUnmaintainedUnits());
         chkNewMonthQuickTrain.setSelected(options.getNewMonthQuickTrain());
+        chkLevelArtillery.setSelected(options.getLevelArtillery());
+        chkLevelScoutingSkills.setSelected(options.getLevelScouting());
+        chkLevelEscapeSkills.setSelected(options.getLevelEscape());
+        chkLevelLeadership.setSelected(options.getLevelLeadership());
+        chkLevelTraining.setSelected(options.getLevelTraining());
+        isLevelOtherCommandSkills.setSelected(options.getLevelOtherCommand());
         chkSelfCorrectMaintenance.setSelected(options.getSelfCorrectMaintenance());
         if (chkNewDayFormationIconOperationalStatus.isSelected() !=
                   options.getNewDayFormationIconOperationalStatus()) {

--- a/MekHQ/src/mekhq/gui/dialog/QuickTrainDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/QuickTrainDialog.java
@@ -74,6 +74,8 @@ public class QuickTrainDialog extends ImmersiveDialogCore {
           "QuickTrainDialog.chkLevelEscapeSkills"));
     private static final JCheckBox chkLevelLeadership = new JCheckBox(getTextAt(RESOURCE_BUNDLE,
           "QuickTrainDialog.chkLevelLeadership"));
+    private static final JCheckBox chkLevelTraining = new JCheckBox(getTextAt(RESOURCE_BUNDLE,
+          "QuickTrainDialog.chkLevelTraining"));
     private static final JCheckBox chkLevelOtherCommandSkills = new JCheckBox(getTextAt(RESOURCE_BUNDLE,
           "QuickTrainDialog.chkLevelOtherCommandSkills"));
 
@@ -95,6 +97,7 @@ public class QuickTrainDialog extends ImmersiveDialogCore {
               chkLevelScoutingSkills.isSelected(),
               chkLevelEscapeSkills.isSelected(),
               chkLevelLeadership.isSelected(),
+              chkLevelTraining.isSelected(),
               chkLevelOtherCommandSkills.isSelected());
     }
 

--- a/MekHQ/src/mekhq/gui/dialog/QuickTrainDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/QuickTrainDialog.java
@@ -90,6 +90,14 @@ public class QuickTrainDialog extends ImmersiveDialogCore {
         return getDialogChoice() == cancelIndex;
     }
 
+    public QuickTrain.QuickTrainOptions getSelectedOptions() {
+        return new QuickTrain.QuickTrainOptions(chkLevelArtillery.isSelected(),
+              chkLevelScoutingSkills.isSelected(),
+              chkLevelEscapeSkills.isSelected(),
+              chkLevelLeadership.isSelected(),
+              chkLevelOtherCommandSkills.isSelected());
+    }
+
     /**
      * Returns {@code true} if the user has chosen the continuous training option, which instructs the system to keep
      * training selected personnel until stopping criteria are met.

--- a/MekHQ/src/mekhq/gui/dialog/QuickTrainDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/QuickTrainDialog.java
@@ -41,6 +41,7 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.util.ArrayList;
 import java.util.List;
+import javax.swing.JCheckBox;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -48,6 +49,7 @@ import javax.swing.JSpinner;
 import javax.swing.SpinnerNumberModel;
 
 import mekhq.campaign.Campaign;
+import mekhq.campaign.personnel.skills.QuickTrain;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogWidth;
 
@@ -63,6 +65,17 @@ import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogWidth;
  */
 public class QuickTrainDialog extends ImmersiveDialogCore {
     private static final String RESOURCE_BUNDLE = "mekhq.resources.QuickTrainDialog";
+
+    private static final JCheckBox chkLevelArtillery = new JCheckBox(getTextAt(RESOURCE_BUNDLE,
+          "QuickTrainDialog.chkLevelArtillery"));
+    private static final JCheckBox chkLevelScoutingSkills = new JCheckBox(getTextAt(RESOURCE_BUNDLE,
+          "QuickTrainDialog.chkLevelScoutingSkills"));
+    private static final JCheckBox chkLevelEscapeSkills = new JCheckBox(getTextAt(RESOURCE_BUNDLE,
+          "QuickTrainDialog.chkLevelEscapeSkills"));
+    private static final JCheckBox chkLevelLeadership = new JCheckBox(getTextAt(RESOURCE_BUNDLE,
+          "QuickTrainDialog.chkLevelLeadership"));
+    private static final JCheckBox chkLevelOtherCommandSkills = new JCheckBox(getTextAt(RESOURCE_BUNDLE,
+          "QuickTrainDialog.chkLevelOtherCommandSkills"));
 
     /**
      * Returns {@code true} if the user has chosen to cancel the dialog.
@@ -101,7 +114,7 @@ public class QuickTrainDialog extends ImmersiveDialogCore {
      * @author Illiani
      * @since 0.50.10
      */
-    public QuickTrainDialog(Campaign campaign, boolean isNobodySelected) {
+    public QuickTrainDialog(Campaign campaign, boolean isNobodySelected, QuickTrain.QuickTrainOptions trainingOptions) {
         super(campaign,
               campaign.getSeniorAdminPerson(Campaign.AdministratorSpecialization.HR),
               null,
@@ -110,7 +123,7 @@ public class QuickTrainDialog extends ImmersiveDialogCore {
               getOutOfCharacterMessage(),
               ImmersiveDialogWidth.SMALL.getWidth(),
               true,
-              getSupplementalPanel(),
+              getSupplementalPanel(trainingOptions),
               null,
               true);
     }
@@ -177,15 +190,32 @@ public class QuickTrainDialog extends ImmersiveDialogCore {
      * @author Illiani
      * @since 0.50.10
      */
-    private static JPanel getSupplementalPanel() {
+    private static JPanel getSupplementalPanel(QuickTrain.QuickTrainOptions trainingOptions) {
         JPanel panel = new JPanel(new GridBagLayout());
         GridBagConstraints constraints = createBaseConstraints();
 
+        int y = 0;
+
+        chkLevelArtillery.setEnabled(trainingOptions.isLevelArtillery());
+        addComponent(panel, chkLevelArtillery, constraints, 0, y++, GridBagConstraints.HORIZONTAL);
+
+        chkLevelScoutingSkills.setEnabled(trainingOptions.isLevelScoutingSkills());
+        addComponent(panel, chkLevelScoutingSkills, constraints, 0, y++, GridBagConstraints.HORIZONTAL);
+
+        chkLevelEscapeSkills.setEnabled(trainingOptions.isLevelEscapeSkills());
+        addComponent(panel, chkLevelEscapeSkills, constraints, 0, y++, GridBagConstraints.HORIZONTAL);
+
+        chkLevelLeadership.setEnabled(trainingOptions.isLevelLeadership());
+        addComponent(panel, chkLevelLeadership, constraints, 0, y++, GridBagConstraints.HORIZONTAL);
+
+        chkLevelOtherCommandSkills.setEnabled(trainingOptions.isLevelOtherCommandSkills());
+        addComponent(panel, chkLevelOtherCommandSkills, constraints, 0, y++, GridBagConstraints.HORIZONTAL);
+
         JLabel lblTargetMilestone = new JLabel(getFormattedTextAt(RESOURCE_BUNDLE, "QuickTrainDialog.spinner"));
-        addComponent(panel, lblTargetMilestone, constraints, 0, GridBagConstraints.NONE);
+        addComponent(panel, lblTargetMilestone, constraints, 0, y, GridBagConstraints.NONE);
 
         JSpinner spnAttributes = new JSpinner(new SpinnerNumberModel(5, 1, 10, 1));
-        addComponent(panel, spnAttributes, constraints, 1, GridBagConstraints.HORIZONTAL);
+        addComponent(panel, spnAttributes, constraints, 1, y, GridBagConstraints.HORIZONTAL);
 
         return panel;
     }
@@ -213,15 +243,16 @@ public class QuickTrainDialog extends ImmersiveDialogCore {
      * @param component   the component to add
      * @param constraints base constraints to use (modified in-place)
      * @param gridX       the column (x) position in the grid
+     * @param gridY       the column (y) position in the grid
      * @param fill        the fill mode from {@link GridBagConstraints}
      *
      * @author Illiani
      * @since 0.50.10
      */
     private static void addComponent(JPanel panel, JComponent component, GridBagConstraints constraints, int gridX,
-          int fill) {
+          int gridY, int fill) {
         constraints.gridx = gridX;
-        constraints.gridy = 0;
+        constraints.gridy = gridY;
         constraints.gridwidth = 1;
         constraints.fill = fill;
         panel.add(component, constraints);

--- a/MekHQ/src/mekhq/gui/dialog/QuickTrainDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/QuickTrainDialog.java
@@ -219,6 +219,9 @@ public class QuickTrainDialog extends ImmersiveDialogCore {
         chkLevelLeadership.setEnabled(trainingOptions.isLevelLeadership());
         addComponent(panel, chkLevelLeadership, constraints, 0, y++, GridBagConstraints.HORIZONTAL);
 
+        chkLevelTraining.setEnabled(trainingOptions.isLevelTraining());
+        addComponent(panel, chkLevelTraining, constraints, 0, y++, GridBagConstraints.HORIZONTAL);
+
         chkLevelOtherCommandSkills.setEnabled(trainingOptions.isLevelOtherCommandSkills());
         addComponent(panel, chkLevelOtherCommandSkills, constraints, 0, y++, GridBagConstraints.HORIZONTAL);
 


### PR DESCRIPTION
Close #8625
Close #8804

As per title. These changes have resulted in both changes to Quick Train run from the Personnel tab, and to MekHQ Client Options (New Day options).