### PR TITLE
Fix #9138: Fixed Personnel Table Incorrectly Highlighting Characters with Permanent Injuries when Those Permanent 'Injuries' are Prosthetics & Implants; Added Personnel Table Column to Display Count of Permanent Modifications Such as Prosthetics & Implants

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -1410,6 +1410,7 @@ PersonnelTableModelColumn.FATIGUE.text=Fatigue
 PersonnelTableModelColumn.EDGE.text=Edge
 PersonnelTableModelColumn.SPA_COUNT.text=SPA Count
 PersonnelTableModelColumn.IMPLANT_COUNT.text=Implant Count
+PersonnelTableModelColumn.MODIFICATION_COUNT.text=Modification Count
 PersonnelTableModelColumn.LOYALTY.text=Loyalty
 PersonnelTableModelColumn.HIGHEST_EDUCATION.text=Highest Education
 PersonnelTableModelColumn.CURRENT_EDUCATION.text=Current Education

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -4517,7 +4517,7 @@ public class Person {
             LOGGER.error(e, "Failed to read person {} from file", person.getFullName());
             person = null;
         }
-        
+
         if (person != null) {
             // < 0.51.00 compatibility handler
             if (!campaign.getVersion().isHigherThan(new Version("0.51.0"))) {
@@ -7726,9 +7726,24 @@ public class Person {
         return false;
     }
 
-    public boolean hasOnlyHealedPermanentInjuries() {
-        return !injuries.isEmpty() &&
-                     injuries.stream().noneMatch(injury -> !injury.isPermanent() || (injury.getTime() > 0));
+    /**
+     * Determines whether the character has any permanent, non-prosthetic injuries.
+     *
+     * @return Returns {@code true} if the character has no non-permanent injuries, has at least one permanent injury,
+     *       and that injury is not a permanent modification, such as an implant.
+     *
+     * @author Illiani
+     * @since 0.51.0
+     */
+    public boolean hasNonProstheticPermanentInjuries() {
+        if (getNonPermanentInjurySeverity() > 0) {
+            return false;
+        }
+
+        ArrayList<Injury> relevantInjuries = new ArrayList<>(injuries);
+        relevantInjuries.removeAll(getProstheticInjuries());
+
+        return !relevantInjuries.isEmpty();
     }
 
     public List<Injury> getInjuriesByLocation(final BodyLocation location) {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -7729,7 +7729,7 @@ public class Person {
     /**
      * Determines whether the character has any permanent, non-prosthetic injuries.
      *
-     * <p>If {@link #isUseAlternateAdvancedMedical} is {@code true} we check whether the character has
+     * <p>If {@code isUseAlternateAdvancedMedical} is {@code true} we check whether the character has
      * non-prosthetic permanent injuries. Otherwise we use legacy testing that just checks for permanent injuries.</p>
      *
      * @return Returns {@code true} if the character has no non-permanent injuries, has at least one permanent injury,

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -7729,21 +7729,29 @@ public class Person {
     /**
      * Determines whether the character has any permanent, non-prosthetic injuries.
      *
+     * <p>If {@link #isUseAlternateAdvancedMedical} is {@code true} we check whether the character has
+     * non-prosthetic permanent injuries. Otherwise we use legacy testing that just checks for permanent injuries.</p>
+     *
      * @return Returns {@code true} if the character has no non-permanent injuries, has at least one permanent injury,
      *       and that injury is not a permanent modification, such as an implant.
      *
      * @author Illiani
      * @since 0.51.0
      */
-    public boolean hasNonProstheticPermanentInjuries() {
-        if (getNonPermanentInjurySeverity() > 0) {
-            return false;
+    public boolean hasNonProstheticPermanentInjuries(boolean isUseAlternateAdvancedMedical) {
+        if (isUseAlternateAdvancedMedical) {
+            if (getNonPermanentInjurySeverity() > 0) {
+                return false;
+            }
+
+            ArrayList<Injury> relevantInjuries = new ArrayList<>(injuries);
+            relevantInjuries.removeAll(getProstheticInjuries());
+
+            return !relevantInjuries.isEmpty();
         }
 
-        ArrayList<Injury> relevantInjuries = new ArrayList<>(injuries);
-        relevantInjuries.removeAll(getProstheticInjuries());
-
-        return !relevantInjuries.isEmpty();
+        return !injuries.isEmpty() &&
+                     injuries.stream().noneMatch(injury -> !injury.isPermanent() || (injury.getTime() > 0));
     }
 
     public List<Injury> getInjuriesByLocation(final BodyLocation location) {

--- a/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
@@ -60,6 +60,7 @@ import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.force.Formation;
 import mekhq.campaign.market.PersonnelMarket;
 import mekhq.campaign.mission.Scenario;
+import mekhq.campaign.personnel.Injury;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.education.Academy;
@@ -183,6 +184,7 @@ public enum PersonnelTableModelColumn {
     BLOODMARK("PersonnelTableModelColumn.BLOODMARK.text"),
     FATIGUE("PersonnelTableModelColumn.FATIGUE.text"),
     SPA_COUNT("PersonnelTableModelColumn.SPA_COUNT.text"),
+    MODIFICATION_COUNT("PersonnelTableModelColumn.MODIFICATION_COUNT.text"),
     IMPLANT_COUNT("PersonnelTableModelColumn.IMPLANT_COUNT.text"),
     LOYALTY("PersonnelTableModelColumn.LOYALTY.text"),
     HIGHEST_EDUCATION("PersonnelTableModelColumn.HIGHEST_EDUCATION.text"),
@@ -775,6 +777,7 @@ public enum PersonnelTableModelColumn {
             case IMMORTAL -> resources.getString(person.getStatus().isDead() ? "NA.text"
                                                        : (convertBooleanToYesNo(person.isImmortal())));
             case IMPLANT_COUNT -> Integer.toString(person.countOptions(PersonnelOptions.MD_ADVANTAGES));
+            case MODIFICATION_COUNT -> Integer.toString(person.getProstheticInjuries().size());
             case INJURIES -> campaign.getCampaignOptions().isUseAdvancedMedical()
                                    ? Integer.toString(person.getInjuries().size())
                                    : Integer.toString(person.getHits());
@@ -1117,6 +1120,13 @@ public enum PersonnelTableModelColumn {
                 return person.getAbilityListAsString(PersonnelOptions.LVL3_ADVANTAGES);
             case IMPLANT_COUNT:
                 return person.getAbilityListAsString(PersonnelOptions.MD_ADVANTAGES);
+            case MODIFICATION_COUNT:
+                StringBuilder modificationCount = new StringBuilder("<html>");
+                for (Injury injury : person.getProstheticInjuries()) {
+                    modificationCount.append(injury.getName()).append("<br>");
+                }
+                modificationCount.append("</html>");
+                return modificationCount.toString();
             default:
                 return null;
         }
@@ -1380,6 +1390,7 @@ public enum PersonnelTableModelColumn {
                 case FATIGUE -> campaign.getCampaignOptions().isUseFatigue();
                 case SPA_COUNT -> campaign.getCampaignOptions().isUseAbilities();
                 case IMPLANT_COUNT -> campaign.getCampaignOptions().isUseImplants();
+                case MODIFICATION_COUNT -> campaign.getCampaignOptions().isUseAlternativeAdvancedMedical();
                 case LOYALTY -> campaign.getCampaignOptions().isUseLoyaltyModifiers() &&
                                       !campaign.getCampaignOptions().isUseHideLoyalty();
                 default -> false;
@@ -1436,6 +1447,7 @@ public enum PersonnelTableModelColumn {
                  BLOODMARK,
                  SPA_COUNT,
                  IMPLANT_COUNT,
+                 MODIFICATION_COUNT,
                  LOYALTY -> new IntegerStringSorter();
             case STRENGTH, BODY, REFLEXES, DEXTERITY, INTELLIGENCE, WILLPOWER, CHARISMA, EDGE ->
                   new AttributeScoreSorter();

--- a/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
@@ -51,6 +51,7 @@ import megamek.common.units.SmallCraft;
 import megamek.common.units.UnitType;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.force.Formation;
 import mekhq.campaign.market.PersonnelMarket;
 import mekhq.campaign.personnel.Person;
@@ -181,12 +182,13 @@ public class PersonnelTableModel extends DataTableModel<Person> {
 
             // Colouring - determine color and collect ALL applicable color reasons
             boolean personIsDamaged;
-            if (campaign.getCampaignOptions().isUseAdvancedMedical()) {
+            final CampaignOptions campaignOptions = campaign.getCampaignOptions();
+            if (campaignOptions.isUseAdvancedMedical()) {
                 personIsDamaged = person.hasInjuries(true);
             } else {
                 personIsDamaged = person.getHits() > 0;
             }
-            boolean personIsFatigued = (campaign.getCampaignOptions().isUseFatigue()
+            boolean personIsFatigued = (campaignOptions.isUseFatigue()
                                               &&
                                               (getEffectiveFatigue(person.getAdjustedFatigue(),
                                                     person.getPermanentFatigue(),
@@ -196,6 +198,7 @@ public class PersonnelTableModel extends DataTableModel<Person> {
             // Collect all applicable color reasons for tooltip
             List<String> colorReasonKeys = new ArrayList<>();
 
+            boolean isUseAlternateAdvancedMedical = campaignOptions.isUseAlternativeAdvancedMedical();
             if (!isSelected) {
                 // Set color based on priority (first match wins for display color)
                 // But collect ALL applicable reasons for tooltip
@@ -217,7 +220,7 @@ public class PersonnelTableModel extends DataTableModel<Person> {
                 } else if (personIsFatigued) {
                     setForeground(MekHQ.getMHQOptions().getFatiguedForeground());
                     setBackground(MekHQ.getMHQOptions().getFatiguedBackground());
-                } else if (person.hasOnlyHealedPermanentInjuries()) {
+                } else if (person.hasNonProstheticPermanentInjuries(isUseAlternateAdvancedMedical)) {
                     setForeground(MekHQ.getMHQOptions().getHealedInjuriesForeground());
                     setBackground(MekHQ.getMHQOptions().getHealedInjuriesBackground());
                 } else {
@@ -244,7 +247,7 @@ public class PersonnelTableModel extends DataTableModel<Person> {
                 if (personIsFatigued) {
                     colorReasonKeys.add("colorReason.personnel.fatigued");
                 }
-                if (person.hasOnlyHealedPermanentInjuries()) {
+                if (person.hasNonProstheticPermanentInjuries(isUseAlternateAdvancedMedical)) {
                     colorReasonKeys.add("colorReason.personnel.healedInjuries");
                 }
             }

--- a/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
+++ b/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
@@ -873,6 +873,7 @@ public class PersonnelTableModelColumnTest {
                      UNLUCKY,
                      BLOODMARK,
                      SPA_COUNT,
+                     MODIFICATION_COUNT,
                      IMPLANT_COUNT,
                      LOYALTY -> assertInstanceOf(IntegerStringSorter.class,
                       personnelTableModelColumn.getComparator(mockCampaign));


### PR DESCRIPTION
Fix #9138

We were using a conditional that predated prosthetics, so it was incorrectly returning true when it should have been false. Prosthetics, implants, etc are all considered 'injuries' internally, hence this bug.

This PR also adds a new column to the Other view in the personnel tab that displays how many permanent modifications (implants, prosthetics, etc). This column is only visible if Alt Advanced Medical is being used, as this column only contains information relevant to that system.

Hovering over the entry for a given character will show what modifications they have (as shown below).

<img width="1216" height="233" alt="image" src="https://github.com/user-attachments/assets/57bc99ba-87e2-4030-86ad-4e852183d819" />