### PR TITLE
Added Ability to Pay XP to Replenish Edge at Any Time

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -432,6 +432,10 @@ lblUseEdge.tooltip=Characters can purchase and benefit from Edge, which allows t
 lblUseSupportEdge.text=Support Personnel Use Edge
 lblUseSupportEdge.tooltip=Allows non-combat roles to benefit from Edge re-rolls, although with a\
   \ shorter list of triggers.
+lblEdgeRefreshCost.text=Edge Refresh Cost
+lblEdgeRefreshCost.tooltip=Edge normally replenishes periodically, however players can choose to spend character XP to\
+  \ immediately replenish all that a character's Edge. Useful when faced with a difficult scenario, or challenging \
+  repair.
 lblUseImplants.text=Use Implants
 lblUseImplants.tooltip=Allows personnel to have implants (e.g., Manei Domini)
 lblUseAlternativeQualityAveraging.text=Use Higher-Precision Skill Averaging

--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -90,7 +90,8 @@ AreYouSure.text=Are you sure?
 #### PersonnelTableMouseAdapter Class - TODO : unfinished, with cleanup required
 improved.format=%s improved %s!
 refreshEdge.success={0} <b>{1}spent{2}</b> {3} XP to immediately replenish all spent Edge points.
-refreshEdge.failure={0} <b>{1}couldn''t{2}</b> spend {1} XP to replenish their spent Edge points, as they had insufficient XP.
+refreshEdge.failure={0} <b>{1}couldn''t{2}</b> spend {3} XP to replenish their spent Edge points, as they had \
+  insufficient XP.
 refreshEdge.none={0} <b>{1}couldn''t{2}</b> spend XP to replenish their spent Edge points, as they haven''t used any Edge.
 gainedEdge.format=%s gained edge point!
 gained.format=%s gained %s!

--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -89,9 +89,9 @@ AreYouSure.text=Are you sure?
 ##### Adapter
 #### PersonnelTableMouseAdapter Class - TODO : unfinished, with cleanup required
 improved.format=%s improved %s!
-refreshEdge.success={0} spent {1} XP to immediately replenish all spent Edge points.
-refreshEdge.failure={0} couldn''t spend {1} XP to replenish their spent Edge points, as they had insufficient XP.
-refreshEdge.none={0} couldn''t spend XP to replenish their spent Edge points, as they haven''t used any Edge.
+refreshEdge.success={0} <b>{1}spent{2}</b> {3} XP to immediately replenish all spent Edge points.
+refreshEdge.failure={0} <b>{1}couldn''t{2}</b> spend {1} XP to replenish their spent Edge points, as they had insufficient XP.
+refreshEdge.none={0} <b>{1}couldn''t{2}</b> spend XP to replenish their spent Edge points, as they haven''t used any Edge.
 gainedEdge.format=%s gained edge point!
 gained.format=%s gained %s!
 removed.format=%s removed %s!

--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -89,6 +89,9 @@ AreYouSure.text=Are you sure?
 ##### Adapter
 #### PersonnelTableMouseAdapter Class - TODO : unfinished, with cleanup required
 improved.format=%s improved %s!
+refreshEdge.success={0} spent {1} XP to immediately replenish all spent Edge points.
+refreshEdge.failure={0} couldn''t spend {1} XP to replenish their spent Edge points, as they had insufficient XP.
+refreshEdge.none={0} couldn''t spend XP to replenish their spent Edge points, as they haven''t used any Edge.
 gainedEdge.format=%s gained edge point!
 gained.format=%s gained %s!
 removed.format=%s removed %s!
@@ -196,6 +199,8 @@ rangemaster.text=Range Master
 rangemaster_med.text=Range Master (Medium)
 rangemaster_lng.text=Range Master (Long)
 rangemaster_xtm.text=Range Master (Extreme)
