### PR TITLE
Corrected a Few Instances Where We Were Fetching All Injuries Instead of Just Permanent Modifications

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -1926,12 +1926,10 @@ public class CampaignNewDayManager {
         int myomerProsthetics = 0;
         boolean hasPowerSupply = false;
 
-        for (Injury injury : person.getInjuries()) {
-            InjurySubType injurySubType = injury.getSubType();
-            if (injurySubType.isPermanentModification()) {
-                prostheticMedicalReliance++;
-            }
+        for (Injury injury : person.getProstheticInjuries()) {
+            prostheticMedicalReliance++;
 
+            InjurySubType injurySubType = injury.getSubType();
             if (injurySubType.isMyomerProsthetic()) {
                 myomerProsthetics++;
             }

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateImplants.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateImplants.java
@@ -256,7 +256,7 @@ public class AdvancedMedicalAlternateImplants {
         int prostheticThreshold = 3;
         int eligibleProstheticsCount = 0;
 
-        for (Injury injury : person.getInjuries()) {
+        for (Injury injury : person.getProstheticInjuries()) {
             ProstheticType prostheticType = getProstheticTypeFromInjuryType(injury.getType());
 
             if (prostheticType != null) {
@@ -360,7 +360,7 @@ public class AdvancedMedicalAlternateImplants {
     }
 
     public static void checkForDermalEligibility(Person person) {
-        List<Injury> injuries = person.getInjuries();
+        List<Injury> injuries = person.getProstheticInjuries();
 
         int dermalArmorCount = 0;
         int dermalCamoCount = 0;


### PR DESCRIPTION
While investigating #9151 I spotted some instances where we were fetching all injuries, when we only wanted injuries that are permanent modifications.

Fundamentally this change doesn't change how these calls ultimately work, but it is cleaner and ensures we're not parsing all injuries unnecessarily.