### PR TITLE
Close #8736: Added Campaign Option So Players Can Adjust The Base Target Number for StratCon Reinforcement Attempts

### DIFF
--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -238,5 +238,5 @@ stratCon.earlyContractEnd.objectives=You have resolved all outstanding objective
   <p>The contract will end tomorrow. If the contract was successful, any outstanding payments will be rendered once \
   the contract has concluded.</p>
 gameOptions.save.failure.title=Broken Game Options
-gameOptions.save.failure.body=MegaMek's game options failed to save.n\n\All options have been reset to their default \
-  values.n\n\If this keeps happening, please report to the MekHQ team.
+gameOptions.save.failure.body=MegaMek's game options failed to save.nAll options have been reset to their default \
+  values.n\If this keeps happening, please report to the MekHQ team.

--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -238,5 +238,5 @@ stratCon.earlyContractEnd.objectives=You have resolved all outstanding objective
   <p>The contract will end tomorrow. If the contract was successful, any outstanding payments will be rendered once \
   the contract has concluded.</p>
 gameOptions.save.failure.title=Broken Game Options
-gameOptions.save.failure.body=MegaMek's game options failed to save.nAll options have been reset to their default \
+gameOptions.save.failure.body=MegaMek's game options failed to save.n\All options have been reset to their default \
   values.n\If this keeps happening, please report to the MekHQ team.

--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1898,6 +1898,9 @@ lblPlayerControlsAttachedUnits.tooltip=All attached units are placed under your 
 lblUseAdvancedBuildingGunEmplacements.text=Use Advanced Building Gun Emplacements
 lblUseAdvancedBuildingGunEmplacements.tooltip=When enabled gun emplacement generation will use TO:AR Advanced\
   \ Building-based gun emplacements instead of the legacy gun emplacements.
