### PR TITLE
Revamp the Top Bar in the CampaignGUI

### DIFF
--- a/MekHQ/resources/mekhq/resources/AdvanceTime.properties
+++ b/MekHQ/resources/mekhq/resources/AdvanceTime.properties
@@ -1,0 +1,34 @@
+# Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+#
+# This file is part of MekHQ.
+#
+# MekHQ is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (GPL),
+# version 3 or (at your option) any later version,
+# as published by the Free Software Foundation.
+#
+# MekHQ is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# A copy of the GPL should have been included with this project;
+# if not, see <https://www.gnu.org/licenses/>.
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+advanceDay.label=<html><center>Advance Day</center></html>
+advanceDay.toolTip=Advance forward one day.
+advanceNDays.toolTip=Advance Multiple Days

--- a/MekHQ/resources/mekhq/resources/CampaignGUI.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignGUI.properties
@@ -230,15 +230,10 @@ menuCopySystemData.tip=Copies information on the OS, Java and the MegaMek suite 
 savePrompt.title=Save First?
 savePrompt.text=Do you want to save the game before starting a new campaign?
 ## Unsorted Resources
-currentLocation.title=Current Location
-campaignControls.title=Campaign Controls
-btnAdvanceDay.text=Advance Day
-btnAdvanceDay.toolTipText=Advance forward one day.
-btnAdvanceMultipleDays.text=Advance Multiple Days
 btnMassTraining.text=Mass Personnel Training
 btnMassTraining.toolTipText=This launches the Mass Personnel Training Dialog, which allows you to train large numbers of personnel at the same time.
 btnGlossary.text=Glossary
-btnBugReport.text=Report a Bug
+btnBugReport.text=Report Bug
 panCommand.TabConstraints.tabTitle=Command Center
 panHangar.TabConstraints.tabTitle=Hangar
 panRepairBay.TabConstraints.tabTitle=Repair Bay

