### PR TITLE
Corrected 'Should Die' Checks in a Handful of Places

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/CamOpsSalvageUtilities.java
+++ b/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/CamOpsSalvageUtilities.java
@@ -35,6 +35,7 @@ package mekhq.campaign.mission.camOpsSalvage;
 import static java.lang.Math.max;
 import static megamek.common.compute.Compute.d6;
 import static megamek.common.equipment.MiscType.F_NAVAL_TUG_ADAPTOR;
+import static megamek.common.units.Crew.DEATH;
 import static mekhq.campaign.enums.DailyReportType.FINANCES;
 import static mekhq.campaign.enums.DailyReportType.MEDICAL;
 import static mekhq.campaign.enums.DailyReportType.PERSONNEL;
@@ -394,7 +395,7 @@ public class CamOpsSalvageUtilities {
     }
 
     private static void testForDeath(Campaign campaign, Person victim, List<Person> techs) {
-        if (victim.getTotalInjurySeverity() >= 6) {
+        if (victim.getTotalInjurySeverity() >= DEATH) {
             victim.changeStatus(campaign, campaign.getLocalDate(), PersonnelStatus.ACCIDENTAL);
             techs.remove(victim); // We're nice enough that we only kill each tech once
         }

--- a/MekHQ/src/mekhq/campaign/personnel/Bloodmark.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Bloodmark.java
@@ -35,6 +35,7 @@ package mekhq.campaign.personnel;
 import static java.lang.Math.min;
 import static megamek.common.compute.Compute.d6;
 import static megamek.common.compute.Compute.randomInt;
+import static megamek.common.units.Crew.DEATH;
 import static mekhq.campaign.enums.DailyReportType.PERSONNEL;
 import static mekhq.campaign.personnel.enums.BloodmarkLevel.BLOODMARK_ZERO;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
@@ -371,7 +372,7 @@ public class Bloodmark {
             if (wounds > 0) {
                 InjuryUtil.resolveCombatDamage(campaign, person, wounds);
             }
-            if (person.getInjuries().size() >= 6) {
+            if (person.getTotalInjurySeverity() >= DEATH) {
                 person.changeStatus(campaign, today, PersonnelStatus.HOMICIDE);
             }
         } else {

--- a/MekHQ/src/mekhq/campaign/personnel/skills/EscapeSkills.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/EscapeSkills.java
@@ -34,6 +34,7 @@ package mekhq.campaign.personnel.skills;
 
 import static java.lang.Math.floor;
 import static megamek.common.compute.Compute.d6;
+import static megamek.common.units.Crew.DEATH;
 import static mekhq.campaign.enums.DailyReportType.PERSONNEL;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
@@ -210,7 +211,7 @@ public class EscapeSkills {
         boolean useAdvancedMedical = campaignOptions.isUseAdvancedMedical();
         if (useAdvancedMedical) {
             InjuryUtil.resolveCombatDamage(campaign, prisoner, injuries);
-            if (prisoner.getInjuries().size() > 5) {
+            if (prisoner.getTotalInjurySeverity() >= DEATH) {
                 prisoner.changeStatus(campaign, campaign.getLocalDate(), PersonnelStatus.HOMICIDE);
             }
         } else {

--- a/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionCensureEvent.java
+++ b/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionCensureEvent.java
@@ -34,6 +34,7 @@ package mekhq.campaign.universe.factionStanding;
 
 import static megamek.common.compute.Compute.randomInt;
 import static megamek.common.enums.SkillLevel.VETERAN;
+import static megamek.common.units.Crew.DEATH;
 import static mekhq.campaign.enums.DailyReportType.POLITICS;
 import static mekhq.campaign.personnel.PersonUtility.overrideSkills;
 import static mekhq.campaign.personnel.skills.SkillType.S_ADMIN;
@@ -339,7 +340,7 @@ public class FactionCensureEvent {
         int secondInCommandInjuries = isSuccessful ? randomInt(3) + 1 : randomInt(6) + 1;
         if (useAdvancedMedical) {
             InjuryUtil.resolveCombatDamage(campaign, commander, commanderInjuries);
-            if (commander.getInjuries().size() > 5) {
+            if (commander.getTotalInjurySeverity() >= DEATH) {
                 commander.changeStatus(campaign, campaign.getLocalDate(), PersonnelStatus.KIA);
             }
 

--- a/MekHQ/src/mekhq/gui/dialog/AdvancedReplacementLimbDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AdvancedReplacementLimbDialog.java
@@ -37,6 +37,7 @@ import static megamek.client.ui.WrapLayout.wordWrap;
 import static megamek.client.ui.util.UIUtil.scaleForGUI;
 import static megamek.common.options.PilotOptions.LVL3_ADVANTAGES;
 import static megamek.common.options.PilotOptions.MD_ADVANTAGES;
+import static megamek.common.units.Crew.DEATH;
 import static mekhq.campaign.enums.DailyReportType.MEDICAL;
 import static mekhq.campaign.enums.DailyReportType.SKILL_CHECKS;
 import static mekhq.campaign.personnel.PersonnelOptions.COMPULSION_BIONIC_HATE;
@@ -929,7 +930,7 @@ public class AdvancedReplacementLimbDialog extends JDialog {
      * @since 0.50.10
      */
     private void checkForDeath() {
-        if (patient.getTotalInjurySeverity() > 5) {
+        if (patient.getTotalInjurySeverity() >= DEATH) {
             patient.changeStatus(campaign, campaign.getLocalDate(), PersonnelStatus.MEDICAL_COMPLICATIONS);
         }
     }


### PR DESCRIPTION
While investigating #9151 I spotted a handful of instances where were incorrectly checking for character death. Specifically, we were testing how many injuries a character had sustained against the 'death' count of 6+ Hits. However, not all injuries inflict Hits. With this in mind, a character with 6+ permanent modifications (prosthetics, implants, etc, etc) would be considered eligible for death.

To rectify this I switched these calls over to `getTotalInjurySeverity()`. This method fetches the 'severity' of each injury (how many TW-scale Hits it is worth), as well as any actual TW-scale Hits. This means that 'injuries' with a severity of 0 are now correctly excluded from any 'death checks'.

While I was doing this I also moved us over to the static `DEATH` rather than having 6 (or 5) defined everywhere.