### PR TITLE
Extract menu-related properties from CampaignGUI into MekHQMenu.properties

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignGUI.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignGUI.properties
@@ -29,72 +29,12 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 # Resources for the CampaignGUI class
-# Menu Resources
-# File Menu
-fileMenu.text=File
-menuLoad.text=Load Campaign...
-menuSave.text=Save Campaign...
-menuNew.text=New Campaign...
-# Menu Import
-menuImport.text=Import
-miImportCampaignPreset.text=Campaign Options from a Preset xml file...
-miImportCampaignPreset.toolTipText=This loads campaign options from a preset XML file. This will only apply the continuous portions of the preset.
-miImportPerson.text=Personnel from a prsx file...
-miImportIndividualRankSystem.text=Individual Rank System from an xml file...
-miImportIndividualRankSystem.toolTipText=<html>This will replace the current campaign's rank system with the imported rank system. <br>If this contains a duplicate rank system code, it will instead return the previously loaded rank system with that code.</html>
-miImportParts.text=Parts from a 'parts' file...
-miLoadForces.text=Forces from a MUL File...
-# Menu Export
-menuExport.text=Export
-menuExportCSV.text=CSV File
-miExportPersonnel.text=Personnel...
-miExportUnit.text=Units...
-miExportFinances.text=Finances...
-menuExportXML.text=XML File
-miExportCampaignPreset.text=Campaign Preset...
-miExportRankSystems.text=Rank Systems...
-miExportIndividualRankSystem.text=Campaign Rank System...
-miExportPlanets.text=Planets...
-miExportCampaignSubset.text=Campaign Subset...
-# Refresh Menu
-menuRefresh.text=Refresh
-miRefreshUnitCache.text=Refresh Unit Cache
-miRefreshCamouflage.text=Refresh Camouflage Directory
-miRefreshPortraits.text=Refresh Portrait Directory
-miRefreshFormationIcons.text=Refresh Formation Icon Directory
-miRefreshStoryIcons.text=Refresh Story Arc Icon Directory
-miRefreshAwards.text=Refresh Award Icon Directory
-miRefreshRanks.text=Refresh Rank Systems from File
-miRefreshFinancialInstitutions.text=Refresh Financial Institutions from File
-miRefreshFinancialInstitutions.toolTipText=This reloads the financial institutions files, which is primarily useful when editing the userdata institutions file and testing out the changes there.
-# Menu File Others
-miMercRoster.text=Upload to MercRoster Database...
-menuOptions.text=Campaign Options...
-miGameOptions.text=MegaMek Options...
-miGameOptions.toolTipText=This launches the MegaMek Options Dialog, which allows you to customize your MegaMek Game Options.
-miMHQOptions.text=MekHQ Client Options...
-miMHQOptions.toolTipText=This launches the MekHQ Options Dialog.
-miMMClientOptions.text=MegaMek Client Options...
-miMMClientOptions.toolTipText=This launches the MegaMek Client Options Dialog.
-menuThemes.text=Themes
-menuExit.text=Exit
+
+# Menus
 mekSelectorDialog.unsupported.gunEmplacement=Gun Emplacements are %s<b>not supported</b>%s by MekHQ.
 mekSelectorDialog.unsupported.droneOs=Drone units are %s<b>not supported</b>%s by MekHQ.
 mekSelectorDialog.unsupported.null=Unit does not have an entity.
-# Marketplace Menu
-menuMarket.text=Marketplace
-miRecruitment.text=Recruitment...
-miContractMarket.text=Contract Market...
-miUnitMarket.text=Unit Market...
-miShipSearch.text=Ship Search...
-miPurchaseUnit.text=Purchase Unit
-miBuyParts.text=Purchase Parts
-miBulkRecruitment.text=Bulk Recruitment (GM)
-menuRecruitment.text=Recruitment (GM)
-menuRecruitment.blank=Blank Character
-menuRecruitment.combat=Combat
-menuRecruitment.support=Support
-menuRecruitment.civilian=Civilian
+
 # Dynamic Buttons
 pnlMarkets.title=Marketplace
 btnContractMarket.market=<html><center>Contract Market</center></html>
