### PR TITLE
Fixed Description of Training Skill to Reflect Function

### DIFF
--- a/MekHQ/resources/mekhq/resources/SkillType.properties
+++ b/MekHQ/resources/mekhq/resources/SkillType.properties
@@ -153,7 +153,7 @@ StreetwiseAny.flavorText=No mechanical effects.
 SurvivalAny.flavorText=No mechanical effects.
 TrackingAny.flavorText=If the appropriate campaign option is enabled, this skill is used in StratCon, primarily \
   by Patrol Combat Teams, to scout hexes.
-Training.flavorText=No mechanical effects.
+Training.flavorText=Used by educators leading the Training combat role (see the glossary for more information).
 CareerAny.flavorText=No mechanical effects.
 Running.flavorText=No mechanical effects.
 Swimming.flavorText=No mechanical effects.


### PR DESCRIPTION
`No mechanical effects.` -> `Used by educators leading the Training combat role (see the glossary for more information).`