### PR TITLE
Fix #9151: Fixed 'Injured Personnel' Nag Triggering for Characters With Permanent Injuries (Including Permanent Modifications)

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -7610,8 +7610,16 @@ public class Person {
         return getInjuryByLocation(location) != null;
     }
 
+    /**
+     * Determines whether this entity has any non-permanent injuries that require medical attention.
+     *
+     * @return {@code true} if there is at least one non-permanent injury present; {@code false} otherwise
+     */
     public boolean needsAMFixing() {
-        return !injuries.isEmpty();
+        ArrayList<Injury> allInjuries = new ArrayList<>(getInjuries());
+        allInjuries.removeAll(getPermanentInjuries());
+
+        return !allInjuries.isEmpty();
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -7616,10 +7616,8 @@ public class Person {
      * @return {@code true} if there is at least one non-permanent injury present; {@code false} otherwise
      */
     public boolean needsAMFixing() {
-        ArrayList<Injury> allInjuries = new ArrayList<>(getInjuries());
-        allInjuries.removeAll(getPermanentInjuries());
-
-        return !allInjuries.isEmpty();
+        boolean ignorePermanentInjuries = true;
+        return hasInjuries(ignorePermanentInjuries);
     }
 
     /**


### PR DESCRIPTION
Fix #9151

We were incorrectly returning `true` if the character had _any_ injuries, not non-permanent injuries.