+spendOnReplenishEdge.multiple=Replenish All Edge ({0} XP, modified by Talent)
+spendOnReplenishEdge.single=Replenish All Edge ({0} XP)
 spendOnCurrentSkills.text=Current Skills
 spendOnNewSkills.text=New Skills
 combatGunnerySkills.text=Gunnery

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3927,7 +3927,7 @@ public class Campaign implements ITechManager, ILocation {
                     roll = tech.isRightTechTypeFor(theRefit) ? d6(2) : Utilities.roll3d6();
                     // This is needed to update the edge values of individual crewmen
                     if (tech.isEngineer()) {
-                        tech.setEdgeUsed(tech.getEdgeUsed() - 1);
+                        tech.setEdgeUsedThisRound(tech.getEdgeUsedThisRound() - 1);
                     }
                     report += " <b>failed!</b> but uses Edge to reroll...getting a " + roll + ": ";
                 }
@@ -4130,7 +4130,7 @@ public class Campaign implements ITechManager, ILocation {
                 roll = tech.isRightTechTypeFor(partWork) ? d6(2) : Utilities.roll3d6();
                 // This is needed to update the edge values of individual crewmen
                 if (tech.isEngineer()) {
-                    tech.setEdgeUsed(tech.getEdgeUsed() + 1);
+                    tech.setEdgeUsedThisRound(tech.getEdgeUsedThisRound() + 1);
                 }
                 report += " <b>failed!</b> and would destroy the part, but uses Edge to reroll...getting a " +
                                 roll +

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
@@ -579,6 +579,7 @@ public class CampaignOptions {
 
     private int attributeCost;
     private int edgeCost;
+    private int edgeRefreshCost;
     // endregion Experience Tab
 
     // region Skills Tab
@@ -1250,6 +1251,7 @@ public class CampaignOptions {
         missionXpSuccess = 3;
         missionXpOutstandingSuccess = 5;
         edgeCost = 10;
+        edgeRefreshCost = 20; // Taken from ATOW
         attributeCost = 100;
         // endregion Experience Tab
 
@@ -4528,6 +4530,14 @@ public class CampaignOptions {
 
     public void setEdgeCost(final int edgeCost) {
         this.edgeCost = edgeCost;
+    }
+
+    public int getEdgeRefreshCost() {
+        return edgeRefreshCost;
+    }
+
+    public void setEdgeRefreshCost(final int edgeRefreshCost) {
+        this.edgeRefreshCost = edgeRefreshCost;
     }
 
     public int getAttributeCost() {

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
@@ -1251,7 +1251,7 @@ public class CampaignOptions {
         missionXpSuccess = 3;
         missionXpOutstandingSuccess = 5;
         edgeCost = 10;
-        edgeRefreshCost = 20; // Taken from ATOW
+        edgeRefreshCost = 20; // ATOW 3rd printing, p.43, 'edge recovery'
         attributeCost = 100;
         // endregion Experience Tab
 

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
@@ -136,6 +136,7 @@ public class CampaignOptionsMarshaller {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "missionXpOutstandingSuccess",
               campaignOptions.getMissionXpOutstandingSuccess());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "edgeCost", campaignOptions.getEdgeCost());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "edgeRefreshCost", campaignOptions.getEdgeRefreshCost());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "attributeCost", campaignOptions.getAttributeCost());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "limitByYear", campaignOptions.isLimitByYear());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "disallowExtinctStuff", campaignOptions.isDisallowExtinctStuff());

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
@@ -154,6 +154,7 @@ public class CampaignOptionsUnmarshaller {
             case "missionXpOutstandingSuccess" -> campaignOptions.setMissionXpOutstandingSuccess(parseInt(
                   nodeContents));
             case "edgeCost" -> campaignOptions.setEdgeCost(parseInt(nodeContents));
+            case "edgeRefreshCost" -> campaignOptions.setEdgeRefreshCost(parseInt(nodeContents));
             case "attributeCost" -> campaignOptions.setAttributeCost(parseInt(nodeContents));
             case "waitingPeriod" -> campaignOptions.setWaitingPeriod(parseInt(nodeContents));
             case "acquisitionSkill" -> {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -5773,6 +5773,12 @@ public class Person {
         final SkillType skillType = getType(skillName);
         int cost = hasSkill(skillName) ? skill.getCostToImprove() : skillType.getCost(0);
 
+        double multiplier = getTalentBasedXpCostMultiplier(useReasoning, skillType);
+
+        return (int) round(cost * multiplier);
+    }
+
+    public double getTalentBasedXpCostMultiplier(boolean useReasoning, @Nullable SkillType skillType) {
         double multiplier = getReasoningXpCostMultiplier(useReasoning);
 
         if (options.booleanOption(FLAW_SLOW_LEARNER)) {
@@ -5783,7 +5789,7 @@ public class Person {
             multiplier -= 0.2;
         }
 
-        if (skillType.isAffectedByGremlinsOrTechEmpathy()) {
+        if (skillType != null && skillType.isAffectedByGremlinsOrTechEmpathy()) {
             if (options.booleanOption(FLAW_GREMLINS)) {
                 multiplier += 0.1;
             }
@@ -5793,7 +5799,7 @@ public class Person {
             }
         }
 
-        return (int) round(cost * multiplier);
+        return multiplier;
     }
     // endregion skill
 
@@ -6021,12 +6027,19 @@ public class Person {
         return atowAttributes.getCurrentEdge();
     }
 
-    public void setEdgeUsed(final int edgeUsedThisRound) {
+    public void setEdgeUsedThisRound(final int edgeUsedThisRound) {
         this.edgeUsedThisRound = edgeUsedThisRound;
     }
 
-    public int getEdgeUsed() {
+    public int getEdgeUsedThisRound() {
         return edgeUsedThisRound;
+    }
+
+    public int getUsedEdge() {
+        int currentEdge = getCurrentEdge();
+        int maximumEdge = getAdjustedEdge();
+
+        return maximumEdge - currentEdge;
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -1895,9 +1895,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
     private void replenishEdgeActin(Person person) {
         if (person.getUsedEdge() <= 0) {
             getCampaign().addReport(PERSONNEL, getFormattedText("refreshEdge.none",
-                  spanOpeningWithCustomColor(getWarningColor()),
-                  CLOSING_SPAN_TAG,
-                  person.getHyperlinkedName()));
+                  person.getHyperlinkedName(), spanOpeningWithCustomColor(getWarningColor()), CLOSING_SPAN_TAG));
             return;
         }
 

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -67,7 +67,6 @@ import static mekhq.campaign.randomEvents.personalities.PersonalityController.wr
 import static mekhq.campaign.randomEvents.prisoners.PrisonerEventManager.checkForIntelBreachEvent;
 import static mekhq.campaign.randomEvents.prisoners.PrisonerEventManager.processAdHocExecution;
 import static mekhq.utilities.MHQInternationalization.getFormattedText;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 import static mekhq.utilities.MHQInternationalization.getText;
 import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
 import static mekhq.utilities.ReportingUtilities.getAmazingColor;
@@ -1904,10 +1903,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
         int currentXp = person.getXP();
         if (currentXp < actualCost) {
-            String RESOURCE_BUNDLE = "mekhq.resources.GUI";
-            String thingy = getFormattedTextAt(RESOURCE_BUNDLE, "refreshEdge.failure", person.getHyperlinkedName(),
-                  actualCost);
-            getCampaign().addReport(PERSONNEL, thingy);
+            getCampaign().addReport(PERSONNEL, getFormattedText("refreshEdge.failure", person.getHyperlinkedName(),
+                  actualCost));
             return;
         }
 

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -70,7 +70,10 @@ import static mekhq.utilities.MHQInternationalization.getFormattedText;
 import static mekhq.utilities.MHQInternationalization.getText;
 import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
 import static mekhq.utilities.ReportingUtilities.getAmazingColor;
+import static mekhq.utilities.ReportingUtilities.getNegativeColor;
 import static mekhq.utilities.ReportingUtilities.getPositiveColor;
+import static mekhq.utilities.ReportingUtilities.getWarningColor;
+import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
 import static mekhq.utilities.spaUtilities.SpaUtilities.getSpaCategory;
 
 import java.awt.Color;
@@ -1892,6 +1895,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
     private void replenishEdgeActin(Person person) {
         if (person.getUsedEdge() <= 0) {
             getCampaign().addReport(PERSONNEL, getFormattedText("refreshEdge.none",
+                  spanOpeningWithCustomColor(getWarningColor()),
+                  CLOSING_SPAN_TAG,
                   person.getHyperlinkedName()));
             return;
         }
@@ -1903,7 +1908,10 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
         int currentXp = person.getXP();
         if (currentXp < actualCost) {
-            getCampaign().addReport(PERSONNEL, getFormattedText("refreshEdge.failure", person.getHyperlinkedName(),
+            getCampaign().addReport(PERSONNEL, getFormattedText("refreshEdge.failure",
+                  person.getHyperlinkedName(),
+                  spanOpeningWithCustomColor(getNegativeColor()),
+                  CLOSING_SPAN_TAG,
                   actualCost));
             return;
         }
@@ -1913,6 +1921,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
         getCampaign().addReport(PERSONNEL, getFormattedText("refreshEdge.success",
               person.getHyperlinkedName(),
+              spanOpeningWithCustomColor(getPositiveColor()),
+              CLOSING_SPAN_TAG,
               actualCost));
 
         getCampaign().personUpdated(person);

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -67,6 +67,7 @@ import static mekhq.campaign.randomEvents.personalities.PersonalityController.wr
 import static mekhq.campaign.randomEvents.prisoners.PrisonerEventManager.checkForIntelBreachEvent;
 import static mekhq.campaign.randomEvents.prisoners.PrisonerEventManager.processAdHocExecution;
 import static mekhq.utilities.MHQInternationalization.getFormattedText;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 import static mekhq.utilities.MHQInternationalization.getText;
 import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
 import static mekhq.utilities.ReportingUtilities.getAmazingColor;
@@ -243,6 +244,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
     private static final String CMD_ACQUIRE_CUSTOM_CHOICE = "CUSTOM_CHOICE";
     private static final String CMD_BUY_OFF_FLAW = "BUY_OFF_FLAW";
     private static final String CMD_REFUND_SKILL = "REFUND_SKILL";
+    private static final String CMD_REPLENISH_EDGE = "REPLENISH_EDGE";
     private static final String CMD_IMPROVE = "IMPROVE";
     private static final String CMD_BUY_TRAIT = "BUY_TRAIT";
     private static final String CMD_CHANGE_ATTRIBUTE = "CHANGE_ATTRIBUTE";
@@ -680,6 +682,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                       skillName));
 
                 getCampaign().personUpdated(selectedPerson);
+                break;
+            }
+            case CMD_REPLENISH_EDGE: {
+                for (Person person : people) {
+                    replenishEdgeActin(person);
+                }
                 break;
             }
             case CMD_REFUND_SKILL: {
@@ -1882,6 +1890,37 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
         }
     }
 
+    private void replenishEdgeActin(Person person) {
+        if (person.getUsedEdge() <= 0) {
+            getCampaign().addReport(PERSONNEL, getFormattedText("refreshEdge.none",
+                  person.getHyperlinkedName()));
+            return;
+        }
+
+        double talentBasedXpCostMultiplier = person.getTalentBasedXpCostMultiplier(
+              getCampaignOptions().isUseReasoningXpMultiplier(), null);
+        int baseCost = getCampaignOptions().getEdgeRefreshCost();
+        int actualCost = (int) round(baseCost * talentBasedXpCostMultiplier);
+
+        int currentXp = person.getXP();
+        if (currentXp < actualCost) {
+            String RESOURCE_BUNDLE = "mekhq.resources.GUI";
+            String thingy = getFormattedTextAt(RESOURCE_BUNDLE, "refreshEdge.failure", person.getHyperlinkedName(),
+                  actualCost);
+            getCampaign().addReport(PERSONNEL, thingy);
+            return;
+        }
+
+        person.spendXP(actualCost);
+        person.resetCurrentEdge();
+
+        getCampaign().addReport(PERSONNEL, getFormattedText("refreshEdge.success",
+              person.getHyperlinkedName(),
+              actualCost));
+
+        getCampaign().personUpdated(person);
+    }
+
     /**
      * Handles the limb replacement procedure for the selected person. This method determines the suitable doctors,
      * calculates the cost of the procedure, and processes the surgery if the user accepts it.
@@ -2882,12 +2921,16 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
         // endregion Education Menu
 
         // region Spend XP Menu
+        menu = new JMenu(resources.getString("spendXP.text"));
+        popup.add(menu);
+
+        final boolean isUseReasoningMultiplier = getCampaignOptions().isUseReasoningXpMultiplier();
+        addEdgeRefreshOption(oneSelected, person, isUseReasoningMultiplier, menu);
+
         if (oneSelected && person.getStatus().isActiveFlexible()) {
-            final boolean isUseReasoningMultiplier = getCampaignOptions().isUseReasoningXpMultiplier();
             final double reasoningXpCostMultiplier = person.getReasoningXpCostMultiplier(isUseReasoningMultiplier);
             final double xpCostMultiplier = getCampaignOptions().getXpCostMultiplier();
 
-            menu = new JMenu(resources.getString("spendXP.text"));
             submenu = new JMenu(resources.getString("abilities.text"));
             menu.add(submenu);
             if (getCampaignOptions().isUseAbilities()) {
@@ -4370,6 +4413,29 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
         // endregion GM Menu
 
         return Optional.of(popup);
+    }
+
+    private void addEdgeRefreshOption(boolean oneSelected, Person person, boolean isUseReasoningMultiplier,
+          JMenu menu) {
+        final boolean isUseEdge = getCampaignOptions().isUseEdge() || getCampaignOptions().isUseSupportEdge();
+        int replenishEdgeCost = getCampaignOptions().getEdgeRefreshCost();
+
+        JMenuItem replenishEdge = new JMenuItem();
+        if (oneSelected) {
+            double talentMultiplier = person.getTalentBasedXpCostMultiplier(isUseReasoningMultiplier, null);
+            replenishEdgeCost = (int) round(replenishEdgeCost * talentMultiplier);
+            replenishEdge.setText(getFormattedText("spendOnReplenishEdge.single", replenishEdgeCost));
+            replenishEdge.setEnabled(isUseEdge &&
+                                           person.getXP() >= replenishEdgeCost &&
+                                           person.getUsedEdge() != 0);
+        } else {
+            replenishEdge.setText(getFormattedText("spendOnReplenishEdge.multiple", replenishEdgeCost));
+            replenishEdge.setEnabled(isUseEdge);
+        }
+
+        replenishEdge.setActionCommand(makeCommand(CMD_REPLENISH_EDGE));
+        replenishEdge.addActionListener(this);
+        menu.add(replenishEdge);
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/PersonnelTab.java
@@ -112,6 +112,8 @@ public class PersonnelTab {
     private JCheckBox chkOnlyCommandersMatterBattleArmor;
     private JCheckBox chkUseEdge;
     private JCheckBox chkUseSupportEdge;
+    private JLabel lblEdgeRefreshCost;
+    private JSpinner spnEdgeRefreshCost;
     private JCheckBox chkUseImplants;
     private JCheckBox chkUseAlternativeQualityAveraging;
 
@@ -394,6 +396,8 @@ public class PersonnelTab {
         chkOnlyCommandersMatterBattleArmor = new JCheckBox();
         chkUseEdge = new JCheckBox();
         chkUseSupportEdge = new JCheckBox();
+        lblEdgeRefreshCost = new JLabel();
+        spnEdgeRefreshCost = new JSpinner();
         chkUseImplants = new JCheckBox();
         chkUseAlternativeQualityAveraging = new JCheckBox();
 
@@ -508,6 +512,10 @@ public class PersonnelTab {
         chkUseEdge.addMouseListener(createTipPanelUpdater(generalHeader, "UseEdge"));
         chkUseSupportEdge = new CampaignOptionsCheckBox("UseSupportEdge");
         chkUseSupportEdge.addMouseListener(createTipPanelUpdater(generalHeader, "UseSupportEdge"));
+        lblEdgeRefreshCost = new CampaignOptionsLabel("EdgeRefreshCost", getMetadata(new Version(0, 51, 0)));
+        lblEdgeRefreshCost.addMouseListener(createTipPanelUpdater(generalHeader, "EdgeRefreshCost"));
+        spnEdgeRefreshCost = new CampaignOptionsSpinner("EdgeRefreshCost", 20, 0, 100, 1);
+        spnEdgeRefreshCost.addMouseListener(createTipPanelUpdater(generalHeader, "EdgeRefreshCost"));
         chkUseImplants = new CampaignOptionsCheckBox("UseImplants");
         chkUseImplants.addMouseListener(createTipPanelUpdater(generalHeader, "UseImplants"));
         chkUseAlternativeQualityAveraging = new CampaignOptionsCheckBox("UseAlternativeQualityAveraging",
@@ -552,6 +560,12 @@ public class PersonnelTab {
 
         layout.gridy++;
         panel.add(chkUseSupportEdge, layout);
+
+        layout.gridx = 0;
+        layout.gridy++;
+        panel.add(lblEdgeRefreshCost, layout);
+        layout.gridx++;
+        panel.add(spnEdgeRefreshCost, layout);
 
         layout.gridx = 0;
         layout.gridy++;
@@ -646,15 +660,19 @@ public class PersonnelTab {
         chkUseBlobInfantry.addMouseListener(createTipPanelUpdater(generalHeader, "UseBlobInfantry"));
         chkUseBlobBattleArmor = new CampaignOptionsCheckBox("UseBlobBattleArmor", getMetadata(new Version(0, 50, 12)));
         chkUseBlobBattleArmor.addMouseListener(createTipPanelUpdater(generalHeader, "UseBlobBattleArmor"));
-        chkUseBlobVehicleCrewGround = new CampaignOptionsCheckBox("UseBlobVehicleCrewGround", getMetadata(new Version(0, 50, 12)));
+        chkUseBlobVehicleCrewGround = new CampaignOptionsCheckBox("UseBlobVehicleCrewGround",
+              getMetadata(new Version(0, 50, 12)));
         chkUseBlobVehicleCrewGround.addMouseListener(createTipPanelUpdater(generalHeader, "UseBlobVehicleCrewGround"));
-        chkUseBlobVehicleCrewVTOL = new CampaignOptionsCheckBox("UseBlobVehicleCrewVTOL", getMetadata(new Version(0, 50, 12)));
+        chkUseBlobVehicleCrewVTOL = new CampaignOptionsCheckBox("UseBlobVehicleCrewVTOL",
+              getMetadata(new Version(0, 50, 12)));
         chkUseBlobVehicleCrewVTOL.addMouseListener(createTipPanelUpdater(generalHeader, "UseBlobVehicleCrewVTOL"));
-        chkUseBlobVehicleCrewNaval = new CampaignOptionsCheckBox("UseBlobVehicleCrewNaval", getMetadata(new Version(0, 50, 12)));
+        chkUseBlobVehicleCrewNaval = new CampaignOptionsCheckBox("UseBlobVehicleCrewNaval",
+              getMetadata(new Version(0, 50, 12)));
         chkUseBlobVehicleCrewNaval.addMouseListener(createTipPanelUpdater(generalHeader, "UseBlobVehicleCrewNaval"));
         chkUseBlobVesselPilot = new CampaignOptionsCheckBox("UseBlobVesselPilot", getMetadata(new Version(0, 50, 12)));
         chkUseBlobVesselPilot.addMouseListener(createTipPanelUpdater(generalHeader, "UseBlobVesselPilot"));
-        chkUseBlobVesselGunner = new CampaignOptionsCheckBox("UseBlobVesselGunner", getMetadata(new Version(0, 50, 12)));
+        chkUseBlobVesselGunner = new CampaignOptionsCheckBox("UseBlobVesselGunner",
+              getMetadata(new Version(0, 50, 12)));
         chkUseBlobVesselGunner.addMouseListener(createTipPanelUpdater(generalHeader, "UseBlobVesselGunner"));
         chkUseBlobVesselCrew = new CampaignOptionsCheckBox("UseBlobVesselCrew", getMetadata(new Version(0, 50, 12)));
         chkUseBlobVesselCrew.addMouseListener(createTipPanelUpdater(generalHeader, "UseBlobVesselCrew"));
@@ -925,7 +943,9 @@ public class PersonnelTab {
 
         // Contents
         chkUseAdvancedMedical = new CampaignOptionsCheckBox("UseAdvancedMedical",
-              getMetadata(LEGACY_RULE_BEFORE_METADATA, CampaignOptionFlag.CUSTOM_SYSTEM, CampaignOptionFlag.DOCUMENTED));
+              getMetadata(LEGACY_RULE_BEFORE_METADATA,
+                    CampaignOptionFlag.CUSTOM_SYSTEM,
+                    CampaignOptionFlag.DOCUMENTED));
         chkUseAdvancedMedical.addMouseListener(createTipPanelUpdater(medicalHeader, "UseAdvancedMedical"));
 
         lblHealWaitingPeriod = new CampaignOptionsLabel("HealWaitingPeriod");
@@ -1269,7 +1289,9 @@ public class PersonnelTab {
         dependentsPanel = createDependentsPanel();
 
         // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("PrisonersAndDependentsTab", true, "PrisonersAndDependentsTab",
+        final JPanel panel = new CampaignOptionsStandardPanel("PrisonersAndDependentsTab",
+              true,
+              "PrisonersAndDependentsTab",
               getMetadata(null, CampaignOptionFlag.CUSTOM_SYSTEM, CampaignOptionFlag.DOCUMENTED));
         final GridBagConstraints layoutParent = new CampaignOptionsGridBagConstraints(panel);
 
@@ -1468,6 +1490,7 @@ public class PersonnelTab {
         chkOnlyCommandersMatterBattleArmor.setSelected(options.isOnlyCommandersMatterBattleArmor());
         chkUseEdge.setSelected(options.isUseEdge());
         chkUseSupportEdge.setSelected(options.isUseSupportEdge());
+        spnEdgeRefreshCost.setValue(options.getEdgeRefreshCost());
         chkUseImplants.setSelected(options.isUseImplants());
         chkUseAlternativeQualityAveraging.setSelected(options.isAlternativeQualityAveraging());
         chkUsePersonnelRemoval.setSelected(options.isUsePersonnelRemoval());
@@ -1578,6 +1601,7 @@ public class PersonnelTab {
         options.setOnlyCommandersMatterBattleArmor(chkOnlyCommandersMatterBattleArmor.isSelected());
         options.setUseEdge(chkUseEdge.isSelected());
         options.setUseSupportEdge(chkUseSupportEdge.isSelected());
+        options.setEdgeRefreshCost((int) spnEdgeRefreshCost.getValue());
         options.setUseImplants(chkUseImplants.isSelected());
         options.setAlternativeQualityAveraging(chkUseAlternativeQualityAveraging.isSelected());
         options.setUsePersonnelRemoval(chkUsePersonnelRemoval.isSelected());


### PR DESCRIPTION
Designed to work alongside an earlier change that reduced the rate Edge is replenished, this PR allows players to pay 20 XP (campaign option) to replenish all spent edge. Perfect if there is a hard repair task or scenario you want to be fully loaded for.