### PR TITLE
Lowered Accessibility of `CurrentLocation` Text Helper Methods

### DIFF
--- a/MekHQ/src/mekhq/campaign/CurrentLocation.java
+++ b/MekHQ/src/mekhq/campaign/CurrentLocation.java
@@ -49,7 +49,6 @@ import mekhq.campaign.events.TransitCompleteEvent;
 import mekhq.campaign.events.TransitStatusChangedEvent;
 import mekhq.campaign.personnel.medical.advancedMedicalAlternate.Inoculations;
 import mekhq.campaign.universe.PlanetarySystem;
-import mekhq.utilities.MHQInternationalization;
 import mekhq.utilities.MHQXMLUtility;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -351,13 +350,5 @@ public class CurrentLocation extends AbstractLocation {
         }
 
         return retVal;
-    }
-
-    public static String getFormattedTextAt(String key, Object... args) {
-        return MHQInternationalization.getFormattedTextAt(RESOURCE_BUNDLE, key, args);
-    }
-
-    public static String getTextAt(String key) {
-        return MHQInternationalization.getTextAt(RESOURCE_BUNDLE, key);
     }
 }

--- a/MekHQ/src/mekhq/gui/view/CurrentLocationPanel.java
+++ b/MekHQ/src/mekhq/gui/view/CurrentLocationPanel.java
@@ -33,8 +33,6 @@
 
 package mekhq.gui.view;
 
-import static mekhq.campaign.CurrentLocation.getFormattedTextAt;
-import static mekhq.campaign.CurrentLocation.getTextAt;
 import static mekhq.campaign.market.personnelMarket.enums.PersonnelMarketStyle.PERSONNEL_MARKET_DISABLED;
 import static mekhq.campaign.personnel.skills.SkillType.EXP_REGULAR;
 
@@ -68,10 +66,11 @@ import mekhq.campaign.universe.SocioIndustrialData;
 import mekhq.campaign.universe.StarUtil;
 import mekhq.campaign.universe.enums.HiringHallLevel;
 import mekhq.gui.CampaignGUI;
-import mekhq.gui.baseComponents.ScalingWidthConstrainedPanel;
 import mekhq.gui.baseComponents.ScalingVerticalFillImage;
+import mekhq.gui.baseComponents.ScalingWidthConstrainedPanel;
 import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
 import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
+import mekhq.utilities.MHQInternationalization;
 import mekhq.utilities.ReportingUtilities;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -90,6 +89,7 @@ import org.apache.logging.log4j.util.Strings;
  * </p>
  */
 public class CurrentLocationPanel extends ScalingWidthConstrainedPanel {
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.CurrentLocation";
 
     private static final File JUMP_SHIP_IMAGE = new File(Configuration.unitImagesDir(), "jumpships/invader.png");
 
@@ -156,8 +156,8 @@ public class CurrentLocationPanel extends ScalingWidthConstrainedPanel {
     }
 
     /**
-     * Updates the location title, dynamic images, planetary/transit info text, and the
-     * visibility and state of the Hiring Hall button based on the current location context.
+     * Updates the location title, dynamic images, planetary/transit info text, and the visibility and state of the
+     * Hiring Hall button based on the current location context.
      */
     private void refresh() {
         CampaignOptions options = campaign.getCampaignOptions();
@@ -261,7 +261,7 @@ public class CurrentLocationPanel extends ScalingWidthConstrainedPanel {
      *   <li>Temperature.</li>
      *   <li>Gravity.</li>
      * </ul>
-     *
+     * <p>
      * Each characteristic is colored dynamically based on the severity of the penalties it causes.
      *
      * @return a formatted HTML string representing the planetary conditions
@@ -319,8 +319,8 @@ public class CurrentLocationPanel extends ScalingWidthConstrainedPanel {
     /**
      * Generates a description for the current travel course.
      *
-     * @return a formatted HTML string detailing the final destination system and remaining jumps,
-     * or an empty/fallback string if the player is not currently traveling.
+     * @return a formatted HTML string detailing the final destination system and remaining jumps, or an empty/fallback
+     *       string if the player is not currently traveling.
      */
     public String getCourseInfo() {
         JumpPath jumpPath = campaign.getCurrentLocation().getJumpPath();
@@ -337,7 +337,7 @@ public class CurrentLocationPanel extends ScalingWidthConstrainedPanel {
      * Generates jump cost summary line.
      *
      * @return a formatted HTML string with remaining (or weekly average in case of traveling to a planet) jump cost,
-     *         information, or an empty string if not traveling
+     *       information, or an empty string if not traveling
      */
     public String getJumpCostInfo() {
         AbstractLocation location = campaign.getCurrentLocation();
@@ -358,6 +358,7 @@ public class CurrentLocationPanel extends ScalingWidthConstrainedPanel {
     }
 
     // TODO: reuse the calculation logic from Maintenance::getTargetForMaintenance
+
     /**
      * Generates a status line detailing the socio-industrial conditions of the current planet.
      *
@@ -368,7 +369,7 @@ public class CurrentLocationPanel extends ScalingWidthConstrainedPanel {
      *   <li>Raw material output.</li>
      *   <li>Total population.</li>
      * </ul>
-     *
+     * <p>
      * Each metric is color-coded based on its rating.
      *
      * @return a formatted HTML string containing the socio-industrial status
@@ -432,6 +433,14 @@ public class CurrentLocationPanel extends ScalingWidthConstrainedPanel {
     private static String getDefaultFontHexColor() {
         Color color = UIManager.getColor("Label.foreground");
         return MHQOptions.convertFontColorToHexColor(color == null ? Color.WHITE : color);
+    }
+
+    private static String getFormattedTextAt(String key, Object... args) {
+        return MHQInternationalization.getFormattedTextAt(RESOURCE_BUNDLE, key, args);
+    }
+
+    private static String getTextAt(String key) {
+        return MHQInternationalization.getTextAt(RESOURCE_BUNDLE, key);
     }
 
     // ======================================


### PR DESCRIPTION
Spotted a couple of help methods in `CurrentLocation` that had been set up as global statics. Methods like this should never be made global as they should not be accessed outside of the relevant class/package.

Reduced accessibility to local static and moved the helper into the class that uses them.