### PR TITLE
Fix #9154: Fix infantry being unsellable / save breaking if customized via Customize Unit

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2009 Jay Lawson (jaylawson39 at yahoo.com). All rights reserved.
- * Copyright (C) 2013-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2013-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -213,7 +213,10 @@ public class Refit extends Part implements IAcquisitionWork {
         campaign = oldUnit.getCampaign();
         calculate();
 
-        if (customJob) {
+        // Using Customize -> Refit/Customize... -> Customize to Model will pass in TRUE for "custom". We do not want
+        // to rename infantry if we're refitting to an existing model, but if we're editing in the MekLab tab we
+        // should propose a new name.
+        if (customJob && isSavingFile) {
             suggestNewName();
         }
     }

--- a/MekHQ/testresources/data/mekfiles/Foot Platoon (DCMS) (Laser 2620+).blk
+++ b/MekHQ/testresources/data/mekfiles/Foot Platoon (DCMS) (Laser 2620+).blk
@@ -1,0 +1,87 @@
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+#Saved from version 0.50.12 on 2026-02-26
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Foot Platoon (DCMS)
+</Name>
+
+<Model>
+(Laser 2620+)
+</Model>
+
+<mul id:>
+1144
+</mul id:>
+
+<source>
+TW,TM
+</source>
+
+<year>
+2620
+</year>
+
+<originalBuildYear>
+2620
+</originalBuildYear>
+
+<type>
+IS Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Leg
+</motion_type>
+
+<Troopers Equipment>
+Draconis Combine Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+
+<notes>
+Intro date based on prototype date of DCMS armor kit. Magna laser rifle is standard DCMS laser weapon.
+</notes>
+
+<squad_size>
+7
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+Laser Rifle (Magna)
+</Primary>
+
+# Fluff Date: 2026-03-18 15:07:44
+<overview>
+<p>The Combine's martial traditions extend beyond the BattleMech cockpit, and the Dictum Honorium demands that all citizens contribute their talents to the defense of House Kurita. Infantry soldiers of the DCMS embody that expectation on garrison worlds across the realm. Foot infantry are the cheapest troops the DCMS can field, and the Combine fields them in enormous numbers. Every military district maintains garrison formations whose sole purpose is holding ground that BattleMech regiments cannot occupy permanently. Slow and vulnerable in open terrain, these soldiers prove their worth through discipline and endurance, standing post on worlds across the Combine because the Dragon demands nothing less. Equipped with laser rifles that outrange and outpenetrate ballistic weapons at every engagement distance. The cost is significant: laser rifles are expensive to procure, and each soldier must carry additional power packs that add weight and logistical burden. Where the budget allows, they are worth every C-bill.</p>
+</overview>
+

--- a/MekHQ/testresources/data/mekfiles/Foot Platoon (DCMS) (MG 2620+).blk
+++ b/MekHQ/testresources/data/mekfiles/Foot Platoon (DCMS) (MG 2620+).blk
@@ -1,0 +1,95 @@
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+#Saved from version 0.50.12 on 2026-02-26
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Foot Platoon (DCMS)
+</Name>
+
+<Model>
+(MG 2620+)
+</Model>
+
+<mul id:>
+1146
+</mul id:>
+
+<source>
+TW,TM
+</source>
+
+<year>
+2620
+</year>
+
+<originalBuildYear>
+2620
+</originalBuildYear>
+
+<type>
+IS Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Leg
+</motion_type>
+
+<Troopers Equipment>
+Draconis Combine Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+
+<notes>
+Intro date based on prototype date of DCMS armor kit
+</notes>
+
+<squad_size>
+7
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Machine Gun (Portable)
+</Secondary>
+
+# Fluff Date: 2026-03-18 15:07:44
+<overview>
+<p>The Combine's martial traditions extend beyond the BattleMech cockpit, and the Dictum Honorium demands that all citizens contribute their talents to the defense of House Kurita. Infantry soldiers of the DCMS embody that expectation on garrison worlds across the realm. Foot infantry are the cheapest troops the DCMS can field, and the Combine fields them in enormous numbers. Every military district maintains garrison formations whose sole purpose is holding ground that BattleMech regiments cannot occupy permanently. Slow and vulnerable in open terrain, these soldiers prove their worth through discipline and endurance, standing post on worlds across the Combine because the Dragon demands nothing less. Their support squads operate portable machine guns that deliver sustained automatic fire at ranges well beyond personal weapons. A single well-placed machine gun team can suppress an entire enemy platoon and threaten light vehicles that would otherwise ignore conventional infantry.</p>
+</overview>
+

--- a/MekHQ/unittests/mekhq/campaign/parts/RefitTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/RefitTest.java
@@ -79,6 +79,7 @@ import mekhq.campaign.unit.UnitTestUtilities;
 import mekhq.utilities.MHQXMLUtility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -88,6 +89,7 @@ import org.mockito.quality.Strictness;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
+import testUtilities.MHQTestUtilities;
 
 @ExtendWith(value = MockitoExtension.class)
 public class RefitTest {
@@ -922,5 +924,57 @@ public class RefitTest {
 
         // We should have 0 points of standard armor on order
         assertNull(refit.getNewArmorSupplies());
+    }
+
+    @Nested
+    class InfantryRefitConstructorTest {
+        @Test
+        public void customTrueSaveFalse_nameUnchanged() {
+            Entity oldEntity = MHQTestUtilities.getEntityForUnitTesting(
+                  "Foot Platoon (DCMS) (Laser 2620+)", true);
+            assertNotNull(oldEntity);
+            Player mockPlayer = mock(Player.class);
+            when(mockPlayer.getName()).thenReturn("Test Player");
+            oldEntity.setOwner(mockPlayer);
+
+            Entity newEntity = MHQTestUtilities.getEntityForUnitTesting(
+                  "Foot Platoon (DCMS) (MG 2620+)", true);
+            assertNotNull(newEntity);
+
+            String originalChassis = newEntity.getChassis();
+            String originalModel = newEntity.getModel();
+
+            Unit oldUnit = new Unit(oldEntity, mockCampaign);
+            oldUnit.setId(UUID.randomUUID());
+            oldUnit.initializeParts(false);
+
+            Refit refit = new Refit(oldUnit, newEntity, true, false, false);
+
+            assertEquals(originalChassis, refit.getNewEntity().getChassis());
+            assertEquals(originalModel, refit.getNewEntity().getModel());
+        }
+
+        @Test
+        public void customTrueSaveTrue_nameReplacedWithAutoName() {
+            Entity oldEntity = MHQTestUtilities.getEntityForUnitTesting(
+                  "Foot Platoon (DCMS) (Laser 2620+)", true);
+            assertNotNull(oldEntity);
+            Player mockPlayer = mock(Player.class);
+            when(mockPlayer.getName()).thenReturn("Test Player");
+            oldEntity.setOwner(mockPlayer);
+
+            Entity newEntity = MHQTestUtilities.getEntityForUnitTesting(
+                  "Foot Platoon (DCMS) (MG 2620+)", true);
+            assertNotNull(newEntity);
+
+            Unit oldUnit = new Unit(oldEntity, mockCampaign);
+            oldUnit.setId(UUID.randomUUID());
+            oldUnit.initializeParts(false);
+
+            Refit refit = new Refit(oldUnit, newEntity, true, false, true);
+
+            assertEquals("Foot Platoon", refit.getNewEntity().getChassis());
+            assertEquals("(Machine Gun (Portable))", refit.getNewEntity().getModel());
+        }
     }
 }


### PR DESCRIPTION
Fixes #9154

Prevent infantry that are being customized to an existing model from generating a new chassis / model name. 

Prior to this change, this would rename an Entity if it is a custom job, even if being refit to an existing unit. The name change/suggestion is needed for the MekHQ MekLab refits, but not for customize to model refits. 

