### PR TITLE
Close #6682, #6684, #6685: Added 14 New SPAs/Flaws Focused on Admin & Doctors

### DIFF
--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -158,6 +158,8 @@ unableToEnterSystem.outlawed.ooc=Outlawing can occur as the result of supremely 
 medicalCosts.transaction=Medicine costs for {0}
 mentalBreak.check=Resisting Mental Break
 discontinuationSyndrome.check=Resisting Discontinuation Syndrome
+embezzle.roll=Embezzle
+embezzle.transaction=Widows & Orphan Fund
 # Bioweapon Attack
 bioweaponAttack.inCharacter={0}, this is an emergency.\
   <p>I''ve just confirmed the release of an engineered biological agent within the current system. Multiple \

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -71,6 +71,7 @@ import static mekhq.campaign.personnel.skills.Aging.applyAgingSPA;
 import static mekhq.campaign.personnel.skills.Aging.getMilestone;
 import static mekhq.campaign.personnel.skills.QuickTrain.QuickTrainOptions.getQuickTrainOptionsForNewDay;
 import static mekhq.campaign.personnel.skills.SkillModifierData.IGNORE_AGE;
+import static mekhq.campaign.personnel.skills.SkillType.S_ADMIN;
 import static mekhq.campaign.personnel.turnoverAndRetention.Fatigue.areFieldKitchensWithinCapacity;
 import static mekhq.campaign.personnel.turnoverAndRetention.Fatigue.checkFieldKitchenCapacity;
 import static mekhq.campaign.personnel.turnoverAndRetention.Fatigue.checkFieldKitchenUsage;
@@ -165,6 +166,7 @@ import mekhq.campaign.personnel.medical.advancedMedicalAlternate.Inoculations;
 import mekhq.campaign.personnel.skills.AttributeCheckUtility;
 import mekhq.campaign.personnel.skills.EscapeSkills;
 import mekhq.campaign.personnel.skills.QuickTrain;
+import mekhq.campaign.personnel.skills.SkillCheckUtility;
 import mekhq.campaign.personnel.skills.enums.AgingMilestone;
 import mekhq.campaign.personnel.skills.enums.SkillAttribute;
 import mekhq.campaign.personnel.turnoverAndRetention.Fatigue;
