### PR TITLE
Prevent Simulated Relationship History Applying to Spouses & Children of Personnel

### DIFF
--- a/MekHQ/src/mekhq/campaign/HumanResources.java
+++ b/MekHQ/src/mekhq/campaign/HumanResources.java
@@ -2235,7 +2235,7 @@ public class HumanResources {
                 specialAbilityGenerator.generateSpecialAbilities(campaign, child, experienceLevel);
             }
 
-            recruitPerson(campaign, child, PrisonerStatus.FREE, true, false, false);
+            recruitPerson(campaign, child, PrisonerStatus.FREE, true, false, false, true);
 
             if (currentChildren.contains(child)) {
                 campaign.addReport(DailyReportType.PERSONNEL,

--- a/MekHQ/src/mekhq/campaign/HumanResources.java
+++ b/MekHQ/src/mekhq/campaign/HumanResources.java
@@ -2183,7 +2183,7 @@ public class HumanResources {
         ResourceBundle resources = campaign.getResources();
 
         for (Person spouse : allSpouses) {
-            recruitPerson(campaign, spouse, PrisonerStatus.FREE, true, false, false);
+            recruitPerson(campaign, spouse, PrisonerStatus.FREE, true, false, false, true);
 
             if (currentSpouse == spouse) {
                 campaign.addReport(DailyReportType.PERSONNEL,


### PR DESCRIPTION
Spotted two instances where we could potentially try to simulate the relationship history of children and spouses (ex or otherwise) of new recruits.

I _think_ this is a benign bug, but not wholly sure. Either way, fixed now.