@@ -104,133 +44,7 @@ btnUnitMarket.market=<html><center>Unit Market</center></html>
 btnUnitMarket.toolTipText=<html>Opens the Unit Market to purchase new 'Mechs, vehicles, aerospace assets, etc.</html>
 btnUnitMarket.manual=<html><center>Purchase Units</center></html>
 btnPartsMarket.manual=<html><center>Purchase Parts</center></html>
-# Menu Astech Pool
-menuAstechPool.text=Astech Pool
-miHireAstechs.text=Hire Astechs
-popupHireAstechsNum.text=Hire How Many Astechs?
-miFireAstechs.text=Release Astechs
-miFireAstechs.disabledTip=No astechs in the pool to release.
-popupFireAstechsNum.text=Release How Many Astechs?
-miFullStrengthAstechs.text=Bring All Tech Teams to Full Strength
-miFullStrengthAstechs.disabledTip=Tech teams are already at full strength and the pool is empty.
-miFireAllAstechs.text=Release All Astechs from Pool
-miFireAllAstechs.disabledTip=The astech pool is already empty.
-# Menu Medic Pool
-menuMedicPool.text=Medic Pool
-miHireMedics.text=Hire Medics
-popupHireMedicsNum.text=Hire How Many Medics?
-miFireMedics.text=Release Medics
-miFireMedics.disabledTip=No medics in the pool to release.
-popupFireMedicsNum.text=Release How Many Medics?
-miFullStrengthMedics.text=Bring All Medical Teams to Full Strength
-miFullStrengthMedics.disabledTip=Medical teams are already at full strength and the pool is empty.
-miFireAllMedics.text=Release All Medics from Pool
-miFireAllMedics.disabledTip=The medic pool is already empty.
-# Menu Soldier Pool
-menuSoldierPool.text=Soldier Pool
-miHireSoldiers.text=Hire Soldiers
-popupHireSoldiersNum.text=Hire How Many Soldiers?
-miFireSoldiers.text=Release Soldiers
-popupFireSoldiersNum.text=Release How Many Soldiers?
-miFullStrengthSoldiers.text=Bring All Infantry Units to Full Strength
-miFireAllSoldiers.text=Release All Soldiers from Pool
-# Menu Battle Armor Pool
-menuBattleArmorPool.text=Battle Armor Pool
-miHireBattleArmor.text=Hire Battle Armor
-popupHireBattleArmorNum.text=Hire How Many Battle Armor?
-miFireBattleArmor.text=Release Battle Armor
-popupFireBattleArmorNum.text=Release How Many Battle Armor?
-miFullStrengthBattleArmor.text=Bring All Battle Armor Units to Full Strength
-miFireAllBattleArmor.text=Release All Battle Armor from Pool
-# Menu Vehicle Crew Ground Pool
-menuVehicleCrewGroundPool.text=Vehicle Crew (Ground) Pool
-miHireVehicleCrewGround.text=Hire Vehicle Crew (Ground)
-popupHireVehicleCrewGroundNum.text=Hire How Many Vehicle Crew (Ground)?
-miFireVehicleCrewGround.text=Release Vehicle Crew (Ground)
-popupFireVehicleCrewGroundNum.text=Release How Many Vehicle Crew (Ground)?
-miFullStrengthVehicleCrewGround.text=Bring All Ground Vehicle Units to Full Strength
-miFireAllVehicleCrewGround.text=Release All Vehicle Crew (Ground) from Pool
-# Menu Vehicle Crew VTOL Pool
-menuVehicleCrewVTOLPool.text=Vehicle Crew (VTOL) Pool
-miHireVehicleCrewVTOL.text=Hire Vehicle Crew (VTOL)
-popupHireVehicleCrewVTOLNum.text=Hire How Many Vehicle Crew (VTOL)?
-miFireVehicleCrewVTOL.text=Release Vehicle Crew (VTOL)
-popupFireVehicleCrewVTOLNum.text=Release How Many Vehicle Crew (VTOL)?
-miFullStrengthVehicleCrewVTOL.text=Bring All VTOL Units to Full Strength
-miFireAllVehicleCrewVTOL.text=Release All Vehicle Crew (VTOL) from Pool
-# Menu Vehicle Crew Naval Pool
-menuVehicleCrewNavalPool.text=Vehicle Crew (Naval) Pool
-miHireVehicleCrewNaval.text=Hire Vehicle Crew (Naval)
-popupHireVehicleCrewNavalNum.text=Hire How Many Vehicle Crew (Naval)?
-miFireVehicleCrewNaval.text=Release Vehicle Crew (Naval)
-popupFireVehicleCrewNavalNum.text=Release How Many Vehicle Crew (Naval)?
-miFullStrengthVehicleCrewNaval.text=Bring All Naval Vehicle Units to Full Strength
-miFireAllVehicleCrewNaval.text=Release All Vehicle Crew (Naval) from Pool
-# Menu Vessel Pilot Pool
-menuVesselPilotPool.text=Vessel Pilot Pool
-miHireVesselPilot.text=Hire Vessel Pilots
-popupHireVesselPilotNum.text=Hire How Many Vessel Pilots?
-miFireVesselPilot.text=Release Vessel Pilots
-popupFireVesselPilotNum.text=Release How Many Vessel Pilots?
-miFullStrengthVesselPilot.text=Bring All Vessels to Full Pilot Strength
-miFireAllVesselPilot.text=Release All Vessel Pilots from Pool
-# Menu Vessel Gunner Pool
-menuVesselGunnerPool.text=Vessel Gunner Pool
-miHireVesselGunner.text=Hire Vessel Gunners
-popupHireVesselGunnerNum.text=Hire How Many Vessel Gunners?
-miFireVesselGunner.text=Release Vessel Gunners
-popupFireVesselGunnerNum.text=Release How Many Vessel Gunners?
-miFullStrengthVesselGunner.text=Bring All Vessels to Full Gunner Strength
-miFireAllVesselGunner.text=Release All Vessel Gunners from Pool
-# Menu Vessel Crew Pool
-menuVesselCrewPool.text=Vessel Crew Pool
-miHireVesselCrew.text=Hire Vessel Crew
-popupHireVesselCrewNum.text=Hire How Many Vessel Crew?
-miFireVesselCrew.text=Release Vessel Crew
-popupFireVesselCrewNum.text=Release How Many Vessel Crew?
-miFullStrengthVesselCrew.text=Bring All Vessels to Full Crew Strength
-miFireAllVesselCrew.text=Release All Vessel Crew from Pool
-# Menu Temp Pool (shared blob crew tooltip strings)
-miFireBlobCrew.disabledTip=No temp crew in the pool to release.
-miFullStrengthBlobCrew.disabledTip=All units of this type are already at full crew strength.
-miFireAllBlobCrew.disabledTip=No unassigned temp crew in the pool to release.
-menuTempPool.text=Temp Pool
-miTempPoolFullStrength.text=Bring All Temps to Full Strength
-miTempPoolFullStrength.disabledTip=All temp pools are already at full strength.
-miTempPoolReleaseAll.text=Release All Temps
-miTempPoolReleaseAll.disabledTip=All temp pools are already empty.
-miTempPoolReleaseSurplus.text=Release Surplus Temps
-miTempPoolReleaseSurplus.disabledTip=No surplus temps to release.
-# Reports Menu
-menuReports.text=Reports
-miDragoonsRating.text=Unit Rating...
-miPersonnelReport.text=Personnel Report...
-miHangarBreakdown.text=Hangar Breakdown...
-miTransportReport.text=Transport Capacity Report...
-miCargoReport.text=Cargo Report...
-# View Menu
-menuView.text=View
-miShowHistoricalReportLog.text=Historical Daily Report Log
-miRetirementDefectionDialog.text=Employee Turnover Dialog
-miAwardEligibilityDialog.text=Award Eligibility Dialog
-# Manage Campaign Menu
-menuManageCampaign.text=Manage Campaign
-miGMToolsDialog.text=GM Tools Dialog...
-miPlanetarySystemEditor.text=Planetary Data Editor...
-miRandomBloodnames.text=Bloodname Randomization for All Personnel
-miScenarioEditor.text=Scenario Template Editor...
-miCompanyGenerator.text=Quick Start Company Generator...
-miAutoResolveBehaviorSettings.text=Auto Resolve Behavior Settings
-# Help Menu
-menuHelp.text=Help
-menuAbout.text=About MekHQ...
-menuReportBug.text=Report a Bug...
-menuCopySystemData.text=Copy System Data
-menuCopySystemData.tip=Copies information on the OS, Java and the MegaMek suite programs to the clipboard.
-#End Menu Resources
-# In-App New Campaign
-savePrompt.title=Save First?
-savePrompt.text=Do you want to save the game before starting a new campaign?
+
 ## Unsorted Resources
 btnMassTraining.text=Mass Personnel Training
 btnMassTraining.toolTipText=This launches the Mass Personnel Training Dialog, which allows you to train large numbers of personnel at the same time.