--- a/MekHQ/resources/mekhq/resources/CommandSummary.properties
+++ b/MekHQ/resources/mekhq/resources/CommandSummary.properties
@@ -1,0 +1,39 @@
+# Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+#
+# This file is part of MekHQ.
+#
+# MekHQ is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (GPL),
+# version 3 or (at your option) any later version,
+# as published by the Free Software Foundation.
+#
+# MekHQ is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# A copy of the GPL should have been included with this project;
+# if not, see <https://www.gnu.org/licenses/>.
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+panel.title=Command summary
+funds.label.noLoan=<html><b>Funds:</b></html>
+funds.label.hasLoan=<html><nobr><b>Funds <font color="{0}">(has loan)</font>:</b></nobr></html>
+funds.text={0} C-Bills
+reputation.label=<html><nobr><b>Reputation & XP:</b></nobr></html>
+reputation.text=<html><nobr>{0}, {1}</nobr></html>
+combatStrength.label=<html><nobr><b>Combat Strength:</b></nobr></html>
+combatStrength.text=<html><nobr>{0} BV</nobr></html>

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -3568,7 +3568,7 @@ public class AtBDynamicScenarioFactory {
      * @author Illiani
      * @since 0.50.10
      */
-    private static int getBVBudgetForStratConSingles(Campaign campaign, boolean forceStandardBattleValue) {
+    public static int getBVBudgetForStratConSingles(Campaign campaign, boolean forceStandardBattleValue) {
         int defaultBVBudget = 10000; // We use this value if the player has no valid forces
 
         int totalForces = 0;

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -42,7 +42,6 @@ import static mekhq.campaign.universe.Faction.MERCENARY_FACTION_CODE;
 import static mekhq.gui.dialog.nagDialogs.NagController.triggerDailyNags;
 import static mekhq.gui.enums.MHQTabType.COMMAND_CENTER;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
-import static mekhq.utilities.MHQInternationalization.getText;
 
 import java.awt.*;
 import java.awt.event.ActionEvent;
@@ -99,7 +98,6 @@ import mekhq.campaign.campaignOptions.AcquisitionsType;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.enums.DailyReportType;
 import mekhq.campaign.events.*;
-import mekhq.campaign.events.assets.AssetEvent;
 import mekhq.campaign.events.loans.LoanEvent;
 import mekhq.campaign.events.missions.MissionEvent;
 import mekhq.campaign.events.persons.PersonEvent;
@@ -137,8 +135,8 @@ import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.NewsItem;
 import mekhq.campaign.universe.Systems;
-import mekhq.campaign.universe.factionStanding.GoingRogue;
 import mekhq.campaign.utilities.AutomatedTechAssignments;
+import mekhq.gui.baseComponents.HorizontallyConstrainedPanel;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
 import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
 import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
@@ -154,10 +152,11 @@ import mekhq.gui.dialog.reportDialogs.ReputationReportDialog;
 import mekhq.gui.dialog.reportDialogs.TransportReportDialog;
 import mekhq.gui.enums.MHQTabType;
 import mekhq.gui.model.PartsTableModel;
+import mekhq.gui.view.AdvanceTimePanel;
+import mekhq.gui.view.CommandSummaryPanel;
 import mekhq.gui.view.CurrentLocationPanel;
 import mekhq.io.FileType;
 import mekhq.utilities.MHQXMLUtility;
-import mekhq.utilities.ReportingUtilities;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -172,8 +171,15 @@ public class CampaignGUI extends JPanel {
     @Serial
     private static final long serialVersionUID = 3126634639249129512L;
     // region Variable Declarations
-    public static final int MAX_START_WIDTH = 1400;
-    public static final int MAX_START_HEIGHT = 900;
+    private static final int MAX_START_WIDTH = 1400;
+    private static final int MAX_START_HEIGHT = 900;
+    private static final int MIN_WINDOW_WIDTH = 1024;
+    private static final int MIN_WINDOW_HEIGHT = 768;
+    private static final int TOP_PANEL_HEIGHT = 90;
+    public static int THIN_GAP = 2;
+    public static int SMALL_GAP = 4;
+    public static int MEDIUM_GAP = 8;
+
     // the max quantity when mass purchasing parts, hiring, etc. using the JSpinner
     public static final int MAX_QUANTITY_SPINNER = 10000;
 
@@ -199,7 +205,6 @@ public class CampaignGUI extends JPanel {
 
     /* Components for the status panel */
     private JPanel statusPanel;
-    private JLabel lblFunds;
     private JLabel lblTempAsTechs;
     private JLabel lblTempMedics;
     private JLabel lblTempSoldiers;
@@ -222,23 +227,12 @@ public class CampaignGUI extends JPanel {
     private JMenu menuVesselGunnerPool;
     private JMenu menuVesselCrewPool;
 
-    /* for the top button panel */
+    /* Top Panel */
     private JPanel pnlTop;
-    private CurrentLocationPanel pnlLocation;
-    private final RoundedJButton btnAdvanceMultipleDays = new RoundedJButton(resourceMap.getString(
-          "btnAdvanceMultipleDays.text"));
-    private final RoundedJButton btnMassTraining = new RoundedJButton(resourceMap.getString("btnMassTraining.text"));
-    private final RoundedMMToggleButton btnGMMode = new RoundedMMToggleButton(resourceMap.getString("btnGMMode.text"));
-    private final RoundedMMToggleButton btnOvertime = new RoundedMMToggleButton(resourceMap.getString("btnOvertime.text"));
-    private final RoundedJButton btnGoRogue = new RoundedJButton(resourceMap.getString("btnGoRogue.text"));
-    private final RoundedJButton btnCompanyGenerator = new RoundedJButton(resourceMap.getString(
-          "btnCompanyGenerator.text"));
-    private final RoundedJButton btnGlossary = new RoundedJButton(resourceMap.getString("btnGlossary.text"));
-    private final RoundedJButton btnBugReport = new RoundedJButton(resourceMap.getString("btnBugReport.text"));
+    private RoundedJButton btnCompanyGenerator;
     private final RoundedJButton btnContractMarket =
           new RoundedJButton(resourceMap.getString("btnContractMarket.market"));
     private final RoundedJButton btnUnitMarket = new RoundedJButton(resourceMap.getString("btnUnitMarket.market"));
-    private final RoundedJButton btnPartsMarket = new RoundedJButton(resourceMap.getString("btnPartsMarket.manual"));
 
     ReportHyperlinkListener reportHLL;
 
@@ -344,7 +338,7 @@ public class CampaignGUI extends JPanel {
             }
         });
 
-        initTopButtons();
+        initTopPanel();
         initStatusBar();
 
         setLayout(new BorderLayout());
@@ -355,8 +349,8 @@ public class CampaignGUI extends JPanel {
 
         standardTabs.values().forEach(CampaignGuiTab::refreshAll);
 
-        refreshCalendar();
-        refreshFunds();
+        refreshWindowTitle();
+        refreshCampaignControlButtons();
         refreshTempAsTechs();
         refreshTempMedics();
         refreshTempSoldiers();
@@ -372,6 +366,9 @@ public class CampaignGUI extends JPanel {
         Dimension dim = Toolkit.getDefaultToolkit().getScreenSize();
 
         frame.setSize(Math.min(MAX_START_WIDTH, dim.width), Math.min(MAX_START_HEIGHT, dim.height));
+        frame.setMinimumSize(new Dimension(MIN_WINDOW_WIDTH, MIN_WINDOW_HEIGHT));
+        pnlTop.setMinimumSize(new Dimension(MIN_WINDOW_WIDTH, TOP_PANEL_HEIGHT));
+        pnlTop.setMaximumSize(new Dimension(Integer.MAX_VALUE, TOP_PANEL_HEIGHT));
 
         // Determine the new location of the window
         int w = frame.getSize().width;
@@ -725,7 +722,7 @@ public class CampaignGUI extends JPanel {
             god.setEditable(true);
             if (god.showDialog().isConfirmed()) {
                 getCampaign().setGameOptions(god.getOptions());
-                refreshCalendar();
+                refreshWindowTitle();
             }
         });
         menuFile.add(miGameOptions);
@@ -1287,7 +1284,6 @@ public class CampaignGUI extends JPanel {
         statusPanel = new JPanel(new FlowLayout(FlowLayout.LEADING, 20, 4));
         statusPanel.getAccessibleContext().setAccessibleName("Status Bar");
 
-        lblFunds = new JLabel();
         lblTempAsTechs = new JLabel();
         lblTempMedics = new JLabel();
         lblTempSoldiers = new JLabel();
@@ -1300,7 +1296,12 @@ public class CampaignGUI extends JPanel {
         lblTempVesselCrew = new JLabel();
         lblPartsAvailabilityRating = new JLabel();
 
-        statusPanel.add(lblFunds);
+        RoundedMMToggleButton btnOvertime = new RoundedMMToggleButton(resourceMap.getString("btnOvertime.text"));
+        btnOvertime.setToolTipText(resourceMap.getString("btnOvertime.toolTipText"));
+        btnOvertime.setSelected(getCampaign().isOvertimeAllowed());
+        btnOvertime.addActionListener(evt -> getCampaign().setOvertime(btnOvertime.isSelected()));
+
+        statusPanel.add(btnOvertime);
         statusPanel.add(lblTempAsTechs);
         statusPanel.add(lblTempMedics);
         statusPanel.add(lblTempSoldiers);
@@ -1329,92 +1330,45 @@ public class CampaignGUI extends JPanel {
      * <p>Accessibility names and layout constraints are assigned to ensure that the UI is properly arranged and
      * accessible.</p>
      */
-    private void initTopButtons() {
-        pnlTop = new JPanel(new GridBagLayout());
-        pnlTop.getAccessibleContext().setAccessibleName(getText("currentLocation.title"));
+    private void initTopPanel() {
+        pnlTop = new JPanel();
+        pnlTop.setLayout(new BoxLayout(pnlTop, BoxLayout.X_AXIS));
 
-        pnlLocation = new CurrentLocationPanel(getCampaign(), this::openRecruitmentDialog);
-        pnlLocation.setMinimumSize(new Dimension(320, 60));
-        GridBagConstraints gridBagConstraints = new GridBagConstraints();
-        gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 0;
-        gridBagConstraints.fill = GridBagConstraints.VERTICAL;
-        gridBagConstraints.weighty = 1.0;
-        gridBagConstraints.gridheight = 2;
-        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-        gridBagConstraints.insets = new Insets(0, 0, 0, 5);
-        pnlTop.add(pnlLocation, gridBagConstraints);
-
-        gridBagConstraints.gridx = 1;
-        gridBagConstraints.gridy = 0;
-        gridBagConstraints.fill = GridBagConstraints.VERTICAL;
-        gridBagConstraints.weightx = 1.0;
-        gridBagConstraints.weighty = 0.0;
-        gridBagConstraints.gridheight = 2;
-        gridBagConstraints.anchor = GridBagConstraints.SOUTHWEST;
-        gridBagConstraints.insets = new Insets(0, 0, 0, 0);
-        pnlTop.add(getMarketButtons(), gridBagConstraints);
-
-        gridBagConstraints.gridx = 2;
-        gridBagConstraints.gridy = 0;
-        gridBagConstraints.fill = GridBagConstraints.NONE;
-        gridBagConstraints.weightx = 0.0;
-        gridBagConstraints.weighty = 0.0;
-        gridBagConstraints.gridheight = 2;
-        gridBagConstraints.anchor = GridBagConstraints.NORTHEAST;
-        gridBagConstraints.insets = new Insets(0, 0, 0, 0);
-        pnlTop.add(getButtonPanel(), gridBagConstraints);
+        pnlTop.add(new CurrentLocationPanel(365, 420, getCampaign(), this::openRecruitmentDialog));
+        pnlTop.add(createMarketsPanel(95, 130));
+        pnlTop.add(new CommandSummaryPanel(250, 280, getCampaign()));
+        pnlTop.add(Box.createHorizontalGlue());
+        pnlTop.add(new AdvanceTimePanel(170, 240, getCampaign().getLocalDate(),
+              getCampaignController()::advanceDay, () -> new AdvanceDaysDialog(getFrame(), this).setVisible(true)));
+        pnlTop.add(createCampaignControlPanel(140, 170));
     }
 
-    private JPanel getMarketButtons() {
-        JPanel pnlButton = new JPanel(new GridBagLayout());
-        pnlButton.setBorder(RoundedLineBorder.createRoundedLineBorder(resourceMap.getString("lblMarkets.title")));
+    private JPanel createMarketsPanel(int minWidth, int maxWidth) {
+        JPanel pnlMarkets = new HorizontallyConstrainedPanel(minWidth, maxWidth);
+        pnlMarkets.setLayout(new GridBagLayout());
+        pnlMarkets.setBorder(RoundedLineBorder.createRoundedLineBorder(resourceMap.getString("lblMarkets.title")));
 
         GridBagConstraints gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.fill = GridBagConstraints.BOTH;
+        gridBagConstraints.weightx = 1;
+        gridBagConstraints.weighty = 1;
 
         btnContractMarket.addActionListener(e -> showContractMarket());
         btnContractMarket.setHorizontalTextPosition(SwingConstants.CENTER);
         btnContractMarket.setVerticalTextPosition(SwingConstants.CENTER);
-        gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 0;
-        gridBagConstraints.gridwidth = 2;
-        gridBagConstraints.fill = GridBagConstraints.BOTH;
-        gridBagConstraints.weightx = 1.0;
-        gridBagConstraints.weighty = 1.0;
-        gridBagConstraints.insets = new Insets(3, 3, 3, 3);
-        pnlButton.add(btnContractMarket, gridBagConstraints);
+        pnlMarkets.add(btnContractMarket, gridBagConstraints);
 
         btnUnitMarket.addActionListener(e -> showUnitMarket());
         btnUnitMarket.setHorizontalTextPosition(SwingConstants.CENTER);
         btnUnitMarket.setVerticalTextPosition(SwingConstants.CENTER);
-        gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 1;
-        gridBagConstraints.gridwidth = 1;
-        gridBagConstraints.fill = GridBagConstraints.BOTH;
-        gridBagConstraints.weightx = 1.0;
-        gridBagConstraints.weighty = 1.0;
-        gridBagConstraints.insets = new Insets(3, 3, 3, 3);
-        pnlButton.add(btnUnitMarket, gridBagConstraints);
-
-        btnPartsMarket.addActionListener(e -> showPartsMarket());
-        btnPartsMarket.setHorizontalTextPosition(SwingConstants.CENTER);
-        btnPartsMarket.setVerticalTextPosition(SwingConstants.CENTER);
-        gridBagConstraints.gridx = 1;
-        gridBagConstraints.gridy = 1;
-        gridBagConstraints.fill = GridBagConstraints.BOTH;
-        gridBagConstraints.weightx = 1.0;
-        gridBagConstraints.weighty = 1.0;
-        gridBagConstraints.insets = new Insets(3, 3, 3, 3);
-        pnlButton.add(btnPartsMarket, gridBagConstraints);
+        gridBagConstraints.insets = new Insets(SMALL_GAP, 0, 0, 0);
+        pnlMarkets.add(btnUnitMarket, gridBagConstraints);
 
         refreshMarketButtonLabels();
 
-        return pnlButton;
-    }
-
-    @Deprecated(since = "0.50.07", forRemoval = true)
-    public void refreshDynamicButtons() {
-        refreshMarketButtonLabels();
+        return pnlMarkets;
     }
 
     public void refreshMarketButtonLabels() {
@@ -1429,151 +1383,54 @@ public class CampaignGUI extends JPanel {
         btnUnitMarket.setText(label);
     }
 
-    private JPanel getButtonPanel() {
-        JPanel pnlButton = new JPanel(new GridBagLayout());
-        pnlButton.setBorder(RoundedLineBorder.createRoundedLineBorder(resourceMap.getString("campaignControls.title")));
+    private JPanel createCampaignControlPanel(int minWidth, int maxWidth) {
+        JPanel pnlButton = new HorizontallyConstrainedPanel(minWidth, maxWidth);
+        pnlButton.setLayout(new GridBagLayout());
+        GridBagConstraints gridBagConstraints = new GridBagConstraints();
 
-        GridBagConstraints gridBagConstraints;
-        btnGlossary.addActionListener(evt -> new NewGlossaryDialog(getFrame()));
-        gridBagConstraints = new GridBagConstraints();
-        gridBagConstraints.gridx = 1;
+        gridBagConstraints.weightx = 1;
+        gridBagConstraints.weighty = 1;
+        gridBagConstraints.gridwidth = 2;
+        gridBagConstraints.fill = GridBagConstraints.BOTH;
+
+        btnCompanyGenerator = new RoundedJButton(resourceMap.getString("btnCompanyGenerator.text"));
+        btnCompanyGenerator.addActionListener(
+              e -> new CompanyGenerationDialog(getFrame(), getCampaign()).setVisible(true));
         gridBagConstraints.gridy = 0;
-        gridBagConstraints.fill = GridBagConstraints.VERTICAL;
-        gridBagConstraints.weightx = 0.0;
-        gridBagConstraints.weighty = 0.0;
-        gridBagConstraints.gridheight = 2;
-        gridBagConstraints.gridwidth = 1;
-        gridBagConstraints.anchor = GridBagConstraints.NORTHEAST;
-        gridBagConstraints.insets = new Insets(3, 3, 3, 15);
-        pnlButton.add(btnGlossary, gridBagConstraints);
-
-        btnGoRogue.addActionListener(e -> new GoingRogue(getCampaign(), getCampaign().getCommander(),
-              getCampaign().getSecondInCommand()));
-        gridBagConstraints = new GridBagConstraints();
-        gridBagConstraints.gridx = 2;
-        gridBagConstraints.gridy = 0;
-        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
-        gridBagConstraints.weightx = 0;
-        gridBagConstraints.weighty = 0.0;
-        gridBagConstraints.anchor = GridBagConstraints.EAST;
-        gridBagConstraints.insets = new Insets(3, 3, 3, 15);
-        pnlButton.add(btnGoRogue, gridBagConstraints);
-
-        btnCompanyGenerator.addActionListener(e -> new CompanyGenerationDialog(getFrame(), getCampaign()).setVisible(
-              true));
-        gridBagConstraints = new GridBagConstraints();
-        gridBagConstraints.gridx = 2;
-        gridBagConstraints.gridy = 1;
-        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
-        gridBagConstraints.weightx = 0;
-        gridBagConstraints.weighty = 0.0;
-        gridBagConstraints.anchor = GridBagConstraints.EAST;
-        gridBagConstraints.insets = new Insets(3, 3, 3, 15);
+        gridBagConstraints.insets = new Insets(MEDIUM_GAP - 2, SMALL_GAP, -2, SMALL_GAP);
         pnlButton.add(btnCompanyGenerator, gridBagConstraints);
 
+        RoundedMMToggleButton btnGMMode = new RoundedMMToggleButton(resourceMap.getString("btnGMMode.text"));
         btnGMMode.setToolTipText(resourceMap.getString("btnGMMode.toolTipText"));
         btnGMMode.setSelected(getCampaign().isGM());
         btnGMMode.addActionListener(e -> {
             getCampaign().setGMMode(btnGMMode.isSelected());
             refreshGMMenuItems();
         });
-        gridBagConstraints = new GridBagConstraints();
-        gridBagConstraints.gridx = 3;
-        gridBagConstraints.gridy = 0;
-        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
-        gridBagConstraints.weightx = 0;
-        gridBagConstraints.weighty = 0.0;
-        gridBagConstraints.anchor = GridBagConstraints.EAST;
-        gridBagConstraints.insets = new Insets(3, 3, 3, 15);
+        gridBagConstraints.gridy = 1;
+        gridBagConstraints.insets = new Insets(MEDIUM_GAP - 2, SMALL_GAP, 0, SMALL_GAP);
         pnlButton.add(btnGMMode, gridBagConstraints);
 
-        btnOvertime.setToolTipText(resourceMap.getString("btnOvertime.toolTipText"));
-        btnOvertime.setSelected(getCampaign().isOvertimeAllowed());
-        btnOvertime.addActionListener(evt -> getCampaign().setOvertime(btnOvertime.isSelected()));
-        gridBagConstraints = new GridBagConstraints();
-        gridBagConstraints.gridx = 3;
-        gridBagConstraints.gridy = 1;
-        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
-        gridBagConstraints.weightx = 0;
-        gridBagConstraints.weighty = 0.0;
-        gridBagConstraints.anchor = GridBagConstraints.EAST;
-        gridBagConstraints.insets = new Insets(3, 3, 3, 15);
-        pnlButton.add(btnOvertime, gridBagConstraints);
-
-        btnAdvanceMultipleDays.addActionListener(e -> new AdvanceDaysDialog(getFrame(), this).setVisible(true));
-        gridBagConstraints = new GridBagConstraints();
-        gridBagConstraints.gridx = 4;
-        gridBagConstraints.gridy = 0;
-        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
-        gridBagConstraints.weightx = 0;
-        gridBagConstraints.weighty = 0.0;
-        gridBagConstraints.anchor = GridBagConstraints.EAST;
-        gridBagConstraints.insets = new Insets(3, 3, 3, 3);
-        pnlButton.add(btnAdvanceMultipleDays, gridBagConstraints);
-
-        btnMassTraining.setToolTipText(resourceMap.getString("btnMassTraining.toolTipText"));
-        btnMassTraining.addActionListener(e -> new BatchXPDialog(getFrame(), getCampaign()).setVisible(true));
-        gridBagConstraints = new GridBagConstraints();
-        gridBagConstraints.gridx = 4;
-        gridBagConstraints.gridy = 1;
-        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
-        gridBagConstraints.weightx = 0;
-        gridBagConstraints.weighty = 0.0;
-        gridBagConstraints.anchor = GridBagConstraints.EAST;
-        gridBagConstraints.insets = new Insets(3, 3, 3, 3);
-        pnlButton.add(btnMassTraining, gridBagConstraints);
-
-        // This button uses a mnemonic that is unique and listed in the initMenu JavaDoc
-        String padding = "       ";
-        RoundedJButton btnAdvanceDay = new RoundedJButton(padding +
-                                                                resourceMap.getString("btnAdvanceDay.text") +
-                                                                padding);
-        btnAdvanceDay.setToolTipText(resourceMap.getString("btnAdvanceDay.toolTipText"));
-        btnAdvanceDay.addActionListener(evt -> {
-            // We disable the button here, as we don't want the user to be able to advance
-            // day  again, until after Advance Day has completed.
-            btnAdvanceDay.setEnabled(false);
-            btnAdvanceMultipleDays.setEnabled(false);
-
-            SwingUtilities.invokeLater(() -> {
-                try {
-                    setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-                    getCampaignController().advanceDay();
-                } finally {
-                    btnAdvanceDay.setEnabled(true);
-                    btnAdvanceMultipleDays.setEnabled(true);
-                    setCursor(Cursor.getDefaultCursor());
-                }
-            });
-        });
-        btnAdvanceDay.setMnemonic(KeyEvent.VK_A);
-        gridBagConstraints = new GridBagConstraints();
-        gridBagConstraints.gridx = 5;
-        gridBagConstraints.gridy = 0;
-        gridBagConstraints.fill = GridBagConstraints.VERTICAL;
-        gridBagConstraints.weightx = 0.0;
-        gridBagConstraints.weighty = 0.0;
-        gridBagConstraints.gridheight = 2;
+        gridBagConstraints.gridy = 2;
+        gridBagConstraints.weighty = 0;
         gridBagConstraints.gridwidth = 1;
-        gridBagConstraints.anchor = GridBagConstraints.NORTHEAST;
-        gridBagConstraints.insets = new Insets(3, 15, 3, 0);
-        pnlButton.add(btnAdvanceDay, gridBagConstraints);
+        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
 
+        RoundedJButton btnGlossary = new RoundedJButton(resourceMap.getString("btnGlossary.text"));
+        btnGlossary.addActionListener(evt -> new NewGlossaryDialog(getFrame()));
+        gridBagConstraints.weightx = 0.4;
+        gridBagConstraints.insets = new Insets(SMALL_GAP, SMALL_GAP, THIN_GAP, 0);
+        pnlButton.add(btnGlossary, gridBagConstraints);
+
+        RoundedJButton btnBugReport = new RoundedJButton(resourceMap.getString("btnBugReport.text"));
         btnBugReport.addActionListener(evt -> new EasyBugReportDialog(getFrame(), getCampaign()));
-        gridBagConstraints = new GridBagConstraints();
-        gridBagConstraints.gridx = 6;
-        gridBagConstraints.gridy = 0;
-        gridBagConstraints.fill = GridBagConstraints.VERTICAL;
-        gridBagConstraints.weightx = 0.0;
-        gridBagConstraints.weighty = 0.0;
-        gridBagConstraints.gridheight = 2;
-        gridBagConstraints.gridwidth = 1;
-        gridBagConstraints.anchor = GridBagConstraints.NORTHEAST;
-        gridBagConstraints.insets = new Insets(3, 15, 3, 15);
+        gridBagConstraints.weightx = 0.6;
+        gridBagConstraints.insets = new Insets(SMALL_GAP, SMALL_GAP, THIN_GAP, SMALL_GAP);
         pnlButton.add(btnBugReport, gridBagConstraints);
 
         return pnlButton;
     }
+
     // endregion Initialization
 
     public @Nullable CampaignGuiTab getTab(final MHQTabType tabType) {
@@ -2344,7 +2201,7 @@ public class CampaignGUI extends JPanel {
         if (factionIntroDate != newOptions.isFactionIntroDate()) {
             getCampaign().updateTechFactionCode();
         }
-        refreshCalendar();
+        refreshWindowTitle();
         getCampaign().reloadNews();
     }
 
@@ -3144,23 +3001,8 @@ public class CampaignGUI extends JPanel {
         }
     }
 
-    public void refreshCalendar() {
+    public void refreshWindowTitle() {
         getFrame().setTitle(getCampaign().getTitle());
-    }
-
-    /**
-     * Refreshes the 'funds' display on the GUI.
-     */
-    private void refreshFunds() {
-        Money funds = getCampaign().getFunds();
-        String inDebt = "";
-        if (getCampaign().getFinances().isInDebt()) {
-            // FIXME : Localize
-            inDebt = " <font color='" + ReportingUtilities.getNegativeColor() + "'>(in Debt)</font>";
-        }
-        // FIXME : Localize
-        String text = "<html><b>Funds</b>: " + funds.toAmountAndSymbolString() + inDebt + "</html>";
-        lblFunds.setText(text);
     }
 
     private void refreshTempAsTechs() {
@@ -3293,7 +3135,11 @@ public class CampaignGUI extends JPanel {
         }
     }
 
-    private final ActionScheduler fundsScheduler = new ActionScheduler(this::refreshFunds);
+    private void refreshCampaignControlButtons() {
+        boolean emptyHangar = getCampaign().getUnits().isEmpty();
+        boolean noPersonnel = getCampaign().getPersonnel().isEmpty();
+        btnCompanyGenerator.setVisible(emptyHangar && noPersonnel);
+    }
 
     public int getTabIndexByName(String tabTitle) {
         int retVal = -1;
@@ -3513,8 +3359,6 @@ public class CampaignGUI extends JPanel {
         Campaign campaign = getCampaign();
         Money overdueAmount = campaign.getFinances().checkOverdueLoanPayments(campaign);
         if (overdueAmount.isPositive()) {
-            refreshFunds();
-
             String inCharacterMessage = getFormattedTextAt(resourceMap.getBaseBundleName(),
                   "dialogOverdueLoans.ic",
                   campaign.getCommanderAddress());
@@ -3593,8 +3437,8 @@ public class CampaignGUI extends JPanel {
      */
     @Subscribe
     public void handleNewDay(NewDayEvent newDayEvent) {
-        refreshCalendar();
-        refreshFunds();
+        refreshWindowTitle();
+        refreshCampaignControlButtons();
         refreshPartsAvailability();
         refreshMarketButtonLabels();
 
@@ -3641,7 +3485,6 @@ public class CampaignGUI extends JPanel {
         refreshTempVesselCrew();
 
         refreshAllTabs();
-        fundsScheduler.schedule();
         refreshPartsAvailability();
 
         miRetirementDefectionDialog.setVisible(optionsChangedEvent.getOptions().isUseRandomRetirement());
@@ -3668,7 +3511,6 @@ public class CampaignGUI extends JPanel {
      */
     @Subscribe
     public void handle(TransactionEvent transactionEvent) {
-        fundsScheduler.schedule();
         refreshPartsAvailability();
     }
 
@@ -3684,23 +3526,7 @@ public class CampaignGUI extends JPanel {
      */
     @Subscribe
     public void handle(LoanEvent loanEvent) {
-        fundsScheduler.schedule();
         refreshPartsAvailability();
-    }
-
-    /**
-     * Handles updates related to assets within the campaign.
-     *
-     * <p>Schedules a funds update to ensure the campaign's financial state is current when assets change.</p>
-     *
-     * <p><b>Important:</b> This method is not directly evoked, so IDEA will tell you it has no uses. IDEA is
-     * wrong.</p>
-     *
-     * @param assetEvent the event indicating a change in assets
-     */
-    @Subscribe
-    public void handle(AssetEvent assetEvent) {
-        fundsScheduler.schedule();
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/CommandCenterTab.java
+++ b/MekHQ/src/mekhq/gui/CommandCenterTab.java
@@ -98,6 +98,7 @@ import mekhq.campaign.report.CargoReport;
 import mekhq.campaign.report.HangarReport;
 import mekhq.campaign.report.PersonnelReport;
 import mekhq.campaign.report.TransportReport;
+import mekhq.campaign.universe.factionStanding.GoingRogue;
 import mekhq.campaign.work.IAcquisitionWork;
 import mekhq.gui.adapter.ProcurementTableMouseAdapter;
 import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
@@ -138,6 +139,9 @@ public final class CommandCenterTab extends CampaignGuiTab {
     private JLabel lblTransportCapacity;
     private JLabel lblCargoSummary;
     private JLabel lblFacilityCapacities;
+
+    // faction panel
+    private JPanel panFaction;
 
     // objectives panel
     private JPanel panObjectives;
@@ -242,17 +246,11 @@ public final class CommandCenterTab extends CampaignGuiTab {
         JPanel panCommand = new JPanel(new GridBagLayout());
 
         initInfoPanel();
+        initFactionPanel();
         initLogPanel();
         initReportsPanel();
         initProcurementPanel();
         initObjectivesPanel();
-        //icon panel
-        JPanel panIcon = new JPanel(new BorderLayout());
-        lblIcon = new JLabel();
-        lblIcon.getAccessibleContext().setAccessibleName("Player Camouflage");
-        panIcon.add(lblIcon, BorderLayout.CENTER);
-        ImageIcon icon = getAndScaleCampaignIcon();
-        lblIcon.setIcon(icon);
 
         /* Set overall layout */
         GridBagConstraints gridBagConstraints = new GridBagConstraints();
@@ -277,7 +275,7 @@ public final class CommandCenterTab extends CampaignGuiTab {
         gridBagConstraints.gridwidth = 1;
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         gridBagConstraints.fill = GridBagConstraints.NONE;
-        gridBagConstraints.weightx = 1.0;
+        gridBagConstraints.weightx = 0.0;
         gridBagConstraints.weighty = 0.0;
         panCommand.add(panReports, gridBagConstraints);
         gridBagConstraints.gridx = 3;
@@ -299,7 +297,7 @@ public final class CommandCenterTab extends CampaignGuiTab {
         gridBagConstraints.fill = GridBagConstraints.NONE;
         gridBagConstraints.weightx = 0.0;
         gridBagConstraints.weighty = 0.0;
-        panCommand.add(panIcon, gridBagConstraints);
+        panCommand.add(panFaction, gridBagConstraints);
 
         JPanel pnlTutorial = new TutorialHyperlinkPanel("commandCenterTab");
 
@@ -491,6 +489,26 @@ public final class CommandCenterTab extends CampaignGuiTab {
         panInfo.setBorder(RoundedLineBorder.createRoundedLineBorder(getCampaign().getName()));
     }
 
+    private void initFactionPanel() {
+        lblIcon = new JLabel();
+        lblIcon.getAccessibleContext().setAccessibleName("Player Camouflage");
+        ImageIcon icon = getAndScaleCampaignIcon();
+        lblIcon.setIcon(icon);
+        lblIcon.setMaximumSize(new Dimension(Integer.MAX_VALUE, lblIcon.getPreferredSize().height));
+
+        RoundedJButton btnGoRogue = new RoundedJButton(resourceMap.getString("btnGoRogue.text"));
+        btnGoRogue.setMaximumSize(new Dimension(Integer.MAX_VALUE, btnGoRogue.getPreferredSize().height));
+        btnGoRogue.addActionListener(e -> new GoingRogue(getCampaign(), getCampaign().getCommander(),
+              getCampaign().getSecondInCommand()));
+
+        panFaction = new JPanel();
+        panFaction.setLayout(new BoxLayout(panFaction, BoxLayout.Y_AXIS));
+        panFaction.add(lblIcon);
+        panFaction.add(Box.createVerticalStrut(5));
+        panFaction.add(btnGoRogue);
+
+    }
+
     /**
      * Initialize the panel for showing any objectives that might exist. Objectives might come from different play
      * modes.
@@ -638,6 +656,10 @@ public final class CommandCenterTab extends CampaignGuiTab {
         /* shopping buttons */
         JPanel panProcurementButtons = new JPanel(new GridLayout(8, 1, 0, 5));
         panProcurementButtons.getAccessibleContext().setAccessibleName("Procurement Actions");
+
+        RoundedJButton btnPartsMarket = new RoundedJButton(resourceMap.getString("btnPartsMarket.manual"));
+        btnPartsMarket.addActionListener(e -> getCampaignGui().showPartsMarket());
+        panProcurementButtons.add(btnPartsMarket);
 
         RoundedJButton btnNeededParts = new RoundedJButton(resourceMap.getString("btnNeededParts.text"));
         btnNeededParts.setToolTipText(resourceMap.getString("btnNeededParts.toolTipText"));

--- a/MekHQ/src/mekhq/gui/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/PersonnelTab.java
@@ -39,6 +39,7 @@ import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.awt.GridLayout;
 import java.awt.Insets;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -79,6 +80,7 @@ import mekhq.campaign.personnel.skills.QuickTrain;
 import mekhq.gui.adapter.PersonnelTableMouseAdapter;
 import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
 import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
+import mekhq.gui.dialog.BatchXPDialog;
 import mekhq.gui.dialog.QuickTrainDialog;
 import mekhq.gui.enums.MHQTabType;
 import mekhq.gui.enums.PersonnelFilter;
@@ -102,7 +104,6 @@ public final class PersonnelTab extends CampaignGuiTab {
     private MMComboBox<PersonnelTabView> choicePersonView;
     private JScrollPane scrollPersonnelView;
     private JCheckBox chkGroupByUnit;
-    private RoundedJButton btnQuickTrain;
 
     private PersonnelTableModel personModel;
     private TableRowSorter<PersonnelTableModel> personnelSorter;
@@ -217,7 +218,8 @@ public final class PersonnelTab extends CampaignGuiTab {
         gridBagConstraints.insets = new Insets(5, 5, 0, 0);
         add(chkGroupByUnit, gridBagConstraints);
 
-        btnQuickTrain = new RoundedJButton(resourceMap.getString("btnQuickTrain.text"));
+        // Action buttons: Quick, and Mass training
+        RoundedJButton btnQuickTrain = new RoundedJButton(resourceMap.getString("btnQuickTrain.text"));
         btnQuickTrain.setToolTipText(resourceMap.getString("btnQuickTrain.toolTipText"));
         btnQuickTrain.addActionListener(e -> {
             List<Person> selectedPersons = getSelectedPersons();
@@ -235,15 +237,18 @@ public final class PersonnelTab extends CampaignGuiTab {
                       dialog.isContinuousTraining());
             }
         });
+        RoundedJButton btnMassTraining = new RoundedJButton(resourceMap.getString("btnMassTraining.text"));
+        btnMassTraining.setToolTipText(resourceMap.getString("btnMassTraining.toolTipText"));
+        btnMassTraining.addActionListener(e -> new BatchXPDialog(getFrame(), getCampaign()).setVisible(true));
+
+        // Group action buttons
+        JPanel panActions = new JPanel(new GridLayout(1, 2, 5, 0));
+        panActions.add(btnQuickTrain);
+        panActions.add(btnMassTraining);
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 5;
         gridBagConstraints.gridy = 0;
-        gridBagConstraints.fill = GridBagConstraints.NONE;
-        gridBagConstraints.weightx = 1.0;
-        gridBagConstraints.weighty = 0.0;
-        gridBagConstraints.anchor = GridBagConstraints.WEST;
-        gridBagConstraints.insets = new Insets(5, 5, 0, 0);
-        add(btnQuickTrain, gridBagConstraints);
+        add(panActions, gridBagConstraints);
 
         personModel = new PersonnelTableModel(getCampaign());
         personnelTable = new JTable(personModel);

--- a/MekHQ/src/mekhq/gui/WarehouseTab.java
+++ b/MekHQ/src/mekhq/gui/WarehouseTab.java
@@ -184,6 +184,9 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
         btnMassRepair.addActionListener(evt -> new MRMSDialog(getCampaignGui().getFrame(), true, getCampaignGui(),
               MRMSMode.WAREHOUSE).setVisible(true));
 
+        RoundedJButton btnPartsMarket = new RoundedJButton(resourceMap.getString("btnPartsMarket.manual"));
+        btnPartsMarket.addActionListener(e -> getCampaignGui().showPartsMarket());
+
         GridBagConstraints gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 0;
@@ -258,6 +261,16 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
         gridBagConstraints.insets = new Insets(5, 5, 5, 5);
         panSupplies.add(btnMassRepair, gridBagConstraints);
 
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 6;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.weightx = 1.0; // expand for layout padding
+        gridBagConstraints.weighty = 0.0;
+        gridBagConstraints.fill = GridBagConstraints.NONE;
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
+        gridBagConstraints.insets = new Insets(5, 5, 5, 5);
+        panSupplies.add(btnPartsMarket, gridBagConstraints);
+
         PartsInUseManager partsInUseManager = new PartsInUseManager(getCampaign());
         Set<PartInUse> partsInUse = partsInUseManager.getPartsInUse(true, false, QUALITY_A);
         partsModel = new PartsTableModel(partsInUse);
@@ -286,7 +299,7 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 1;
-        gridBagConstraints.gridwidth = 6;
+        gridBagConstraints.gridwidth = 7;
         gridBagConstraints.fill = GridBagConstraints.BOTH;
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.weighty = 1.0;

--- a/MekHQ/src/mekhq/gui/baseComponents/HorizontallyConstrainedPanel.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/HorizontallyConstrainedPanel.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package mekhq.gui.baseComponents;
+
+import java.awt.Dimension;
+import javax.swing.JPanel;
+
+/**
+ * A custom {@link JPanel} that enforces minimum and maximum width constraints.
+ * <p>
+ * This component is useful in flexible UI layouts (such as {@code BoxLayout}) where a panel's horizontal growth and
+ * shrinkage must be explicitly limited. It overrides the standard sizing methods to ensure the width always respects
+ * the specified {@code minWidth} and {@code maxWidth}, while allowing the height to scale dynamically based on the
+ * layout manager's calculations.
+ * </p>
+ */
+public class HorizontallyConstrainedPanel extends JPanel {
+    private final int minWidth;
+    private final int maxWidth;
+
+    public HorizontallyConstrainedPanel(int minWidth, int maxWidth) {
+        if (minWidth > maxWidth) {
+            throw new IllegalArgumentException("minWidth cannot be greater than maxWidth");
+        }
+        this.minWidth = minWidth;
+        this.maxWidth = maxWidth;
+    }
+
+    @Override
+    public Dimension getMinimumSize() {
+        return new Dimension(minWidth, super.getMinimumSize().height);
+    }
+
+    @Override
+    public Dimension getMaximumSize() {
+        return new Dimension(maxWidth, Integer.MAX_VALUE);
+    }
+
+    @Override
+    public Dimension getPreferredSize() {
+        return new Dimension(maxWidth, super.getPreferredSize().height);
+    }
+}

--- a/MekHQ/src/mekhq/gui/dialog/AdvanceDaysDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AdvanceDaysDialog.java
@@ -543,7 +543,7 @@ public class AdvanceDaysDialog extends AbstractMHQDialogBasic {
             getSpnDays().setValue(days);
         }
 
-        getGUI().refreshCalendar();
+        getGUI().refreshWindowTitle();
         getGUI().refreshAllTabs();
     }
 

--- a/MekHQ/src/mekhq/gui/view/AdvanceTimePanel.java
+++ b/MekHQ/src/mekhq/gui/view/AdvanceTimePanel.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package mekhq.gui.view;
+
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.Insets;
+import java.awt.event.KeyEvent;
+import java.time.LocalDate;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
+import javax.swing.SwingUtilities;
+
+import megamek.common.event.Subscribe;
+import mekhq.MekHQ;
+import mekhq.campaign.events.NewDayEvent;
+import mekhq.gui.CampaignGUI;
+import mekhq.gui.baseComponents.HorizontallyConstrainedPanel;
+import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
+import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
+import mekhq.utilities.MHQInternationalization;
+
+/**
+ * Provides UI controls for advancing the campaign timeline, shows the current date.
+ * <p>
+ * This panel subscribes to the global event bus updates to stay synchronized with the current date changes.
+ * </p>
+ */
+public class AdvanceTimePanel extends HorizontallyConstrainedPanel {
+
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.AdvanceTime";
+
+    private static final String ADVANCE_N_DAYS_ICON = "data/images/widgets/advance_n_days.png";
+    private static final String ADVANCE_DAY_ICON = "data/images/widgets/advance_day.png";
+
+    /**
+     * Constructs a new {@code AdvanceTimePanel}.
+     *
+     * @param minWidth               the minimum enforced width of the panel in pixels
+     * @param maxWidth               the maximum enforced width of the panel in pixels
+     * @param date                   the initial campaign date to display
+     * @param advanceDay             a {@link Runnable} that advances a single day
+     * @param openAdvanceNDaysDialog a {@link Runnable} that triggers the Advance Multiple Days dialog
+     */
+    public AdvanceTimePanel(int minWidth, int maxWidth, LocalDate date,
+          Runnable advanceDay, Runnable openAdvanceNDaysDialog) {
+        super(minWidth, maxWidth);
+
+        // Advance Multiple Days button
+
+        RoundedJButton btnAdvanceNDays = new RoundedJButton();
+        ImageIcon icon = new ImageIcon(ADVANCE_N_DAYS_ICON);
+        if (icon.getIconHeight() > 0) {
+            btnAdvanceNDays.setIcon(icon);
+        } else {
+            btnAdvanceNDays.setText("..."); // fallback to text if the icon file is missing or not yet merged
+        }
+        btnAdvanceNDays.setToolTipText(getTextAt("advanceNDays.toolTip"));
+        btnAdvanceNDays.addActionListener(e -> openAdvanceNDaysDialog.run());
+        int advanceNDaysWidth = icon.getIconWidth() + CampaignGUI.MEDIUM_GAP * 3;
+        int advanceNDaysHeight = icon.getIconHeight() + CampaignGUI.MEDIUM_GAP * 2;
+        btnAdvanceNDays.setMinimumSize(new Dimension(advanceNDaysWidth, advanceNDaysHeight));
+        btnAdvanceNDays.setMaximumSize(new Dimension(advanceNDaysWidth, Integer.MAX_VALUE));
+
+        // Advance Day button
+
+        RoundedJButton btnAdvanceDay = new RoundedJButton(getTextAt("advanceDay.label"));
+        btnAdvanceDay.setIcon(new ImageIcon(ADVANCE_DAY_ICON));
+        // This button uses a mnemonic that is unique and listed in the initMenu JavaDoc
+        btnAdvanceDay.setMnemonic(KeyEvent.VK_A);
+        btnAdvanceDay.setToolTipText(getTextAt("advanceDay.toolTip"));
+        btnAdvanceDay.setIconTextGap(CampaignGUI.MEDIUM_GAP);
+        btnAdvanceDay.addActionListener(evt -> {
+            // We disable the button here, as we don't want the user to be able to advance
+            // day  again, until after Advance Day has completed.
+            btnAdvanceDay.setEnabled(false);
+            btnAdvanceNDays.setEnabled(false);
+
+            SwingUtilities.invokeLater(() -> {
+                try {
+                    setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+                    advanceDay.run();
+                } finally {
+                    btnAdvanceDay.setEnabled(true);
+                    btnAdvanceNDays.setEnabled(true);
+                    setCursor(Cursor.getDefaultCursor());
+                }
+            });
+        });
+        btnAdvanceDay.setMnemonic(KeyEvent.VK_A);
+        Insets insets = RoundedLineBorder.createRoundedLineBorder().getBorderInsets(this);
+        int reservedStaticWidth = CampaignGUI.SMALL_GAP + advanceNDaysWidth + insets.left + insets.right;
+        btnAdvanceDay.setMinimumSize(new Dimension(minWidth - reservedStaticWidth, advanceNDaysHeight));
+        btnAdvanceDay.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
+
+        // Panel layout
+
+        setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
+        add(btnAdvanceDay);
+        add(Box.createHorizontalStrut(CampaignGUI.SMALL_GAP));
+        add(btnAdvanceNDays);
+
+        refresh(date);
+        MekHQ.registerHandler(this);
+    }
+
+    /**
+     * Updates the panel's border to display the current campaign date.
+     *
+     * @param date the new local date to display
+     */
+    private void refresh(LocalDate date) {
+        String formattedDate = MekHQ.getMHQOptions().getLongDisplayFormattedDate(date);
+        setBorder(RoundedLineBorder.createRoundedLineBorder(formattedDate));
+    }
+
+    /**
+     * Retrieves localized text from the panel's resource bundle.
+     */
+    private static String getTextAt(String key) {
+        return MHQInternationalization.getTextAt(RESOURCE_BUNDLE, key);
+    }
+
+    // ======================================
+    // Event handlers for UI synchronization
+    // ======================================
+
+    @Subscribe
+    public void handle(NewDayEvent event) {
+        refresh(event.getCampaign().getLocalDate());
+    }
+
+}

--- a/MekHQ/src/mekhq/gui/view/CommandSummaryPanel.java
+++ b/MekHQ/src/mekhq/gui/view/CommandSummaryPanel.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package mekhq.gui.view;
+
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import javax.swing.JLabel;
+
+import megamek.common.event.Subscribe;
+import mekhq.MekHQ;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.events.NewDayEvent;
+import mekhq.campaign.events.OptionsChangedEvent;
+import mekhq.campaign.events.assets.AssetEvent;
+import mekhq.campaign.events.loans.LoanEvent;
+import mekhq.campaign.events.transactions.TransactionEvent;
+import mekhq.campaign.mission.AtBDynamicScenarioFactory;
+import mekhq.campaign.personnel.skills.SkillType;
+import mekhq.gui.ActionScheduler;
+import mekhq.gui.CampaignGUI;
+import mekhq.gui.baseComponents.HorizontallyConstrainedPanel;
+import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
+import mekhq.utilities.MHQInternationalization;
+import mekhq.utilities.ReportingUtilities;
+
+/**
+ * Displays a command summary including current funds, unit reputation, experience rating, and the combat strength
+ * used for StratCon calculations.
+ * <p>
+ * This panel subscribes to the global event bus updates to stay synchronized with changes in the displayed stats.
+ * </p>
+ */
+public class CommandSummaryPanel extends HorizontallyConstrainedPanel {
+
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.CommandSummary";
+
+    private final JLabel lblFunds = new JLabel();
+    private final JLabel lblFundsValue = new JLabel();
+    private final JLabel lblUnitReputationValue = new JLabel();
+    private final JLabel lblCombatStrengthValue = new JLabel();
+
+    /**
+     * Scheduler used to debounce funds refreshing. Multiple rapid financial events will collapse
+     * into a single UI update.
+     */
+    private final ActionScheduler refreshFundsScheduler = new ActionScheduler(this::refreshFunds);
+
+    private final Campaign campaign;
+
+    /**
+     * Constructs a new {@code CommandSummaryPanel}.
+     *
+     * @param minWidth the minimum enforced width of the panel in pixels
+     * @param maxWidth the maximum enforced width of the panel in pixels
+     * @param campaign the active {@link Campaign} to pull statistics from
+     */
+    public CommandSummaryPanel(int minWidth, int maxWidth, Campaign campaign) {
+        super(minWidth, maxWidth);
+        this.campaign = campaign;
+
+        setBorder(RoundedLineBorder.createRoundedLineBorder(getTextAt("panel.title")));
+        setLayout(new GridBagLayout());
+        GridBagConstraints gridBagConstraints = new GridBagConstraints();
+
+        // Column 0: static labels
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
+
+        add(lblFunds, gridBagConstraints);
+        gridBagConstraints.gridy++;
+        add(new JLabel(getTextAt("reputation.label")), gridBagConstraints);
+        gridBagConstraints.gridy++;
+        add(new JLabel(getTextAt("combatStrength.label")), gridBagConstraints);
+
+        // Column 1: dynamic data values
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.weightx = 1;
+        gridBagConstraints.insets = new Insets(0, CampaignGUI.MEDIUM_GAP, 0, 0);
+
+        add(lblFundsValue, gridBagConstraints);
+        gridBagConstraints.gridy++;
+        add(lblUnitReputationValue, gridBagConstraints);
+        gridBagConstraints.gridy++;
+        add(lblCombatStrengthValue, gridBagConstraints);
+
+        refreshAll();
+        MekHQ.registerHandler(this);
+    }
+
+    /**
+     * Fully recalculates and updates all metrics on the panel.
+     */
+    private void refreshAll() {
+        String experience = SkillType.getColoredExperienceLevelName(campaign.getReputation().getAverageSkillLevel());
+        lblUnitReputationValue.setText(getFormattedTextAt("reputation.text", campaign.getUnitRatingText(), experience));
+        int totalBv = AtBDynamicScenarioFactory.getBVBudgetForStratConSingles(campaign, true);
+        lblCombatStrengthValue.setText(getFormattedTextAt("combatStrength.text", totalBv));
+        refreshFunds();
+    }
+
+    /**
+     * Refreshes only the funds label. Checks if the unit holds any active loans and
+     * alters the formatting accordingly.
+     */
+    private void refreshFunds() {
+        String amount = campaign.getFunds().toAmountString();
+        lblFundsValue.setText(getFormattedTextAt("funds.text", amount));
+        if (campaign.getFinances().isInDebt()) {
+            lblFunds.setText(getFormattedTextAt("funds.label.hasLoan", ReportingUtilities.getNegativeColor()));
+        } else  {
+            lblFunds.setText(getTextAt("funds.label.noLoan"));
+        }
+    }
+
+    /**
+    * Retrieves and formats localized text from the panel's resource bundle.
+    */
+    private static String getFormattedTextAt(String key, Object... args) {
+        return MHQInternationalization.getFormattedTextAt(RESOURCE_BUNDLE, key, args);
+    }
+
+    /**
+     * Retrieves localized text from the panel's resource bundle.
+     */
+    private static String getTextAt(String key) {
+        return MHQInternationalization.getTextAt(RESOURCE_BUNDLE, key);
+    }
+
+    // ======================================
+    // Event handlers for UI synchronization
+    // ======================================
+
+    @Subscribe
+    public void handle(NewDayEvent event) {
+        refreshAll();
+    }
+
+    @Subscribe
+    public void handle(final OptionsChangedEvent event) {
+        refreshAll();
+    }
+
+    @Subscribe
+    public void handle(TransactionEvent event) {
+        refreshFundsScheduler.schedule();
+    }
+
+    @Subscribe
+    public void handle(LoanEvent event) {
+        refreshFundsScheduler.schedule();
+    }
+
+    @Subscribe
+    public void handle(AssetEvent event) {
+        refreshFundsScheduler.schedule();
+    }
+
+}

--- a/MekHQ/src/mekhq/gui/view/CurrentLocationPanel.java
+++ b/MekHQ/src/mekhq/gui/view/CurrentLocationPanel.java
@@ -45,7 +45,6 @@ import java.awt.Insets;
 import java.io.File;
 import java.time.LocalDate;
 import javax.swing.JLabel;
-import javax.swing.JPanel;
 import javax.swing.UIManager;
 
 import megamek.common.Configuration;
@@ -63,11 +62,13 @@ import mekhq.campaign.mission.TransportCostCalculations;
 import mekhq.campaign.universe.Atmosphere;
 import mekhq.campaign.universe.Planet;
 import mekhq.campaign.universe.PlanetarySystem;
-import mekhq.campaign.universe.PlanetarySystem.PlanetarySophistication;
 import mekhq.campaign.universe.PlanetarySystem.PlanetaryRating;
+import mekhq.campaign.universe.PlanetarySystem.PlanetarySophistication;
 import mekhq.campaign.universe.SocioIndustrialData;
 import mekhq.campaign.universe.StarUtil;
 import mekhq.campaign.universe.enums.HiringHallLevel;
+import mekhq.gui.CampaignGUI;
+import mekhq.gui.baseComponents.HorizontallyConstrainedPanel;
 import mekhq.gui.baseComponents.VerticalFillImage;
 import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
 import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
@@ -78,15 +79,17 @@ import org.apache.commons.lang3.StringUtils;
 /**
  * A UI panel that displays the current location details.
  * <p>
- * Visually represents whether the player is currently on a planet, in transit, or at a jump point,
- * provides relevant planetary statistics (e.g. atmosphere, gravity, socio-industrial data) or
- * travel progress, and includes an entry point to the Recruitment Dialog.
+ * Visually represents whether the player is currently on a planet, in transit, or at a jump point, provides relevant
+ * planetary statistics (e.g. atmosphere, gravity, socio-industrial data) or travel progress, and includes an entry
+ * point to the personnel market.
+ * </p>
+ * <p>
+ * This panel subscribes to the global event bus updates to stay synchronized with changes in the campaign's current
+ * location and transit status.
  * </p>
  */
-public class CurrentLocationPanel extends JPanel {
+public class CurrentLocationPanel extends HorizontallyConstrainedPanel {
 
-    private static final int THIN_GAP = 2;
-    private static final int MEDIUM_GAP = 8;
     private static final File JUMP_SHIP_IMAGE = new File(Configuration.unitImagesDir(), "jumpships/invader.png");
 
     private final Campaign campaign;
@@ -98,18 +101,20 @@ public class CurrentLocationPanel extends JPanel {
     private final RoundedJButton btnHiringHall = new RoundedJButton();
 
     /**
-     * Constructs a new CurrentLocationPanel.
+     * Constructs a new {@code CurrentLocationPanel}.
      *
+     * @param minWidth              the minimum enforced width of the panel in pixels
+     * @param maxWidth              the maximum enforced width of the panel in pixels
      * @param campaign              the active {@link Campaign} instance
-     * @param openRecruitmentDialog a {@link Runnable} that triggers the opening of the Recruitment UI
+     * @param openRecruitmentDialog a {@link Runnable} that triggers the opening of the Recruitment Dialog UI
      */
-    public CurrentLocationPanel(Campaign campaign, Runnable openRecruitmentDialog) {
-        super();
+    public CurrentLocationPanel(int minWidth, int maxWidth, Campaign campaign, Runnable openRecruitmentDialog) {
+        super(minWidth, maxWidth);
         this.campaign = campaign;
 
         setLayout(new GridBagLayout());
         GridBagConstraints gridBagConstraints = new GridBagConstraints();
-        gridBagConstraints.insets = new Insets(0, THIN_GAP, 0, MEDIUM_GAP);
+        gridBagConstraints.insets = new Insets(0, CampaignGUI.THIN_GAP, 0, CampaignGUI.MEDIUM_GAP);
 
         imgLocation.setMaxHeight(60);
         gridBagConstraints.gridx = 0;
@@ -124,6 +129,7 @@ public class CurrentLocationPanel extends JPanel {
         gridBagConstraints.weightx = 1;
         gridBagConstraints.weighty = 0;
         gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.insets = new Insets(0, 0, 0, CampaignGUI.SMALL_GAP);
         add(lblLocationPrimaryInfo, gridBagConstraints);
 
         gridBagConstraints.gridy++;
@@ -420,15 +426,17 @@ public class CurrentLocationPanel extends JPanel {
         return MHQOptions.convertFontColorToHexColor(color == null ? Color.WHITE : color);
     }
 
-    // Handle current location and travel status change events
+    // ======================================
+    // Event handlers for UI synchronization
+    // ======================================
 
     @Subscribe
-    public void handleLocationChanged(LocationChangedEvent e) {
+    public void handle(LocationChangedEvent event) {
         refresh();
     }
 
     @Subscribe
-    public void handleTransitStatusChanged(TransitStatusChangedEvent e) {
+    public void handle(TransitStatusChangedEvent event) {
         refresh();
     }
 


### PR DESCRIPTION
- Improved the top bar's adaptability to different window sizes
- Enforced a minimum window size for the `CampaignGUI`
- The "Company Generator" button is now dynamically hidden and will only appear when both the hangar and personnel lists are empty
- Modularized the top bar by introducing the `AdvanceTimePanel` (displaying the current date and Advance Day buttons) and the `CommandSummaryPanel` (displaying funds, unit rating, and combat force)
- Moved the "Change Faction" button under the player faction icon
- Moved the "Purchase Parts" button from the top bar to the Procurement panel within the CommandCenterTab, as well as to the Warehouse tab
- Moved the "Mass Personnel Training" button to the Personnel Tab
- Moved the "Allow Overtime" toggle down into the status bar
- Simplified UI initialization and update logic within `CampaignGUI`
- Introduced shared layout gap size constants in `CampaignGUI`

Important: this PR uses two icons that will be placed in the data project, but it can be safely merged without them because missing icon case is gracefully handles.

Before:
<img width="1400" height="755" alt="Before" src="https://github.com/user-attachments/assets/6a38d3a7-2d23-4acc-a465-afcaa7f7990e" />

After:
<img width="1377" height="749" alt="After" src="https://github.com/user-attachments/assets/099fe77e-cb76-4f23-9300-ed4e157ce571" />