@@ -901,6 +903,10 @@ public class CampaignNewDayManager {
                 if (campaignOptions.isUseFunctionalEscapeArtist() && person.getStatus().isPoW()) {
                     EscapeSkills.performEscapeAttemptCheck(campaign, person);
                 }
+
+                if (personnelOptions.booleanOption(UNOFFICIAL_EMBEZZLER)) {
+                    embezzleFunds(person);
+                }
             }
 
             if (today.getDayOfYear() == 1 && campaignOptions.isUseAlternativeAdvancedMedical()) {
@@ -952,6 +958,45 @@ public class CampaignNewDayManager {
                   campaign,
                   quickTrainOptions,
                   true);
+        }
+    }
+
+    /**
+     * Attempts to have the given person embezzle funds from the campaign.
+     *
+     * <p>Performs an Administration ({@code S_ADMIN}) skill check for the specified person. If the check succeeds, a
+     * small percentage of the current campaign balance is transferred out of campaign finances and paid directly to the
+     * person.</p>
+     *
+     * <p>The embezzled amount is calculated as 0.1% of the current campaign balance, rounded to the nearest whole
+     * unit. The debit is recorded as a {@link TransactionType#MISCELLANEOUS} transaction, and the result of the skill
+     * check (success or failure) is appended to the campaign report log.</p>
+     *
+     * @param person the {@link Person} attempting to embezzle funds; must not be {@code null}
+     *
+     * @author Illiani
+     * @since 0.51.0
+     */
+    private void embezzleFunds(Person person) {
+        String reason = getTextAt(RESOURCE_BUNDLE, "embezzle.roll");
+        SkillCheckUtility skillCheck = new SkillCheckUtility(reason, person, S_ADMIN, List.of(), 0, false, true);
+        String report = skillCheck.getResultsText();
+        campaign.addReport(SKILL_CHECKS, report);
+
+        if (skillCheck.isSuccess()) {
+            Money currentCampaignFunds = finances.getBalance();
+            double embezzlePercentile = 0.001;
+
+            Money embezzleAmount = currentCampaignFunds.multipliedBy(embezzlePercentile);
+            embezzleAmount = embezzleAmount.round();
+            if (embezzleAmount.isZero()) {
+                return;
+            }
+
+            finances.debit(TransactionType.MISCELLANEOUS, today, embezzleAmount,
+                  getTextAt(RESOURCE_BUNDLE, "embezzle.transaction"));
+
+            person.payPerson(embezzleAmount);
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/mission/TransportCostCalculations.java
+++ b/MekHQ/src/mekhq/campaign/mission/TransportCostCalculations.java
@@ -63,6 +63,7 @@ import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.enums.TransactionType;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
+import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.unit.CargoStatistics;
 import mekhq.campaign.unit.HangarStatistics;
 import mekhq.campaign.unit.Unit;
@@ -152,6 +153,7 @@ public class TransportCostCalculations {
     private double additionalCargoSpaceRequired;
     private double cargoBayCost;
     private double tetrisMasterMultiplier = 1.0;
+    private boolean hasTransportNegotiatorSPA;
     private int requiredCargoDropShips;
 
     private int additionalSmallCraftBaysRequired;
@@ -433,7 +435,7 @@ public class TransportCostCalculations {
         this.crewExperienceLevel = crewExperienceLevel;
         this.allPersonnel = allPersonnel;
 
-        setTetrisMasterMultiplier();
+        setSPAValues();
     }
 
     /**
@@ -446,13 +448,23 @@ public class TransportCostCalculations {
      * @author Illiani
      * @since 0.50.10
      */
-    private void setTetrisMasterMultiplier() {
+    private void setSPAValues() {
         Collection<Person> activePersonnel = allPersonnel.stream()
                                                    .filter(p -> p.getStatus().isActive())
                                                    .toList();
         for (Person person : activePersonnel) {
-            if (person.getOptions().booleanOption(PersonnelOptions.ADMIN_TETRIS_MASTER)) {
+            PersonnelOptions personnelOptions = person.getOptions();
+
+            boolean isTransportAdmin = person.hasRole(PersonnelRole.ADMINISTRATOR_TRANSPORT);
+            boolean isLogisticsAdmin = person.hasRole(PersonnelRole.ADMINISTRATOR_LOGISTICS);
+            if ((isTransportAdmin || isLogisticsAdmin) &&
+                      personnelOptions.booleanOption(PersonnelOptions.ADMIN_TETRIS_MASTER)) {
                 tetrisMasterMultiplier += 0.05;
+            }
+
+            if (isTransportAdmin &&
+                      personnelOptions.booleanOption(PersonnelOptions.UNOFFICIAL_TRANSPORT_NEGOTIATOR)) {
+                hasTransportNegotiatorSPA = true;
             }
         }
     }
@@ -507,6 +519,10 @@ public class TransportCostCalculations {
         calculateAdditionalJumpCollarsRequirements();
 
         adjustForCrewExperienceLevel();
+
+        if (hasTransportNegotiatorSPA) {
+            totalCost = totalCost.multipliedBy(1.05);
+        }
 
         totalCost = totalCost.round();
     }

--- a/MekHQ/src/mekhq/campaign/personnel/Injury.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Injury.java
@@ -314,6 +314,10 @@ public class Injury {
         return type.getSubType();
     }
 
+    public boolean isDisease() {
+        return type.getSubType().isDisease();
+    }
+
     public Collection<Modifier> getModifiers() {
         return type.getModifiers(this);
     }

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -113,6 +113,7 @@ public class PersonnelOptions extends PilotOptions {
     public static final String UNOFFICIAL_PROTHESIS_TECHNICIAN = "unofficial_prothesis_technician";
     public static final String UNOFFICIAL_SHAKEY_SCALPEL = "unofficial_shakey_scalpel";
     public static final String UNOFFICIAL_PATIENT_EDUCATOR = "unofficial_patient_educator";
+    public static final String UNOFFICIAL_RADIO_HOBBYIST = "unofficial_radio_hobbyist";
     public static final String UNOFFICIAL_USELESS_TALENT = "unofficial_useless_talent";
     public static final String UNOFFICIAL_PATHOLOGIC_INSIGHT = "unofficial_pathologic_insight";
     public static final String UNOFFICIAL_BARGAIN_HUNTER = "unofficial_bargain_hunter";
@@ -291,6 +292,7 @@ public class PersonnelOptions extends PilotOptions {
         addOption(l3a, UNOFFICIAL_PROTHESIS_TECHNICIAN, false);
         addOption(l3a, UNOFFICIAL_SHAKEY_SCALPEL, false);
         addOption(l3a, UNOFFICIAL_PATIENT_EDUCATOR, false);
+        addOption(l3a, UNOFFICIAL_RADIO_HOBBYIST, false);
         addOption(l3a, UNOFFICIAL_USELESS_TALENT, false);
         addOption(l3a, UNOFFICIAL_PATHOLOGIC_INSIGHT, false);
         addOption(l3a, UNOFFICIAL_PICK_POCKET, false);

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -113,6 +113,7 @@ public class PersonnelOptions extends PilotOptions {
     public static final String UNOFFICIAL_PROTHESIS_TECHNICIAN = "unofficial_prothesis_technician";
     public static final String UNOFFICIAL_SHAKEY_SCALPEL = "unofficial_shakey_scalpel";
     public static final String UNOFFICIAL_PATIENT_EDUCATOR = "unofficial_patient_educator";
+    public static final String UNOFFICIAL_USELESS_TALENT = "unofficial_useless_talent";
     public static final String UNOFFICIAL_PATHOLOGIC_INSIGHT = "unofficial_pathologic_insight";
     public static final String UNOFFICIAL_BARGAIN_HUNTER = "unofficial_bargain_hunter";
     public static final String FLAW_VACCINE_DODGER = "flaw_vaccine_dodger";
@@ -290,6 +291,7 @@ public class PersonnelOptions extends PilotOptions {
         addOption(l3a, UNOFFICIAL_PROTHESIS_TECHNICIAN, false);
         addOption(l3a, UNOFFICIAL_SHAKEY_SCALPEL, false);
         addOption(l3a, UNOFFICIAL_PATIENT_EDUCATOR, false);
+        addOption(l3a, UNOFFICIAL_USELESS_TALENT, false);
         addOption(l3a, UNOFFICIAL_PATHOLOGIC_INSIGHT, false);
         addOption(l3a, UNOFFICIAL_PICK_POCKET, false);
         addOption(l3a, FLAW_VACCINE_DODGER, false);

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -114,6 +114,7 @@ public class PersonnelOptions extends PilotOptions {
     public static final String UNOFFICIAL_SHAKEY_SCALPEL = "unofficial_shakey_scalpel";
     public static final String UNOFFICIAL_PATIENT_EDUCATOR = "unofficial_patient_educator";
     public static final String UNOFFICIAL_RADIO_HOBBYIST = "unofficial_radio_hobbyist";
+    public static final String UNOFFICIAL_PAPER_SURGEON = "unofficial_paper_surgeon";
     public static final String UNOFFICIAL_HYPOCHONDRIAC = "unofficial_hypochondriac";
     public static final String UNOFFICIAL_USELESS_TALENT = "unofficial_useless_talent";
     public static final String UNOFFICIAL_PATHOLOGIC_INSIGHT = "unofficial_pathologic_insight";
@@ -294,6 +295,7 @@ public class PersonnelOptions extends PilotOptions {
         addOption(l3a, UNOFFICIAL_SHAKEY_SCALPEL, false);
         addOption(l3a, UNOFFICIAL_PATIENT_EDUCATOR, false);
         addOption(l3a, UNOFFICIAL_RADIO_HOBBYIST, false);
+        addOption(l3a, UNOFFICIAL_PAPER_SURGEON, false);
         addOption(l3a, UNOFFICIAL_HYPOCHONDRIAC, false);
         addOption(l3a, UNOFFICIAL_USELESS_TALENT, false);
         addOption(l3a, UNOFFICIAL_PATHOLOGIC_INSIGHT, false);

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -108,6 +108,7 @@ public class PersonnelOptions extends PilotOptions {
     public static final String UNOFFICIAL_PICK_POCKET = "unofficial_pick_pocket";
     public static final String UNOFFICIAL_NATURAL_THESPIAN = "unofficial_natural_thespian";
     public static final String UNOFFICIAL_BIOLOGICAL_MACHINIST = "unofficial_biological_machinist";
+    public static final String UNOFFICIAL_HOLISTIC_CARE = "unofficial_holistic_care";
     public static final String FLAW_VACCINE_DODGER = "flaw_vaccine_dodger";
     public static final String FLAW_SUPER_SPREADER = "flaw_super_spreader";
     public static final String FLAW_POOR_IMMUNE_SYSTEM = "flaw_poor_immune_system";

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -109,6 +109,8 @@ public class PersonnelOptions extends PilotOptions {
     public static final String UNOFFICIAL_NATURAL_THESPIAN = "unofficial_natural_thespian";
     public static final String UNOFFICIAL_BIOLOGICAL_MACHINIST = "unofficial_biological_machinist";
     public static final String UNOFFICIAL_HOLISTIC_CARE = "unofficial_holistic_care";
+    public static final String UNOFFICIAL_TRAUMA_SURGEON = "unofficial_trauma_surgeon";
+    public static final String UNOFFICIAL_PROTHESIS_TECHNICIAN = "unofficial_prothesis_technician";
     public static final String UNOFFICIAL_BARGAIN_HUNTER = "unofficial_bargain_hunter";
     public static final String FLAW_VACCINE_DODGER = "flaw_vaccine_dodger";
     public static final String FLAW_SUPER_SPREADER = "flaw_super_spreader";
@@ -281,6 +283,8 @@ public class PersonnelOptions extends PilotOptions {
         addOption(l3a, UNOFFICIAL_BIOLOGICAL_MACHINIST, false);
         addOption(l3a, UNOFFICIAL_HOLISTIC_CARE, false);
         addOption(l3a, UNOFFICIAL_BARGAIN_HUNTER, false);
+        addOption(l3a, UNOFFICIAL_TRAUMA_SURGEON, false);
+        addOption(l3a, UNOFFICIAL_PROTHESIS_TECHNICIAN, false);
         addOption(l3a, UNOFFICIAL_PICK_POCKET, false);
         addOption(l3a, FLAW_VACCINE_DODGER, false);
         addOption(l3a, FLAW_SUPER_SPREADER, false);

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -111,6 +111,8 @@ public class PersonnelOptions extends PilotOptions {
     public static final String UNOFFICIAL_HOLISTIC_CARE = "unofficial_holistic_care";
     public static final String UNOFFICIAL_TRAUMA_SURGEON = "unofficial_trauma_surgeon";
     public static final String UNOFFICIAL_PROTHESIS_TECHNICIAN = "unofficial_prothesis_technician";
+    public static final String UNOFFICIAL_SHAKEY_SCALPEL = "unofficial_shakey_scalpel";
+    public static final String UNOFFICIAL_PATHOLOGIC_INSIGHT = "unofficial_pathologic_insight";
     public static final String UNOFFICIAL_BARGAIN_HUNTER = "unofficial_bargain_hunter";
     public static final String FLAW_VACCINE_DODGER = "flaw_vaccine_dodger";
     public static final String FLAW_SUPER_SPREADER = "flaw_super_spreader";
@@ -285,6 +287,8 @@ public class PersonnelOptions extends PilotOptions {
         addOption(l3a, UNOFFICIAL_BARGAIN_HUNTER, false);
         addOption(l3a, UNOFFICIAL_TRAUMA_SURGEON, false);
         addOption(l3a, UNOFFICIAL_PROTHESIS_TECHNICIAN, false);
+        addOption(l3a, UNOFFICIAL_SHAKEY_SCALPEL, false);
+        addOption(l3a, UNOFFICIAL_PATHOLOGIC_INSIGHT, false);
         addOption(l3a, UNOFFICIAL_PICK_POCKET, false);
         addOption(l3a, FLAW_VACCINE_DODGER, false);
         addOption(l3a, FLAW_SUPER_SPREADER, false);

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -112,6 +112,7 @@ public class PersonnelOptions extends PilotOptions {
     public static final String UNOFFICIAL_TRAUMA_SURGEON = "unofficial_trauma_surgeon";
     public static final String UNOFFICIAL_PROTHESIS_TECHNICIAN = "unofficial_prothesis_technician";
     public static final String UNOFFICIAL_SHAKEY_SCALPEL = "unofficial_shakey_scalpel";
+    public static final String UNOFFICIAL_PATIENT_EDUCATOR = "unofficial_patient_educator";
     public static final String UNOFFICIAL_PATHOLOGIC_INSIGHT = "unofficial_pathologic_insight";
     public static final String UNOFFICIAL_BARGAIN_HUNTER = "unofficial_bargain_hunter";
     public static final String FLAW_VACCINE_DODGER = "flaw_vaccine_dodger";
@@ -288,6 +289,7 @@ public class PersonnelOptions extends PilotOptions {
         addOption(l3a, UNOFFICIAL_TRAUMA_SURGEON, false);
         addOption(l3a, UNOFFICIAL_PROTHESIS_TECHNICIAN, false);
         addOption(l3a, UNOFFICIAL_SHAKEY_SCALPEL, false);
+        addOption(l3a, UNOFFICIAL_PATIENT_EDUCATOR, false);
         addOption(l3a, UNOFFICIAL_PATHOLOGIC_INSIGHT, false);
         addOption(l3a, UNOFFICIAL_PICK_POCKET, false);
         addOption(l3a, FLAW_VACCINE_DODGER, false);

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -114,6 +114,7 @@ public class PersonnelOptions extends PilotOptions {
     public static final String UNOFFICIAL_SHAKEY_SCALPEL = "unofficial_shakey_scalpel";
     public static final String UNOFFICIAL_PATIENT_EDUCATOR = "unofficial_patient_educator";
     public static final String UNOFFICIAL_RADIO_HOBBYIST = "unofficial_radio_hobbyist";
+    public static final String UNOFFICIAL_HYPOCHONDRIAC = "unofficial_hypochondriac";
     public static final String UNOFFICIAL_USELESS_TALENT = "unofficial_useless_talent";
     public static final String UNOFFICIAL_PATHOLOGIC_INSIGHT = "unofficial_pathologic_insight";
     public static final String UNOFFICIAL_BARGAIN_HUNTER = "unofficial_bargain_hunter";
@@ -293,6 +294,7 @@ public class PersonnelOptions extends PilotOptions {
         addOption(l3a, UNOFFICIAL_SHAKEY_SCALPEL, false);
         addOption(l3a, UNOFFICIAL_PATIENT_EDUCATOR, false);
         addOption(l3a, UNOFFICIAL_RADIO_HOBBYIST, false);
+        addOption(l3a, UNOFFICIAL_HYPOCHONDRIAC, false);
         addOption(l3a, UNOFFICIAL_USELESS_TALENT, false);
         addOption(l3a, UNOFFICIAL_PATHOLOGIC_INSIGHT, false);
         addOption(l3a, UNOFFICIAL_PICK_POCKET, false);

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -102,6 +102,7 @@ public class PersonnelOptions extends PilotOptions {
     public static final String FLAW_TRANSIT_DISORIENTATION_SYNDROME = "flaw_transit_disorientation_syndrome";
     public static final String FLAW_ILLITERATE = "flaw_illiterate";
     public static final String UNOFFICIAL_HOUDINI = "unofficial_houdini";
+    public static final String UNOFFICIAL_TRANSPORT_NEGOTIATOR = "unofficial_transport_negotiator";
     public static final String UNOFFICIAL_MASTER_IMPERSONATOR = "unofficial_master_impersonator";
     public static final String UNOFFICIAL_COUNTERFEITER = "unofficial_counterfeiter";
     public static final String UNOFFICIAL_PICK_POCKET = "unofficial_pick_pocket";
@@ -271,6 +272,7 @@ public class PersonnelOptions extends PilotOptions {
         addOption(l3a, FLAW_TRANSIT_DISORIENTATION_SYNDROME, false);
         addOption(l3a, FLAW_ILLITERATE, false);
         addOption(l3a, UNOFFICIAL_HOUDINI, false);
+        addOption(l3a, UNOFFICIAL_TRANSPORT_NEGOTIATOR, false);
         addOption(l3a, UNOFFICIAL_MASTER_IMPERSONATOR, false);
         addOption(l3a, UNOFFICIAL_COUNTERFEITER, false);
         addOption(l3a, UNOFFICIAL_NATURAL_THESPIAN, false);

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -109,6 +109,7 @@ public class PersonnelOptions extends PilotOptions {
     public static final String UNOFFICIAL_NATURAL_THESPIAN = "unofficial_natural_thespian";
     public static final String UNOFFICIAL_BIOLOGICAL_MACHINIST = "unofficial_biological_machinist";
     public static final String UNOFFICIAL_HOLISTIC_CARE = "unofficial_holistic_care";
+    public static final String UNOFFICIAL_BARGAIN_HUNTER = "unofficial_bargain_hunter";
     public static final String FLAW_VACCINE_DODGER = "flaw_vaccine_dodger";
     public static final String FLAW_SUPER_SPREADER = "flaw_super_spreader";
     public static final String FLAW_POOR_IMMUNE_SYSTEM = "flaw_poor_immune_system";
@@ -278,6 +279,8 @@ public class PersonnelOptions extends PilotOptions {
         addOption(l3a, UNOFFICIAL_COUNTERFEITER, false);
         addOption(l3a, UNOFFICIAL_NATURAL_THESPIAN, false);
         addOption(l3a, UNOFFICIAL_BIOLOGICAL_MACHINIST, false);
+        addOption(l3a, UNOFFICIAL_HOLISTIC_CARE, false);
+        addOption(l3a, UNOFFICIAL_BARGAIN_HUNTER, false);
         addOption(l3a, UNOFFICIAL_PICK_POCKET, false);
         addOption(l3a, FLAW_VACCINE_DODGER, false);
         addOption(l3a, FLAW_SUPER_SPREADER, false);

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -115,6 +115,7 @@ public class PersonnelOptions extends PilotOptions {
     public static final String UNOFFICIAL_PATIENT_EDUCATOR = "unofficial_patient_educator";
     public static final String UNOFFICIAL_RADIO_HOBBYIST = "unofficial_radio_hobbyist";
     public static final String UNOFFICIAL_PAPER_SURGEON = "unofficial_paper_surgeon";
+    public static final String UNOFFICIAL_LOSES_PAPERWORK = "unofficial_loses_paperwork";
     public static final String UNOFFICIAL_HYPOCHONDRIAC = "unofficial_hypochondriac";
     public static final String UNOFFICIAL_USELESS_TALENT = "unofficial_useless_talent";
     public static final String UNOFFICIAL_PATHOLOGIC_INSIGHT = "unofficial_pathologic_insight";
@@ -296,6 +297,7 @@ public class PersonnelOptions extends PilotOptions {
         addOption(l3a, UNOFFICIAL_PATIENT_EDUCATOR, false);
         addOption(l3a, UNOFFICIAL_RADIO_HOBBYIST, false);
         addOption(l3a, UNOFFICIAL_PAPER_SURGEON, false);
+        addOption(l3a, UNOFFICIAL_LOSES_PAPERWORK, false);
         addOption(l3a, UNOFFICIAL_HYPOCHONDRIAC, false);
         addOption(l3a, UNOFFICIAL_USELESS_TALENT, false);
         addOption(l3a, UNOFFICIAL_PATHOLOGIC_INSIGHT, false);

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -116,6 +116,7 @@ public class PersonnelOptions extends PilotOptions {
     public static final String UNOFFICIAL_RADIO_HOBBYIST = "unofficial_radio_hobbyist";
     public static final String UNOFFICIAL_PAPER_SURGEON = "unofficial_paper_surgeon";
     public static final String UNOFFICIAL_LOSES_PAPERWORK = "unofficial_loses_paperwork";
+    public static final String UNOFFICIAL_EMBEZZLER = "unofficial_embezzler";
     public static final String UNOFFICIAL_HYPOCHONDRIAC = "unofficial_hypochondriac";
     public static final String UNOFFICIAL_USELESS_TALENT = "unofficial_useless_talent";
     public static final String UNOFFICIAL_PATHOLOGIC_INSIGHT = "unofficial_pathologic_insight";
@@ -298,6 +299,7 @@ public class PersonnelOptions extends PilotOptions {
         addOption(l3a, UNOFFICIAL_RADIO_HOBBYIST, false);
         addOption(l3a, UNOFFICIAL_PAPER_SURGEON, false);
         addOption(l3a, UNOFFICIAL_LOSES_PAPERWORK, false);
+        addOption(l3a, UNOFFICIAL_EMBEZZLER, false);
         addOption(l3a, UNOFFICIAL_HYPOCHONDRIAC, false);
         addOption(l3a, UNOFFICIAL_USELESS_TALENT, false);
         addOption(l3a, UNOFFICIAL_PATHOLOGIC_INSIGHT, false);

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateHealing.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateHealing.java
@@ -33,9 +33,11 @@
 package mekhq.campaign.personnel.medical.advancedMedicalAlternate;
 
 import static java.lang.Math.max;
+import static megamek.common.compute.Compute.randomInt;
 import static mekhq.campaign.personnel.PersonnelOptions.ATOW_FIT;
 import static mekhq.campaign.personnel.PersonnelOptions.ATOW_TOUGHNESS;
 import static mekhq.campaign.personnel.PersonnelOptions.EDGE_MEDICAL;
+import static mekhq.campaign.personnel.PersonnelOptions.UNOFFICIAL_HOLISTIC_CARE;
 import static mekhq.campaign.personnel.medical.advancedMedicalAlternate.HealingMarginOfSuccessEffects.getEffectFromHealingAttempt;
 import static mekhq.campaign.personnel.skills.SkillType.S_SURGERY;
 import static mekhq.campaign.personnel.skills.enums.SkillAttribute.BODY;
@@ -325,13 +327,16 @@ public class AdvancedMedicalAlternateHealing {
     public static void performAssistedHealingCheck(LocalDate today, boolean isUseFatigue, int fatigueRate,
           Person patient, Person doctor, List<TargetRollModifier> modifiers, Set<BodyLocation> prostheticPenalties,
           boolean useEdge) {
+        boolean hasHolisticCareSPA = doctor.getOptions().booleanOption(UNOFFICIAL_HOLISTIC_CARE);
+
         // We need a defensive copy of the list as we're going to be removing injuries from it when successfully healing
         for (Injury injury : new ArrayList<>(patient.getInjuries())) {
             if (!injury.isPermanent()) {
                 // This needs to be refetched each cycle as the number of concurrent injuries might have changed
                 int injuryPenalty = max(0, patient.getTotalInjurySeverity() - patient.getAdjustedToughness());
 
-                injury.changeTime(-1);
+                int healingDelta = hasHolisticCareSPA && randomInt(20) == 0 ? -2 : -1;
+                injury.changeTime(healingDelta);
 
                 if (injury.getTime() <= 0) {
                     int miscPenalty = getMiscPenalty(injuryPenalty, prostheticPenalties, injury.getLocation());

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateHealing.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateHealing.java
@@ -38,6 +38,7 @@ import static mekhq.campaign.personnel.PersonnelOptions.ATOW_FIT;
 import static mekhq.campaign.personnel.PersonnelOptions.ATOW_TOUGHNESS;
 import static mekhq.campaign.personnel.PersonnelOptions.EDGE_MEDICAL;
 import static mekhq.campaign.personnel.PersonnelOptions.UNOFFICIAL_HOLISTIC_CARE;
+import static mekhq.campaign.personnel.PersonnelOptions.UNOFFICIAL_HYPOCHONDRIAC;
 import static mekhq.campaign.personnel.PersonnelOptions.UNOFFICIAL_PATHOLOGIC_INSIGHT;
 import static mekhq.campaign.personnel.PersonnelOptions.UNOFFICIAL_PROTHESIS_TECHNICIAN;
 import static mekhq.campaign.personnel.PersonnelOptions.UNOFFICIAL_TRAUMA_SURGEON;
@@ -208,7 +209,8 @@ public class AdvancedMedicalAlternateHealing {
         boolean hasTraumaSurgeon = personnelOptions.booleanOption(UNOFFICIAL_TRAUMA_SURGEON);
         boolean hasProthesisTechnician = personnelOptions.booleanOption(UNOFFICIAL_PROTHESIS_TECHNICIAN);
         boolean hasPathologicInsight = personnelOptions.booleanOption(UNOFFICIAL_PATHOLOGIC_INSIGHT);
-        
+        boolean hasHypochondriac = personnelOptions.booleanOption(UNOFFICIAL_HYPOCHONDRIAC);
+
         // We need a defensive copy of the list as we're going to be removing injuries from it when successfully healing
         for (Injury injury : new ArrayList<>(patient.getInjuries())) {
             addPathologicInsightModifier(modifiers, injury, hasPathologicInsight);
@@ -223,6 +225,8 @@ public class AdvancedMedicalAlternateHealing {
                       injury.getLocation(),
                       hasTraumaSurgeon,
                       hasProthesisTechnician);
+                miscPenalty += hasHypochondriac ? 1 : 0;
+
                 int marginOfSuccess = getMarginOfSuccessForUnassistedHealing(patient, modifiers, miscPenalty, useEdge);
 
                 if (injury.getTime() <= 0) { // Time to try and fully heal the injury
@@ -362,14 +366,17 @@ public class AdvancedMedicalAlternateHealing {
     public static void performAssistedHealingCheck(LocalDate today, boolean isUseFatigue, int fatigueRate,
           Person patient, Person doctor, List<TargetRollModifier> modifiers, Set<BodyLocation> prostheticPenalties,
           boolean useEdge) {
-        boolean hasHolisticCareSPA = doctor.getOptions().booleanOption(UNOFFICIAL_HOLISTIC_CARE);
 
-        PersonnelOptions personnelOptions = doctor.getOptions();
-        boolean hasTraumaSurgeon = personnelOptions.booleanOption(UNOFFICIAL_TRAUMA_SURGEON);
-        boolean hasProthesisTechnician = personnelOptions.booleanOption(UNOFFICIAL_PROTHESIS_TECHNICIAN);
-        boolean hasPathologicInsight = personnelOptions.booleanOption(UNOFFICIAL_PATHOLOGIC_INSIGHT);
+        PersonnelOptions doctorPersonnelOptions = doctor.getOptions();
+        boolean hasHolisticCareSPA = doctorPersonnelOptions.booleanOption(UNOFFICIAL_HOLISTIC_CARE);
+        boolean hasTraumaSurgeon = doctorPersonnelOptions.booleanOption(UNOFFICIAL_TRAUMA_SURGEON);
+        boolean hasProthesisTechnician = doctorPersonnelOptions.booleanOption(UNOFFICIAL_PROTHESIS_TECHNICIAN);
+        boolean hasPathologicInsight = doctorPersonnelOptions.booleanOption(UNOFFICIAL_PATHOLOGIC_INSIGHT);
+
+        PersonnelOptions patientPersonnelOptions = patient.getOptions();
+        boolean hasHypochondriac = patientPersonnelOptions.booleanOption(UNOFFICIAL_HYPOCHONDRIAC);
+
         // We need a defensive copy of the list as we're going to be removing injuries from it when successfully healing
-
         for (Injury injury : new ArrayList<>(patient.getInjuries())) {
             addPathologicInsightModifier(modifiers, injury, hasPathologicInsight);
 
@@ -383,6 +390,8 @@ public class AdvancedMedicalAlternateHealing {
                 if (injury.getTime() <= 0) {
                     int miscPenalty = getMiscPenalty(injuryPenalty, prostheticPenalties, injury.getLocation(),
                           hasTraumaSurgeon, hasProthesisTechnician);
+                    miscPenalty += hasHypochondriac ? 1 : 0;
+
                     int marginOfSuccess = getMarginOfSuccessForAssistedHealing(doctor, modifiers, miscPenalty, useEdge);
 
                     processHealingEffects(isUseFatigue, fatigueRate, patient, injury, marginOfSuccess, today);

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateHealing.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateHealing.java
@@ -38,6 +38,8 @@ import static mekhq.campaign.personnel.PersonnelOptions.ATOW_FIT;
 import static mekhq.campaign.personnel.PersonnelOptions.ATOW_TOUGHNESS;
 import static mekhq.campaign.personnel.PersonnelOptions.EDGE_MEDICAL;
 import static mekhq.campaign.personnel.PersonnelOptions.UNOFFICIAL_HOLISTIC_CARE;
+import static mekhq.campaign.personnel.PersonnelOptions.UNOFFICIAL_PROTHESIS_TECHNICIAN;
+import static mekhq.campaign.personnel.PersonnelOptions.UNOFFICIAL_TRAUMA_SURGEON;
 import static mekhq.campaign.personnel.medical.advancedMedicalAlternate.HealingMarginOfSuccessEffects.getEffectFromHealingAttempt;
 import static mekhq.campaign.personnel.skills.SkillType.S_SURGERY;
 import static mekhq.campaign.personnel.skills.enums.SkillAttribute.BODY;
@@ -201,13 +203,21 @@ public class AdvancedMedicalAlternateHealing {
     public static void performUnassistedHealingCheck(LocalDate today, boolean isUseFatigue, int fatigueRate,
           Person patient, List<TargetRollModifier> modifiers, Set<BodyLocation> prostheticPenalties, boolean useEdge) {
         // We need a defensive copy of the list as we're going to be removing injuries from it when successfully healing
+
+        PersonnelOptions personnelOptions = patient.getOptions();
+        boolean hasTraumaSurgeon = personnelOptions.booleanOption(UNOFFICIAL_TRAUMA_SURGEON);
+        boolean hasProthesisTechnician = personnelOptions.booleanOption(UNOFFICIAL_PROTHESIS_TECHNICIAN);
         for (Injury injury : new ArrayList<>(patient.getInjuries())) {
             if (!injury.isPermanent()) {
                 // This needs to be refetched each cycle as the number of concurrent injuries might have changed
                 int injuryPenalty = max(0, patient.getTotalInjurySeverity() - patient.getAdjustedToughness());
 
                 injury.changeTime(-1);
-                int miscPenalty = getMiscPenalty(injuryPenalty, prostheticPenalties, injury.getLocation());
+                int miscPenalty = getMiscPenalty(injuryPenalty,
+                      prostheticPenalties,
+                      injury.getLocation(),
+                      hasTraumaSurgeon,
+                      hasProthesisTechnician);
                 int marginOfSuccess = getMarginOfSuccessForUnassistedHealing(patient, modifiers, miscPenalty, useEdge);
 
                 if (injury.getTime() <= 0) { // Time to try and fully heal the injury
@@ -231,21 +241,34 @@ public class AdvancedMedicalAlternateHealing {
      * represented by a prosthetic and that location is present in {@code prostheticPenalties}, the prosthetic penalty
      * is added.</p>
      *
-     * @param injuryPenalty       the total injury severity for the patient
-     * @param prostheticPenalties the set of body locations that incur prosthetic penalties
-     * @param location            the body location of the injury being healed
+     * @param injuryPenalty          the total injury severity for the patient
+     * @param prostheticPenalties    the set of body locations that incur prosthetic penalties
+     * @param location               the body location of the injury being healed
+     * @param hasTraumaSurgeon       {@code true} if the patient has the trauma surgeon SPA (reduces injury penalty)
+     * @param hasProthesisTechnician {@code true} if the patient has the prothesis technician SPA (reduces prosthetic
+     *                               penalty)
      *
      * @return the sum of the base injury penalty and any applicable prosthetic penalty
      *
      * @author Illiani
      * @since 0.50.10
      */
-    private static int getMiscPenalty(int injuryPenalty, Set<BodyLocation> prostheticPenalties, BodyLocation location) {
+    private static int getMiscPenalty(int injuryPenalty, Set<BodyLocation> prostheticPenalties, BodyLocation location,
+          boolean hasTraumaSurgeon, boolean hasProthesisTechnician) {
         int miscPenalty = injuryPenalty;
+        int traumaSurgeonModifier = hasTraumaSurgeon ? -1 : 0;
+        miscPenalty = max(0, miscPenalty + traumaSurgeonModifier);
 
+        boolean hasProstheticPenalty = false;
         BodyLocation primaryLocation = location.getPrimaryLocation();
         if (prostheticPenalties.contains(primaryLocation)) {
             miscPenalty += PROSTHETIC_PENALTY;
+            hasProstheticPenalty = true;
+        }
+
+        if (hasProstheticPenalty) {
+            int technicianModifier = hasProthesisTechnician ? -1 : 0;
+            miscPenalty = max(0, miscPenalty + technicianModifier);
         }
 
         return miscPenalty;
@@ -330,6 +353,10 @@ public class AdvancedMedicalAlternateHealing {
         boolean hasHolisticCareSPA = doctor.getOptions().booleanOption(UNOFFICIAL_HOLISTIC_CARE);
 
         // We need a defensive copy of the list as we're going to be removing injuries from it when successfully healing
+
+        PersonnelOptions personnelOptions = doctor.getOptions();
+        boolean hasTraumaSurgeon = personnelOptions.booleanOption(UNOFFICIAL_TRAUMA_SURGEON);
+        boolean hasProthesisTechnician = personnelOptions.booleanOption(UNOFFICIAL_PROTHESIS_TECHNICIAN);
         for (Injury injury : new ArrayList<>(patient.getInjuries())) {
             if (!injury.isPermanent()) {
                 // This needs to be refetched each cycle as the number of concurrent injuries might have changed
@@ -339,7 +366,8 @@ public class AdvancedMedicalAlternateHealing {
                 injury.changeTime(healingDelta);
 
                 if (injury.getTime() <= 0) {
-                    int miscPenalty = getMiscPenalty(injuryPenalty, prostheticPenalties, injury.getLocation());
+                    int miscPenalty = getMiscPenalty(injuryPenalty, prostheticPenalties, injury.getLocation(),
+                          hasTraumaSurgeon, hasProthesisTechnician);
                     int marginOfSuccess = getMarginOfSuccessForAssistedHealing(doctor, modifiers, miscPenalty, useEdge);
 
                     processHealingEffects(isUseFatigue, fatigueRate, patient, injury, marginOfSuccess, today);

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateHealing.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateHealing.java
@@ -38,6 +38,7 @@ import static mekhq.campaign.personnel.PersonnelOptions.ATOW_FIT;
 import static mekhq.campaign.personnel.PersonnelOptions.ATOW_TOUGHNESS;
 import static mekhq.campaign.personnel.PersonnelOptions.EDGE_MEDICAL;
 import static mekhq.campaign.personnel.PersonnelOptions.UNOFFICIAL_HOLISTIC_CARE;
+import static mekhq.campaign.personnel.PersonnelOptions.UNOFFICIAL_PATHOLOGIC_INSIGHT;
 import static mekhq.campaign.personnel.PersonnelOptions.UNOFFICIAL_PROTHESIS_TECHNICIAN;
 import static mekhq.campaign.personnel.PersonnelOptions.UNOFFICIAL_TRAUMA_SURGEON;
 import static mekhq.campaign.personnel.medical.advancedMedicalAlternate.HealingMarginOfSuccessEffects.getEffectFromHealingAttempt;
@@ -202,12 +203,16 @@ public class AdvancedMedicalAlternateHealing {
      */
     public static void performUnassistedHealingCheck(LocalDate today, boolean isUseFatigue, int fatigueRate,
           Person patient, List<TargetRollModifier> modifiers, Set<BodyLocation> prostheticPenalties, boolean useEdge) {
-        // We need a defensive copy of the list as we're going to be removing injuries from it when successfully healing
 
         PersonnelOptions personnelOptions = patient.getOptions();
         boolean hasTraumaSurgeon = personnelOptions.booleanOption(UNOFFICIAL_TRAUMA_SURGEON);
         boolean hasProthesisTechnician = personnelOptions.booleanOption(UNOFFICIAL_PROTHESIS_TECHNICIAN);
+        boolean hasPathologicInsight = personnelOptions.booleanOption(UNOFFICIAL_PATHOLOGIC_INSIGHT);
+        
+        // We need a defensive copy of the list as we're going to be removing injuries from it when successfully healing
         for (Injury injury : new ArrayList<>(patient.getInjuries())) {
+            addPathologicInsightModifier(modifiers, injury, hasPathologicInsight);
+
             if (!injury.isPermanent()) {
                 // This needs to be refetched each cycle as the number of concurrent injuries might have changed
                 int injuryPenalty = max(0, patient.getTotalInjurySeverity() - patient.getAdjustedToughness());
@@ -230,6 +235,13 @@ public class AdvancedMedicalAlternateHealing {
                     injury.changeTime(1); // Undo the prior reduction
                 }
             }
+        }
+    }
+
+    private static void addPathologicInsightModifier(List<TargetRollModifier> modifiers, Injury injury,
+          boolean hasPathologicInsight) {
+        if (hasPathologicInsight && injury.isDisease()) {
+            modifiers.add(new TargetRollModifier(-2, "Pathologic Insight"));
         }
     }
 
@@ -352,12 +364,15 @@ public class AdvancedMedicalAlternateHealing {
           boolean useEdge) {
         boolean hasHolisticCareSPA = doctor.getOptions().booleanOption(UNOFFICIAL_HOLISTIC_CARE);
 
-        // We need a defensive copy of the list as we're going to be removing injuries from it when successfully healing
-
         PersonnelOptions personnelOptions = doctor.getOptions();
         boolean hasTraumaSurgeon = personnelOptions.booleanOption(UNOFFICIAL_TRAUMA_SURGEON);
         boolean hasProthesisTechnician = personnelOptions.booleanOption(UNOFFICIAL_PROTHESIS_TECHNICIAN);
+        boolean hasPathologicInsight = personnelOptions.booleanOption(UNOFFICIAL_PATHOLOGIC_INSIGHT);
+        // We need a defensive copy of the list as we're going to be removing injuries from it when successfully healing
+
         for (Injury injury : new ArrayList<>(patient.getInjuries())) {
+            addPathologicInsightModifier(modifiers, injury, hasPathologicInsight);
+
             if (!injury.isPermanent()) {
                 // This needs to be refetched each cycle as the number of concurrent injuries might have changed
                 int injuryPenalty = max(0, patient.getTotalInjurySeverity() - patient.getAdjustedToughness());

--- a/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
@@ -517,6 +517,13 @@ public class Skill {
             }
         }
 
+        // Administration
+        if (Objects.equals(S_ADMIN, name)) {
+            if (characterOptions.booleanOption(UNOFFICIAL_LOSES_PAPERWORK)) {
+                modifier -= 2;
+            }
+        }
+
         return modifier;
     }
 

--- a/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
@@ -493,6 +493,13 @@ public class Skill {
             }
         }
 
+        // Surgery/Any
+        if (Objects.equals(S_SURGERY, name)) {
+            if (characterOptions.booleanOption(UNOFFICIAL_SHAKEY_SCALPEL)) {
+                modifier -= 2;
+            }
+        }
+
         return modifier;
     }
 

--- a/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
@@ -500,6 +500,13 @@ public class Skill {
             }
         }
 
+        // Training
+        if (Objects.equals(S_TRAINING, name)) {
+            if (characterOptions.booleanOption(UNOFFICIAL_PATIENT_EDUCATOR)) {
+                modifier += 2;
+            }
+        }
+
         return modifier;
     }
 

--- a/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
@@ -507,6 +507,13 @@ public class Skill {
             }
         }
 
+        // Communications/Any
+        if (Objects.equals(S_COMMUNICATIONS, name)) {
+            if (characterOptions.booleanOption(UNOFFICIAL_RADIO_HOBBYIST)) {
+                modifier += 2;
+            }
+        }
+
         return modifier;
     }
 

--- a/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
@@ -498,6 +498,9 @@ public class Skill {
             if (characterOptions.booleanOption(UNOFFICIAL_SHAKEY_SCALPEL)) {
                 modifier -= 2;
             }
+            if (characterOptions.booleanOption(UNOFFICIAL_PAPER_SURGEON)) {
+                modifier -= 2;
+            }
         }
 
         // Training

--- a/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
@@ -468,14 +468,14 @@ public class Skill {
             }
         }
 
-        // Ranger
+        // Tracking
         if (Objects.equals(S_TRACKING, name)) {
             if (characterOptions.booleanOption(UNOFFICIAL_RANGER)) {
                 modifier += 1;
             }
         }
 
-        // Ranger
+        // Stealth
         if (Objects.equals(S_STEALTH, name)) {
             if (characterOptions.booleanOption(UNOFFICIAL_GHOST)) {
                 modifier += 1;
@@ -483,6 +483,13 @@ public class Skill {
 
             if (characterOptions.booleanOption(UNOFFICIAL_LOUD_MOUTH)) {
                 modifier -= 1;
+            }
+        }
+
+        // Appraisal
+        if (Objects.equals(S_APPRAISAL, name)) {
+            if (characterOptions.booleanOption(UNOFFICIAL_BARGAIN_HUNTER)) {
+                modifier += 1;
             }
         }
 

--- a/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
@@ -489,7 +489,7 @@ public class Skill {
         // Appraisal
         if (Objects.equals(S_APPRAISAL, name)) {
             if (characterOptions.booleanOption(UNOFFICIAL_BARGAIN_HUNTER)) {
-                modifier += 1;
+                modifier += 2;
             }
         }
 


### PR DESCRIPTION
# Requires #374

Close #6682
Close #6684
Close #6685

- Transport Negotiator (Reduces transport costs)
- Bargain Hunters (improves Appraisal checks)
- Shakey Scalpel (penalty to Surgery checks)
- Embezzler (monthly chance to steal campaign funds :D)
- Paper Surgeon (penalty to Surgery checks)
- Loses Paperwork (penalty to Administration checks)
- Patient Educator (bonus to Training checks)
- Pathologic Insight (bonus to Surgery checks made to heal diseases)
- Holistic Care (daily chance to reduce healing time by 2 days instead of 1)
- Trauma Surgeon (reduces the injury penalty when healing injuries)
- Useless Talent (doesn't do anything)
- Radio Hobbyist (bonus to Communications/Any checks)
- Hypochondriac (increases the injury penalty when being healed)
- Experienced Prothesis Technician (reduces the penalty to healing checks from permanent modifications)

The goal of this PR is to increase the variety of SPAs/Flaws unique to non-technical support staff.