### PR TITLE
Added Edge Refresh Period Campaign Option So Players Can Control How Often Spent Edge Points Are Replenished

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -432,6 +432,8 @@ lblUseEdge.tooltip=Characters can purchase and benefit from Edge, which allows t
 lblUseSupportEdge.text=Support Personnel Use Edge
 lblUseSupportEdge.tooltip=Allows non-combat roles to benefit from Edge re-rolls, although with a\
   \ shorter list of triggers.
+lblEdgeRefreshPeriod.text=Edge Refresh Period
+lblEdgeRefreshPeriod.tooltip=How often should a character regain all previously spent Edge points?
 lblUseImplants.text=Use Implants
 lblUseImplants.tooltip=Allows personnel to have implants (e.g., Manei Domini)
 lblUseAlternativeQualityAveraging.text=Use Higher-Precision Skill Averaging

--- a/MekHQ/resources/mekhq/resources/EdgeRefreshPeriod.properties
+++ b/MekHQ/resources/mekhq/resources/EdgeRefreshPeriod.properties
@@ -1,0 +1,41 @@
+# Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+#
+# This file is part of MekHQ.
+#
+# MekHQ is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (GPL),
+# version 3 or (at your option) any later version,
+# as published by the Free Software Foundation.
+#
+# MekHQ is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# A copy of the GPL should have been included with this project;
+# if not, see <https://www.gnu.org/licenses/>.
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+# suppress inspection "UnusedProperty" for the whole file
+NEVER.label=Never
+NEVER.tooltip=Spent Edge never replenishes
+DAILY.label=Daily
+DAILY.tooltip=Spent Edge replenishes daily
+WEEKLY.label=Weekly
+WEEKLY.tooltip=Spent Edge replenishes every Monday
+MONTHLY.label=Monthly
+MONTHLY.tooltip=Spent Edge replenishes on the first day of the month
+ANNUALLY.label=Annually
+ANNUALLY.tooltip=Spent Edge replenishes on the first day of the year

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -148,6 +148,7 @@ import mekhq.campaign.personnel.autoAwards.AutoAwardsController;
 import mekhq.campaign.personnel.education.Academy;
 import mekhq.campaign.personnel.education.EducationController;
 import mekhq.campaign.personnel.enums.BloodmarkLevel;
+import mekhq.campaign.personnel.enums.EdgeRefreshPeriod;
 import mekhq.campaign.personnel.enums.ExtraIncome;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.generator.AbstractSkillGenerator;
