### PR TITLE
Fix #5722, #7438: Added New Repair GM Option to Instantly Acquire Required Part and GM Repair

### DIFF
--- a/MekHQ/resources/mekhq/resources/TaskTableMouseAdapter.properties
+++ b/MekHQ/resources/mekhq/resources/TaskTableMouseAdapter.properties
@@ -29,3 +29,4 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 TaskTableMouseAdapter.FIX_GM_ACQUIRE=Complete Task (GM Acquire Part)
+TaskTableMouseAdapter.FIX_GM_ACQUIRE.report=GM Repair, {0} {1}

--- a/MekHQ/resources/mekhq/resources/TaskTableMouseAdapter.properties
+++ b/MekHQ/resources/mekhq/resources/TaskTableMouseAdapter.properties
@@ -1,0 +1,31 @@
+# Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+#
+# This file is part of MekHQ.
+#
+# MekHQ is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (GPL),
+# version 3 or (at your option) any later version,
+# as published by the Free Software Foundation.
+#
+# MekHQ is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# A copy of the GPL should have been included with this project;
+# if not, see <https://www.gnu.org/licenses/>.
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+TaskTableMouseAdapter.FIX_GM_ACQUIRE=SComplete Task (GM Acquire Part)

--- a/MekHQ/resources/mekhq/resources/TaskTableMouseAdapter.properties
+++ b/MekHQ/resources/mekhq/resources/TaskTableMouseAdapter.properties
@@ -28,4 +28,4 @@
 # Microsoft's "Game Content Usage Rules"
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
-TaskTableMouseAdapter.FIX_GM_ACQUIRE=SComplete Task (GM Acquire Part)
+TaskTableMouseAdapter.FIX_GM_ACQUIRE=Complete Task (GM Acquire Part)

--- a/MekHQ/src/mekhq/gui/adapter/TaskTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TaskTableMouseAdapter.java
@@ -33,6 +33,7 @@
 package mekhq.gui.adapter;
 
 import static mekhq.campaign.enums.DailyReportType.TECHNICAL;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import java.awt.event.ActionEvent;
