### PR TITLE
RFE: Make temp personnel UI more compact

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignGUI.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignGUI.properties
@@ -434,3 +434,18 @@ dialogScenarioAcceptance.button.accept=Commence Drop
 dialogScenarioAcceptance.button.cancel=Return to the Launch Bay
 cadreReassignment.text=One or more formations were assigned to Cadre duties. With the contract now concluded, they have \
   been reassigned to Frontline.
+# Status Bar - Temp Personnel
+statusBar.pnlTempPersonnel.title=Temp
+statusBar.pnlVehicleCrew.title=Vehicle Crew
+statusBar.pnlVesselCrew.title=Vessel
+statusBar.lblTempAsTechs.text=AsTechs
+statusBar.lblTempMedics.text=Medics
+statusBar.lblTempSoldiers.text=Soldiers
+statusBar.lblTempBattleArmor.text=Battle Armor
+statusBar.lblTempVehicleCrewGround.text=Ground
+statusBar.lblTempVehicleCrewVTOL.text=VTOL
+statusBar.lblTempVehicleCrewNaval.text=Naval
+statusBar.lblTempVesselPilot.text=Pilots
+statusBar.lblTempVesselGunner.text=Gunners
+statusBar.lblTempVesselCrew.text=Crew
+statusBar.lblPartsAvailabilityRating.text=Parts Availability Modifier

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -60,6 +60,7 @@ import java.util.*;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.zip.GZIPOutputStream;
+import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JFrame;
@@ -68,6 +69,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTable;
 import javax.swing.SwingConstants;
+import javax.swing.border.Border;
 
 import megamek.client.ui.dialogs.UnitLoadingDialog;
 import megamek.client.ui.dialogs.unitSelectorDialogs.AbstractUnitSelectorDialog;
