### PR TITLE
Fix #9053: one-shot weapon cannot be fired after reloading, except if game is saved and reloaded

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -316,8 +316,8 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
 
         // Reset fired, mainly for One-Shot weapons
         try {
-            mounted.getLinked().setFired(false);
-        } finally {
+            mounted.getLinkedBy().setFired(false);
+        } catch (Exception ignored) {
             LOGGER.debug("Unable to reset fired state for mounted {}", mounted);
         }
 

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -53,11 +53,13 @@ import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.AmmoType;
 import megamek.common.equipment.EquipmentType;
 import megamek.common.equipment.Mounted;
+import megamek.common.equipment.WeaponMounted;
 import megamek.common.rolls.TargetRoll;
 import megamek.common.units.Aero;
 import megamek.common.units.Jumpship;
 import megamek.common.units.ProtoMek;
 import megamek.common.units.SmallCraft;
+import megamek.common.weapons.Weapon;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
@@ -310,6 +312,13 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
             unload();
             mounted.changeAmmoType(getType());
             mounted.setShotsLeft(shots);
+        }
+
+        // Reset fired, mainly for One-Shot weapons
+        try {
+            mounted.getLinked().setFired(false);
+        } finally {
+            LOGGER.debug("Unable to reset fired state for mounted {}", mounted);
         }
 
         shotsNeeded -= shots;

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -318,7 +318,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         try {
             mounted.getLinkedBy().setFired(false);
         } catch (Exception ignored) {
-            LOGGER.debug("Unable to reset fired state for mounted {}", mounted);
+            LOGGER.error("Unable to reset fired state for mounted {}", mounted);
         }
 
         shotsNeeded -= shots;

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/AmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/AmmoBinTest.java
@@ -58,7 +58,10 @@ import javax.xml.parsers.ParserConfigurationException;
 import megamek.Version;
 import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.AmmoType;
+import megamek.common.equipment.EquipmentType;
 import megamek.common.equipment.Mounted;
+import megamek.common.equipment.WeaponMounted;
+import megamek.common.equipment.WeaponType;
 import megamek.common.units.Entity;
 import megamek.common.units.ProtoMek;
 import mekhq.campaign.Campaign;
@@ -1175,6 +1178,60 @@ public class AmmoBinTest {
 
         // ... but the correct amount of our original ammo type unloaded from the bin.
         assertEquals(ammoType.getShots(), quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void loadBinForOneShotResetsFiredState() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("IS Ammo RL-10");
+
+        // Create an Ammo Bin with no ammo ...
+        int shotsNeeded = ammoType.getShots();
+        int equipmentNum = 42;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, equipmentNum, shotsNeeded, true, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        AmmoMounted mockMounted = mock(AmmoMounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn((Mounted) mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+
+        // ...Set up the linking weapon...
+        WeaponType launcherType = (WeaponType) EquipmentUtilities.getEquipmentType("RL 10");
+        WeaponMounted launcher = new WeaponMounted(mockEntity, launcherType);
+        launcher.setLinked(mockMounted);
+        when(mockMounted.getLinkedBy()).thenReturn((Mounted) launcher);
+
+        // ...set the linking weapon as having fired...
+        launcher.setFired(true);
+
+        // ... and add just enough ammo of the right type to the warehouse ...
+        quartermaster.addAmmo(ammoType, ammoType.getShots());
+
+        // ... and try to load it.
+        ammoBin.loadBin();
+
+        // The launcher should now no longer be in the "fired" state.
+        assertFalse(launcher.isFired());
+
+        // We should have no shots needed ...
+        assertEquals(0, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(shotsNeeded));
+
+        // ... and no more ammo available in the warehouse
+        assertEquals(0, quartermaster.getAmmoAvailable(ammoType));
     }
 
     @Test


### PR DESCRIPTION
We keep the OS launcher weapons mounted to their entities, and we never unset `fired` on One-Shot weapons during the game... so we never unset `fired` on OS weapons, period.

This adds a step to try to unset the `fired` state on all weapons when their ammo is reloaded.
Doing so is fine as all ammo-based weapons need `setFired(false)` before the next scenario, it's just that this is usually handled within the MegaMek client for non-OS weapons.

If, for some reason, the linking weapon for a bin can't be found, we'll print an error message.

Testing:
- Ran all 3 projects' unit tests
- Added a unit test for the new code

Fix #9053 