@@ -291,13 +105,6 @@ btnCompanyGenerator.toolTipText=<html>Primarily used for starting a new campaign
 era-appropriate 'Mek force, assigns qualified combat / support personnel, and allocates starting C-Bills.</html>
 btnShowAllTechs.text=Show All Tech Types
 btnGMMode.text=GM Mode
-dlgNoFinances.text=No finances to export
-dlgNoPersonnel.text=No personnel to export
-dlgNoUnits.text=No units to export
-dlgSaveFinancesCSV.text=Save Finances to CSV
-dlgSavePersonnelCSV.text=Save Personnel to CSV
-dlgSaveUnitsCSV.text=Save Units to CSV
-dlgSavePlanetsXML.text=Save Planets to XML
 btnOvertime.toolTipText=If toggled, techs will work up to 12-hour shifts, rather than 8 hours. However, they will also suffer a penalty during overtime hours.
 btnGMMode.toolTipText=<html>Toggles Game Master mode. Unlocks rule overrides and restricted features for manual \
 editing of finances, personnel stats, etc.</html>
@@ -412,8 +219,8 @@ lblTransportCapacity.text=<html><nobr><b>Transport Capacity:</b></nobr></html>;
 lblCargoSummary.text=<html><nobr><b>Cargo Summary:</b></nobr></html>;
 lblFacilityCapacities.text=<html><nobr><b>Facility Capacities:</b></nobr></html>;
 panLog.title=Daily Activity Log
