### PR TITLE
Fix: Briefing window Deployment Coverage not updating live

### DIFF
--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -171,6 +171,7 @@ public final class BriefingTab extends CampaignGuiTab {
     private MMComboBox<ScenarioQueueFilter> scenarioFilter;
     private JScrollPane scrollMissionView;
     private JScrollPane scrollScenarioView;
+    private MissionViewPanel missionViewPanel;
     private JPanel panScenarioActions;
     private JButton btnAddScenario;
     private JButton btnEditMission;
@@ -412,6 +413,7 @@ public final class BriefingTab extends CampaignGuiTab {
         scrollScenarioView.setViewportView(null);
         scrollScenarioView.setMinimumSize(new Dimension(350, 220));
         panLanceAssignment = new LanceAssignmentView(getCampaign());
+        panLanceAssignment.setAssignmentChangeListener(this::updateMissionDeploymentCoverage);
 
         scenarioWorkTabs = new JTabbedPane();
         styleBriefingTabs(scenarioWorkTabs);
@@ -2531,6 +2533,12 @@ public final class BriefingTab extends CampaignGuiTab {
         refreshAssignmentsTabAvailability(getSelectedScenario());
     }
 
+    private void updateMissionDeploymentCoverage() {
+        if (missionViewPanel != null) {
+            missionViewPanel.updateDeploymentCoverage();
+        }
+    }
+
     /*
      * (non-Javadoc)
      *
@@ -2546,13 +2554,15 @@ public final class BriefingTab extends CampaignGuiTab {
         final Mission mission = comboMission.getSelectedItem();
         if (mission == null) {
             scrollMissionView.setViewportView(null);
+            missionViewPanel = null;
             btnEditMission.setEnabled(false);
             btnCompleteMission.setEnabled(false);
             btnDeleteMission.setEnabled(false);
             btnAddScenario.setEnabled(false);
             btnGMGenerateScenarios.setEnabled(false);
         } else {
-            scrollMissionView.setViewportView(new MissionViewPanel(mission, getCampaignGui()));
+            missionViewPanel = new MissionViewPanel(mission, getCampaignGui());
+            scrollMissionView.setViewportView(missionViewPanel);
             // This odd code is to make sure that the scrollbar stays at the top
             // I can't just call it here, because it ends up getting reset somewhere later
             SwingUtilities.invokeLater(() -> scrollMissionView.getVerticalScrollBar().setValue(0));
@@ -2749,6 +2759,7 @@ public final class BriefingTab extends CampaignGuiTab {
         scenarioDataScheduler.schedule();
         if (getCampaignOptions().isUseStratCon()) {
             lanceAssignmentScheduler.schedule();
+            updateMissionDeploymentCoverage();
         }
     }
 
@@ -2760,6 +2771,7 @@ public final class BriefingTab extends CampaignGuiTab {
         }
         if (getCampaignOptions().isUseStratCon()) {
             lanceAssignmentScheduler.schedule();
+            updateMissionDeploymentCoverage();
         }
     }
 

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -2531,6 +2531,7 @@ public final class BriefingTab extends CampaignGuiTab {
         panLanceAssignment.refresh();
         refreshSelectedScenarioActions(getSelectedScenario());
         refreshAssignmentsTabAvailability(getSelectedScenario());
+        updateMissionDeploymentCoverage();
     }
 
     private void updateMissionDeploymentCoverage() {
@@ -2759,7 +2760,6 @@ public final class BriefingTab extends CampaignGuiTab {
         scenarioDataScheduler.schedule();
         if (getCampaignOptions().isUseStratCon()) {
             lanceAssignmentScheduler.schedule();
-            updateMissionDeploymentCoverage();
         }
     }
 
@@ -2771,7 +2771,6 @@ public final class BriefingTab extends CampaignGuiTab {
         }
         if (getCampaignOptions().isUseStratCon()) {
             lanceAssignmentScheduler.schedule();
-            updateMissionDeploymentCoverage();
         }
     }
 

--- a/MekHQ/src/mekhq/gui/view/LanceAssignmentView.java
+++ b/MekHQ/src/mekhq/gui/view/LanceAssignmentView.java
@@ -83,10 +83,22 @@ public class LanceAssignmentView extends JPanel {
     private JComboBox<AtBContract> cbContract;
     private RequiredLancesTableModel requiredLancesModel;
     private LanceAssignmentTableModel lanceAssignmentModel;
+    private Runnable assignmentChangeListener;
 
     public LanceAssignmentView(Campaign c) {
         campaign = c;
         initComponents();
+    }
+
+    /**
+     * Registers a listener that is invoked whenever the unit assignments change (e.g. a force's contract or role is
+     * edited). This allows external views, such as the contract summary panel, to refresh derived information like
+     * deployment coverage.
+     *
+     * @param listener the action to run when assignments change, or {@code null} to clear it
+     */
+    public void setAssignmentChangeListener(Runnable listener) {
+        this.assignmentChangeListener = listener;
     }
 
     private void initComponents() {
@@ -329,6 +341,9 @@ public class LanceAssignmentView extends JPanel {
         public void tableChanged(TableModelEvent ev) {
             ((RequiredLancesTableModel) tblRequiredLances.getModel()).fireTableDataChanged();
             updateDeploymentSummary();
+            if (assignmentChangeListener != null) {
+                assignmentChangeListener.run();
+            }
         }
     };
 

--- a/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
@@ -97,6 +97,7 @@ public class MissionViewPanel extends JScrollablePanel {
     private JLabel txtSalvageValueMerc;
     private JLabel lblSalvageValueEmployer;
     private JLabel txtSalvageValueEmployer;
+    private JLabel txtDeploymentCoverage;
 
     private final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.ContractViewPanel",
           MekHQ.getMHQOptions().getLocale());
@@ -106,6 +107,31 @@ public class MissionViewPanel extends JScrollablePanel {
         this.mission = m;
         this.gui = gui;
         initComponents();
+    }
+
+    /**
+     * Recomputes and updates the Deployment Coverage label so it reflects the current assignment state without needing
+     * to rebuild the whole panel. Has no effect when the panel does not display a deployment coverage value (e.g. for
+     * non-AtB contracts, when StratCon is disabled, or when the contract is not currently active).
+     */
+    public void updateDeploymentCoverage() {
+        if ((txtDeploymentCoverage == null) || !(mission instanceof AtBContract contract)) {
+            return;
+        }
+
+        Campaign campaign = gui.getCampaign();
+        if (!campaign.getCampaignOptions().isUseStratCon() || !contract.isActiveOn(campaign.getLocalDate())) {
+            return;
+        }
+
+        int assignedCombatElements = RequiredLancesTableModel.getAssignedCombatElementCount(campaign, contract);
+        int requiredCombatElements = contract.getRequiredCombatElements();
+        txtDeploymentCoverage.setText(assignedCombatElements + " / " + requiredCombatElements);
+        if (RequiredLancesTableModel.hasDeploymentShortfall(campaign, contract)) {
+            txtDeploymentCoverage.setForeground(MekHQ.getMHQOptions().getBelowContractMinimumForeground());
+        } else {
+            txtDeploymentCoverage.setForeground(MekHQ.getMHQOptions().getFontColorPositive());
+        }
     }
 
     private void initComponents() {
@@ -557,7 +583,7 @@ public class MissionViewPanel extends JScrollablePanel {
         JLabel lblCargoRequirement = new JLabel();
         JLabel txtCargoRequirement = new JLabel();
         JLabel lblDeploymentCoverage = new JLabel();
-        JLabel txtDeploymentCoverage = new JLabel();
+        txtDeploymentCoverage = new JLabel();
         JLabel lblScore = new JLabel();
         JLabel txtScore = new JLabel();
         JLabel lblSupportPoints = new JLabel();
@@ -988,7 +1014,7 @@ public class MissionViewPanel extends JScrollablePanel {
                 txtDeploymentCoverage.setName("txtDeploymentCoverage");
                 txtDeploymentCoverage.setText(assignedCombatElements + " / " + requiredCombatElements);
                 txtDeploymentCoverage.setToolTipText(deploymentCoverageTooltip);
-                if (assignedCombatElements < requiredCombatElements) {
+                if (RequiredLancesTableModel.hasDeploymentShortfall(campaign, contract)) {
                     txtDeploymentCoverage.setForeground(MekHQ.getMHQOptions().getBelowContractMinimumForeground());
                 } else {
                     txtDeploymentCoverage.setForeground(MekHQ.getMHQOptions().getFontColorPositive());

--- a/MekHQ/src/mekhq/gui/view/RequiredLancesTableModel.java
+++ b/MekHQ/src/mekhq/gui/view/RequiredLancesTableModel.java
@@ -97,7 +97,7 @@ class RequiredLancesTableModel extends DataTableModel<AtBContract> {
             CombatRole requiredRole = contract.getContractType().getRequiredCombatRole();
             int requiredRoleColumn = getColumnForRole(requiredRole);
             if (requiredRoleColumn >= 0) {
-                int assignedRoleElements = getAssignedCombatRoleCount(contract, requiredRole);
+                int assignedRoleElements = getAssignedCombatRoleCount(campaign, contract, requiredRole);
                 int requiredRoleElements = Math.max(requiredCombatElements / 2, 1);
                 if (assignedRoleElements < requiredRoleElements) {
                     contractShortfalls.add(columnNames[requiredRoleColumn] + ' ' + assignedRoleElements + '/' +
@@ -112,7 +112,33 @@ class RequiredLancesTableModel extends DataTableModel<AtBContract> {
         return shortfalls;
     }
 
-    private int getAssignedCombatRoleCount(AtBContract contract, CombatRole requiredRole) {
+    /**
+     * Determines whether the given contract currently has any deployment shortfall, using the same criteria as the
+     * deployment requirements table: the total number of assigned combat elements must meet the contract requirement,
+     * and any contract-required combat role must have at least half of the required combat elements assigned to it.
+     *
+     * @param campaign the campaign the contract belongs to
+     * @param contract the contract to evaluate
+     *
+     * @return {@code true} if the contract is short on total coverage or on its required role, {@code false} otherwise
+     */
+    static boolean hasDeploymentShortfall(Campaign campaign, AtBContract contract) {
+        int assignedCombatElements = getAssignedCombatElementCount(campaign, contract);
+        int requiredCombatElements = contract.getRequiredCombatElements();
+        if (assignedCombatElements < requiredCombatElements) {
+            return true;
+        }
+
+        CombatRole requiredRole = contract.getContractType().getRequiredCombatRole();
+        if (getColumnForRole(requiredRole) >= 0) {
+            int assignedRoleElements = getAssignedCombatRoleCount(campaign, contract, requiredRole);
+            int requiredRoleElements = Math.max(requiredCombatElements / 2, 1);
+            return assignedRoleElements < requiredRoleElements;
+        }
+        return false;
+    }
+
+    private static int getAssignedCombatRoleCount(Campaign campaign, AtBContract contract, CombatRole requiredRole) {
         int assignedCombatElements = 0;
         for (CombatTeam combatTeam : campaign.getCombatTeamsAsList()) {
             if (contract.equals(combatTeam.getContract(campaign)) &&
@@ -124,7 +150,7 @@ class RequiredLancesTableModel extends DataTableModel<AtBContract> {
         return assignedCombatElements;
     }
 
-    private int getColumnForRole(CombatRole role) {
+    private static int getColumnForRole(CombatRole role) {
         if (role == null) {
             return -1;
         }
@@ -197,7 +223,7 @@ class RequiredLancesTableModel extends DataTableModel<AtBContract> {
         int requiredRoleColumn = getColumnForRole(requiredRole);
 
         if (column == requiredRoleColumn) {
-            int t = getAssignedCombatRoleCount(contract, requiredRole);
+            int t = getAssignedCombatRoleCount(campaign, contract, requiredRole);
             int required = Math.max(contract.getRequiredCombatElements() / 2, 1);
             if (t < required) {
                 return t + "/" + required;


### PR DESCRIPTION
## Summary

In the briefing window, the **Deployment Coverage** value shown in the left-hand contract summary panel (`MissionViewPanel`) was only computed when the mission was first selected. Editing force assignments in the right-hand **Assignments** tab updated that tab but left the left panel stale until the campaign was reloaded. This PR makes the left panel update in real time and aligns its red/green coloring with the Assignments tab.

## Changes

- **`MissionViewPanel`**: Promoted `txtDeploymentCoverage` to a field and added a public `updateDeploymentCoverage()` method that recomputes coverage and re-applies coloring in place. It safely no-ops when there is no coverage to display (non-AtB contract, StratCon disabled, or inactive contract).
- **`LanceAssignmentView`**: Added a `setAssignmentChangeListener(Runnable)` callback, invoked from the existing assignment table listener, so external views can react to assignment edits (contract/role changes only fire `fireTableDataChanged()`, not a campaign event).
- **`BriefingTab`**: Holds a reference to the active `MissionViewPanel` and wires the callback to refresh the left panel whenever assignments change.
- **`RequiredLancesTableModel`**: Extracted the shortfall logic into a shared static `hasDeploymentShortfall(campaign, contract)` so the left panel and the Assignments tab use identical criteria (total coverage **and** required-role coverage). Made the supporting role-count/column helpers static and updated all call sites.

## Behavior

- The left-panel Deployment Coverage now updates immediately as forces are assigned/reassigned.
- The value is **red** when there is any shortfall (total below requirement, or the contract's required role below half) and **green** only when fully covered — matching the Assignments tab.
- The information remains displayed in both locations.

## Screenshots

<img width="3415" height="1365" alt="image" src="https://github.com/user-attachments/assets/9fc2525d-4af0-4a4b-a6f7-3dee59fce971" />
<img width="3442" height="1567" alt="image" src="https://github.com/user-attachments/assets/23024166-10b9-45ae-b9b8-2de8a828fe77" />
<img width="3435" height="1562" alt="image" src="https://github.com/user-attachments/assets/5f2bde41-92e9-4bad-88c9-663d58797b40" />
