### PR TITLE
Close #9008: Updated Training Combat Formations to Use Skill Milestones Instead of Skill Levels

### DIFF
--- a/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
+++ b/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
@@ -1526,7 +1526,7 @@ TRAINING_COMBAT_TEAMS.definition=Training <a href='GLOSSARY:COMBAT_TEAMS'>Combat
   <p>There are some restrictions on what can be taught. Only profession and scouting skills can be taught. New skills\
   \ cannot be trained, so the character must at least possess the skill before it can be improved. Furthermore, the \
   maximum that a skill can be improved to is to Regular, or the highest experience milestone an educator has in that \
-  skill  minus 1, whichever is lowest.</p>\
+  skill minus 1, whichever is lowest.</p>\
   <p>It's important to note that while educator skill level factors in all relevant modifiers, trainee skill level \
   (the level improved) only factors in the raw level of the skill (ignoring all modifiers). This represents all \
   characters receiving the same level of education regardless of individual talents.</p>\

--- a/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
+++ b/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
@@ -1525,8 +1525,8 @@ TRAINING_COMBAT_TEAMS.definition=Training <a href='GLOSSARY:COMBAT_TEAMS'>Combat
   commander) are referred to as the formation 'Educators.'</p>\
   <p>There are some restrictions on what can be taught. Only profession and scouting skills can be taught. New skills\
   \ cannot be trained, so the character must at least possess the skill before it can be improved. Furthermore, the \
-  maximum level that a skill can be improved to is 3, or the highest level an educator has in that skill minus 1, \
-  whichever is lowest.</p>\
+  maximum that a skill can be improved to is to Regular, or the highest experience milestone an educator has in that \
+  skill  minus 1, whichever is lowest.</p>\
   <p>It's important to note that while educator skill level factors in all relevant modifiers, trainee skill level \
   (the level improved) only factors in the raw level of the skill (ignoring all modifiers). This represents all \
   characters receiving the same level of education regardless of individual talents.</p>\

--- a/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
@@ -68,6 +68,7 @@ import mekhq.campaign.personnel.skills.ScoutingSkills;
 import mekhq.campaign.personnel.skills.Skill;
 import mekhq.campaign.personnel.skills.SkillCheckUtility;
 import mekhq.campaign.personnel.skills.SkillModifierData;
+import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.personnel.skills.enums.MarginOfSuccess;
 import mekhq.campaign.stratCon.StratConCampaignState;
 import mekhq.campaign.unit.Unit;
@@ -104,6 +105,8 @@ public class TrainingCombatTeams {
     @Deprecated(since = "0.50.10")
     private static final ResourceBundle resources = ResourceBundle.getBundle(RESOURCE_BUNDLE,
           MekHQ.getMHQOptions().getLocale());
+
+    private static final int EXPERIENCE_LEVEL_REDUCTION = -1;
 
     /**
      * Processes all training combat teams in the campaign.
@@ -254,13 +257,15 @@ public class TrainingCombatTeams {
                     Skill traineeSkill = trainee.getSkill(commanderSkill);
 
                     if (traineeSkill != null) {
+                        SkillType skillType = traineeSkill.getType();
+                        int targetLevel = skillType.getRegularLevel();
+
                         int traineeSkillLevel = traineeSkill.getLevel();
-                        if (traineeSkillLevel > 3) {
+                        if (traineeSkillLevel >= targetLevel) {
                             continue;
                         }
 
-                        // The commander is required to be one step above the skill level they are teaching.
-                        if (traineeSkillLevel < (educatorSkills.get(commanderSkill) - 1)) {
+                        if (traineeSkillLevel < educatorSkills.get(commanderSkill)) {
                             skillsBeingTrained.add(traineeSkill);
                         }
                     }
@@ -358,7 +363,7 @@ public class TrainingCombatTeams {
         skillsBeingTrained.sort(Comparator.comparingInt(Skill::getLevel));
         Skill targetSkill = skillsBeingTrained.getFirst();
 
-        // The +1 is to account for the next experience level to be gained
+        // The +1 is to account for the next skill level to be gained
         int targetSkillLevel = targetSkill.getLevel() + 1;
 
         // Reasoning cost changes should always take place before global changes
@@ -478,7 +483,8 @@ public class TrainingCombatTeams {
                 Skill skill = educator.getSkill(professionSkill);
 
                 if (skill != null) {
-                    educatorSkills.merge(professionSkill, skill.getTotalSkillLevel(skillModifierData), Math::max);
+                    int experienceLevel = skill.getExperienceLevel(skillModifierData) + EXPERIENCE_LEVEL_REDUCTION;
+                    educatorSkills.merge(professionSkill, experienceLevel, Math::max);
                 }
             }
         }

--- a/MekHQ/src/mekhq/campaign/utilities/glossary/GlossaryEntry.java
+++ b/MekHQ/src/mekhq/campaign/utilities/glossary/GlossaryEntry.java
@@ -148,7 +148,7 @@ public enum GlossaryEntry {
     TECH_TIME("TECH_TIME", new Version("0.50.06")),
     TEMP_PERSONNEL("TEMP_PERSONNEL", new Version("0.50.06")),
     TOE("TOE", new Version("0.50.06")),
-        ("TRAINING_COMBAT_TEAMS", new Version("0.50.10")),
+    TRAINING_COMBAT_TEAMS("TRAINING_COMBAT_TEAMS", new Version("0.50.10")),
     TURNING_POINTS("TURNING_POINTS", new Version("0.50.06")),
     TURNOVER("TURNOVER", new Version("0.50.06")),
     UNABLE_TO_START_SCENARIO("UNABLE_TO_START_SCENARIO", new Version("0.50.06")),

--- a/MekHQ/src/mekhq/campaign/utilities/glossary/GlossaryEntry.java
+++ b/MekHQ/src/mekhq/campaign/utilities/glossary/GlossaryEntry.java
@@ -148,7 +148,7 @@ public enum GlossaryEntry {
     TECH_TIME("TECH_TIME", new Version("0.50.06")),
     TEMP_PERSONNEL("TEMP_PERSONNEL", new Version("0.50.06")),
     TOE("TOE", new Version("0.50.06")),
-    TRAINING_COMBAT_TEAMS("TRAINING_COMBAT_TEAMS", new Version("0.50.10")),
+        ("TRAINING_COMBAT_TEAMS", new Version("0.50.10")),
     TURNING_POINTS("TURNING_POINTS", new Version("0.50.06")),
     TURNOVER("TURNOVER", new Version("0.50.06")),
     UNABLE_TO_START_SCENARIO("UNABLE_TO_START_SCENARIO", new Version("0.50.06")),


### PR DESCRIPTION
Close #9008

Training Combat formations previously measured Skill Level to Skill Level (1, 2, 3, 4, etc) not Skill Experience Milestone (Green, Regular, etc). This created an issue with player campaign settings. If they did not have level 3 set as Regular, then their training formations would be less effective.

Now we directly use educator experience level and cap it at Regular.

It is still possible some characters may reach higher than Regular, due to external modifiers. This is intentional.