-# New Day Blockers
-# Overdue Loans
+
+# New Day Blockers: Overdue Loans
 dialogOverdueLoans.ic={0}, we're unable to meet an upcoming loan payment as we lack the funds to cover our obligations.\
   \ This is a critical issue that requires immediate attention. Without addressing it, we risk defaulting, which would\
   \ damage our financial standing and limit future operational flexibility.\
@@ -427,7 +234,8 @@ dialogOverdueLoans.ooc=This is a critical situation, and you will be unable to p
   <br>- Take out another loan.\
   <br>- Default on the loan. Though you will be required to sell units to the bank, based on the loan's collateral.\
   <br>- Use GM Mode to delete the loan.</p>
-# Invalid Faction
+
+# New Day Blockers: Invalid Faction
 dialogInvalidFaction.ic={0}, our parent faction has gone dark. All attempts at communication have failed, and we have\
   \ received no orders, updates, or logistical support. This is a serious situation that requires immediate attention.\
   <p>Without direction or resupply from High Command, the unit will be unable to proceed with operations.</p>\
@@ -442,6 +250,7 @@ dialogScenarioAcceptance.button.accept=Commence Drop
 dialogScenarioAcceptance.button.cancel=Return to the Launch Bay
 cadreReassignment.text=One or more formations were assigned to Cadre duties. With the contract now concluded, they have \
   been reassigned to Frontline.
