### PR TITLE
Fix #9167: Increased Width of Daily Report Display Slightly

### DIFF
--- a/MekHQ/src/mekhq/gui/CommandCenterTab.java
+++ b/MekHQ/src/mekhq/gui/CommandCenterTab.java
@@ -528,7 +528,7 @@ public final class CommandCenterTab extends CampaignGuiTab {
      * Initialize the panel for displaying the daily report log
      */
     private void initLogPanel() {
-        Dimension size = scaleForGUI(400, 100);
+        Dimension size = scaleForGUI(450, 100);
 
         pnlGeneralLog = new DailyReportLogPanel(getCampaignGui());
         pnlGeneralLog.setBorder(RoundedLineBorder.createRoundedLineBorder(resourceMap.getString("panLog.title")));


### PR DESCRIPTION
Fix #9167

This is the best I can do to mitigate the issue highlighted in the above case. However, we need to be careful, as for every person this display is too small for, there are `n` for whom it is too big.

1080 is the smallest resolution my monitors can decrease to, reasonably, and also the smallest resolution we officially support. I've checked this change with that resolution and it should work ok. However, how a gui appears differs greatly based on local settings.

This really is the best I can offer.