### PR TITLE
Replaced Instances of Joint `getHits` and `getInjuries.size()` With `getTotalInjurySeverity`

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/SalvageTechData.java
+++ b/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/SalvageTechData.java
@@ -32,8 +32,6 @@
  */
 package mekhq.campaign.mission.camOpsSalvage;
 
-import static java.lang.Math.max;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -63,7 +61,7 @@ public record SalvageTechData(Person tech, UUID techId, String rank, int rankNum
               tech.getLastName(),
               tech.getCurrentEdge(),
               tech.getSkillLevel(campaign, isSecondaryTech, true).toString(),
-              max(tech.getHits(), tech.getInjuries().size()),
+              tech.getTotalInjurySeverity(),
               tech.getMinutesLeft());
     }
 }

--- a/MekHQ/src/mekhq/campaign/randomEvents/prisoners/EventEffectsManager.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/prisoners/EventEffectsManager.java
@@ -287,7 +287,7 @@ public class EventEffectsManager {
         // this event, they will never actually die.
         int wounds = max(magnitude, 1);
 
-        int priorHits = max(target.getHits(), target.getInjuries().size());
+        int priorHits = target.getTotalInjurySeverity();
 
         wounds = InjurySPAUtility.adjustInjuriesAndFatigueForSPAs(target,
               campaign.getCampaignOptions().isUseInjuryFatigue(),
@@ -347,7 +347,7 @@ public class EventEffectsManager {
 
             int wounds = Math.clamp(d6(), 1, 5);
 
-            int priorHits = max(target.getHits(), target.getInjuries().size());
+            int priorHits = target.getTotalInjurySeverity();
 
             wounds = InjurySPAUtility.adjustInjuriesAndFatigueForSPAs(target, isUseInjuryFatigue, fatigueRate, wounds);
 


### PR DESCRIPTION
While investigating #9151 I spotted there were numerous instances where we were fetching both `getHits()` and `getInjuries.size()` and then using `Math.max()` to get the highest value.

In all instances we should, instead, have been using `getTotalInjurySeverity()` as this will return the total sum of all injury severity - including raw TW-scale Hits.

Previously, if the character had a mix of TW-scale Hits and Injuries, only one would have been counted.