### PR TITLE
Display Edge in Salvage Tech Picker Dialogue

### DIFF
--- a/MekHQ/resources/mekhq/resources/SalvageTechPicker.properties
+++ b/MekHQ/resources/mekhq/resources/SalvageTechPicker.properties
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+# Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
 #
 # This file is part of MekHQ.
 #
@@ -43,5 +43,6 @@ SalvageTechPicker.column.skill=Skill Level
 SalvageTechPicker.column.profession.primary=Primary Role
 SalvageTechPicker.column.profession.secondary=Secondary Role
 SalvageTechPicker.column.techUnits=Units
+SalvageTechPicker.column.edge=Edge
 SalvageTechPicker.column.injuries=Injuries
 SalvageTechPicker.column.minutes=Minutes

--- a/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/CamOpsSalvageUtilities.java
+++ b/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/CamOpsSalvageUtilities.java
@@ -372,7 +372,7 @@ public class CamOpsSalvageUtilities {
 
             Person victim = ObjectUtility.getRandomItem(techs);
 
-            if (campaignOptions.isUseEdge() && victim.getCurrentEdge() > 0) {
+            if (campaignOptions.isUseEdge() && campaignOptions.isUseSupportEdge() && victim.getCurrentEdge() > 0) {
                 if (performEdgeReroll(campaign, victim)) {
                     continue;
                 }

--- a/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/SalvageTechData.java
+++ b/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/SalvageTechData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -44,8 +44,8 @@ import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.unit.Unit;
 
 public record SalvageTechData(Person tech, UUID techId, String rank, int rankNumeric, PersonnelRole primaryRole,
-      PersonnelRole secondaryRole, List<String> techUnits, String firstName, String lastName, String skillLevelName,
-      int injuries, int minutesAvailable) {
+      PersonnelRole secondaryRole, List<String> techUnits, String firstName, String lastName, int edge,
+      String skillLevelName, int injuries, int minutesAvailable) {
     public static SalvageTechData buildData(Campaign campaign, Person tech) {
         boolean isSecondaryTech = tech.getSecondaryRole().isTechSecondary();
         List<String> techUnits = new ArrayList<>();
@@ -61,6 +61,7 @@ public record SalvageTechData(Person tech, UUID techId, String rank, int rankNum
               List.copyOf(techUnits),
               tech.getFirstName(),
               tech.getLastName(),
+              tech.getCurrentEdge(),
               tech.getSkillLevel(campaign, isSecondaryTech, true).toString(),
               max(tech.getHits(), tech.getInjuries().size()),
               tech.getMinutesLeft());

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -59,21 +59,7 @@ import java.awt.Insets;
 import java.io.File;
 import java.time.LocalDate;
 import java.util.*;
-import javax.swing.AbstractButton;
-import javax.swing.BorderFactory;
-import javax.swing.JButton;
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JSplitPane;
-import javax.swing.JTabbedPane;
-import javax.swing.JTable;
-import javax.swing.ListSelectionModel;
-import javax.swing.ScrollPaneConstants;
-import javax.swing.SwingUtilities;
-import javax.swing.UIManager;
+import javax.swing.*;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableRowSorter;
 
@@ -1482,8 +1468,12 @@ public final class BriefingTab extends CampaignGuiTab {
             }
         }
 
+        Campaign campaign = getCampaign();
+        CampaignOptions campaignOptions = campaign.getCampaignOptions();
+        boolean isClanCampaign = campaign.isClanCampaign();
+        boolean isUseEdge = campaignOptions.isUseEdge() && campaignOptions.isUseSupportEdge();
         SalvageTechPicker techPicker = new SalvageTechPicker(techData, priorSelectedTechs,
-              getCampaign().isClanCampaign(), getBattlefieldControlType(scenario));
+              isClanCampaign, getBattlefieldControlType(scenario), isUseEdge);
         boolean wasConfirmed = techPicker.wasConfirmed();
         if (wasConfirmed) {
             scenario.clearSalvageTechs();
@@ -1689,7 +1679,7 @@ public final class BriefingTab extends CampaignGuiTab {
             }
         }
 
-                List<String> buttons = List.of(getTextAt(RESOURCE_BUNDLE, "dialogScenarioAcceptance.button.accept"),
+        List<String> buttons = List.of(getTextAt(RESOURCE_BUNDLE, "dialogScenarioAcceptance.button.accept"),
               getTextAt(RESOURCE_BUNDLE, "dialogScenarioAcceptance.button.cancel"));
 
         ImmersiveDialogSimple dialog = new ImmersiveDialogSimple(getCampaign(),

--- a/MekHQ/src/mekhq/gui/dialog/camOpsSalvage/SalvageTechPicker.java
+++ b/MekHQ/src/mekhq/gui/dialog/camOpsSalvage/SalvageTechPicker.java
@@ -56,6 +56,7 @@ import javax.swing.RowSorter;
 import javax.swing.SortOrder;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.TableColumn;
 import javax.swing.table.TableRowSorter;
 
 import megamek.client.ui.preferences.JWindowPreference;
@@ -93,6 +94,7 @@ public class SalvageTechPicker extends JDialog {
 
     private boolean wasConfirmed;
     private final SalvageTechTableModel tableModel;
+    private static boolean isUseEdge = true;
 
     /**
      * Checks whether the user confirmed their tech selection.
@@ -130,12 +132,14 @@ public class SalvageTechPicker extends JDialog {
      * @param alreadySelectedTechs list of tech UUIDs that should start as pre-selected.
      * @param isClanCampaign       {@code true} if the campaign is Clan affiliated
      * @param fieldControl         who controls the field at the end of the scenario
+     * @param isUseEdge            determines if the Edge column should be visible or not
      *
      * @author Illiani
      * @since 0.50.10
      */
     public SalvageTechPicker(List<SalvageTechData> techs, List<UUID> alreadySelectedTechs, boolean isClanCampaign,
-          ScenarioTemplate.BattlefieldControlType fieldControl) {
+          ScenarioTemplate.BattlefieldControlType fieldControl, boolean isUseEdge) {
+        SalvageTechPicker.isUseEdge = isUseEdge;
         setTitle(getText("accessingTerminal.title"));
         setModal(true);
         setLayout(new BorderLayout());
@@ -245,6 +249,16 @@ public class SalvageTechPicker extends JDialog {
               .setPreferredWidth(WIDTH_100);
         table.getColumnModel().getColumn(SalvageTechTableModel.COL_UNITS)
               .setPreferredWidth(WIDTH_40);
+        if (isUseEdge) {
+            table.getColumnModel().getColumn(SalvageTechTableModel.COL_EDGE)
+                  .setPreferredWidth(WIDTH_40);
+        } else {
+            //hide this column when edge is not in use by setting all widths to zero
+            TableColumn columnToHide = table.getColumnModel().getColumn(SalvageTechTableModel.COL_EDGE);
+            columnToHide.setMinWidth(0);
+            columnToHide.setMaxWidth(0);
+            columnToHide.setPreferredWidth(0);
+        }
         table.getColumnModel().getColumn(SalvageTechTableModel.COL_SKILL_LEVEL)
               .setPreferredWidth(WIDTH_60);
         table.getColumnModel().getColumn(SalvageTechTableModel.COL_INJURIES)
@@ -311,6 +325,8 @@ public class SalvageTechPicker extends JDialog {
                   new NaturalOrderComparator());
             sorter.setComparator(SalvageTechTableModel.COL_SECONDARY_PROFESSION,
                   new NaturalOrderComparator());
+            sorter.setComparator(SalvageTechTableModel.COL_EDGE,
+                  Comparator.comparingInt(i -> ((int) i)));
             sorter.setComparator(SalvageTechTableModel.COL_INJURIES,
                   Comparator.comparingInt(i -> ((int) i)));
             sorter.setComparator(SalvageTechTableModel.COL_UNITS,
@@ -398,12 +414,14 @@ public class SalvageTechPicker extends JDialog {
         private static final int COL_PRIMARY_PROFESSION = 5;
         /** Column index for secondary profession. */
         private static final int COL_SECONDARY_PROFESSION = 6;
+        /** Column index for current/total edge. */
+        private static final int COL_EDGE = 7;
         /** Column index for maintained unit count. */
-        private static final int COL_UNITS = 7;
+        private static final int COL_UNITS = 8;
         /** Column index for injury count. */
-        private static final int COL_INJURIES = 8;
+        private static final int COL_INJURIES = 9;
         /** Column index for available minutes. */
-        private static final int COL_MINUTES_AVAILABLE = 9;
+        private static final int COL_MINUTES_AVAILABLE = 10;
 
         private final List<SalvageTechData> techs;
         private final boolean[] selected;
@@ -417,6 +435,7 @@ public class SalvageTechPicker extends JDialog {
               getTextAt(RESOURCE_BUNDLE, "SalvageTechPicker.column.skill"),
               getTextAt(RESOURCE_BUNDLE, "SalvageTechPicker.column.profession.primary"),
               getTextAt(RESOURCE_BUNDLE, "SalvageTechPicker.column.profession.secondary"),
+              getTextAt(RESOURCE_BUNDLE, "SalvageTechPicker.column.edge"),
               getTextAt(RESOURCE_BUNDLE, "SalvageTechPicker.column.techUnits"),
               getTextAt(RESOURCE_BUNDLE, "SalvageTechPicker.column.injuries"),
               getTextAt(RESOURCE_BUNDLE, "SalvageTechPicker.column.minutes")
@@ -468,7 +487,7 @@ public class SalvageTechPicker extends JDialog {
                 case COL_SELECT -> Boolean.class;
                 case COL_RANK, COL_FIRST_NAME, COL_LAST_NAME, COL_SKILL_LEVEL, COL_PRIMARY_PROFESSION,
                      COL_SECONDARY_PROFESSION -> String.class;
-                case COL_INJURIES, COL_MINUTES_AVAILABLE, COL_UNITS -> Integer.class;
+                case COL_INJURIES, COL_MINUTES_AVAILABLE, COL_UNITS, COL_EDGE -> Integer.class;
                 default -> Object.class;
             };
         }
@@ -490,6 +509,7 @@ public class SalvageTechPicker extends JDialog {
                 case COL_SKILL_LEVEL -> data.skillLevelName();
                 case COL_PRIMARY_PROFESSION -> data.primaryRole().getLabel(isClanCampaign);
                 case COL_SECONDARY_PROFESSION -> data.secondaryRole().getLabel(isClanCampaign);
+                case COL_EDGE -> data.edge();
                 case COL_UNITS -> data.techUnits().size();
                 case COL_INJURIES -> data.injuries();
                 case COL_MINUTES_AVAILABLE -> data.minutesAvailable();


### PR DESCRIPTION
With risky salvage operations, when assigning techs as salvage supervisors it is important to know if a tech has any edge left, as this would enable a reroll if anything were to go wrong.

This PR addresses this by adding a new column showing the current edge of all techs, allowing the player to make a better informed decision on who to select.

The new column is not shown if either edge or edge for support personnel is not enabled in the campaign.

Using edge during risky salvage is now also dependent on both edge and edge for support personnel being enabled. Previously, only edge needed to be enabled.