### PR TITLE
When Picking Salvage Forces, the Number of Injuries Shown for Techs Will Now Display TW-Scale Hit Counts, Instead

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/SalvageFormationData.java
+++ b/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/SalvageFormationData.java
@@ -56,8 +56,9 @@ import mekhq.campaign.unit.ITransportAssignment;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.enums.TransporterType;
 
-public record SalvageFormationData(Formation formation, FormationType formationType, @Nullable Person tech, double maximumCargoCapacity,
-                                   double maximumTowCapacity, int salvageCapableUnits, boolean hasTug) {
+public record SalvageFormationData(Formation formation, FormationType formationType, @Nullable Person tech,
+      double maximumCargoCapacity,
+      double maximumTowCapacity, int salvageCapableUnits, boolean hasTug) {
     private static final String RESOURCE_BUNDLE = "mekhq.resources.SalvageFormationData";
 
     public static SalvageFormationData buildData(Campaign campaign, Formation formation, boolean isSpaceScenario) {
@@ -153,7 +154,7 @@ public record SalvageFormationData(Formation formation, FormationType formationT
             int injuries;
             if (campaign.getCampaignOptions().isUseAdvancedMedical()) {
                 injuryLabelKey = "SalvageFormationData.injuries";
-                injuries = tech.getInjuries().size();
+                injuries = tech.getTotalInjurySeverity();
             } else {
                 injuryLabelKey = "SalvageFormationData.hits";
                 injuries = tech.getHits();


### PR DESCRIPTION
While investigating #9151 I spotted that we were displaying total injury count in the 'injuries' column in the salvage tech picker. However, not all injuries constitute a TW-scale Hit, which is the information players really want. How we display 'Severity', instead. Which is basically just the number of TW-scale Hits the characters various injuries are worth.