### PR TITLE
Fixed Background Marriages Occurring Within the Company Generator Failing to Add Spouses to Campaign Under Certain Circumstances Resulting in the Marriage Being Erased On Campaign Load

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -1664,7 +1664,7 @@ public class CampaignNewDayManager {
     private void processWeeklyRelationshipEvents(Person person) {
         if (today.getDayOfWeek() == DayOfWeek.MONDAY) {
             campaign.getDivorce().processNewWeek(campaign, today, person, false);
-            campaign.getMarriage().processNewWeek(campaign, today, person, false);
+            campaign.getMarriage().processNewWeek(campaign, today, person);
             campaign.getProcreation().processNewWeek(campaign, today, person);
         }
     }

--- a/MekHQ/src/mekhq/campaign/personnel/marriage/AbstractMarriage.java
+++ b/MekHQ/src/mekhq/campaign/personnel/marriage/AbstractMarriage.java
@@ -290,13 +290,11 @@ public abstract class AbstractMarriage {
     /**
      * Processes new day random marriage for an individual.
      *
-     * @param campaign     the campaign to process
-     * @param today        the current day
-     * @param person       the person to process
-     * @param isBackground whether the marriage occurred in a character's background
+     * @param campaign the campaign to process
+     * @param today    the current day
+     * @param person   the person to process
      */
-    public void processNewWeek(final Campaign campaign, final LocalDate today, final Person person,
-          boolean isBackground) {
+    public void processNewWeek(final Campaign campaign, final LocalDate today, final Person person) {
         if (canMarry(today, person, true) != null) {
             return;
         }
@@ -311,7 +309,7 @@ public abstract class AbstractMarriage {
                 isInterUnit = true;
             }
 
-            marryRandomSpouse(campaign, today, person, isInterUnit, isBackground);
+            marryRandomSpouse(campaign, today, person, isInterUnit, false);
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/universe/generators/companyGenerators/AbstractCompanyGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/generators/companyGenerators/AbstractCompanyGenerator.java
@@ -704,11 +704,7 @@ public abstract class AbstractCompanyGenerator {
 
                 for (final CompanyGenerationPersonTracker tracker : trackers) {
                     if (getOptions().isSimulateRandomMarriages()) {
-                        // While this is happening to generate a character's background, it does not use the
-                        // simulated relationship history system. Therefore, 'isBackground' needs to == false,
-                        // otherwise any marriages will be voided the next time the campaign is loaded as the spouse
-                        // will not be added to the campaign
-                        campaign.getMarriage().processNewWeek(campaign, date, tracker.getPerson(), false);
+                        campaign.getMarriage().processNewWeek(campaign, date, tracker.getPerson());
                     }
 
                     if (getOptions().isSimulateRandomProcreation()) {

--- a/MekHQ/src/mekhq/campaign/universe/generators/companyGenerators/AbstractCompanyGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/generators/companyGenerators/AbstractCompanyGenerator.java
@@ -704,7 +704,11 @@ public abstract class AbstractCompanyGenerator {
 
                 for (final CompanyGenerationPersonTracker tracker : trackers) {
                     if (getOptions().isSimulateRandomMarriages()) {
-                        campaign.getMarriage().processNewWeek(campaign, date, tracker.getPerson(), true);
+                        // While this is happening to generate a character's background, it does not use the
+                        // simulated relationship history system. Therefore, 'isBackground' needs to == false,
+                        // otherwise any marriages will be voided the next time the campaign is loaded as the spouse
+                        // will not be added to the campaign
+                        campaign.getMarriage().processNewWeek(campaign, date, tracker.getPerson(), false);
                     }
 
                     if (getOptions().isSimulateRandomProcreation()) {
@@ -1731,7 +1735,7 @@ public abstract class AbstractCompanyGenerator {
     private Money rollRandomStartingCash() {
         return getOptions().isRandomizeStartingCash()
                      ? Money.of(Math.pow(10, 6))
-                       .multipliedBy(Utilities.dice(getOptions().getRandomStartingCashDiceCount(), 6))
+                             .multipliedBy(Utilities.dice(getOptions().getRandomStartingCashDiceCount(), 6))
                      : Money.zero();
     }
 

--- a/MekHQ/unittests/mekhq/campaign/personnel/marriage/AbstractMarriageTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/marriage/AbstractMarriageTest.java
@@ -491,19 +491,19 @@ public class AbstractMarriageTest {
     //region New Week
     @Test
     public void testProcessNewWeek() {
-        doCallRealMethod().when(mockMarriage).processNewWeek(any(), any(), any(), anyBoolean());
-        doNothing().when(mockMarriage).marryRandomSpouse(any(), any(), any(), anyBoolean(), eq(true));
+        doCallRealMethod().when(mockMarriage).processNewWeek(any(), any(), any());
+        doNothing().when(mockMarriage).marryRandomSpouse(any(), any(), any(), anyBoolean(), eq(false));
 
         final Person mockPerson = mock(Person.class);
 
         when(mockMarriage.canMarry(any(), any(), anyBoolean())).thenReturn("Married");
-        mockMarriage.processNewWeek(mockCampaign, LocalDate.ofYearDay(3025, 1), mockPerson, true);
+        mockMarriage.processNewWeek(mockCampaign, LocalDate.ofYearDay(3025, 1), mockPerson);
         verify(mockMarriage, times(0)).randomMarriage();
         verify(mockMarriage, times(0)).marryRandomSpouse(any(), any(), any(), anyBoolean(), anyBoolean());
 
         when(mockMarriage.canMarry(any(), any(), anyBoolean())).thenReturn(null);
         when(mockMarriage.randomMarriage()).thenReturn(true);
-        mockMarriage.processNewWeek(mockCampaign, LocalDate.ofYearDay(3025, 1), mockPerson, true);
+        mockMarriage.processNewWeek(mockCampaign, LocalDate.ofYearDay(3025, 1), mockPerson);
         verify(mockMarriage, times(1)).randomMarriage();
         verify(mockMarriage, times(1)).marryRandomSpouse(any(), any(), any(), anyBoolean(), anyBoolean());
     }


### PR DESCRIPTION
This bug came about due to use of the `isBackground` flag. That flag prevents characters from being added to a campaign, generally due to the addition being from the Simulate Relationship Histories campaign option. However, this flag had been incorrectly set to `true` for the company generator.

If, during the company generator's processes, a character got married. And the character they married was external to the unit (an NPC). Then (and only then) that character would **not** to added to the campaign roster, resulting in the marriage being removed the next time the campaign loaded (to protect the user from NPEs).