### PR TITLE
Removed Boilerplate Code Surrounding the Addition of Daily Report Tabs

### DIFF
--- a/MekHQ/src/mekhq/gui/CommandCenterTab.java
+++ b/MekHQ/src/mekhq/gui/CommandCenterTab.java
@@ -582,31 +582,41 @@ public final class CommandCenterTab extends CampaignGuiTab {
 
         tabLogs = new EnhancedTabbedPane();
         tabLogs.setName("dailyReportTabs");
-        tabLogs.addTab(GENERAL.getIconString(), pnlGeneralLog);
-        tabLogs.setToolTipTextAt(GENERAL.getTabIndex(), GENERAL.getTooltip());
-        tabLogs.addTab(BATTLE.getIconString(), pnlBattleLog);
-        tabLogs.setToolTipTextAt(BATTLE.getTabIndex(), BATTLE.getTooltip());
-        tabLogs.addTab(PERSONNEL.getIconString(), pnlPersonnelLog);
-        tabLogs.setToolTipTextAt(PERSONNEL.getTabIndex(), PERSONNEL.getTooltip());
-        tabLogs.addTab(MEDICAL.getIconString(), pnlMedicalLog);
-        tabLogs.setToolTipTextAt(MEDICAL.getTabIndex(), MEDICAL.getTooltip());
-        tabLogs.addTab(FINANCES.getIconString(), pnlFinancesLog);
-        tabLogs.setToolTipTextAt(FINANCES.getTabIndex(), FINANCES.getTooltip());
-        tabLogs.addTab(ACQUISITIONS.getIconString(), pnlAcquisitionsLog);
-        tabLogs.setToolTipTextAt(ACQUISITIONS.getTabIndex(), ACQUISITIONS.getTooltip());
-        tabLogs.addTab(TECHNICAL.getIconString(), pnlTechnicalLog);
-        tabLogs.setToolTipTextAt(TECHNICAL.getTabIndex(), TECHNICAL.getTooltip());
-        tabLogs.addTab(POLITICS.getIconString(), pnlPoliticsLog);
-        tabLogs.setToolTipTextAt(POLITICS.getTabIndex(), POLITICS.getTooltip());
-        tabLogs.addTab(SKILL_CHECKS.getIconString(), pnlSkillLog);
-        tabLogs.setToolTipTextAt(SKILL_CHECKS.getTabIndex(), SKILL_CHECKS.getTooltip());
-        tabLogs.addTab(AGGREGATE.getIconString(), pnlAggregateLog);
-        tabLogs.setToolTipTextAt(AGGREGATE.getTabIndex(), AGGREGATE.getTooltip());
+        addDailyReportTab(tabLogs, pnlGeneralLog, GENERAL);
+        addDailyReportTab(tabLogs, pnlBattleLog, BATTLE);
+        addDailyReportTab(tabLogs, pnlPersonnelLog, PERSONNEL);
+        addDailyReportTab(tabLogs, pnlMedicalLog, MEDICAL);
+        addDailyReportTab(tabLogs, pnlFinancesLog, FINANCES);
+        addDailyReportTab(tabLogs, pnlAcquisitionsLog, ACQUISITIONS);
+        addDailyReportTab(tabLogs, pnlTechnicalLog, TECHNICAL);
+        addDailyReportTab(tabLogs, pnlPoliticsLog, POLITICS);
+        addDailyReportTab(tabLogs, pnlSkillLog, SKILL_CHECKS);
+        addDailyReportTab(tabLogs, pnlAggregateLog, AGGREGATE);
 
         tabLogs.addChangeListener(evt -> {
             int selectedIndex = tabLogs.getSelectedIndex();
             clearDailyReportNag(selectedIndex);
         });
+    }
+
+    /**
+     * Sets a named {@link JLabel} as the tab component for the given {@link DailyReportType}, allowing it to be
+     * retrieved and shown/hidden later via {@link JTabbedPane#getTabComponentAt(int)}.
+     *
+     * @param tabbedPane the tabbed pane to set the component on
+     * @param panel      the {@link JPanel} associated with the tab
+     * @param type       the {@link DailyReportType} whose tab should receive the component
+     *
+     * @author Illiani
+     * @since 0.51.0
+     */
+    public static void addDailyReportTab(EnhancedTabbedPane tabbedPane, JPanel panel, DailyReportType type) {
+        tabbedPane.addTab(type.getIconString(), panel);
+        tabbedPane.setToolTipTextAt(type.getTabIndex(), type.getTooltip());
+
+        JLabel label = new JLabel(type.getIconString());
+        label.setName(type.name());
+        tabbedPane.setTabComponentAt(type.getTabIndex(), label);
     }
 
     public void clearDailyReportNag(int selectedIndex) {

--- a/MekHQ/src/mekhq/gui/dialog/AdvanceDaysDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AdvanceDaysDialog.java
@@ -33,6 +33,7 @@
 package mekhq.gui.dialog;
 
 import static mekhq.campaign.enums.DailyReportType.*;
+import static mekhq.gui.CommandCenterTab.addDailyReportTab;
 
 import java.awt.Container;
 import java.awt.GridLayout;
@@ -297,26 +298,16 @@ public class AdvanceDaysDialog extends AbstractMHQDialogBasic {
         getAggregateLogPanel().refreshLog(commandCenterTab.getAggregateLog().getLogText(), AGGREGATE);
 
         EnhancedTabbedPane dailyReportTab = new EnhancedTabbedPane();
-        dailyReportTab.addTab(GENERAL.getIconString(), getDailyLogPanel());
-        dailyReportTab.setToolTipTextAt(GENERAL.getTabIndex(), GENERAL.getTooltip());
-        dailyReportTab.addTab(BATTLE.getIconString(), getBattleLogPanel());
-        dailyReportTab.setToolTipTextAt(BATTLE.getTabIndex(), BATTLE.getTooltip());
-        dailyReportTab.addTab(PERSONNEL.getIconString(), getPersonnelLogPanel());
-        dailyReportTab.setToolTipTextAt(PERSONNEL.getTabIndex(), PERSONNEL.getTooltip());
-        dailyReportTab.addTab(MEDICAL.getIconString(), getMedicalLogPanel());
-        dailyReportTab.setToolTipTextAt(MEDICAL.getTabIndex(), MEDICAL.getTooltip());
-        dailyReportTab.addTab(FINANCES.getIconString(), getFinancesLogPanel());
-        dailyReportTab.setToolTipTextAt(FINANCES.getTabIndex(), FINANCES.getTooltip());
-        dailyReportTab.addTab(ACQUISITIONS.getIconString(), getAcquisitionsLogPanel());
-        dailyReportTab.setToolTipTextAt(ACQUISITIONS.getTabIndex(), ACQUISITIONS.getTooltip());
-        dailyReportTab.addTab(TECHNICAL.getIconString(), getTechnicalLogPanel());
-        dailyReportTab.setToolTipTextAt(TECHNICAL.getTabIndex(), TECHNICAL.getTooltip());
-        dailyReportTab.addTab(POLITICS.getIconString(), getPoliticsLogPanel());
-        dailyReportTab.setToolTipTextAt(POLITICS.getTabIndex(), POLITICS.getTooltip());
-        dailyReportTab.addTab(SKILL_CHECKS.getIconString(), getSkillLogPanel());
-        dailyReportTab.setToolTipTextAt(SKILL_CHECKS.getTabIndex(), SKILL_CHECKS.getTooltip());
-        dailyReportTab.addTab(AGGREGATE.getIconString(), getSkillLogPanel());
-        dailyReportTab.setToolTipTextAt(AGGREGATE.getTabIndex(), AGGREGATE.getTooltip());
+        addDailyReportTab(dailyReportTab, getDailyLogPanel(), GENERAL);
+        addDailyReportTab(dailyReportTab, getBattleLogPanel(), BATTLE);
+        addDailyReportTab(dailyReportTab, getPersonnelLogPanel(), PERSONNEL);
+        addDailyReportTab(dailyReportTab, getMedicalLogPanel(), MEDICAL);
+        addDailyReportTab(dailyReportTab, getFinancesLogPanel(), FINANCES);
+        addDailyReportTab(dailyReportTab, getAcquisitionsLogPanel(), ACQUISITIONS);
+        addDailyReportTab(dailyReportTab, getTechnicalLogPanel(), TECHNICAL);
+        addDailyReportTab(dailyReportTab, getPoliticsLogPanel(), POLITICS);
+        addDailyReportTab(dailyReportTab, getSkillLogPanel(), SKILL_CHECKS);
+        addDailyReportTab(dailyReportTab, getAggregateLogPanel(), AGGREGATE);
 
         // Layout the Panel
         final JPanel panel = new JPanel();


### PR DESCRIPTION
While refactoring I also expanded how we add tabs so that they include a component element, should we ever need it. This avoids an NPE if we try to access a tab via `getComponentAt(index)`