### PR TITLE
Close #8725: LAM Will Now Fit in Either Aerospace or Mek Bays Depending on Availability When Calculating Transportation Costs or CamOps Reputation

### DIFF
--- a/MekHQ/src/mekhq/campaign/camOpsReputation/TransportationRating.java
+++ b/MekHQ/src/mekhq/campaign/camOpsReputation/TransportationRating.java
@@ -90,13 +90,21 @@ public class TransportationRating {
         // ASF
         capacity = transportationCapacities.get("asfBays") + spareCapacity;
         requirements = transportationRequirements.get("asfCount");
+        spareCapacity = Math.max(0, capacity - requirements);
+
+        int lamCount = transportationRequirements.getOrDefault("lamCount", 0);
+        if (spareCapacity > 0) {
+            int deduction = Math.min(spareCapacity, lamCount);
+            requirements += deduction;
+            lamCount -= deduction;
+        }
 
         rating = calculateRating(capacity, requirements);
         capacityRating = getCapacityRating(rating, capacityRating);
 
         // Meks
         capacity = transportationCapacities.get("mekBays");
-        requirements = transportationRequirements.get("mekCount");
+        requirements = transportationRequirements.get("mekCount") + lamCount;
 
         rating = calculateRating(capacity, requirements);
         capacityRating = getCapacityRating(rating, capacityRating);

--- a/MekHQ/src/mekhq/campaign/mission/TransportCostCalculations.java
+++ b/MekHQ/src/mekhq/campaign/mission/TransportCostCalculations.java
@@ -629,13 +629,18 @@ public class TransportCostCalculations {
         int asfBayUsage = asfBays - asfCount;
         int mekBayUsage = mekBays - mekCount;
 
-        // If we have more spare aerospace bays, we're going to put our LAM in there; otherwise we'll put them in the
-        // mek bays. Cost is identical for each.
-        if (asfBayUsage > mekBayUsage) {
-            asfBayUsage -= -lamCount;
-        } else {
-            mekBayUsage -= lamCount;
+        // Do we have spare ASF bays? If so, try and use them for LAM units
+        if (asfBayUsage > 0) {
+            if (asfBayUsage > lamCount) {
+                asfBayUsage -= lamCount;
+            } else {
+                lamCount -= asfBayUsage;
+                asfBayUsage = 0;
+            }
         }
+
+        // Any remainder are placed in mek bays. Both ASF and Mek bay rentals cost the same, so this works out
+        mekBayUsage -= lamCount;
 
         additionalASFBaysRequired = -min(0, asfBayUsage);
         additionalASFBaysCost = round(additionalASFBaysRequired * ASF_COST);

--- a/MekHQ/src/mekhq/campaign/mission/TransportCostCalculations.java
+++ b/MekHQ/src/mekhq/campaign/mission/TransportCostCalculations.java
@@ -624,7 +624,6 @@ public class TransportCostCalculations {
 
         // ASF (including Conv Fighters)
         int asfBays = getTotalASFBays() + smallCraftSpareCapacity;
-        int lamUsage = lamCount;
         int asfBayUsage = asfBays - asfCount;
 
         if (asfBays > asfCount) {

--- a/MekHQ/src/mekhq/campaign/mission/TransportCostCalculations.java
+++ b/MekHQ/src/mekhq/campaign/mission/TransportCostCalculations.java
@@ -622,29 +622,25 @@ public class TransportCostCalculations {
         totalCost = totalCost.plus(additionalSmallCraftBaysCost);
         int smallCraftSpareCapacity = max(0, smallCraftBayUsage);
 
-        // ASF (including conventional fighters), Meks, and LAM
+        // ASF (including Conv Fighters)
         int asfBays = getTotalASFBays() + smallCraftSpareCapacity;
-        int mekBays = getTotalMekBays();
-
+        int lamUsage = lamCount;
         int asfBayUsage = asfBays - asfCount;
-        int mekBayUsage = mekBays - mekCount;
 
-        // Do we have spare ASF bays? If so, try and use them for LAM units
-        if (asfBayUsage > lamCount) {
-            asfBayUsage -= lamCount;
-            lamCount = 0;
-        } else {
-            lamCount -= asfBayUsage;
-            asfBayUsage = 0;
+        if (asfBays > asfCount) {
+            int spareCapacity = asfBays - asfCount;
+            int deduction = Math.min(spareCapacity, lamCount);
+            asfCount += deduction;
+            lamCount -= deduction;
         }
-
-        // Any remaining LAM are placed in mek bays. Both ASF and Mek bay rentals cost the same, so this works out
-        mekBayUsage -= lamCount;
 
         additionalASFBaysRequired = -min(0, asfBayUsage);
         additionalASFBaysCost = round(additionalASFBaysRequired * ASF_COST);
         totalCost = totalCost.plus(additionalASFBaysCost);
 
+        // Meks
+        int mekBays = getTotalMekBays();
+        int mekBayUsage = mekBays - (mekCount + lamCount);
         additionalMekBaysRequired = -min(0, mekBayUsage);
         additionalMekBaysCost = round(additionalMekBaysRequired * MEK_COST);
         totalCost = totalCost.plus(additionalMekBaysCost);

--- a/MekHQ/src/mekhq/campaign/mission/TransportCostCalculations.java
+++ b/MekHQ/src/mekhq/campaign/mission/TransportCostCalculations.java
@@ -630,16 +630,15 @@ public class TransportCostCalculations {
         int mekBayUsage = mekBays - mekCount;
 
         // Do we have spare ASF bays? If so, try and use them for LAM units
-        if (asfBayUsage > 0) {
-            if (asfBayUsage > lamCount) {
-                asfBayUsage -= lamCount;
-            } else {
-                lamCount -= asfBayUsage;
-                asfBayUsage = 0;
-            }
+        if (asfBayUsage > lamCount) {
+            asfBayUsage -= lamCount;
+            lamCount = 0;
+        } else {
+            lamCount -= asfBayUsage;
+            asfBayUsage = 0;
         }
 
-        // Any remainder are placed in mek bays. Both ASF and Mek bay rentals cost the same, so this works out
+        // Any remaining LAM are placed in mek bays. Both ASF and Mek bay rentals cost the same, so this works out
         mekBayUsage -= lamCount;
 
         additionalASFBaysRequired = -min(0, asfBayUsage);

--- a/MekHQ/src/mekhq/campaign/mission/TransportCostCalculations.java
+++ b/MekHQ/src/mekhq/campaign/mission/TransportCostCalculations.java
@@ -54,6 +54,7 @@ import megamek.codeUtilities.MathUtility;
 import megamek.common.annotations.Nullable;
 import megamek.common.units.Entity;
 import megamek.common.units.Jumpship;
+import megamek.common.units.LandAirMek;
 import megamek.common.units.SpaceStation;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Hangar;
@@ -189,6 +190,7 @@ public class TransportCostCalculations {
     private int lightVehicleCount;
     private int mekCount;
     private int asfCount;
+    private int lamCount;
     private int protoMekCount;
     private int battleArmorCount;
     private int infantryCount;
@@ -370,6 +372,14 @@ public class TransportCostCalculations {
 
     public void setMekCount(int mekCount) {
         this.mekCount = mekCount;
+    }
+
+    int getLAMCount() {
+        return lamCount;
+    }
+
+    public void setLAMCount(int lamCount) {
+        this.lamCount = lamCount;
     }
 
     int getAsfCount() {
@@ -612,16 +622,25 @@ public class TransportCostCalculations {
         totalCost = totalCost.plus(additionalSmallCraftBaysCost);
         int smallCraftSpareCapacity = max(0, smallCraftBayUsage);
 
-        // ASF (including Conv Fighters)
+        // ASF (including conventional fighters), Meks, and LAM
         int asfBays = getTotalASFBays() + smallCraftSpareCapacity;
+        int mekBays = getTotalMekBays();
+
         int asfBayUsage = asfBays - asfCount;
+        int mekBayUsage = mekBays - mekCount;
+
+        // If we have more spare aerospace bays, we're going to put our LAM in there; otherwise we'll put them in the
+        // mek bays. Cost is identical for each.
+        if (asfBayUsage > mekBayUsage) {
+            asfBayUsage -= -lamCount;
+        } else {
+            mekBayUsage -= lamCount;
+        }
+
         additionalASFBaysRequired = -min(0, asfBayUsage);
         additionalASFBaysCost = round(additionalASFBaysRequired * ASF_COST);
         totalCost = totalCost.plus(additionalASFBaysCost);
 
-        // Meks
-        int mekBays = getTotalMekBays();
-        int mekBayUsage = mekBays - mekCount;
         additionalMekBaysRequired = -min(0, mekBayUsage);
         additionalMekBaysCost = round(additionalMekBaysRequired * MEK_COST);
         totalCost = totalCost.plus(additionalMekBaysCost);
@@ -731,6 +750,8 @@ public class TransportCostCalculations {
                     dropShipCount += getAdditionalCollarNeeds(spaceStation);
                 } else if (entity.isSmallCraft()) {
                     smallCraftCount++;
+                } else if (entity instanceof LandAirMek) {
+                    lamCount++;
                 } else if (entity.isMek()) {
                     mekCount++;
                 } else if (entity.isFighter()) {


### PR DESCRIPTION
Close #8725

As per title.

The logic is this:

- First we attempt to fit LAM units in any spare ASF bays, with the remainder placed in Mek bays

Both transport costs and CamOps Reputation have been updated