@@ -173,9 +175,11 @@ public class CampaignGUI extends JPanel {
     private JLabel lblTempVehicleCrewGround;
     private JLabel lblTempVehicleCrewVTOL;
     private JLabel lblTempVehicleCrewNaval;
+    private JPanel pnlVehicleCrew;
     private JLabel lblTempVesselPilot;
     private JLabel lblTempVesselGunner;
     private JLabel lblTempVesselCrew;
+    private JPanel pnlVesselCrew;
     private JLabel lblPartsAvailabilityRating;
 
     /* Top Panel */
@@ -392,17 +396,36 @@ public class CampaignGUI extends JPanel {
         btnOvertime.setSelected(getCampaign().isOvertimeAllowed());
         btnOvertime.addActionListener(evt -> getCampaign().setOvertime(btnOvertime.isSelected()));
 
+        Border innerBorder = BorderFactory.createCompoundBorder(
+              new RoundedLineBorder(UIUtil.uiIndependentGray(), 1, 8),
+              BorderFactory.createEmptyBorder(1, 3, 1, 3));
+
+        pnlVehicleCrew = new JPanel(new FlowLayout(FlowLayout.LEADING, 6, 0));
+        pnlVehicleCrew.setBorder(innerBorder);
+        pnlVehicleCrew.add(new JLabel(statusBarLabel("statusBar.pnlVehicleCrew.title")));
+        pnlVehicleCrew.add(lblTempVehicleCrewGround);
+        pnlVehicleCrew.add(lblTempVehicleCrewVTOL);
+        pnlVehicleCrew.add(lblTempVehicleCrewNaval);
+
+        pnlVesselCrew = new JPanel(new FlowLayout(FlowLayout.LEADING, 6, 0));
+        pnlVesselCrew.setBorder(innerBorder);
+        pnlVesselCrew.add(new JLabel(statusBarLabel("statusBar.pnlVesselCrew.title")));
+        pnlVesselCrew.add(lblTempVesselPilot);
+        pnlVesselCrew.add(lblTempVesselGunner);
+        pnlVesselCrew.add(lblTempVesselCrew);
+
+        JPanel pnlTempPersonnel = new JPanel(new FlowLayout(FlowLayout.LEADING, 8, 2));
+        pnlTempPersonnel.setBorder(RoundedLineBorder.createSubtleRoundedLineBorder());
+        pnlTempPersonnel.add(new JLabel(statusBarLabel("statusBar.pnlTempPersonnel.title")));
+        pnlTempPersonnel.add(lblTempAsTechs);
+        pnlTempPersonnel.add(lblTempMedics);
+        pnlTempPersonnel.add(lblTempSoldiers);
+        pnlTempPersonnel.add(lblTempBattleArmor);
+        pnlTempPersonnel.add(pnlVehicleCrew);
+        pnlTempPersonnel.add(pnlVesselCrew);
+
         statusPanel.add(btnOvertime);
-        statusPanel.add(lblTempAsTechs);
-        statusPanel.add(lblTempMedics);
-        statusPanel.add(lblTempSoldiers);
-        statusPanel.add(lblTempBattleArmor);
-        statusPanel.add(lblTempVehicleCrewGround);
-        statusPanel.add(lblTempVehicleCrewVTOL);
-        statusPanel.add(lblTempVehicleCrewNaval);
-        statusPanel.add(lblTempVesselPilot);
-        statusPanel.add(lblTempVesselGunner);
-        statusPanel.add(lblTempVesselCrew);
+        statusPanel.add(pnlTempPersonnel);
         statusPanel.add(lblPartsAvailabilityRating);
     }
 
@@ -1386,16 +1409,22 @@ public class CampaignGUI extends JPanel {
         getFrame().setTitle(getCampaign().getTitle());
     }
 
+    private String statusBarLabel(String key, Object... args) {
+        String label = getFormattedTextAt("mekhq.resources.CampaignGUI", key);
+        if (args.length == 0) {
+            return "<html><b>" + label + "</b></html>";
+        }
+        return "<html><b>" + label + "</b>: " + args[0] + "</html>";
+    }
+
     private void refreshTempAsTechs() {
-        // FIXME : Localize
-        String text = "<html><b>Temp AsTechs</b>: " + getCampaign().getTemporaryAsTechPool() + "</html>";
-        lblTempAsTechs.setText(text);
+        lblTempAsTechs.setText(statusBarLabel("statusBar.lblTempAsTechs.text",
+              getCampaign().getTemporaryAsTechPool()));
     }
 
     private void refreshTempMedics() {
-        // FIXME : Localize
-        String text = "<html><b>Temp Medics</b>: " + getCampaign().getTemporaryMedicPool() + "</html>";
-        lblTempMedics.setText(text);
+        lblTempMedics.setText(statusBarLabel("statusBar.lblTempMedics.text",
+              getCampaign().getTemporaryMedicPool()));
     }
 
     private void refreshTempSoldiers() {
@@ -1404,9 +1433,8 @@ public class CampaignGUI extends JPanel {
             return;
         }
         lblTempSoldiers.setVisible(true);
-        // FIXME : Localize
-        String text = "<html><b>Temp Soldiers</b>: " + getCampaign().getTempCrewPool(PersonnelRole.SOLDIER) + "</html>";
-        lblTempSoldiers.setText(text);
+        lblTempSoldiers.setText(statusBarLabel("statusBar.lblTempSoldiers.text",
+              getCampaign().getTempCrewPool(PersonnelRole.SOLDIER)));
     }
 
     private void refreshTempBattleArmor() {
@@ -1415,88 +1443,92 @@ public class CampaignGUI extends JPanel {
             return;
         }
         lblTempBattleArmor.setVisible(true);
-        // FIXME : Localize
-        String text = "<html><b>Temp Battle Armor</b>: " + getCampaign().getTempCrewPool(PersonnelRole.BATTLE_ARMOUR) +
-                            "</html>";
-        lblTempBattleArmor.setText(text);
+        lblTempBattleArmor.setText(statusBarLabel("statusBar.lblTempBattleArmor.text",
+              getCampaign().getTempCrewPool(PersonnelRole.BATTLE_ARMOUR)));
     }
 
     private void refreshTempVehicleCrewGround() {
         if (!getCampaign().getCampaignOptions().isUseBlobVehicleCrewGround()) {
             lblTempVehicleCrewGround.setVisible(false);
+            refreshVehicleCrewPanelVisibility();
             return;
         }
         lblTempVehicleCrewGround.setVisible(true);
-        // FIXME : Localize
-        String text = "<html><b>Temp Vehicle Crew (Ground)</b>: " +
-                            getCampaign().getTempCrewPool(PersonnelRole.VEHICLE_CREW_GROUND) +
-                            "</html>";
-        lblTempVehicleCrewGround.setText(text);
+        lblTempVehicleCrewGround.setText(statusBarLabel("statusBar.lblTempVehicleCrewGround.text",
+              getCampaign().getTempCrewPool(PersonnelRole.VEHICLE_CREW_GROUND)));
+        refreshVehicleCrewPanelVisibility();
     }
 
     private void refreshTempVehicleCrewVTOL() {
         if (!getCampaign().getCampaignOptions().isUseBlobVehicleCrewVTOL()) {
             lblTempVehicleCrewVTOL.setVisible(false);
+            refreshVehicleCrewPanelVisibility();
             return;
         }
         lblTempVehicleCrewVTOL.setVisible(true);
-        // FIXME : Localize
-        String text = "<html><b>Temp Vehicle Crew (VTOL)</b>: " +
-                            getCampaign().getTempCrewPool(PersonnelRole.VEHICLE_CREW_VTOL) +
-                            "</html>";
-        lblTempVehicleCrewVTOL.setText(text);
+        lblTempVehicleCrewVTOL.setText(statusBarLabel("statusBar.lblTempVehicleCrewVTOL.text",
+              getCampaign().getTempCrewPool(PersonnelRole.VEHICLE_CREW_VTOL)));
+        refreshVehicleCrewPanelVisibility();
     }
 
     private void refreshTempVehicleCrewNaval() {
         if (!getCampaign().getCampaignOptions().isUseBlobVehicleCrewNaval()) {
             lblTempVehicleCrewNaval.setVisible(false);
+            refreshVehicleCrewPanelVisibility();
             return;
         }
         lblTempVehicleCrewNaval.setVisible(true);
-        // FIXME : Localize
-        String text = "<html><b>Temp Vehicle Crew (Naval)</b>: " +
-                            getCampaign().getTempCrewPool(PersonnelRole.VEHICLE_CREW_NAVAL) +
-                            "</html>";
-        lblTempVehicleCrewNaval.setText(text);
+        lblTempVehicleCrewNaval.setText(statusBarLabel("statusBar.lblTempVehicleCrewNaval.text",
+              getCampaign().getTempCrewPool(PersonnelRole.VEHICLE_CREW_NAVAL)));
+        refreshVehicleCrewPanelVisibility();
+    }
+
+    private void refreshVehicleCrewPanelVisibility() {
+        pnlVehicleCrew.setVisible(lblTempVehicleCrewGround.isVisible()
+                                        || lblTempVehicleCrewVTOL.isVisible()
+                                        || lblTempVehicleCrewNaval.isVisible());
     }
 
     private void refreshTempVesselPilot() {
         if (!getCampaign().getCampaignOptions().isUseBlobVesselPilot()) {
             lblTempVesselPilot.setVisible(false);
+            refreshVesselCrewPanelVisibility();
             return;
         }
         lblTempVesselPilot.setVisible(true);
-        // FIXME : Localize
-        String text = "<html><b>Temp Vessel Pilots</b>: " +
-                            getCampaign().getTempCrewPool(PersonnelRole.VESSEL_PILOT) +
-                            "</html>";
-        lblTempVesselPilot.setText(text);
+        lblTempVesselPilot.setText(statusBarLabel("statusBar.lblTempVesselPilot.text",
+              getCampaign().getTempCrewPool(PersonnelRole.VESSEL_PILOT)));
+        refreshVesselCrewPanelVisibility();
     }
 
     private void refreshTempVesselGunner() {
         if (!getCampaign().getCampaignOptions().isUseBlobVesselGunner()) {
             lblTempVesselGunner.setVisible(false);
+            refreshVesselCrewPanelVisibility();
             return;
         }
         lblTempVesselGunner.setVisible(true);
-        // FIXME : Localize
-        String text = "<html><b>Temp Vessel Gunners</b>: " +
-                            getCampaign().getTempCrewPool(PersonnelRole.VESSEL_GUNNER) +
-                            "</html>";
-        lblTempVesselGunner.setText(text);
+        lblTempVesselGunner.setText(statusBarLabel("statusBar.lblTempVesselGunner.text",
+              getCampaign().getTempCrewPool(PersonnelRole.VESSEL_GUNNER)));
+        refreshVesselCrewPanelVisibility();
     }
 
     private void refreshTempVesselCrew() {
         if (!getCampaign().getCampaignOptions().isUseBlobVesselCrew()) {
             lblTempVesselCrew.setVisible(false);
+            refreshVesselCrewPanelVisibility();
             return;
         }
         lblTempVesselCrew.setVisible(true);
-        // FIXME : Localize
-        String text = "<html><b>Temp Vessel Crew</b>: " +
-                            getCampaign().getTempCrewPool(PersonnelRole.VESSEL_CREW) +
-                            "</html>";
-        lblTempVesselCrew.setText(text);
+        lblTempVesselCrew.setText(statusBarLabel("statusBar.lblTempVesselCrew.text",
+              getCampaign().getTempCrewPool(PersonnelRole.VESSEL_CREW)));
+        refreshVesselCrewPanelVisibility();
+    }
+
+    private void refreshVesselCrewPanelVisibility() {
+        pnlVesselCrew.setVisible(lblTempVesselPilot.isVisible()
+                                       || lblTempVesselGunner.isVisible()
+                                       || lblTempVesselCrew.isVisible());
     }
 
     private void refreshPartsAvailability() {
@@ -1504,8 +1536,7 @@ public class CampaignGUI extends JPanel {
             lblPartsAvailabilityRating.setText("");
         } else {
             int partsAvailability = getCampaign().findAtBPartsAvailabilityLevel();
-            // FIXME : Localize
-            lblPartsAvailabilityRating.setText(String.format("<html><b>Parts Availability Modifier</b>: %d</html>",
+            lblPartsAvailabilityRating.setText(statusBarLabel("statusBar.lblPartsAvailabilityRating.text",
                   partsAvailability));
         }
     }


### PR DESCRIPTION
With all the new temp personnel enabled, I couldn't see the parts availability modifier anymore! This change rearranges the temp personnel display to use less space.

Before:
<img width="3398" height="566" alt="image" src="https://github.com/user-attachments/assets/07cda581-b503-4f93-b93e-0158209dd939" />

After with only a few enabled: 
<img width="3406" height="350" alt="image" src="https://github.com/user-attachments/assets/fa0d21fd-68c0-4ef4-9038-34785a7c1b1c" />

After with all enabled:
<img width="3392" height="342" alt="image" src="https://github.com/user-attachments/assets/75c76501-db4e-4668-ad4d-615fdcd8dcec" />