+lblReinforcementBaseTargetNumber.text=Base Reinforcement Target Number
+lblReinforcementBaseTargetNumber.tooltip=The starting target number for reinforcement attempts. This value will then \
+  be adjusted based on any applicable modifiers.
 lblSPAUpgradeIntensity.text=SPA Chance
 lblSPAUpgradeIntensity.tooltip=How likely it is that regular+ OpFor pilots will receive SPAs. -1\
   \ indicates never, 3 indicates always.

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
@@ -680,6 +680,7 @@ public class CampaignOptions {
     private int fixedMapChance;
     private boolean useAdvancedBuildingGunEmplacements;
     private int spaUpgradeIntensity;
+    private int reinforcementBaseTargetNumber;
     private int alliedFacilityModifierDieSize;
     private int enemyFacilityModifierDieSize;
     private int scenarioModMax;
@@ -1360,6 +1361,7 @@ public class CampaignOptions {
         setOpForLanceTypeVehicles(3);
         setFixedMapChance(25);
         setUseAdvancedBuildingGunEmplacements(false);
+        reinforcementBaseTargetNumber = 7;
         setSpaUpgradeIntensity(0);
         setAlliedFacilityModifierDieSize(2);
         setEnemyFacilityModifierDieSize(2);
@@ -5294,6 +5296,14 @@ public class CampaignOptions {
 
     public void setSpaUpgradeIntensity(final int spaUpgradeIntensity) {
         this.spaUpgradeIntensity = spaUpgradeIntensity;
+    }
+
+    public int getReinforcementBaseTargetNumber() {
+        return reinforcementBaseTargetNumber;
+    }
+
+    public void setReinforcementBaseTargetNumber(final int reinforcementBaseTargetNumber) {
+        this.reinforcementBaseTargetNumber = reinforcementBaseTargetNumber;
     }
 
     public int getAlliedFacilityModifierDieSize() {

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
@@ -1168,6 +1168,8 @@ public class CampaignOptionsMarshaller {
               "useAdvancedBuildingGunEmplacements",
               campaignOptions.isUseAdvancedBuildingGunEmplacements());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "spaUpgradeIntensity", campaignOptions.getSpaUpgradeIntensity());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "reinforcementBaseTargetNumber",
+              campaignOptions.getReinforcementBaseTargetNumber());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "alliedFacilityModifierDieSize",
               campaignOptions.getAlliedFacilityModifierDieSize());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "enemyFacilityModifierDieSize",

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
@@ -924,6 +924,8 @@ public class CampaignOptionsUnmarshaller {
             case "useAdvancedBuildingGunEmplacements" ->
                   campaignOptions.setUseAdvancedBuildingGunEmplacements(parseBoolean(
                         nodeContents));
+            case "reinforcementBaseTargetNumber" ->
+                  campaignOptions.setReinforcementBaseTargetNumber(parseInt(nodeContents));
             case "spaUpgradeIntensity" -> campaignOptions.setSpaUpgradeIntensity(parseInt(nodeContents));
             case "alliedFacilityModifierDieSize" ->
                   campaignOptions.setAlliedFacilityModifierDieSize(parseInt(nodeContents));

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -2227,15 +2227,17 @@ public class StratConRulesManager {
      *             <li>-- If command rights indicate that a liaison is required, the modifier is adjusted.</li>
      * </ol>
      *
-     * @param commandLiaison the {@link Person} acting as the command liaison, or {@code null} if no liaison exists.
-     * @param contract       the {@link AtBContract} defining the terms of the contract for this scenario.
+     * @param commandLiaison   the {@link Person} acting as the command liaison, or {@code null} if no liaison exists.
+     * @param contract         the {@link AtBContract} defining the terms of the contract for this scenario.
+     * @param baseTargetNumber the starting target number before adjustments
      *
      * @return a {@link TargetRoll} object representing the calculated reinforcement target number, with appropriate
      *       modifiers applied.
      */
-    public static TargetRoll calculateReinforcementTargetNumber(@Nullable Person commandLiaison, AtBContract contract) {
+    public static TargetRoll calculateReinforcementTargetNumber(@Nullable Person commandLiaison, AtBContract contract,
+          int baseTargetNumber) {
         // Create Target Roll
-        TargetRoll reinforcementTargetNumber = new TargetRoll(7, "Base Target Number");
+        TargetRoll reinforcementTargetNumber = new TargetRoll(baseTargetNumber, "Base Target Number");
 
         // Base Target Number
         Skill skill = commandLiaison != null ? commandLiaison.getSkill(S_ADMIN) : null;

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/RulesetsTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/RulesetsTab.java
@@ -119,6 +119,8 @@ public class RulesetsTab {
     private JCheckBox chkUseAdvancedBuildingGunEmplacements;
     private JLabel lblSPAUpgradeIntensity;
     private JSpinner spnSPAUpgradeIntensity;
+    private JLabel lblReinforcementBaseTargetNumber;
+    private JSpinner spnReinforcementBaseTargetNumber;
     private JCheckBox chkAutoConfigMunitions;
 
     private JPanel pnlScenarioModifiers;
@@ -240,6 +242,8 @@ public class RulesetsTab {
 
         lblSPAUpgradeIntensity = new JLabel();
         spnSPAUpgradeIntensity = new JSpinner();
+        lblReinforcementBaseTargetNumber = new JLabel();
+        spnReinforcementBaseTargetNumber = new JSpinner();
         chkAutoConfigMunitions = new JCheckBox();
 
         pnlScenarioModifiers = new JPanel();
@@ -325,6 +329,10 @@ public class RulesetsTab {
         lblSPAUpgradeIntensity = new CampaignOptionsLabel("SPAUpgradeIntensity");
         spnSPAUpgradeIntensity = new CampaignOptionsSpinner("SPAUpgradeIntensity",
               0, -1, 3, 1);
+        lblReinforcementBaseTargetNumber = new CampaignOptionsLabel("ReinforcementBaseTargetNumber",
+              getMetadata(new Version(0, 51, 0)));
+        spnReinforcementBaseTargetNumber = new CampaignOptionsSpinner("ReinforcementBaseTargetNumber",
+              7, -10, 10, 1);
         chkAutoConfigMunitions = new CampaignOptionsCheckBox("AutoConfigMunitions",
               getMetadata(LEGACY_RULE_BEFORE_METADATA,
                     CampaignOptionFlag.CUSTOM_SYSTEM,
@@ -397,6 +405,12 @@ public class RulesetsTab {
 
         layout.gridy++;
         panel.add(chkUseAdvancedBuildingGunEmplacements, layout);
+
+        layout.gridy++;
+        layout.gridwidth = 1;
+        panel.add(lblReinforcementBaseTargetNumber, layout);
+        layout.gridx++;
+        panel.add(spnReinforcementBaseTargetNumber, layout);
 
         layout.gridy++;
         layout.gridwidth = 1;
@@ -874,6 +888,10 @@ public class RulesetsTab {
               "PlayerControlsAttachedUnits"));
         chkUseAdvancedBuildingGunEmplacements.addMouseListener(createTipPanelUpdater(stratConHeader,
               "UseAdvancedBuildingGunEmplacements"));
+        lblReinforcementBaseTargetNumber.addMouseListener(createTipPanelUpdater(stratConHeader,
+              "ReinforcementBaseTargetNumber"));
+        spnReinforcementBaseTargetNumber.addMouseListener(createTipPanelUpdater(stratConHeader,
+              "ReinforcementBaseTargetNumber"));
         lblSPAUpgradeIntensity.addMouseListener(createTipPanelUpdater(stratConHeader, "SPAUpgradeIntensity"));
         spnSPAUpgradeIntensity.addMouseListener(createTipPanelUpdater(stratConHeader, "SPAUpgradeIntensity"));
         chkAutoConfigMunitions.addMouseListener(createTipPanelUpdater(stratConHeader, "AutoConfigMunitions"));
@@ -1017,6 +1035,7 @@ public class RulesetsTab {
         options.setAttachedPlayerCamouflage(chkAttachedPlayerCamouflage.isSelected());
         options.setPlayerControlsAttachedUnits(chkPlayerControlsAttachedUnits.isSelected());
         options.setUseAdvancedBuildingGunEmplacements(chkUseAdvancedBuildingGunEmplacements.isSelected());
+        options.setReinforcementBaseTargetNumber((int) spnReinforcementBaseTargetNumber.getValue());
         options.setSpaUpgradeIntensity((int) spnSPAUpgradeIntensity.getValue());
         options.setAutoConfigMunitions(chkAutoConfigMunitions.isSelected());
         options.setEnemyFacilityModifierDieSize((int) spnEnemyFacilityModifierDieSize.getValue());
@@ -1084,6 +1103,7 @@ public class RulesetsTab {
         chkAttachedPlayerCamouflage.setSelected(options.isAttachedPlayerCamouflage());
         chkPlayerControlsAttachedUnits.setSelected(options.isPlayerControlsAttachedUnits());
         chkUseAdvancedBuildingGunEmplacements.setSelected(options.isUseAdvancedBuildingGunEmplacements());
+        spnReinforcementBaseTargetNumber.setValue(options.getReinforcementBaseTargetNumber());
         spnSPAUpgradeIntensity.setValue(options.getSpaUpgradeIntensity());
         chkAutoConfigMunitions.setSelected(options.isAutoConfigMunitions());
         spnEnemyFacilityModifierDieSize.setValue(options.getEnemyFacilityModifierDieSize());

--- a/MekHQ/src/mekhq/gui/stratCon/StratConScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratCon/StratConScenarioWizard.java
@@ -502,7 +502,7 @@ public class StratConScenarioWizard extends JDialog {
      * Add an "available force list" to the given control
      */
     private JList<Formation> addAvailableForceList(JPanel parent, GridBagConstraints gbc,
-                                                   ScenarioForceTemplate forceTemplate) {
+          ScenarioForceTemplate forceTemplate) {
         JScrollPane forceListContainer = new FastJScrollPane();
 
         ScenarioWizardLanceModel lanceModel = new ScenarioWizardLanceModel(campaign,
@@ -731,11 +731,11 @@ public class StratConScenarioWizard extends JDialog {
         if (isPrimaryForce) {
             String instructions;
             Formation primaryFormation = currentScenario.getBackingScenario()
-                                       .getForces(campaign)
-                                       .getAllSubFormations()
-                                       .stream()
-                                       .findFirst()
-                                       .orElse(null);
+                                               .getForces(campaign)
+                                               .getAllSubFormations()
+                                               .stream()
+                                               .findFirst()
+                                               .orElse(null);
             if (primaryFormation != null) {
                 instructions = MHQInternationalization.getFormattedTextAt(resourcePath,
                       "lblLeadershipCommitForces.text",
@@ -846,8 +846,10 @@ public class StratConScenarioWizard extends JDialog {
         }
 
         Person commandLiaison = campaign.getSeniorAdminPerson(AdministratorSpecialization.COMMAND);
+        int baseTargetNumber = campaign.getCampaignOptions().getReinforcementBaseTargetNumber();
         TargetRoll targetNumber = calculateReinforcementTargetNumber(commandLiaison,
-              currentCampaignState.getContract());
+              currentCampaignState.getContract(),
+              baseTargetNumber);
         int availableSupportPoints = currentCampaignState.getSupportPoints();
 
         AtBContract contract = currentScenario.getBackingContract(campaign);
@@ -903,7 +905,7 @@ public class StratConScenarioWizard extends JDialog {
                                                  0
                                                  :
                                                  (dialog.getSupportPoints() * SUPPORT_POINTS_MODIFIER) /
-                                                       selectedForceCount;
+                                                 selectedForceCount;
                 int finalTargetNumber = targetNumber.getValue() + supportPointModifier;
 
                 btnCommitClicked(finalTargetNumber, false, true);


### PR DESCRIPTION
Close #8736

As per title, defaults to 7 (the current value).