### PR TITLE
Fixed Attribute Cost Campaign Option Not Being Correctly Hooked Up to GUI

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/SkillsTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/SkillsTab.java
@@ -45,6 +45,7 @@ import static mekhq.campaign.personnel.skills.enums.SkillSubType.*;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.createParentPanel;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.getCampaignOptionsResourceBundle;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.getImageDirectory;
+import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.getMetadata;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import java.awt.GridBagConstraints;
@@ -58,6 +59,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSpinner;
 
+import megamek.Version;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.SkillLevel;
 import megamek.logging.MMLogger;
@@ -310,7 +312,7 @@ public class SkillsTab {
         lblEdgeCost = new CampaignOptionsLabel("EdgeCost");
         spnEdgeCost = new CampaignOptionsSpinner("EdgeCost", 100, 0, 500, 1);
 
-        lblAttributeCost = new CampaignOptionsLabel("AttributeCost");
+        lblAttributeCost = new CampaignOptionsLabel("AttributeCost", getMetadata(new Version(0, 51, 0)));
         spnAttributeCost = new CampaignOptionsSpinner("AttributeCost", 100, 0, 500, 1);
 
         // Layout the Panel
@@ -326,9 +328,9 @@ public class SkillsTab {
 
         layout.gridy++;
         layout.gridx = 0;
-        panel.add(lblEdgeCost, layout);
+        panel.add(lblAttributeCost, layout);
         layout.gridx++;
-        panel.add(spnEdgeCost, layout);
+        panel.add(spnAttributeCost, layout);
 
         return panel;
     }
@@ -628,8 +630,8 @@ public class SkillsTab {
             }
         }
 
-        // Edge Costs
         spnEdgeCost.setValue(options.getEdgeCost());
+        spnAttributeCost.setValue(options.getAttributeCost());
     }
 
     /**
@@ -712,8 +714,8 @@ public class SkillsTab {
             updateSkillMilestones(type);
         }
 
-        // Edge Costs
         options.setEdgeCost((int) spnEdgeCost.getValue());
+        options.setAttributeCost((int) spnAttributeCost.getValue());
     }
 
     /**


### PR DESCRIPTION
Unfortunately it looks like, when the ability to change Attribute Costs was added, it was not properly affixed to the UI. Meaning the cost was in place, but there was no way for the players to access it. Now there is.

Marked it as a new-to-51.0 option, as to the player base it effective is.