### PR TITLE
Implement dynamic GUI scaling for the Campaign Window and Top Panel

### DIFF
--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -136,7 +136,7 @@ import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.NewsItem;
 import mekhq.campaign.universe.Systems;
 import mekhq.campaign.utilities.AutomatedTechAssignments;
-import mekhq.gui.baseComponents.HorizontallyConstrainedPanel;
+import mekhq.gui.baseComponents.ScalingWidthConstrainedPanel;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
 import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
 import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
@@ -363,18 +363,16 @@ public class CampaignGUI extends JPanel {
         refreshTempVesselCrew();
         refreshPartsAvailability();
 
-        Dimension dim = Toolkit.getDefaultToolkit().getScreenSize();
+        Dimension screenSize = getUsableScreenSize();
 
-        frame.setSize(Math.min(MAX_START_WIDTH, dim.width), Math.min(MAX_START_HEIGHT, dim.height));
-        frame.setMinimumSize(new Dimension(MIN_WINDOW_WIDTH, MIN_WINDOW_HEIGHT));
-        pnlTop.setMinimumSize(new Dimension(MIN_WINDOW_WIDTH, TOP_PANEL_HEIGHT));
-        pnlTop.setMaximumSize(new Dimension(Integer.MAX_VALUE, TOP_PANEL_HEIGHT));
+        frame.setSize(Math.min(MAX_START_WIDTH, screenSize.width), Math.min(MAX_START_HEIGHT, screenSize.height));
+        refreshGuiScale();
 
         // Determine the new location of the window
         int w = frame.getSize().width;
         int h = frame.getSize().height;
-        int x = (dim.width - w) / 2;
-        int y = (dim.height - h) / 2;
+        int x = (screenSize.width - w) / 2;
+        int y = (screenSize.height - h) / 2;
 
         // Move the window
         frame.setLocation(x, y);
@@ -1334,7 +1332,8 @@ public class CampaignGUI extends JPanel {
         pnlTop = new JPanel();
         pnlTop.setLayout(new BoxLayout(pnlTop, BoxLayout.X_AXIS));
 
-        pnlTop.add(new CurrentLocationPanel(365, 420, getCampaign(), this::openRecruitmentDialog));
+        pnlTop.add(new CurrentLocationPanel(365, 420, TOP_PANEL_HEIGHT - 30,
+              getCampaign(), this::openRecruitmentDialog));
         pnlTop.add(createMarketsPanel(95, 130));
         pnlTop.add(new CommandSummaryPanel(250, 280, getCampaign()));
         pnlTop.add(Box.createHorizontalGlue());
@@ -1344,7 +1343,7 @@ public class CampaignGUI extends JPanel {
     }
 
     private JPanel createMarketsPanel(int minWidth, int maxWidth) {
-        JPanel pnlMarkets = new HorizontallyConstrainedPanel(minWidth, maxWidth);
+        JPanel pnlMarkets = new ScalingWidthConstrainedPanel(minWidth, maxWidth);
         pnlMarkets.setLayout(new GridBagLayout());
         pnlMarkets.setBorder(RoundedLineBorder.createRoundedLineBorder(resourceMap.getString("lblMarkets.title")));
 
@@ -1384,7 +1383,7 @@ public class CampaignGUI extends JPanel {
     }
 
     private JPanel createCampaignControlPanel(int minWidth, int maxWidth) {
-        JPanel pnlButton = new HorizontallyConstrainedPanel(minWidth, maxWidth);
+        JPanel pnlButton = new ScalingWidthConstrainedPanel(minWidth, maxWidth);
         pnlButton.setLayout(new GridBagLayout());
         GridBagConstraints gridBagConstraints = new GridBagConstraints();
 
@@ -1577,6 +1576,24 @@ public class CampaignGUI extends JPanel {
                 miPlaf.addActionListener(this::changeTheme);
             }
         }
+    }
+
+    private void refreshGuiScale() {
+        Dimension screenSize = getUsableScreenSize();
+        int minWidth = Math.min(UIUtil.scaleForGUI(MIN_WINDOW_WIDTH), screenSize.width);
+        int minHeight = Math.min(UIUtil.scaleForGUI(MIN_WINDOW_HEIGHT), screenSize.height);
+        frame.setMinimumSize(new Dimension(minWidth, minHeight));
+        pnlTop.setMinimumSize(new Dimension(minWidth, UIUtil.scaleForGUI(TOP_PANEL_HEIGHT)));
+        pnlTop.setMaximumSize(new Dimension(Integer.MAX_VALUE, UIUtil.scaleForGUI(TOP_PANEL_HEIGHT)));
+    }
+
+    private static Dimension getUsableScreenSize() {
+        GraphicsDevice gd = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice();
+        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+        Insets screenInsets = Toolkit.getDefaultToolkit().getScreenInsets(gd.getDefaultConfiguration());
+        int usableScreenWidth = screenSize.width - screenInsets.left - screenInsets.right;
+        int usableScreenHeight = screenSize.height - screenInsets.top - screenInsets.bottom;
+        return new Dimension(usableScreenWidth, usableScreenHeight);
     }
 
     public void focusOnUnit(UUID id) {
@@ -3682,7 +3699,10 @@ public class CampaignGUI extends JPanel {
     /**
      * Handles changes to general application options.
      *
-     * <p>Updates the visibility of the company generator menu item according to the new option settings.</p>
+     * <p>
+     * Updates the visibility of the company generator menu item according to the new option settings.
+     * Ensures that GUI scale changes are applied.
+     * </p>
      *
      * <p><b>Important:</b> This method is not directly evoked, so IDEA will tell you it has no uses. IDEA is
      * wrong.</p>
@@ -3692,6 +3712,7 @@ public class CampaignGUI extends JPanel {
     @Subscribe
     public void handle(final MHQOptionsChangedEvent mhqOptionsChangedEvent) {
         miCompanyGenerator.setVisible(MekHQ.getMHQOptions().getShowCompanyGenerator());
+        refreshGuiScale();
     }
     // endregion Subscriptions
 }

--- a/MekHQ/src/mekhq/gui/baseComponents/ScalingVerticalFillImage.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/ScalingVerticalFillImage.java
@@ -44,31 +44,36 @@ import java.io.File;
 import java.util.Objects;
 import javax.swing.JComponent;
 
+import megamek.client.ui.clientGUI.GUIPreferences;
+import megamek.client.ui.util.UIUtil;
 import megamek.common.util.ImageUtil;
 
 /**
  * Displays an image that fills the available vertical space up to a specified maximum height,
- * while preserving its original aspect ratio. Includes a ratcheting minimum size mechanism:
- * as the component is resized larger, its minimum size increases (up to the maximum height),
- * preventing it from being shrunk back past its largest realized size. Also supports an internal
- * scaling factor to zoom the image during rendering.
+ * while preserving its original aspect ratio. This maximum height is automatically multiplied by the
+ * {@link GUIPreferences#GUI_SCALE} setting.
+ * <p>
+ * Includes a ratcheting minimum size mechanism: as the component is resized larger, its minimum size
+ * increases (up to the maximum height), preventing it from being shrunk back past its largest realized size.
+ * Also supports an internal scaling factor to zoom the image during rendering.
+ * </p>
  */
-public class VerticalFillImage extends JComponent {
+public class ScalingVerticalFillImage extends JComponent {
 
-    // minimum height allowed
+    /** Minimum height allowed */
     private static final int MIN_HEIGHT = 20;
-    // maximum height allowed
+    /** Maximum height allowed, before GUI scaling */
     private int maxHeight;
-    // minimum height that grows as the component is resized
+    /** Minimum height that grows as the component is resized */
     private int ratchetedHeight = MIN_HEIGHT;
 
-    // caches the current file path to prevent redundant image loading
+    /** Caches the current file path to prevent redundant image loading */
     private String filePath;
-    // image to be rendered, corresponds to filePath
+    /** Image to be rendered, corresponds to filePath */
     private Image image;
-    // image's width-to-height ratio
+    /** Image's width-to-height ratio */
     private float aspectRatio = 1.0f;
-    // scaling factor applied to the image during rendering, does not affect the component size
+    /** Scaling factor applied to the image during rendering, does not affect the component size */
     private float scale = 1.0f;
 
     /**
@@ -77,7 +82,7 @@ public class VerticalFillImage extends JComponent {
     private final ComponentAdapter resizeListener = new ComponentAdapter() {
         @Override
         public void componentResized(ComponentEvent e) {
-            int newHeight = Math.min(getHeight(), maxHeight);
+            int newHeight = Math.min(getHeight(), getScaledMaxHeight());
             int delta = newHeight - ratchetedHeight;
             if (delta <= 0) {
                 return;
@@ -86,7 +91,7 @@ public class VerticalFillImage extends JComponent {
         }
     };
 
-    public VerticalFillImage() {
+    public ScalingVerticalFillImage() {
         super();
         setOpaque(true);
     }
@@ -141,8 +146,8 @@ public class VerticalFillImage extends JComponent {
         if (maxHeight <= 0) {
             throw new IllegalArgumentException("maxHeight <= 0");
         }
-        this.maxHeight = Math.max(maxHeight, MIN_HEIGHT);
-        ratchetedHeight = Math.min(this.maxHeight, ratchetedHeight);
+        this.maxHeight = maxHeight;
+        ratchetedHeight = Math.min(getScaledMaxHeight(), ratchetedHeight);
     }
 
     @Override
@@ -150,9 +155,7 @@ public class VerticalFillImage extends JComponent {
         if (image == null) {
             return new Dimension(0, 0);
         }
-        int h = maxHeight; // prefer max size
-        int w = (int) (h * aspectRatio);
-        return new Dimension(w, h);
+        return getMaximumSize(); // prefer max size
     }
 
     @Override
@@ -165,7 +168,12 @@ public class VerticalFillImage extends JComponent {
 
     @Override
     public Dimension getMaximumSize() {
-        return new Dimension((int) (maxHeight * aspectRatio), maxHeight);
+        int h = getScaledMaxHeight();
+        return new Dimension((int) (h * aspectRatio), h);
+    }
+
+    private int getScaledMaxHeight() {
+        return Math.max(MIN_HEIGHT, UIUtil.scaleForGUI(maxHeight));
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/baseComponents/ScalingVerticalFillImage.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/ScalingVerticalFillImage.java
@@ -125,10 +125,10 @@ public class ScalingVerticalFillImage extends JComponent {
             this.filePath = filePath;
             image = ImageUtil.loadImageFromFile(filePath);
             if (image != null) {
-                int w = image.getWidth(null);
-                int h = image.getHeight(null);
-                if (w > 0 && h > 0) {
-                    aspectRatio = (float) w / h;
+                int width = image.getWidth(null);
+                int height = image.getHeight(null);
+                if (width > 0 && height > 0) {
+                    aspectRatio = (float) width / height;
                 }
             }
         }
@@ -168,8 +168,8 @@ public class ScalingVerticalFillImage extends JComponent {
 
     @Override
     public Dimension getMaximumSize() {
-        int h = getScaledMaxHeight();
-        return new Dimension((int) (h * aspectRatio), h);
+        int height = getScaledMaxHeight();
+        return new Dimension((int) (height * aspectRatio), height);
     }
 
     private int getScaledMaxHeight() {

--- a/MekHQ/src/mekhq/gui/baseComponents/ScalingWidthConstrainedPanel.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/ScalingWidthConstrainedPanel.java
@@ -36,20 +36,27 @@ package mekhq.gui.baseComponents;
 import java.awt.Dimension;
 import javax.swing.JPanel;
 
+import megamek.client.ui.clientGUI.GUIPreferences;
+import megamek.client.ui.util.UIUtil;
+
 /**
- * A custom {@link JPanel} that enforces minimum and maximum width constraints.
+ * A custom {@link JPanel} that enforces minimum and maximum width constraints and respects the GUI scale setting.
  * <p>
  * This component is useful in flexible UI layouts (such as {@code BoxLayout}) where a panel's horizontal growth and
  * shrinkage must be explicitly limited. It overrides the standard sizing methods to ensure the width always respects
- * the specified {@code minWidth} and {@code maxWidth}, while allowing the height to scale dynamically based on the
- * layout manager's calculations.
+ * the specified {@code minWidth} and {@code maxWidth}. These constraints are automatically multiplied by the
+ * {@link GUIPreferences#GUI_SCALE}, while allowing the height to scale dynamically based on the layout manager's
+ * calculations.
  * </p>
  */
-public class HorizontallyConstrainedPanel extends JPanel {
+public class ScalingWidthConstrainedPanel extends JPanel {
+
+    /** Minimum panel width allowed, before GUI scaling */
     private final int minWidth;
+    /** Maximum width allowed, before GUI scaling */
     private final int maxWidth;
 
-    public HorizontallyConstrainedPanel(int minWidth, int maxWidth) {
+    public ScalingWidthConstrainedPanel(int minWidth, int maxWidth) {
         if (minWidth > maxWidth) {
             throw new IllegalArgumentException("minWidth cannot be greater than maxWidth");
         }
@@ -59,16 +66,16 @@ public class HorizontallyConstrainedPanel extends JPanel {
 
     @Override
     public Dimension getMinimumSize() {
-        return new Dimension(minWidth, super.getMinimumSize().height);
+        return new Dimension(UIUtil.scaleForGUI(minWidth), super.getMinimumSize().height);
     }
 
     @Override
     public Dimension getMaximumSize() {
-        return new Dimension(maxWidth, Integer.MAX_VALUE);
+        return new Dimension(UIUtil.scaleForGUI(maxWidth), Integer.MAX_VALUE);
     }
 
     @Override
     public Dimension getPreferredSize() {
-        return new Dimension(maxWidth, super.getPreferredSize().height);
+        return new Dimension(UIUtil.scaleForGUI(maxWidth), super.getPreferredSize().height);
     }
 }

--- a/MekHQ/src/mekhq/gui/view/AdvanceTimePanel.java
+++ b/MekHQ/src/mekhq/gui/view/AdvanceTimePanel.java
@@ -38,16 +38,19 @@ import java.awt.Dimension;
 import java.awt.Insets;
 import java.awt.event.KeyEvent;
 import java.time.LocalDate;
+import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
 import javax.swing.SwingUtilities;
+import javax.swing.border.Border;
+import javax.swing.border.TitledBorder;
 
 import megamek.common.event.Subscribe;
 import mekhq.MekHQ;
 import mekhq.campaign.events.NewDayEvent;
 import mekhq.gui.CampaignGUI;
-import mekhq.gui.baseComponents.HorizontallyConstrainedPanel;
+import mekhq.gui.baseComponents.ScalingWidthConstrainedPanel;
 import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
 import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
 import mekhq.utilities.MHQInternationalization;
@@ -58,7 +61,7 @@ import mekhq.utilities.MHQInternationalization;
  * This panel subscribes to the global event bus updates to stay synchronized with the current date changes.
  * </p>
  */
-public class AdvanceTimePanel extends HorizontallyConstrainedPanel {
+public class AdvanceTimePanel extends ScalingWidthConstrainedPanel {
 
     private static final String RESOURCE_BUNDLE = "mekhq.resources.AdvanceTime";
 
@@ -143,7 +146,9 @@ public class AdvanceTimePanel extends HorizontallyConstrainedPanel {
      */
     private void refresh(LocalDate date) {
         String formattedDate = MekHQ.getMHQOptions().getLongDisplayFormattedDate(date);
-        setBorder(RoundedLineBorder.createRoundedLineBorder(formattedDate));
+        Border innerPadding = BorderFactory.createEmptyBorder(CampaignGUI.THIN_GAP, 0, 0, 0);
+        TitledBorder rounded = RoundedLineBorder.createRoundedLineBorder(formattedDate);
+        setBorder(BorderFactory.createCompoundBorder(rounded, innerPadding));
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/view/CommandSummaryPanel.java
+++ b/MekHQ/src/mekhq/gui/view/CommandSummaryPanel.java
@@ -50,7 +50,7 @@ import mekhq.campaign.mission.AtBDynamicScenarioFactory;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.gui.ActionScheduler;
 import mekhq.gui.CampaignGUI;
-import mekhq.gui.baseComponents.HorizontallyConstrainedPanel;
+import mekhq.gui.baseComponents.ScalingWidthConstrainedPanel;
 import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
 import mekhq.utilities.MHQInternationalization;
 import mekhq.utilities.ReportingUtilities;
@@ -62,7 +62,7 @@ import mekhq.utilities.ReportingUtilities;
  * This panel subscribes to the global event bus updates to stay synchronized with changes in the displayed stats.
  * </p>
  */
-public class CommandSummaryPanel extends HorizontallyConstrainedPanel {
+public class CommandSummaryPanel extends ScalingWidthConstrainedPanel {
 
     private static final String RESOURCE_BUNDLE = "mekhq.resources.CommandSummary";
 

--- a/MekHQ/src/mekhq/gui/view/CurrentLocationPanel.java
+++ b/MekHQ/src/mekhq/gui/view/CurrentLocationPanel.java
@@ -68,8 +68,8 @@ import mekhq.campaign.universe.SocioIndustrialData;
 import mekhq.campaign.universe.StarUtil;
 import mekhq.campaign.universe.enums.HiringHallLevel;
 import mekhq.gui.CampaignGUI;
-import mekhq.gui.baseComponents.HorizontallyConstrainedPanel;
-import mekhq.gui.baseComponents.VerticalFillImage;
+import mekhq.gui.baseComponents.ScalingWidthConstrainedPanel;
+import mekhq.gui.baseComponents.ScalingVerticalFillImage;
 import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
 import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
 import mekhq.utilities.ReportingUtilities;
@@ -88,14 +88,14 @@ import org.apache.commons.lang3.StringUtils;
  * location and transit status.
  * </p>
  */
-public class CurrentLocationPanel extends HorizontallyConstrainedPanel {
+public class CurrentLocationPanel extends ScalingWidthConstrainedPanel {
 
     private static final File JUMP_SHIP_IMAGE = new File(Configuration.unitImagesDir(), "jumpships/invader.png");
 
     private final Campaign campaign;
 
     // UI components
-    private final VerticalFillImage imgLocation = new VerticalFillImage();
+    private final ScalingVerticalFillImage imgLocation = new ScalingVerticalFillImage();
     private final JLabel lblLocationPrimaryInfo = new JLabel();
     private final JLabel lblLocationSecondaryInfo = new JLabel();
     private final RoundedJButton btnHiringHall = new RoundedJButton();
@@ -105,10 +105,12 @@ public class CurrentLocationPanel extends HorizontallyConstrainedPanel {
      *
      * @param minWidth              the minimum enforced width of the panel in pixels
      * @param maxWidth              the maximum enforced width of the panel in pixels
+     * @param iconMaxHeight         the maximum enforced height of the location image in pixels
      * @param campaign              the active {@link Campaign} instance
      * @param openRecruitmentDialog a {@link Runnable} that triggers the opening of the Recruitment Dialog UI
      */
-    public CurrentLocationPanel(int minWidth, int maxWidth, Campaign campaign, Runnable openRecruitmentDialog) {
+    public CurrentLocationPanel(int minWidth, int maxWidth, int iconMaxHeight,
+          Campaign campaign, Runnable openRecruitmentDialog) {
         super(minWidth, maxWidth);
         this.campaign = campaign;
 
@@ -116,7 +118,7 @@ public class CurrentLocationPanel extends HorizontallyConstrainedPanel {
         GridBagConstraints gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.insets = new Insets(0, CampaignGUI.THIN_GAP, 0, CampaignGUI.MEDIUM_GAP);
 
-        imgLocation.setMaxHeight(60);
+        imgLocation.setMaxHeight(iconMaxHeight);
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 0;
         gridBagConstraints.gridheight = 4;


### PR DESCRIPTION
Includes the following changes:
- Add GUI scaling support in `HorizontallyConstrainedPanel` and rename it to `ScalingWidthConstrainedPanel`
- Add GUI scaling support in `VerticalFillImage` and rename it to `ScalingVerticalFillImage`
- Update the `CurrentLocationPanel` to accept `iconMaxHeight` instead of using a hardcoded value
- Introduce `refreshGuiScale()` method in `CampaignGUI` that applies GUI scaling to the Campaign Window and Top Bar
- Improve the documentation

I recommend opening the following screenshots in a separate tab and setting 100% scale before comparing.

Before (70% scale):
<img width="1022" height="739" alt="Before_70" src="https://github.com/user-attachments/assets/ea7b8616-56b4-4b8d-89f9-45edda2a4340" />

After (70% scale):
<img width="845" height="502" alt="After_70" src="https://github.com/user-attachments/assets/a1e1d6f6-1cb4-4ec2-94f1-189067d0645e" />

Before (160% scale):
<img width="1684" height="1052" alt="Before_160" src="https://github.com/user-attachments/assets/bb987706-7c81-481a-a2d0-faeb21cea128" />

After (160% scale):
<img width="1636" height="1051" alt="After_160" src="https://github.com/user-attachments/assets/8d655fec-9496-4ee3-83b0-86078202a009" />