@@ -714,9 +715,7 @@ public class CampaignNewDayManager {
      * <li>- If advanced medical care is unavailable, decreases the healing wait
      * time and
      * applies natural or doctor-assisted healing.</li>
-     * <li><b>Weekly Edge Resets:</b> Resets edge points to their purchased value
-     * weekly (applies
-     * to support personnel).</li>
+     * <li><b>Edge Resets:</b> Resets edge points to their purchased value.</li>
      * <li><b>Vocational XP:</b> Awards monthly vocational experience points to the
      * person where
      * applicable.</li>
@@ -773,6 +772,7 @@ public class CampaignNewDayManager {
         int fatigueRate = campaignOptions.getFatigueRate();
         boolean useBetterMonthlyIncome = campaignOptions.isUseBetterExtraIncome();
         boolean isUseAgeEffects = campaignOptions.isUseAgeEffects();
+        boolean shouldEdgeRefreshToday = EdgeRefreshPeriod.shouldRefresh(campaignOptions.getEdgeRefreshPeriod(), today);
         for (Person person : personnel) {
             if (person.getStatus().isDepartedUnit()) {
                 continue;
@@ -828,8 +828,6 @@ public class CampaignNewDayManager {
                     // If the character has died, we don't need to process relationship events
                     processWeeklyRelationshipEvents(person);
                 }
-
-                person.resetCurrentEdge();
 
                 if (!person.getStatus().isMIA()) {
                     boolean isWithinCapacity = !campaign.isOnContractAndPlanetside() ||
@@ -934,6 +932,10 @@ public class CampaignNewDayManager {
                 if (isDayOfBloodHunt) {
                     Bloodmark.performAssassinationAttempt(campaign, person, today);
                 }
+            }
+
+            if (shouldEdgeRefreshToday) {
+                person.resetCurrentEdge();
             }
         }
 

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
@@ -233,6 +233,7 @@ public class CampaignOptions {
     private boolean onlyCommandersMatterVehicles;
     private boolean onlyCommandersMatterInfantry;
     private boolean onlyCommandersMatterBattleArmor;
+    private EdgeRefreshPeriod edgeRefreshPeriod;
     private boolean useEdge;
     private boolean useSupportEdge;
     private boolean useImplants;
@@ -847,6 +848,7 @@ public class CampaignOptions {
         setUseAbilities(false);
         setOnlyCommandersMatterVehicles(false);
         setOnlyCommandersMatterInfantry(false);
+        edgeRefreshPeriod = EdgeRefreshPeriod.WEEKLY;
         setOnlyCommandersMatterBattleArmor(false);
         setUseEdge(false);
         setUseSupportEdge(false);
@@ -1698,6 +1700,14 @@ public class CampaignOptions {
 
     public void setOnlyCommandersMatterBattleArmor(final boolean onlyCommandersMatterBattleArmor) {
         this.onlyCommandersMatterBattleArmor = onlyCommandersMatterBattleArmor;
+    }
+
+    public EdgeRefreshPeriod getEdgeRefreshPeriod() {
+        return edgeRefreshPeriod;
+    }
+
+    public void setEdgeRefreshPeriod(final EdgeRefreshPeriod edgeRefreshPeriod) {
+        this.edgeRefreshPeriod = edgeRefreshPeriod;
     }
 
     public boolean isUseEdge() {

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
@@ -277,6 +277,10 @@ public class CampaignOptionsMarshaller {
               indent,
               "onlyCommandersMatterBattleArmor",
               campaignOptions.isOnlyCommandersMatterBattleArmor());
+        MHQXMLUtility.writeSimpleXMLTag(pw,
+              indent,
+              "edgeRefreshPeriod",
+              campaignOptions.getEdgeRefreshPeriod().getLookupKey());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useEdge", campaignOptions.isUseEdge());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useSupportEdge", campaignOptions.isUseSupportEdge());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useImplants", campaignOptions.isUseImplants());

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
@@ -333,6 +333,8 @@ public class CampaignOptionsUnmarshaller {
                   nodeContents));
             case "onlyCommandersMatterBattleArmor" -> campaignOptions.setOnlyCommandersMatterBattleArmor(parseBoolean(
                   nodeContents));
+            case "edgeRefreshPeriod" ->
+                  campaignOptions.setEdgeRefreshPeriod(EdgeRefreshPeriod.fromString(nodeContents));
             case "useEdge" -> campaignOptions.setUseEdge(parseBoolean(nodeContents));
             case "useSupportEdge" -> campaignOptions.setUseSupportEdge(parseBoolean(nodeContents));
             case "useImplants" -> campaignOptions.setUseImplants(parseBoolean(nodeContents));

--- a/MekHQ/src/mekhq/campaign/personnel/enums/EdgeRefreshPeriod.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/EdgeRefreshPeriod.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.personnel.enums;
+
+import static mekhq.utilities.MHQInternationalization.getTextAt;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+
+import megamek.logging.MMLogger;
+
+/**
+ * Defines the frequency at which Edge points are refreshed for a campaign.
+ *
+ * <p>Each constant represents a distinct refresh cadence, from never refreshing to refreshing on an annual basis.
+ * The {@link #shouldRefresh(EdgeRefreshPeriod, LocalDate)} method determines whether a refresh should occur on any
+ * given date according to the selected period.
+ *
+ * <p>Labels are loaded from the {@code mekhq.resources.EdgeRefreshPeriod} resource bundle, keyed by {@code
+ * <CONSTANT_NAME>.label} (e.g. {@code DAILY.label}).
+ *
+ * @author Illiani
+ * @since 0.51.0
+ */
+public enum EdgeRefreshPeriod {
+    /**
+     * Edge is never automatically refreshed.
+     */
+    NEVER("NEVER"),
+    /**
+     * Edge refreshes at the start of each new day.
+     */
+    DAILY("DAILY"),
+    /**
+     * Edge refreshes every Monday.
+     */
+    WEEKLY("WEEKLY"),
+    /**
+     * Edge refreshes on the first day of each new month
+     */
+    MONTHLY("MONTHLY"),
+    /**
+     * Edge refreshes on the first day of the year ({@link LocalDate#getDayOfYear()} equals {@code 1}).
+     */
+    ANNUALLY("ANNUALLY");
+
+    private final String lookupKey;
+    private final String label;
+    private final String tooltip;
+
+    EdgeRefreshPeriod(String lookupKey) {
+        this.lookupKey = lookupKey;
+        this.label = generateLabel();
+        this.tooltip = generateTooltip();
+    }
+
+    private final String RESOURCE_BUNDLE = "mekhq.resources.EdgeRefreshPeriod";
+
+    /**
+     * Returns the lookup key for this refresh period.
+     *
+     * @return the lookup key string; never {@code null}
+     *
+     * @author Illiani
+     * @since 0.51.0
+     */
+    public String getLookupKey() {
+        return lookupKey;
+    }
+
+    /**
+     * Returns the human-readable, localized label for this refresh period.
+     *
+     * @return the localized label string; never {@code null}
+     *
+     * @author Illiani
+     * @since 0.51.0
+     */
+    public String getLabel() {
+        return label;
+    }
+
+    /**
+     * Returns the human-readable, localized tooltip for this refresh period.
+     *
+     * @return the localized tooltip string; never {@code null}
+     *
+     * @author Illiani
+     * @since 0.51.0
+     */
+    public String getTooltip() {
+        return tooltip;
+    }
+
+    /**
+     * Loads the localized label from the resource bundle using the lookup key.
+     *
+     * @return the resolved label string for this constant
+     *
+     * @author Illiani
+     * @since 0.51.0
+     */
+    private String generateLabel() {
+        final String RESOURCE_KEY = lookupKey + ".label";
+        return getTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+    }
+
+    /**
+     * Loads the localized tooltip from the resource bundle using the lookup key.
+     *
+     * @return the resolved tooltip string for this constant
+     *
+     * @author Illiani
+     * @since 0.51.0
+     */
+    private String generateTooltip() {
+        final String RESOURCE_KEY = lookupKey + ".tooltip";
+        return getTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+    }
+
+    /**
+     * Determines whether Edge should be refreshed on the given date for the specified refresh period.
+     *
+     * <p>The evaluation rules per period are:</p>
+     * <ul>
+     *     <li>{@link #NEVER}    – always {@code false}</li>
+     *     <li>{@link #DAILY}    – always {@code true}</li>
+     *     <li>{@link #WEEKLY}   – {@code true} when {@code today} is a Monday</li>
+     *     <li>{@link #MONTHLY}  – {@code true} when {@code today} is the 1st day of the month</li>
+     *     <li>{@link #ANNUALLY} – {@code true} when {@code today} is the 1st day of the year</li>
+     * </ul>
+     *
+     * @param period the configured refresh period; must not be {@code null}
+     * @param today  the date to evaluate; must not be {@code null}
+     *
+     * @return {@code true} if a refresh should occur on {@code today}, {@code false} otherwise
+     *
+     * @author Illiani
+     * @since 0.51.0
+     */
+    public static boolean shouldRefresh(EdgeRefreshPeriod period, LocalDate today) {
+        return switch (period) {
+            case NEVER -> false;
+            case DAILY -> true;
+            case WEEKLY -> today.getDayOfWeek() == DayOfWeek.MONDAY;
+            case MONTHLY -> today.getDayOfMonth() == 1;
+            case ANNUALLY -> today.getDayOfYear() == 1;
+        };
+    }
+
+    /**
+     * Parses an {@code EdgeRefreshPeriod} from a string.
+     *
+     * <p>Resolution is attempted in the following order:</p>
+     * <ol>
+     *     <li>Case-insensitive name match (spaces normalized to underscores), e.g. {@code "weekly"} or {@code "per
+     *     week"} → {@link #WEEKLY}.</li>
+     *     <li>Ordinal index, e.g. {@code "2"} → {@link #WEEKLY}.</li>
+     *     <li>If both attempts fail, logs an error and returns {@link #WEEKLY} as the default.</li>
+     * </ol>
+     *
+     * @param text the string to parse; must not be {@code null}
+     *
+     * @return the matching {@code EdgeRefreshPeriod}, or {@link #WEEKLY} if unresolvable
+     *
+     * @author Illiani
+     * @since 0.51.0
+     */
+    public static EdgeRefreshPeriod fromString(String text) {
+        try {
+            return EdgeRefreshPeriod.valueOf(text.toUpperCase().replace(" ", "_"));
+        } catch (Exception ignored) {}
+
+        try {
+            return EdgeRefreshPeriod.values()[Integer.parseInt(text)];
+        } catch (Exception ignored) {}
+
+        MMLogger logger = MMLogger.create(EdgeRefreshPeriod.class);
+        logger.error("Unknown EdgeRefreshPeriod ordinal: {} - returning {}.", text, WEEKLY);
+
+        return WEEKLY;
+    }
+
+    /**
+     * Returns the localized label for this refresh period.
+     *
+     * @return the same value as {@link #getLabel()}; never {@code null}
+     *
+     * @author Illiani
+     * @since 0.51.0
+     */
+    @Override
+    public String toString() {
+        return label;
+    }
+}

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/PersonnelTab.java
@@ -54,6 +54,7 @@ import megamek.common.annotations.Nullable;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.personnel.enums.AwardBonus;
+import mekhq.campaign.personnel.enums.EdgeRefreshPeriod;
 import mekhq.campaign.personnel.enums.TimeInDisplayFormat;
 import mekhq.campaign.randomEvents.prisoners.enums.PrisonerCaptureStyle;
 import mekhq.gui.campaignOptions.CampaignOptionFlag;
@@ -112,6 +113,8 @@ public class PersonnelTab {
     private JCheckBox chkOnlyCommandersMatterBattleArmor;
     private JCheckBox chkUseEdge;
     private JCheckBox chkUseSupportEdge;
+    private JLabel lblEdgeRefreshPeriod;
+    private MMComboBox<EdgeRefreshPeriod> comboEdgeRefreshPeriod;
     private JCheckBox chkUseImplants;
     private JCheckBox chkUseAlternativeQualityAveraging;
 
@@ -394,6 +397,8 @@ public class PersonnelTab {
         chkOnlyCommandersMatterBattleArmor = new JCheckBox();
         chkUseEdge = new JCheckBox();
         chkUseSupportEdge = new JCheckBox();
+        lblEdgeRefreshPeriod = new JLabel();
+        comboEdgeRefreshPeriod = new MMComboBox<>("comboEdgeRefreshPeriod", EdgeRefreshPeriod.values());
         chkUseImplants = new JCheckBox();
         chkUseAlternativeQualityAveraging = new JCheckBox();
 
@@ -508,6 +513,22 @@ public class PersonnelTab {
         chkUseEdge.addMouseListener(createTipPanelUpdater(generalHeader, "UseEdge"));
         chkUseSupportEdge = new CampaignOptionsCheckBox("UseSupportEdge");
         chkUseSupportEdge.addMouseListener(createTipPanelUpdater(generalHeader, "UseSupportEdge"));
+
+        lblEdgeRefreshPeriod = new CampaignOptionsLabel("EdgeRefreshPeriod", getMetadata(new Version(0, 51, 0)));
+        lblEdgeRefreshPeriod.addMouseListener(createTipPanelUpdater(generalHeader, "EdgeRefreshPeriod"));
+        comboEdgeRefreshPeriod.setRenderer(new DefaultListCellRenderer() {
+            @Override
+            public Component getListCellRendererComponent(final JList<?> list, final Object value, final int index,
+                  final boolean isSelected, final boolean cellHasFocus) {
+                super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+                if (value instanceof EdgeRefreshPeriod) {
+                    list.setToolTipText(wordWrap(((EdgeRefreshPeriod) value).getTooltip()));
+                }
+                return this;
+            }
+        });
+        comboEdgeRefreshPeriod.addMouseListener(createTipPanelUpdater(generalHeader, "EdgeRefreshPeriod"));
+
         chkUseImplants = new CampaignOptionsCheckBox("UseImplants");
         chkUseImplants.addMouseListener(createTipPanelUpdater(generalHeader, "UseImplants"));
         chkUseAlternativeQualityAveraging = new CampaignOptionsCheckBox("UseAlternativeQualityAveraging",
@@ -555,8 +576,11 @@ public class PersonnelTab {
 
         layout.gridx = 0;
         layout.gridy++;
-        panel.add(chkUseImplants, layout);
+        panel.add(lblEdgeRefreshPeriod, layout);
+        layout.gridx++;
+        panel.add(comboEdgeRefreshPeriod, layout);
 
+        layout.gridx = 0;
         layout.gridy++;
         panel.add(chkUseImplants, layout);
 
@@ -646,15 +670,19 @@ public class PersonnelTab {
         chkUseBlobInfantry.addMouseListener(createTipPanelUpdater(generalHeader, "UseBlobInfantry"));
         chkUseBlobBattleArmor = new CampaignOptionsCheckBox("UseBlobBattleArmor", getMetadata(new Version(0, 50, 12)));
         chkUseBlobBattleArmor.addMouseListener(createTipPanelUpdater(generalHeader, "UseBlobBattleArmor"));
-        chkUseBlobVehicleCrewGround = new CampaignOptionsCheckBox("UseBlobVehicleCrewGround", getMetadata(new Version(0, 50, 12)));
+        chkUseBlobVehicleCrewGround = new CampaignOptionsCheckBox("UseBlobVehicleCrewGround",
+              getMetadata(new Version(0, 50, 12)));
         chkUseBlobVehicleCrewGround.addMouseListener(createTipPanelUpdater(generalHeader, "UseBlobVehicleCrewGround"));
-        chkUseBlobVehicleCrewVTOL = new CampaignOptionsCheckBox("UseBlobVehicleCrewVTOL", getMetadata(new Version(0, 50, 12)));
+        chkUseBlobVehicleCrewVTOL = new CampaignOptionsCheckBox("UseBlobVehicleCrewVTOL",
+              getMetadata(new Version(0, 50, 12)));
         chkUseBlobVehicleCrewVTOL.addMouseListener(createTipPanelUpdater(generalHeader, "UseBlobVehicleCrewVTOL"));
-        chkUseBlobVehicleCrewNaval = new CampaignOptionsCheckBox("UseBlobVehicleCrewNaval", getMetadata(new Version(0, 50, 12)));
+        chkUseBlobVehicleCrewNaval = new CampaignOptionsCheckBox("UseBlobVehicleCrewNaval",
+              getMetadata(new Version(0, 50, 12)));
         chkUseBlobVehicleCrewNaval.addMouseListener(createTipPanelUpdater(generalHeader, "UseBlobVehicleCrewNaval"));
         chkUseBlobVesselPilot = new CampaignOptionsCheckBox("UseBlobVesselPilot", getMetadata(new Version(0, 50, 12)));
         chkUseBlobVesselPilot.addMouseListener(createTipPanelUpdater(generalHeader, "UseBlobVesselPilot"));
-        chkUseBlobVesselGunner = new CampaignOptionsCheckBox("UseBlobVesselGunner", getMetadata(new Version(0, 50, 12)));
+        chkUseBlobVesselGunner = new CampaignOptionsCheckBox("UseBlobVesselGunner",
+              getMetadata(new Version(0, 50, 12)));
         chkUseBlobVesselGunner.addMouseListener(createTipPanelUpdater(generalHeader, "UseBlobVesselGunner"));
         chkUseBlobVesselCrew = new CampaignOptionsCheckBox("UseBlobVesselCrew", getMetadata(new Version(0, 50, 12)));
         chkUseBlobVesselCrew.addMouseListener(createTipPanelUpdater(generalHeader, "UseBlobVesselCrew"));
@@ -925,7 +953,9 @@ public class PersonnelTab {
 
         // Contents
         chkUseAdvancedMedical = new CampaignOptionsCheckBox("UseAdvancedMedical",
-              getMetadata(LEGACY_RULE_BEFORE_METADATA, CampaignOptionFlag.CUSTOM_SYSTEM, CampaignOptionFlag.DOCUMENTED));
+              getMetadata(LEGACY_RULE_BEFORE_METADATA,
+                    CampaignOptionFlag.CUSTOM_SYSTEM,
+                    CampaignOptionFlag.DOCUMENTED));
         chkUseAdvancedMedical.addMouseListener(createTipPanelUpdater(medicalHeader, "UseAdvancedMedical"));
 
         lblHealWaitingPeriod = new CampaignOptionsLabel("HealWaitingPeriod");
@@ -1269,7 +1299,9 @@ public class PersonnelTab {
         dependentsPanel = createDependentsPanel();
 
         // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("PrisonersAndDependentsTab", true, "PrisonersAndDependentsTab",
+        final JPanel panel = new CampaignOptionsStandardPanel("PrisonersAndDependentsTab",
+              true,
+              "PrisonersAndDependentsTab",
               getMetadata(null, CampaignOptionFlag.CUSTOM_SYSTEM, CampaignOptionFlag.DOCUMENTED));
         final GridBagConstraints layoutParent = new CampaignOptionsGridBagConstraints(panel);
 
@@ -1468,6 +1500,7 @@ public class PersonnelTab {
         chkOnlyCommandersMatterBattleArmor.setSelected(options.isOnlyCommandersMatterBattleArmor());
         chkUseEdge.setSelected(options.isUseEdge());
         chkUseSupportEdge.setSelected(options.isUseSupportEdge());
+        comboEdgeRefreshPeriod.setSelectedItem(options.getEdgeRefreshPeriod());
         chkUseImplants.setSelected(options.isUseImplants());
         chkUseAlternativeQualityAveraging.setSelected(options.isAlternativeQualityAveraging());
         chkUsePersonnelRemoval.setSelected(options.isUsePersonnelRemoval());
@@ -1578,6 +1611,7 @@ public class PersonnelTab {
         options.setOnlyCommandersMatterBattleArmor(chkOnlyCommandersMatterBattleArmor.isSelected());
         options.setUseEdge(chkUseEdge.isSelected());
         options.setUseSupportEdge(chkUseSupportEdge.isSelected());
+        options.setEdgeRefreshPeriod(comboEdgeRefreshPeriod.getSelectedItem());
         options.setUseImplants(chkUseImplants.isSelected());
         options.setAlternativeQualityAveraging(chkUseAlternativeQualityAveraging.isSelected());
         options.setUsePersonnelRemoval(chkUsePersonnelRemoval.isSelected());


### PR DESCRIPTION
# Requires https://github.com/MegaMek/mm-data/pull/378
Edge is, as a mechanic, a point of contention. Some players enjoy the power fantasy of an effectively unkillable character. Others (myself included) prefer to keep an element of danger present at all times.

I am a firm believer in risks and consequences telling a good story. The emergent narrative is fueled by the unexpected. A character that is effectively immune to almost all consequences limits what stories MekHQ can tell.

That all said, I don't believe it is right for me to dictate how 'killable' a players' roster is. I can provide consequences for those who want to engage with such systems, but they must always be optional.

This PR adds a new campaign option that, optionally, reduces the power of Edge by reducing how frequently it is replenished. Players are welcome to pick the option (never, daily, weekly, monthly, or annually) that best suits the 'grittiness' of their campaign.

Weekly is the default option, which matches the current weekly refresh rate. Monthly is the option I, personally, will be using.