+
 # Status Bar - Temp Personnel
 statusBar.pnlTempPersonnel.title=Temp
 statusBar.pnlVehicleCrew.title=Vehicle Crew

--- a/MekHQ/resources/mekhq/resources/MekHQMenuBar.properties
+++ b/MekHQ/resources/mekhq/resources/MekHQMenuBar.properties
@@ -1,0 +1,245 @@
+# Copyright (C) 2005-2026 The MegaMek Team. All Rights Reserved.
+#
+# This file is part of MekHQ.
+#
+# MekHQ is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (GPL),
+# version 3 or (at your option) any later version,
+# as published by the Free Software Foundation.
+#
+# MekHQ is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# A copy of the GPL should have been included with this project;
+# if not, see <https://www.gnu.org/licenses/>.
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# File Menu
+fileMenu.text=File
+menuLoad.text=Load Campaign...
+menuSave.text=Save Campaign...
+menuNew.text=New Campaign...
+
+# Menu Import
+menuImport.text=Import
+miImportCampaignPreset.text=Campaign Options from a Preset xml file...
+miImportCampaignPreset.toolTipText=This loads campaign options from a preset XML file. This will only apply the continuous portions of the preset.
+miImportPerson.text=Personnel from a prsx file...
+miImportIndividualRankSystem.text=Individual Rank System from an xml file...
+miImportIndividualRankSystem.toolTipText=<html>This will replace the current campaign's rank system with the imported rank system. <br>If this contains a duplicate rank system code, it will instead return the previously loaded rank system with that code.</html>
+miImportParts.text=Parts from a 'parts' file...
+miLoadForces.text=Forces from a MUL File...
+
+# Menu Export
+menuExport.text=Export
+menuExportCSV.text=CSV File
+miExportPersonnel.text=Personnel...
+dlgNoPersonnel.text=No personnel to export
+dlgSavePersonnelCSV.text=Save Personnel to CSV
+miExportUnit.text=Units...
+dlgNoUnits.text=No units to export
+dlgSaveUnitsCSV.text=Save Units to CSV
+miExportFinances.text=Finances...
+dlgNoFinances.text=No finances to export
+dlgSaveFinancesCSV.text=Save Finances to CSV
+menuExportXML.text=XML File
+miExportCampaignPreset.text=Campaign Preset...
+miExportRankSystems.text=Rank Systems...
+miExportIndividualRankSystem.text=Campaign Rank System...
+miExportPlanets.text=Planets...
+dlgSavePlanetsXML.text=Save Planets to XML
+miExportCampaignSubset.text=Campaign Subset...
+
+# Refresh Menu
+menuRefresh.text=Refresh
+miRefreshUnitCache.text=Refresh Unit Cache
+miRefreshCamouflage.text=Refresh Camouflage Directory
+miRefreshPortraits.text=Refresh Portrait Directory
+miRefreshFormationIcons.text=Refresh Formation Icon Directory
+miRefreshStoryIcons.text=Refresh Story Arc Icon Directory
+miRefreshAwards.text=Refresh Award Icon Directory
+miRefreshRanks.text=Refresh Rank Systems from File
+miRefreshFinancialInstitutions.text=Refresh Financial Institutions from File
+miRefreshFinancialInstitutions.toolTipText=This reloads the financial institutions files, which is primarily useful when editing the userdata institutions file and testing out the changes there.
+
+# Menu File Others
+miMercRoster.text=Upload to MercRoster Database...
+menuOptions.text=Campaign Options...
+miGameOptions.text=MegaMek Options...
+miGameOptions.toolTipText=This launches the MegaMek Options Dialog, which allows you to customize your MegaMek Game Options.
+miMHQOptions.text=MekHQ Client Options...
+miMHQOptions.toolTipText=This launches the MekHQ Options Dialog.
+miMMClientOptions.text=MegaMek Client Options...
+miMMClientOptions.toolTipText=This launches the MegaMek Client Options Dialog.
+menuThemes.text=Themes
+menuExit.text=Exit
+
+# Marketplace Menu
+menuMarket.text=Marketplace
+miRecruitment.text=Recruitment...
+miContractMarket.text=Contract Market...
+miUnitMarket.text=Unit Market...
+miShipSearch.text=Ship Search...
+miPurchaseUnit.text=Purchase Unit
+miBuyParts.text=Purchase Parts
+miBulkRecruitment.text=Bulk Recruitment (GM)
+menuRecruitment.text=Recruitment (GM)
+menuRecruitment.blank=Blank Character
+menuRecruitment.combat=Combat
+menuRecruitment.support=Support
+menuRecruitment.civilian=Civilian
+
+# Menu Astech Pool
+menuAstechPool.text=Astech Pool
+miHireAstechs.text=Hire Astechs
+popupHireAstechsNum.text=Hire How Many Astechs?
+miFireAstechs.text=Release Astechs
+miFireAstechs.disabledTip=No astechs in the pool to release.
+popupFireAstechsNum.text=Release How Many Astechs?
+miFullStrengthAstechs.text=Bring All Tech Teams to Full Strength
+miFullStrengthAstechs.disabledTip=Tech teams are already at full strength and the pool is empty.
+miFireAllAstechs.text=Release All Astechs from Pool
+miFireAllAstechs.disabledTip=The astech pool is already empty.
+
+# Menu Medic Pool
+menuMedicPool.text=Medic Pool
+miHireMedics.text=Hire Medics
+popupHireMedicsNum.text=Hire How Many Medics?
+miFireMedics.text=Release Medics
+miFireMedics.disabledTip=No medics in the pool to release.
+popupFireMedicsNum.text=Release How Many Medics?
+miFullStrengthMedics.text=Bring All Medical Teams to Full Strength
+miFullStrengthMedics.disabledTip=Medical teams are already at full strength and the pool is empty.
+miFireAllMedics.text=Release All Medics from Pool
+miFireAllMedics.disabledTip=The medic pool is already empty.
+
+# Menu Soldier Pool
+menuSoldierPool.text=Soldier Pool
+miHireSoldiers.text=Hire Soldiers
+popupHireSoldiersNum.text=Hire How Many Soldiers?
+miFireSoldiers.text=Release Soldiers
+popupFireSoldiersNum.text=Release How Many Soldiers?
+miFullStrengthSoldiers.text=Bring All Infantry Units to Full Strength
+miFireAllSoldiers.text=Release All Soldiers from Pool
+
+# Menu Battle Armor Pool
+menuBattleArmorPool.text=Battle Armor Pool
+miHireBattleArmor.text=Hire Battle Armor
+popupHireBattleArmorNum.text=Hire How Many Battle Armor?
+miFireBattleArmor.text=Release Battle Armor
+popupFireBattleArmorNum.text=Release How Many Battle Armor?
+miFullStrengthBattleArmor.text=Bring All Battle Armor Units to Full Strength
+miFireAllBattleArmor.text=Release All Battle Armor from Pool
+
+# Menu Vehicle Crew Ground Pool
+menuVehicleCrewGroundPool.text=Vehicle Crew (Ground) Pool
+miHireVehicleCrewGround.text=Hire Vehicle Crew (Ground)
+popupHireVehicleCrewGroundNum.text=Hire How Many Vehicle Crew (Ground)?
+miFireVehicleCrewGround.text=Release Vehicle Crew (Ground)
+popupFireVehicleCrewGroundNum.text=Release How Many Vehicle Crew (Ground)?
+miFullStrengthVehicleCrewGround.text=Bring All Ground Vehicle Units to Full Strength
+miFireAllVehicleCrewGround.text=Release All Vehicle Crew (Ground) from Pool
+
+# Menu Vehicle Crew VTOL Pool
+menuVehicleCrewVTOLPool.text=Vehicle Crew (VTOL) Pool
+miHireVehicleCrewVTOL.text=Hire Vehicle Crew (VTOL)
+popupHireVehicleCrewVTOLNum.text=Hire How Many Vehicle Crew (VTOL)?
+miFireVehicleCrewVTOL.text=Release Vehicle Crew (VTOL)
+popupFireVehicleCrewVTOLNum.text=Release How Many Vehicle Crew (VTOL)?
+miFullStrengthVehicleCrewVTOL.text=Bring All VTOL Units to Full Strength
+miFireAllVehicleCrewVTOL.text=Release All Vehicle Crew (VTOL) from Pool
+
+# Menu Vehicle Crew Naval Pool
+menuVehicleCrewNavalPool.text=Vehicle Crew (Naval) Pool
+miHireVehicleCrewNaval.text=Hire Vehicle Crew (Naval)
+popupHireVehicleCrewNavalNum.text=Hire How Many Vehicle Crew (Naval)?
+miFireVehicleCrewNaval.text=Release Vehicle Crew (Naval)
+popupFireVehicleCrewNavalNum.text=Release How Many Vehicle Crew (Naval)?
+miFullStrengthVehicleCrewNaval.text=Bring All Naval Vehicle Units to Full Strength
+miFireAllVehicleCrewNaval.text=Release All Vehicle Crew (Naval) from Pool
+
+# Menu Vessel Pilot Pool
+menuVesselPilotPool.text=Vessel Pilot Pool
+miHireVesselPilot.text=Hire Vessel Pilots
+popupHireVesselPilotNum.text=Hire How Many Vessel Pilots?
+miFireVesselPilot.text=Release Vessel Pilots
+popupFireVesselPilotNum.text=Release How Many Vessel Pilots?
+miFullStrengthVesselPilot.text=Bring All Vessels to Full Pilot Strength
+miFireAllVesselPilot.text=Release All Vessel Pilots from Pool
+
+# Menu Vessel Gunner Pool
+menuVesselGunnerPool.text=Vessel Gunner Pool
+miHireVesselGunner.text=Hire Vessel Gunners
+popupHireVesselGunnerNum.text=Hire How Many Vessel Gunners?
+miFireVesselGunner.text=Release Vessel Gunners
+popupFireVesselGunnerNum.text=Release How Many Vessel Gunners?
+miFullStrengthVesselGunner.text=Bring All Vessels to Full Gunner Strength
+miFireAllVesselGunner.text=Release All Vessel Gunners from Pool
+
+# Menu Vessel Crew Pool
+menuVesselCrewPool.text=Vessel Crew Pool
+miHireVesselCrew.text=Hire Vessel Crew
+popupHireVesselCrewNum.text=Hire How Many Vessel Crew?
+miFireVesselCrew.text=Release Vessel Crew
+popupFireVesselCrewNum.text=Release How Many Vessel Crew?
+miFullStrengthVesselCrew.text=Bring All Vessels to Full Crew Strength
+miFireAllVesselCrew.text=Release All Vessel Crew from Pool
+
+# Menu Temp Pool (shared blob crew tooltip strings)
+miFireBlobCrew.disabledTip=No temp crew in the pool to release.
+miFullStrengthBlobCrew.disabledTip=All units of this type are already at full crew strength.
+miFireAllBlobCrew.disabledTip=No unassigned temp crew in the pool to release.
+menuTempPool.text=Temp Pool
+miTempPoolFullStrength.text=Bring All Temps to Full Strength
+miTempPoolFullStrength.disabledTip=All temp pools are already at full strength.
+miTempPoolReleaseAll.text=Release All Temps
+miTempPoolReleaseAll.disabledTip=All temp pools are already empty.
+miTempPoolReleaseSurplus.text=Release Surplus Temps
+miTempPoolReleaseSurplus.disabledTip=No surplus temps to release.
+
+# Reports Menu
+menuReports.text=Reports
+miDragoonsRating.text=Unit Rating...
+miPersonnelReport.text=Personnel Report...
+miHangarBreakdown.text=Hangar Breakdown...
+miTransportReport.text=Transport Capacity Report...
+miCargoReport.text=Cargo Report...
+
+# View Menu
+menuView.text=View
+miShowHistoricalReportLog.text=Historical Daily Report Log
+miRetirementDefectionDialog.text=Employee Turnover Dialog
+miAwardEligibilityDialog.text=Award Eligibility Dialog
+
+# Manage Campaign Menu
+menuManageCampaign.text=Manage Campaign
+miGMToolsDialog.text=GM Tools Dialog...
+miPlanetarySystemEditor.text=Planetary Data Editor...
+miRandomBloodnames.text=Bloodname Randomization for All Personnel
+miScenarioEditor.text=Scenario Template Editor...
+miCompanyGenerator.text=Quick Start Company Generator...
+miAutoResolveBehaviorSettings.text=Auto Resolve Behavior Settings
+
+# Help Menu
+menuHelp.text=Help
+menuAbout.text=About MekHQ...
+menuReportBug.text=Report a Bug...
+
+# In-App New Campaign
+savePrompt.title=Save First?
+savePrompt.text=Do you want to save the game before starting a new campaign?

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -332,7 +332,7 @@ public class CampaignGUI extends JPanel {
         // Move the window
         frame.setLocation(x, y);
 
-        windowMenu = new MekHQMenuBar(getApplication(), this, resourceMap);
+        windowMenu = new MekHQMenuBar(getApplication(), this);
         frame.setJMenuBar(windowMenu);
 
         frame.getContentPane().setLayout(new BorderLayout());

--- a/MekHQ/src/mekhq/gui/menus/MekHQMenuBar.java
+++ b/MekHQ/src/mekhq/gui/menus/MekHQMenuBar.java
@@ -132,9 +132,10 @@ import static mekhq.gui.CampaignGUI.MAX_QUANTITY_SPINNER;
 public class MekHQMenuBar extends JMenuBar {
 
     private static final MMLogger logger = MMLogger.create(MekHQMenuBar.class);
+    private final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.MekHQMenuBar",
+          MekHQ.getMHQOptions().getLocale());
 
     private final CampaignGUI gui;
-    private final ResourceBundle resourceMap;
     private final MekHQ app;
 
     private JMenu menuThemes;
@@ -171,11 +172,10 @@ public class MekHQMenuBar extends JMenuBar {
      * Note 3: Only essential actions (Save, Load, New) have global Ctrl+key accelerators. All other menu items use
      * mnemonics only (accessible via keyboard menu navigation) to avoid duplicate accelerator conflicts.
      */
-    public MekHQMenuBar(MekHQ app, CampaignGUI gui, ResourceBundle resourceMap) {
+    public MekHQMenuBar(MekHQ app, CampaignGUI gui) {
         super();
         this.app = app;
         this.gui = gui;
-        this.resourceMap = resourceMap;
         initMenu();
     }
 


### PR DESCRIPTION
This PR continues work started in #9135. It removes MekHQMenu dependency on resource bundle from CampaignGUI and creates a clear separation between properties they use.

All properties were moved as is and thoroughly checked.