@@ -166,8 +167,9 @@ public class TaskTableMouseAdapter extends JPopupMenuAdapter {
     }
 
     private void reportAndTriggerEvent(IPartWork partWork) {
-        gui.getCampaign()
-              .addReport(TECHNICAL, String.format("GM Repair, %s %s", partWork.getPartName(), partWork.succeed()));
+        gui.getCampaign().addReport(TECHNICAL, getFormattedTextAt(RESOURCE_BUNDLE,
+              "TaskTableMouseAdapter.FIX_GM_ACQUIRE.report",
+              partWork.getPartName(), partWork.succeed()));
         if (partWork.getUnit() != null) {
             partWork.getUnit().refreshPodSpace();
         }

--- a/MekHQ/src/mekhq/gui/adapter/TaskTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TaskTableMouseAdapter.java
@@ -33,6 +33,7 @@
 package mekhq.gui.adapter;
 
 import static mekhq.campaign.enums.DailyReportType.TECHNICAL;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import java.awt.event.ActionEvent;
 import java.util.Optional;
@@ -45,12 +46,15 @@ import javax.swing.JTable;
 
 import megamek.common.rolls.TargetRoll;
 import mekhq.MekHQ;
+import mekhq.campaign.events.AcquisitionEvent;
 import mekhq.campaign.events.parts.PartChangedEvent;
 import mekhq.campaign.events.parts.PartModeChangedEvent;
 import mekhq.campaign.events.units.UnitChangedEvent;
 import mekhq.campaign.parts.Part;
+import mekhq.campaign.parts.missing.MissingPart;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.unit.Unit;
+import mekhq.campaign.work.IAcquisitionWork;
 import mekhq.campaign.work.IPartWork;
 import mekhq.campaign.work.WorkTime;
 import mekhq.gui.CampaignGUI;
@@ -61,6 +65,9 @@ public class TaskTableMouseAdapter extends JPopupMenuAdapter {
     private final CampaignGUI gui;
     private final JTable taskTable;
     private final TaskTableModel taskModel;
+
+
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.TaskTableMouseAdapter";
     //endregion Variable Declaration
 
     //region Constructors
@@ -119,11 +126,21 @@ public class TaskTableMouseAdapter extends JPopupMenuAdapter {
         } else if (command.contains("FIX")) {
             if (partWork.checkFixable() == null) {
                 for (IPartWork p : parts) {
+                    if (command.contains("FIX_GM_ACQUIRE")) {
+                        if (p instanceof MissingPart missingPart) {
+                            Part acquisitionPart = missingPart.getAcquisitionPart();
+                            IAcquisitionWork acquisitionWork = acquisitionPart.getAcquisitionWork();
+                            acquisitionWork.find(0, 1.0);
+                            MekHQ.triggerEvent(new AcquisitionEvent(acquisitionWork));
+                        }
+                    }
+
                     gui.getCampaign()
                           .addReport(TECHNICAL, String.format("GM Repair, %s %s", p.getPartName(), p.succeed()));
                     if (p.getUnit() != null) {
                         p.getUnit().refreshPodSpace();
                     }
+
                     // PodSpace triggers event for each child part
                     if (p instanceof Part) {
                         MekHQ.triggerEvent(new PartChangedEvent((Part) p));
@@ -203,6 +220,12 @@ public class TaskTableMouseAdapter extends JPopupMenuAdapter {
             // Auto complete task
             menuItem = new JMenuItem("Complete Task");
             menuItem.setActionCommand("FIX");
+            menuItem.addActionListener(this);
+            menuItem.setEnabled(isFixable);
+            menu.add(menuItem);
+
+            menuItem = new JMenuItem(getTextAt(RESOURCE_BUNDLE, "TaskTableMouseAdapter.FIX_GM_ACQUIRE"));
+            menuItem.setActionCommand("FIX_GM_ACQUIRE");
             menuItem.addActionListener(this);
             menuItem.setEnabled(isFixable);
             menu.add(menuItem);

--- a/MekHQ/src/mekhq/gui/adapter/TaskTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TaskTableMouseAdapter.java
@@ -50,7 +50,9 @@ import mekhq.campaign.events.AcquisitionEvent;
 import mekhq.campaign.events.parts.PartChangedEvent;
 import mekhq.campaign.events.parts.PartModeChangedEvent;
 import mekhq.campaign.events.units.UnitChangedEvent;
+import mekhq.campaign.parts.Armor;
 import mekhq.campaign.parts.Part;
+import mekhq.campaign.parts.equipment.AmmoBin;
 import mekhq.campaign.parts.missing.MissingPart;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.unit.Unit;
@@ -124,29 +126,55 @@ public class TaskTableMouseAdapter extends JPopupMenuAdapter {
                 }
             }
         } else if (command.contains("FIX")) {
-            if (partWork.checkFixable() == null) {
-                for (IPartWork p : parts) {
-                    if (command.contains("FIX_GM_ACQUIRE")) {
-                        if (p instanceof MissingPart missingPart) {
-                            Part acquisitionPart = missingPart.getAcquisitionPart();
-                            IAcquisitionWork acquisitionWork = acquisitionPart.getAcquisitionWork();
-                            acquisitionWork.find(0, 1.0);
-                            MekHQ.triggerEvent(new AcquisitionEvent(acquisitionWork));
-                        }
-                    }
-
-                    gui.getCampaign()
-                          .addReport(TECHNICAL, String.format("GM Repair, %s %s", p.getPartName(), p.succeed()));
-                    if (p.getUnit() != null) {
-                        p.getUnit().refreshPodSpace();
-                    }
-
-                    // PodSpace triggers event for each child part
-                    if (p instanceof Part) {
-                        MekHQ.triggerEvent(new PartChangedEvent((Part) p));
-                    }
+            for (IPartWork p : parts) {
+                if (partWork.checkFixable() == null) {
+                    processGmAcquireNormal(p, command);
                 }
+                processGMAcquireSpecialCases(p, command);
+
+                reportAndTriggerEvent(p);
             }
+        }
+    }
+
+    private static void processGMAcquireSpecialCases(IPartWork p, String command) {
+        if (command.contains("FIX_GM_ACQUIRE")) {
+            if (p instanceof Armor armor) {
+                int needed = armor.getAmountNeeded();
+                int current = armor.getAmount();
+                armor.setAmount(current + needed);
+            }
+
+            if (p instanceof AmmoBin ammoBin) {
+                Part acquisitionPart = ammoBin.getAcquisitionPart();
+                IAcquisitionWork acquisitionWork = acquisitionPart.getAcquisitionWork();
+                acquisitionWork.find(0, 1.0);
+                ammoBin.loadBin();
+            }
+        }
+    }
+
+    private static void processGmAcquireNormal(IPartWork p, String command) {
+        if (command.contains("FIX_GM_ACQUIRE")) {
+            if (p instanceof MissingPart missingPart) {
+                Part acquisitionPart = missingPart.getAcquisitionPart();
+                IAcquisitionWork acquisitionWork = acquisitionPart.getAcquisitionWork();
+                acquisitionWork.find(0, 1.0);
+                MekHQ.triggerEvent(new AcquisitionEvent(acquisitionWork));
+            }
+        }
+    }
+
+    private void reportAndTriggerEvent(IPartWork p) {
+        gui.getCampaign()
+              .addReport(TECHNICAL, String.format("GM Repair, %s %s", p.getPartName(), p.succeed()));
+        if (p.getUnit() != null) {
+            p.getUnit().refreshPodSpace();
+        }
+
+        // PodSpace triggers event for each child part
+        if (p instanceof Part) {
+            MekHQ.triggerEvent(new PartChangedEvent((Part) p));
         }
     }
 
@@ -227,7 +255,6 @@ public class TaskTableMouseAdapter extends JPopupMenuAdapter {
             menuItem = new JMenuItem(getTextAt(RESOURCE_BUNDLE, "TaskTableMouseAdapter.FIX_GM_ACQUIRE"));
             menuItem.setActionCommand("FIX_GM_ACQUIRE");
             menuItem.addActionListener(this);
-            menuItem.setEnabled(isFixable);
             menu.add(menuItem);
 
             popup.add(menu);

--- a/MekHQ/src/mekhq/gui/adapter/TaskTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TaskTableMouseAdapter.java
@@ -137,15 +137,15 @@ public class TaskTableMouseAdapter extends JPopupMenuAdapter {
         }
     }
 
-    private static void processGMAcquireSpecialCases(IPartWork p, String command) {
+    private static void processGMAcquireSpecialCases(IPartWork partWork, String command) {
         if (command.contains("FIX_GM_ACQUIRE")) {
-            if (p instanceof Armor armor) {
+            if (partWork instanceof Armor armor) {
                 int needed = armor.getAmountNeeded();
                 int current = armor.getAmount();
                 armor.setAmount(current + needed);
             }
 
-            if (p instanceof AmmoBin ammoBin) {
+            if (partWork instanceof AmmoBin ammoBin) {
                 Part acquisitionPart = ammoBin.getAcquisitionPart();
                 IAcquisitionWork acquisitionWork = acquisitionPart.getAcquisitionWork();
                 acquisitionWork.find(0, 1.0);
@@ -154,9 +154,9 @@ public class TaskTableMouseAdapter extends JPopupMenuAdapter {
         }
     }
 
-    private static void processGmAcquireNormal(IPartWork p, String command) {
+    private static void processGmAcquireNormal(IPartWork partWork, String command) {
         if (command.contains("FIX_GM_ACQUIRE")) {
-            if (p instanceof MissingPart missingPart) {
+            if (partWork instanceof MissingPart missingPart) {
                 Part acquisitionPart = missingPart.getAcquisitionPart();
                 IAcquisitionWork acquisitionWork = acquisitionPart.getAcquisitionWork();
                 acquisitionWork.find(0, 1.0);
@@ -165,16 +165,16 @@ public class TaskTableMouseAdapter extends JPopupMenuAdapter {
         }
     }
 
-    private void reportAndTriggerEvent(IPartWork p) {
+    private void reportAndTriggerEvent(IPartWork partWork) {
         gui.getCampaign()
-              .addReport(TECHNICAL, String.format("GM Repair, %s %s", p.getPartName(), p.succeed()));
-        if (p.getUnit() != null) {
-            p.getUnit().refreshPodSpace();
+              .addReport(TECHNICAL, String.format("GM Repair, %s %s", partWork.getPartName(), partWork.succeed()));
+        if (partWork.getUnit() != null) {
+            partWork.getUnit().refreshPodSpace();
         }
 
         // PodSpace triggers event for each child part
-        if (p instanceof Part) {
-            MekHQ.triggerEvent(new PartChangedEvent((Part) p));
+        if (partWork instanceof Part) {
+            MekHQ.triggerEvent(new PartChangedEvent((Part) partWork));
         }
     }
 


### PR DESCRIPTION
Fix #5722
Fix #7438

When players GM repair a task (such as damaged items), if the player doesn't have the replacement part, the task would report it was successful. However, the task would never actually be performed.

This PR adds a new option to GM repair a task and, at the same time, magically procure it via GM acquisition.

Is god darned task took three frickin' hours. Why? Why are Parts such problem children!?