### PR TITLE
Close #9165: Non-Combat Personnel Having Access to Edge is No Longer Reliant on Edge For Combat Personnel Being Enabled

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -426,12 +426,12 @@ lblOnlyCommandersMatterInfantry.tooltip=For all conventional infantry units, onl
 lblOnlyCommandersMatterBattleArmor.text=Only Commanders Matter - Battle Armor
 lblOnlyCommandersMatterBattleArmor.tooltip=For all battle armor units, only the unit commander's SPAs and skills are \
   used.
-lblUseEdge.text=Use Edge
-lblUseEdge.tooltip=Characters can purchase and benefit from Edge, which allows them to re-roll\
-  \ certain undesirable results.
+lblUseCombatEdge.text=Combat Personnel Use Edge
+lblUseCombatEdge.tooltip=Characters can purchase and benefit from Edge, which allows them to re-roll certain \
+  undesirable results.
 lblUseSupportEdge.text=Support Personnel Use Edge
-lblUseSupportEdge.tooltip=Allows non-combat roles to benefit from Edge re-rolls, although with a\
-  \ shorter list of triggers.
+lblUseSupportEdge.tooltip=Allows non-combat roles to benefit from Edge re-rolls, although with a shorter list of \
+  triggers.
 lblUseImplants.text=Use Implants
 lblUseImplants.tooltip=Allows personnel to have implants (e.g., Manei Domini)
 lblUseAlternativeQualityAveraging.text=Use Higher-Precision Skill Averaging

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
@@ -233,7 +233,7 @@ public class CampaignOptions {
     private boolean onlyCommandersMatterVehicles;
     private boolean onlyCommandersMatterInfantry;
     private boolean onlyCommandersMatterBattleArmor;
-    private boolean useEdge;
+    private boolean useCombatEdge;
     private boolean useSupportEdge;
     private boolean useImplants;
     private boolean alternativeQualityAveraging;
@@ -848,7 +848,7 @@ public class CampaignOptions {
         setOnlyCommandersMatterVehicles(false);
         setOnlyCommandersMatterInfantry(false);
         setOnlyCommandersMatterBattleArmor(false);
-        setUseEdge(false);
+        setUseCombatEdge(false);
         setUseSupportEdge(false);
         setUseImplants(false);
         setAlternativeQualityAveraging(false);
@@ -1701,11 +1701,15 @@ public class CampaignOptions {
     }
 
     public boolean isUseEdge() {
-        return useEdge;
+        return useCombatEdge || useSupportEdge;
     }
 
-    public void setUseEdge(final boolean useEdge) {
-        this.useEdge = useEdge;
+    public boolean isUseCombatEdge() {
+        return useCombatEdge;
+    }
+
+    public void setUseCombatEdge(final boolean useCombatEdge) {
+        this.useCombatEdge = useCombatEdge;
     }
 
     public boolean isUseSupportEdge() {
@@ -5802,7 +5806,7 @@ public class CampaignOptions {
         useToughness = gameOptions.getOption(RPG_TOUGHNESS).booleanValue();
         useArtillery = gameOptions.getOption(RPG_ARTILLERY_SKILL).booleanValue();
         useAbilities = gameOptions.getOption(RPG_PILOT_ADVANTAGES).booleanValue();
-        useEdge = gameOptions.getOption(EDGE).booleanValue();
+        useCombatEdge = gameOptions.getOption(EDGE).booleanValue();
         useImplants = gameOptions.getOption(RPG_MANEI_DOMINI).booleanValue();
         useQuirks = gameOptions.getOption(ADVANCED_STRATOPS_QUIRKS).booleanValue();
         allowCanonOnly = gameOptions.getOption(ALLOWED_CANON_ONLY).booleanValue();
@@ -5826,7 +5830,7 @@ public class CampaignOptions {
         gameOptions.getOption(RPG_TOUGHNESS).setValue(useToughness);
         gameOptions.getOption(RPG_ARTILLERY_SKILL).setValue(useArtillery);
         gameOptions.getOption(RPG_PILOT_ADVANTAGES).setValue(useAbilities);
-        gameOptions.getOption(EDGE).setValue(useEdge);
+        gameOptions.getOption(EDGE).setValue(useCombatEdge);
         gameOptions.getOption(RPG_MANEI_DOMINI).setValue(useImplants);
         gameOptions.getOption(ADVANCED_STRATOPS_QUIRKS).setValue(useQuirks);
         gameOptions.getOption(ALLOWED_CANON_ONLY).setValue(allowCanonOnly);

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
@@ -277,7 +277,7 @@ public class CampaignOptionsMarshaller {
               indent,
               "onlyCommandersMatterBattleArmor",
               campaignOptions.isOnlyCommandersMatterBattleArmor());
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useEdge", campaignOptions.isUseEdge());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useCombatEdge", campaignOptions.isUseCombatEdge());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useSupportEdge", campaignOptions.isUseSupportEdge());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useImplants", campaignOptions.isUseImplants());
         MHQXMLUtility.writeSimpleXMLTag(pw,

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
@@ -333,7 +333,9 @@ public class CampaignOptionsUnmarshaller {
                   nodeContents));
             case "onlyCommandersMatterBattleArmor" -> campaignOptions.setOnlyCommandersMatterBattleArmor(parseBoolean(
                   nodeContents));
-            case "useEdge" -> campaignOptions.setUseEdge(parseBoolean(nodeContents));
+            // <51.0 compatibility handler
+            case "useEdge" -> campaignOptions.setUseCombatEdge(parseBoolean(nodeContents));
+            case "useCombatEdge" -> campaignOptions.setUseCombatEdge(parseBoolean(nodeContents));
             case "useSupportEdge" -> campaignOptions.setUseSupportEdge(parseBoolean(nodeContents));
             case "useImplants" -> campaignOptions.setUseImplants(parseBoolean(nodeContents));
             case "alternativeQualityAveraging" -> campaignOptions.setAlternativeQualityAveraging(parseBoolean(

--- a/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/CamOpsSalvageUtilities.java
+++ b/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/CamOpsSalvageUtilities.java
@@ -372,7 +372,8 @@ public class CamOpsSalvageUtilities {
 
             Person victim = ObjectUtility.getRandomItem(techs);
 
-            if (campaignOptions.isUseEdge() && campaignOptions.isUseSupportEdge() && victim.getCurrentEdge() > 0) {
+            if (campaignOptions.isUseSupportEdge() &&
+                      victim.getCurrentEdge() > 0) {
                 if (performEdgeReroll(campaign, victim)) {
                     continue;
                 }

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -5955,6 +5955,35 @@ public class Person {
     // region edge
 
     /**
+     * Determines whether Edge should be used for this person based on the given campaign options.
+     *
+     * <p>Edge is used if any of the following conditions are met:
+     * <ul>
+     *     <li>Edge use is globally enabled via {@link CampaignOptions#isUseEdge()}</li>
+     *     <li>This is a combat role and combat Edge is enabled via {@link CampaignOptions#isUseCombatEdge()}</li>
+     *     <li>This is a support role and support Edge is enabled via {@link CampaignOptions#isUseSupportEdge()}</li>
+     * </ul>
+     *
+     * @param campaignOptions the campaign options defining Edge usage rules; must not be {@code null}
+     *
+     * @return {@code true} if Edge should be used, {@code false} otherwise
+     *
+     * @author Illiani
+     * @since 0.51.0
+     */
+    public boolean isUseEdge(CampaignOptions campaignOptions) {
+        if (campaignOptions.isUseEdge()) {
+            return true;
+        }
+
+        if (isCombat() && campaignOptions.isUseCombatEdge()) {
+            return true;
+        }
+
+        return !isCombat() && campaignOptions.isUseSupportEdge();
+    }
+
+    /**
      * Retrieves the edge value for the current person.
      *
      * <p><b>Usage:</b> This method gets the character's raw Edge score. Generally you likely want to use

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -5980,7 +5980,8 @@ public class Person {
             return true;
         }
 
-        return !isCombat() && campaignOptions.isUseSupportEdge();
+        boolean isSupport = !getPrimaryRole().isCombat() || !getSecondaryRole().isCombat();
+        return !isSupport && campaignOptions.isUseSupportEdge();
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/generator/DefaultPersonnelGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/generator/DefaultPersonnelGenerator.java
@@ -110,7 +110,9 @@ public class DefaultPersonnelGenerator extends AbstractPersonnelGenerator {
         AbstractSkillGenerator skillGenerator = new DefaultSkillGenerator(getSkillPreferences());
 
         skillGenerator.generateSkills(campaign, person, expLvl);
-        skillGenerator.generateAttributes(person, campaignOptions.isUseEdge());
+
+        boolean isUseEdge = person.isUseEdge(campaignOptions);
+        skillGenerator.generateAttributes(person, isUseEdge);
         skillGenerator.generateTraits(person);
 
         // Limit skills by age for children and adolescents

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -4880,7 +4880,7 @@ public class Unit implements ITechnology {
             setTacticsInitiativeBonus(commander);
         }
 
-        if (campaignOptions.isUseAbilities() || campaignOptions.isUseEdge() || campaignOptions.isUseImplants()) {
+        if (campaignOptions.isUseAbilities() || campaignOptions.isUseCombatEdge() || campaignOptions.isUseImplants()) {
             processUnitSPAs(commander);
         }
     }
@@ -5016,7 +5016,7 @@ public class Unit implements ITechnology {
                 if (campaignOptions.isUseImplants() &&
                           group.getKey().equals(PersonnelOptions.MD_ADVANTAGES)) {
                     cyberOptionNames.add(option.getName());
-                } else if (campaignOptions.isUseEdge() &&
+                } else if (campaignOptions.isUseCombatEdge() &&
                                  group.getKey().equals(PersonnelOptions.EDGE_ADVANTAGES)) {
                     optionNames.add(option.getName());
                 } else if (campaignOptions.isUseAbilities() &&
@@ -5120,7 +5120,7 @@ public class Unit implements ITechnology {
 
             // Assign edge points to spacecraft and vehicle crews and infantry units. This overwrites the Edge value
             // assigned above (which will always be 0 in 0.50.10+).
-            if (campaignOptions.isUseEdge()) {
+            if (campaignOptions.isUseCombatEdge()) {
                 setEdgeForCrew(crewSize, commanderOnly);
             }
 
@@ -5159,7 +5159,7 @@ public class Unit implements ITechnology {
 
             // Assign edge points to spacecraft and vehicle crews and infantry units. This overwrites the Edge value
             // assigned above (which will always be 0 in 0.50.10+).
-            if (campaignOptions.isUseEdge()) {
+            if (campaignOptions.isUseCombatEdge()) {
                 setEdgeForCrew(usesSoloPilot() ? 1 : getCrew().size(), commanderOnly);
             }
         }

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -1468,7 +1468,7 @@ public final class BriefingTab extends CampaignGuiTab {
         Campaign campaign = getCampaign();
         CampaignOptions campaignOptions = campaign.getCampaignOptions();
         boolean isClanCampaign = campaign.isClanCampaign();
-        boolean isUseEdge = campaignOptions.isUseEdge() && campaignOptions.isUseSupportEdge();
+        boolean isUseEdge = campaignOptions.isUseSupportEdge();
         SalvageTechPicker techPicker = new SalvageTechPicker(techData, priorSelectedTechs,
               isClanCampaign, getBattlefieldControlType(scenario), isUseEdge);
         boolean wasConfirmed = techPicker.wasConfirmed();

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -334,7 +334,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
     }
 
     private CampaignOptions getCampaignOptions() {
-        return getCampaign().getCampaignOptions();
+        return getCampaignOptions();
     }
 
     public static void connect(CampaignGUI gui, JTable personnelTable, PersonnelTableModel personnelModel,
@@ -1629,7 +1629,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                 boolean isUseAdvancedMedical = getCampaignOptions().isUseAdvancedMedical();
                 int healingPeriod = getCampaignOptions().getNaturalHealingWaitingPeriod();
-                
+
                 selectedPerson.clearDoctorAssignmentForCharacterWithOnlyPermanentInjuries(isUseAdvancedMedical,
                       healingPeriod);
 
@@ -1765,7 +1765,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 RandomSkillPreferences skillPreferences = getCampaign().getRandomSkillPreferences();
                 AbstractSkillGenerator skillGenerator = new DefaultSkillGenerator(skillPreferences);
                 for (Person person : people) {
-                    skillGenerator.generateAttributes(person, getCampaign().getCampaignOptions().isUseEdge());
+                    boolean isUseEdge = person.isUseEdge(getCampaignOptions());
+                    skillGenerator.generateAttributes(person, isUseEdge);
                     MekHQ.triggerEvent(new PersonChangedEvent(person));
                 }
                 break;
@@ -2055,7 +2056,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
               JOptionPane.YES_NO_OPTION)) {
 
             if (isExecution) {
-                if (getCampaign().getCampaignOptions().isTrackFactionStanding()) {
+                if (getCampaignOptions().isTrackFactionStanding()) {
                     FactionStandings factionStandings = getCampaign().getFactionStandings();
 
                     List<Person> listOfPrisoners = Arrays.asList(prisoners);
@@ -2063,7 +2064,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                           factionStandings.executePrisonersOfWar(getCampaign().getFaction().getShortName(),
                                 listOfPrisoners,
                                 getCampaign().getGameYear(),
-                                getCampaign().getCampaignOptions().getRegardMultiplier());
+                                getCampaignOptions().getRegardMultiplier());
 
                     for (String report : reports) {
                         getCampaign().addReport(PERSONNEL, report);

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/PersonnelTab.java
@@ -110,7 +110,7 @@ public class PersonnelTab {
     private JCheckBox chkOnlyCommandersMatterVehicles;
     private JCheckBox chkOnlyCommandersMatterInfantry;
     private JCheckBox chkOnlyCommandersMatterBattleArmor;
-    private JCheckBox chkUseEdge;
+    private JCheckBox chkUseCombatEdge;
     private JCheckBox chkUseSupportEdge;
     private JCheckBox chkUseImplants;
     private JCheckBox chkUseAlternativeQualityAveraging;
@@ -392,7 +392,7 @@ public class PersonnelTab {
         chkOnlyCommandersMatterVehicles = new JCheckBox();
         chkOnlyCommandersMatterInfantry = new JCheckBox();
         chkOnlyCommandersMatterBattleArmor = new JCheckBox();
-        chkUseEdge = new JCheckBox();
+        chkUseCombatEdge = new JCheckBox();
         chkUseSupportEdge = new JCheckBox();
         chkUseImplants = new JCheckBox();
         chkUseAlternativeQualityAveraging = new JCheckBox();
@@ -504,8 +504,8 @@ public class PersonnelTab {
               getMetadata(MILESTONE_BEFORE_METADATA));
         chkOnlyCommandersMatterBattleArmor.addMouseListener(createTipPanelUpdater(generalHeader,
               "OnlyCommandersMatterBattleArmor"));
-        chkUseEdge = new CampaignOptionsCheckBox("UseEdge");
-        chkUseEdge.addMouseListener(createTipPanelUpdater(generalHeader, "UseEdge"));
+        chkUseCombatEdge = new CampaignOptionsCheckBox("UseCombatEdge");
+        chkUseCombatEdge.addMouseListener(createTipPanelUpdater(generalHeader, "UseCombatEdge"));
         chkUseSupportEdge = new CampaignOptionsCheckBox("UseSupportEdge");
         chkUseSupportEdge.addMouseListener(createTipPanelUpdater(generalHeader, "UseSupportEdge"));
         chkUseImplants = new CampaignOptionsCheckBox("UseImplants");
@@ -548,7 +548,7 @@ public class PersonnelTab {
         panel.add(chkOnlyCommandersMatterBattleArmor, layout);
 
         layout.gridy++;
-        panel.add(chkUseEdge, layout);
+        panel.add(chkUseCombatEdge, layout);
 
         layout.gridy++;
         panel.add(chkUseSupportEdge, layout);
@@ -646,15 +646,19 @@ public class PersonnelTab {
         chkUseBlobInfantry.addMouseListener(createTipPanelUpdater(generalHeader, "UseBlobInfantry"));
         chkUseBlobBattleArmor = new CampaignOptionsCheckBox("UseBlobBattleArmor", getMetadata(new Version(0, 50, 12)));
         chkUseBlobBattleArmor.addMouseListener(createTipPanelUpdater(generalHeader, "UseBlobBattleArmor"));
-        chkUseBlobVehicleCrewGround = new CampaignOptionsCheckBox("UseBlobVehicleCrewGround", getMetadata(new Version(0, 50, 12)));
+        chkUseBlobVehicleCrewGround = new CampaignOptionsCheckBox("UseBlobVehicleCrewGround",
+              getMetadata(new Version(0, 50, 12)));
         chkUseBlobVehicleCrewGround.addMouseListener(createTipPanelUpdater(generalHeader, "UseBlobVehicleCrewGround"));
-        chkUseBlobVehicleCrewVTOL = new CampaignOptionsCheckBox("UseBlobVehicleCrewVTOL", getMetadata(new Version(0, 50, 12)));
+        chkUseBlobVehicleCrewVTOL = new CampaignOptionsCheckBox("UseBlobVehicleCrewVTOL",
+              getMetadata(new Version(0, 50, 12)));
         chkUseBlobVehicleCrewVTOL.addMouseListener(createTipPanelUpdater(generalHeader, "UseBlobVehicleCrewVTOL"));
-        chkUseBlobVehicleCrewNaval = new CampaignOptionsCheckBox("UseBlobVehicleCrewNaval", getMetadata(new Version(0, 50, 12)));
+        chkUseBlobVehicleCrewNaval = new CampaignOptionsCheckBox("UseBlobVehicleCrewNaval",
+              getMetadata(new Version(0, 50, 12)));
         chkUseBlobVehicleCrewNaval.addMouseListener(createTipPanelUpdater(generalHeader, "UseBlobVehicleCrewNaval"));
         chkUseBlobVesselPilot = new CampaignOptionsCheckBox("UseBlobVesselPilot", getMetadata(new Version(0, 50, 12)));
         chkUseBlobVesselPilot.addMouseListener(createTipPanelUpdater(generalHeader, "UseBlobVesselPilot"));
-        chkUseBlobVesselGunner = new CampaignOptionsCheckBox("UseBlobVesselGunner", getMetadata(new Version(0, 50, 12)));
+        chkUseBlobVesselGunner = new CampaignOptionsCheckBox("UseBlobVesselGunner",
+              getMetadata(new Version(0, 50, 12)));
         chkUseBlobVesselGunner.addMouseListener(createTipPanelUpdater(generalHeader, "UseBlobVesselGunner"));
         chkUseBlobVesselCrew = new CampaignOptionsCheckBox("UseBlobVesselCrew", getMetadata(new Version(0, 50, 12)));
         chkUseBlobVesselCrew.addMouseListener(createTipPanelUpdater(generalHeader, "UseBlobVesselCrew"));
@@ -925,7 +929,9 @@ public class PersonnelTab {
 
         // Contents
         chkUseAdvancedMedical = new CampaignOptionsCheckBox("UseAdvancedMedical",
-              getMetadata(LEGACY_RULE_BEFORE_METADATA, CampaignOptionFlag.CUSTOM_SYSTEM, CampaignOptionFlag.DOCUMENTED));
+              getMetadata(LEGACY_RULE_BEFORE_METADATA,
+                    CampaignOptionFlag.CUSTOM_SYSTEM,
+                    CampaignOptionFlag.DOCUMENTED));
         chkUseAdvancedMedical.addMouseListener(createTipPanelUpdater(medicalHeader, "UseAdvancedMedical"));
 
         lblHealWaitingPeriod = new CampaignOptionsLabel("HealWaitingPeriod");
@@ -1269,7 +1275,9 @@ public class PersonnelTab {
         dependentsPanel = createDependentsPanel();
 
         // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("PrisonersAndDependentsTab", true, "PrisonersAndDependentsTab",
+        final JPanel panel = new CampaignOptionsStandardPanel("PrisonersAndDependentsTab",
+              true,
+              "PrisonersAndDependentsTab",
               getMetadata(null, CampaignOptionFlag.CUSTOM_SYSTEM, CampaignOptionFlag.DOCUMENTED));
         final GridBagConstraints layoutParent = new CampaignOptionsGridBagConstraints(panel);
 
@@ -1466,7 +1474,7 @@ public class PersonnelTab {
         chkOnlyCommandersMatterVehicles.setSelected(options.isOnlyCommandersMatterVehicles());
         chkOnlyCommandersMatterInfantry.setSelected(options.isOnlyCommandersMatterInfantry());
         chkOnlyCommandersMatterBattleArmor.setSelected(options.isOnlyCommandersMatterBattleArmor());
-        chkUseEdge.setSelected(options.isUseEdge());
+        chkUseCombatEdge.setSelected(options.isUseCombatEdge());
         chkUseSupportEdge.setSelected(options.isUseSupportEdge());
         chkUseImplants.setSelected(options.isUseImplants());
         chkUseAlternativeQualityAveraging.setSelected(options.isAlternativeQualityAveraging());
@@ -1576,7 +1584,7 @@ public class PersonnelTab {
         options.setOnlyCommandersMatterVehicles(chkOnlyCommandersMatterVehicles.isSelected());
         options.setOnlyCommandersMatterInfantry(chkOnlyCommandersMatterInfantry.isSelected());
         options.setOnlyCommandersMatterBattleArmor(chkOnlyCommandersMatterBattleArmor.isSelected());
-        options.setUseEdge(chkUseEdge.isSelected());
+        options.setUseCombatEdge(chkUseCombatEdge.isSelected());
         options.setUseSupportEdge(chkUseSupportEdge.isSelected());
         options.setUseImplants(chkUseImplants.isSelected());
         options.setAlternativeQualityAveraging(chkUseAlternativeQualityAveraging.isSelected());

--- a/MekHQ/src/mekhq/gui/dialog/AttributeCheckDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AttributeCheckDialog.java
@@ -177,7 +177,7 @@ public class AttributeCheckDialog {
               character,
               null,
               getInCharacterMessage(),
-              getButtons(character.getCurrentEdge() > 0, campaign.getCampaignOptions().isUseEdge()),
+              getButtons(character.getCurrentEdge() > 0, character.isUseEdge(campaign.getCampaignOptions())),
               getFormattedTextAt(RESOURCE_BUNDLE, "message.ooc.attribute"),
               null,
               false,

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -47,16 +47,7 @@ import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.time.LocalDate;
 import java.time.Period;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.Enumeration;
-import java.util.Hashtable;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.ResourceBundle;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 import javax.swing.*;
 
 import megamek.client.generator.RandomCallsignGenerator;
@@ -81,6 +72,7 @@ import megamek.common.units.Entity;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.personnel.Bloodname;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
@@ -520,18 +512,18 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
         allSystems = getPlanetarySystemsComboBoxModel();
         Faction originFaction = person.getOriginFaction();
         DefaultComboBoxModel<PlanetarySystem> initialSystems = (originFaction != null)
-              ? getPlanetarySystemsComboBoxModel(originFaction)
-              : allSystems;
+                                                                     ? getPlanetarySystemsComboBoxModel(originFaction)
+                                                                     : allSystems;
         // If the person already has an origin planet that the faction-filtered view excludes (e.g.,
         // a Tharkad-origin character whose faction is now FedSuns), fall back to the all-worlds view
         // so we don't silently drop their existing assignment when they click OK. Tracked back to the
         // checkbox state below via showAllWorldsInitial. (Copilot review on PR #8935.)
         PlanetarySystem existingOriginSystem = (person.getOriginPlanet() != null)
-              ? person.getOriginPlanet().getParentSystem()
-              : null;
+                                                     ? person.getOriginPlanet().getParentSystem()
+                                                     : null;
         boolean showAllWorldsInitial = false;
         if (existingOriginSystem != null && initialSystems != allSystems
-              && initialSystems.getIndexOf(existingOriginSystem) < 0) {
+                  && initialSystems.getIndexOf(existingOriginSystem) < 0) {
             initialSystems = allSystems;
             showAllWorldsInitial = true;
         }
@@ -1318,9 +1310,11 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
         scrOptions.setPreferredSize(UIUtil.scaleForGUI(500, 500));
 
         tabStats.addTab(resourceMap.getString("scrSkills.TabConstraints.tabTitle"), scrSkills);
-        if (campaign.getCampaignOptions().isUseAbilities() ||
-                  campaign.getCampaignOptions().isUseEdge() ||
-                  campaign.getCampaignOptions().isUseImplants()) {
+        CampaignOptions campaignOptions = campaign.getCampaignOptions();
+        if (campaignOptions.isUseAbilities() ||
+                  campaignOptions.isUseImplants() ||
+                  campaignOptions.isUseCombatEdge() && person.isCombat() ||
+                  campaignOptions.isUseSupportEdge() && !person.isCombat()) {
             tabStats.addTab(resourceMap.getString("scrOptions.TabConstraints.tabTitle"), scrOptions);
         }
         tabStats.add(resourceMap.getString("panLog.TabConstraints.tabTitle"),
@@ -1421,11 +1415,11 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
     }
 
     /**
-     * Rebuilds {@code choiceFaction}'s model after a "Show All Factions" toggle, preserving the
-     * current selection across the swap. If there was no current selection (or the previously
-     * selected faction has been filtered out by the new model), the index is explicitly set to
-     * {@code -1} — otherwise Swing's combobox auto-selects the first item on a model swap, which
-     * would silently assign an unintended origin when OK is clicked. (Copilot review on PR #8937.)
+     * Rebuilds {@code choiceFaction}'s model after a "Show All Factions" toggle, preserving the current selection
+     * across the swap. If there was no current selection (or the previously selected faction has been filtered out by
+     * the new model), the index is explicitly set to {@code -1} — otherwise Swing's combobox auto-selects the first
+     * item on a model swap, which would silently assign an unintended origin when OK is clicked. (Copilot review on PR
+     * #8937.)
      */
     private void rebuildFactionsModelPreservingSelection() {
         Faction current = (Faction) choiceFaction.getSelectedItem();
@@ -1526,7 +1520,8 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
                                                      .filter(a -> !a.isConnector())
                                                      .filter(a -> {
                                                          Set<Faction> owners = cachedOwnersAt(a);
-                                                         return isInhabitedAt(owners) && isFactionMatch(owners, faction);
+                                                         return isInhabitedAt(owners) &&
+                                                                      isFactionMatch(owners, faction);
                                                      })
                                                      .sorted(Comparator.comparing(a -> a.getName(birthDate)))
                                                      .toList();
@@ -1538,10 +1533,9 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
     }
 
     /**
-     * Returns {@link #ownersAt(PlanetarySystem, LocalDate)} cached per system for the dialog's
-     * current {@code birthdate}. The cache is invalidated when {@code birthdate} changes, so a
-     * single filter pass resolves each system at most once even when both the inhabited and
-     * faction filters apply.
+     * Returns {@link #ownersAt(PlanetarySystem, LocalDate)} cached per system for the dialog's current
+     * {@code birthdate}. The cache is invalidated when {@code birthdate} changes, so a single filter pass resolves each
+     * system at most once even when both the inhabited and faction filters apply.
      */
     private Set<Faction> cachedOwnersAt(PlanetarySystem system) {
         if (!java.util.Objects.equals(birthdate, ownersCacheBirthdate)) {
@@ -1552,13 +1546,12 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
     }
 
     /**
-     * Renders the dropdown label as e.g. {@code "New Avalon [FS]"} — the date-aware system name
-     * with the resolved owner faction code(s) appended in brackets. Owner is computed by
-     * {@link #ownersAt(PlanetarySystem, LocalDate)} which applies to-the-victor citizenship rules,
-     * so a 3047-born character sees New Avalon as {@code [FS]} rather than the transitional
-     * {@code [FC]}. Multiple owners come out comma-separated, e.g. {@code "World [FACTA, FACTB]"}.
-     * Visible in both filtered and "Show All Worlds" modes — useful both for player context and
-     * for spotting data-side anomalies at a glance.
+     * Renders the dropdown label as e.g. {@code "New Avalon [FS]"} — the date-aware system name with the resolved owner
+     * faction code(s) appended in brackets. Owner is computed by {@link #ownersAt(PlanetarySystem, LocalDate)} which
+     * applies to-the-victor citizenship rules, so a 3047-born character sees New Avalon as {@code [FS]} rather than the
+     * transitional {@code [FC]}. Multiple owners come out comma-separated, e.g. {@code "World [FACTA, FACTB]"}. Visible
+     * in both filtered and "Show All Worlds" modes — useful both for player context and for spotting data-side
+     * anomalies at a glance.
      */
     private String formatSystemForBirthdate(PlanetarySystem system) {
         String name = system.getName(birthdate);
@@ -1583,15 +1576,14 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
      * Cache-bypassing point-in-time owner lookup with to-the-victor citizenship semantics.
      *
      * <p>{@link Planet#getFactionSet(LocalDate)} routes through {@code Planet.CurrentEvents}, a
-     * stateful per-planet event-stream cache that can return stale-forward state when warmed at a
-     * later date and queried at an earlier one (observed during #8934 testing — New Avalon at
-     * 3047-09-25 returning 3067-12-31's {@code DIS} marker because the cache had already advanced
-     * for a campaign-date render). We walk {@link Planet#getEvents()} directly (TreeMap-ordered,
-     * deterministic) instead.</p>
+     * stateful per-planet event-stream cache that can return stale-forward state when warmed at a later date and
+     * queried at an earlier one (observed during #8934 testing — New Avalon at 3047-09-25 returning 3067-12-31's
+     * {@code DIS} marker because the cache had already advanced for a campaign-date render). We walk
+     * {@link Planet#getEvents()} directly (TreeMap-ordered, deterministic) instead.</p>
      *
      * <p>BattleTech canon treats world-citizenship as defined by whoever ends up holding the world
-     * long-term, not by transient umbrella states or active disputes. We substitute the snapshot
-     * with the world's eventual stable owner when:</p>
+     * long-term, not by transient umbrella states or active disputes. We substitute the snapshot with the world's
+     * eventual stable owner when:</p>
      *
      * <ul>
      *   <li>The snapshot is a {@code DIS} (Disputed) marker — to the victor goes the spoils.</li>
@@ -1652,7 +1644,7 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
             // and pollute the picker (Copilot review on PR #8935).
             java.util.List<String> displayed;
             if (snapshot != null && eventualOwner != null && !sameCodes(snapshot, eventualOwner)
-                  && (isDisputedOnly(snapshot) || anyDissolvesNear(snapshot, when))) {
+                      && (isDisputedOnly(snapshot) || anyDissolvesNear(snapshot, when))) {
                 displayed = eventualOwner;
             } else {
                 displayed = snapshot;
@@ -1711,10 +1703,10 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
     }
 
     /**
-     * @return {@code true} if {@code chosen} directly controls the world at the queried date OR is
-     *       lineage-compatible (predecessor/successor) with one of the actual owners. Excludes meta
-     *       umbrella codes ({@code IS}, {@code CLAN.IS}, {@code Periphery.*}, {@code CLAN.*}) so two
-     *       unrelated Inner Sphere factions don't match via the abstract IS umbrella.
+     * @return {@code true} if {@code chosen} directly controls the world at the queried date OR is lineage-compatible
+     *       (predecessor/successor) with one of the actual owners. Excludes meta umbrella codes ({@code IS},
+     *       {@code CLAN.IS}, {@code Periphery.*}, {@code CLAN.*}) so two unrelated Inner Sphere factions don't match
+     *       via the abstract IS umbrella.
      */
     private static boolean isFactionMatch(Set<Faction> owners, Faction chosen) {
         if (owners == null || owners.isEmpty()) {
@@ -1731,7 +1723,7 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
             }
             String ownerCode = owner.getShortName();
             if (containsRealCode(owner.getAlternativeFactionCodes(), chosenCode)
-                  || containsRealCode(chosenAlts, ownerCode)) {
+                      || containsRealCode(chosenAlts, ownerCode)) {
                 return true;
             }
         }
@@ -1755,14 +1747,13 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
 
     private static boolean isMetaFactionCode(String code) {
         return "IS".equals(code) || "CLAN.IS".equals(code)
-              || code.startsWith("Periphery.") || code.startsWith("CLAN.");
+                     || code.startsWith("Periphery.") || code.startsWith("CLAN.");
     }
 
     /**
      * @return {@code true} if the resolved owner set has at least one real (non-abandoned) faction.
-     *       {@code ownersAt(...)} already drops the {@code ABN} marker when other factions are present;
-     *       a system whose ONLY faction is {@code ABN} would still come back non-empty here, so we
-     *       reject that case explicitly.
+     *       {@code ownersAt(...)} already drops the {@code ABN} marker when other factions are present; a system whose
+     *       ONLY faction is {@code ABN} would still come back non-empty here, so we reject that case explicitly.
      */
     private static boolean isInhabitedAt(Set<Faction> owners) {
         if (owners.isEmpty()) {
@@ -2124,21 +2115,28 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
         c.ipadx = 0;
         c.ipady = 0;
 
+        CampaignOptions campaignOptions = campaign.getCampaignOptions();
+        boolean isUseAbilities = campaignOptions.isUseAbilities();
+        boolean isUseEdge = campaignOptions.isUseEdge();
+        boolean isUseImplants = campaignOptions.isUseImplants();
         for (Enumeration<IOptionGroup> i = options.getGroups(); i.hasMoreElements(); ) {
             IOptionGroup group = i.nextElement();
 
-            if (group.getKey().equalsIgnoreCase(PersonnelOptions.LVL3_ADVANTAGES) &&
-                      !campaign.getCampaignOptions().isUseAbilities()) {
+            String key = group.getKey();
+            if (key.equalsIgnoreCase(PersonnelOptions.LVL3_ADVANTAGES) &&
+                      !isUseAbilities) {
                 continue;
             }
 
-            if (group.getKey().equalsIgnoreCase(PersonnelOptions.EDGE_ADVANTAGES) &&
-                      !campaign.getCampaignOptions().isUseEdge()) {
+            if (key.equalsIgnoreCase(PersonnelOptions.EDGE_ADVANTAGES) && !isUseAbilities) {
                 continue;
             }
 
-            if (group.getKey().equalsIgnoreCase(PersonnelOptions.MD_ADVANTAGES) &&
-                      !campaign.getCampaignOptions().isUseImplants()) {
+            if (key.equalsIgnoreCase(PersonnelOptions.EDGE_ADVANTAGES) && !isUseEdge) {
+                continue;
+            }
+
+            if (key.equalsIgnoreCase(PersonnelOptions.MD_ADVANTAGES) && !isUseImplants) {
                 continue;
             }
 

--- a/MekHQ/src/mekhq/gui/dialog/SkillCheckDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/SkillCheckDialog.java
@@ -139,7 +139,7 @@ public class SkillCheckDialog {
               character,
               null,
               getInCharacterMessage(),
-              getButtons(character.getCurrentEdge() > 0, campaign.getCampaignOptions().isUseEdge()),
+              getButtons(character.getCurrentEdge() > 0, character.isUseEdge(campaign.getCampaignOptions())),
               getFormattedTextAt(RESOURCE_BUNDLE, "message.ooc"),
               null,
               false,

--- a/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
@@ -1177,6 +1177,7 @@ public enum PersonnelTableModelColumn {
     }
 
     public boolean isVisible(final Campaign campaign, final PersonnelTabView view, final JTable table) {
+        CampaignOptions campaignOptions = campaign.getCampaignOptions();
         return switch (view) {
             case GRAPHIC -> {
                 table.setRowHeight(UIUtil.scaleForGUI(60));
@@ -1286,8 +1287,8 @@ public enum PersonnelTableModelColumn {
             };
             case BIOGRAPHICAL -> switch (this) {
                 case RANK, FIRST_NAME, LAST_NAME, AGE, PERSONNEL_STATUS, PERSONNEL_ROLE, HIGHEST_EDUCATION -> true;
-                case ORIGIN_FACTION, ORIGIN_PLANET -> campaign.getCampaignOptions().isShowOriginFaction();
-                case SALARY -> campaign.getCampaignOptions().isPayForSalaries();
+                case ORIGIN_FACTION, ORIGIN_PLANET -> campaignOptions.isShowOriginFaction();
+                case SALARY -> campaignOptions.isPayForSalaries();
                 default -> false;
             };
             case FLUFF -> switch (this) {
@@ -1305,10 +1306,10 @@ public enum PersonnelTableModelColumn {
             };
             case DATES -> switch (this) {
                 case RANK, FIRST_NAME, LAST_NAME, BIRTHDAY, DEATH_DATE, RETIREMENT_DATE -> true;
-                case RECRUITMENT_DATE -> campaign.getCampaignOptions().isUseTimeInService();
-                case LAST_RANK_CHANGE_DATE -> campaign.getCampaignOptions().isUseTimeInRank();
-                case DUE_DATE -> campaign.getCampaignOptions().isUseManualProcreation() ||
-                                       !campaign.getCampaignOptions().getRandomProcreationMethod().isNone();
+                case RECRUITMENT_DATE -> campaignOptions.isUseTimeInService();
+                case LAST_RANK_CHANGE_DATE -> campaignOptions.isUseTimeInRank();
+                case DUE_DATE -> campaignOptions.isUseManualProcreation() ||
+                                       !campaignOptions.getRandomProcreationMethod().isNone();
                 default -> false;
             };
             case FLAGS_A -> switch (this) {
@@ -1350,8 +1351,7 @@ public enum PersonnelTableModelColumn {
             };
             case PERSONALITY -> switch (this) {
                 case RANK, FIRST_NAME, LAST_NAME -> true;
-                case AGGRESSION, AMBITION, GREED, SOCIAL, REASONING ->
-                      campaign.getCampaignOptions().isUseRandomPersonalities();
+                case AGGRESSION, AMBITION, GREED, SOCIAL, REASONING -> campaignOptions.isUseRandomPersonalities();
                 default -> false;
             };
             case TRAITS -> switch (this) {
@@ -1370,7 +1370,7 @@ public enum PersonnelTableModelColumn {
                      INTELLIGENCE,
                      WILLPOWER,
                      CHARISMA -> true;
-                case EDGE -> campaign.getCampaignOptions().isUseEdge();
+                case EDGE -> campaignOptions.isUseEdge();
                 default -> false;
             };
             case EDUCATION -> switch (this) {
@@ -1386,13 +1386,13 @@ public enum PersonnelTableModelColumn {
             };
             case OTHER -> switch (this) {
                 case RANK, FIRST_NAME, LAST_NAME -> true;
-                case TOUGHNESS -> campaign.getCampaignOptions().isUseToughness();
-                case FATIGUE -> campaign.getCampaignOptions().isUseFatigue();
-                case SPA_COUNT -> campaign.getCampaignOptions().isUseAbilities();
-                case IMPLANT_COUNT -> campaign.getCampaignOptions().isUseImplants();
-                case MODIFICATION_COUNT -> campaign.getCampaignOptions().isUseAlternativeAdvancedMedical();
-                case LOYALTY -> campaign.getCampaignOptions().isUseLoyaltyModifiers() &&
-                                      !campaign.getCampaignOptions().isUseHideLoyalty();
+                case TOUGHNESS -> campaignOptions.isUseToughness();
+                case FATIGUE -> campaignOptions.isUseFatigue();
+                case SPA_COUNT -> campaignOptions.isUseAbilities();
+                case IMPLANT_COUNT -> campaignOptions.isUseImplants();
+                case MODIFICATION_COUNT -> campaignOptions.isUseAlternativeAdvancedMedical();
+                case LOYALTY -> campaignOptions.isUseLoyaltyModifiers() &&
+                                      !campaignOptions.isUseHideLoyalty();
                 default -> false;
             };
         };


### PR DESCRIPTION
Close #9165

Previously the assumption was that you were either using edge, or you weren't. And if you _were_ using edge, the use of edge among support personnel was an entirely option add-on.

We received a request to break this assumption. So that players could disable edge for combat personnel, and enable it for support. Or visa versa.

This PR establishes that combat edge use and support edge use are distinct from each other. One no longer needs to be enabled for the other to function. It does this by adding an aggregate method that dictates whether edge is used in either case. As well as a helper function to `Person` to determine whether that particular character has access to Edge. These methods, as well as a general shift about, are then propagated across the codebase.

Due to the number of classes this has touched and the non-essential nature of the request I am holding this fix back until after 51.0 has shipped.

I have a low confidence that this task has been completed without error.