### PR TITLE
Fix #8729: Fixed Routed OpFors Generating Scenarios Despite Having No Forces to Fight Them

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -2131,6 +2131,9 @@ public class CampaignNewDayManager {
 
         // Third, on Mondays we generate new scenarios for the week
         if (today.getDayOfWeek() == DayOfWeek.MONDAY) {
+            // StratCon's scenario generation is handled in StratConRulesManager, not here. Though we can't just
+            // filter StratCon campaigns out of this call, because StratCon does do some processing in this method,
+            // just not related to scenario generation.
             AtBScenarioFactory.createScenariosForNewWeek(campaign);
         }
 

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioFactory.java
@@ -140,6 +140,10 @@ public class AtBScenarioFactory {
      * @param campaign the campaign for which to generate scenarios
      */
     public static void createScenariosForNewWeek(Campaign campaign) {
+        // StratCon's scenario generation is handled in StratConRulesManager, not here. Though we can't just filter
+        // StratCon campaigns out of this method, because StratCon does do some processing here, just not related to
+        // scenario generation.
+
         // First, we only want to generate if we have an active contract
         if (!campaign.hasActiveContract()) {
             return;

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -216,6 +216,10 @@ public class StratConRulesManager {
      */
     public static void generateScenariosDatesForWeek(Campaign campaign, StratConCampaignState campaignState,
           AtBContract contract, StratConTrackState track, boolean isUseStratConSingles) {
+        // Important note: we don't check to see whether the OpFor has been routed when scheduling scenario dates.
+        // This is because it's possible the OpFor will rally between the start of the week and when the scenario is
+        // scheduled.
+
         int scenarioRolls = isUseStratConSingles ? 1 :
                                   // We divide the number of scenario rolls by the number of tracks so that we're not
                                   // unintentionally multiplying Intensity by tracks
@@ -3876,7 +3880,11 @@ public class StratConRulesManager {
                     }
                     weeklyScenarioDates.removeIf(date -> date.equals(today));
 
-                    generateDailyScenariosForTrack(campaign, campaignState, contract, scenarioCount);
+                    // If the OpFor is routed, we want to just discard any scheduled scenarios, clearly they've been
+                    // canceled due to impending defeat
+                    if (!contract.getMoraleLevel().isRouted()) {
+                        generateDailyScenariosForTrack(campaign, campaignState, contract, scenarioCount);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fix #8729

This was caused by an oversight in how we scheduled and then executed scenario generation. If the OpFor routed before a scheduled scenario's date, that scenario would still go ahead. Now we discard the scheduled scenario entirely.