### PR TITLE
Fixed `getFormattedText` Incorrectly Double Formatting Text Resulting in Display Errors

### DIFF
--- a/MekHQ/src/mekhq/utilities/MHQInternationalization.java
+++ b/MekHQ/src/mekhq/utilities/MHQInternationalization.java
@@ -124,7 +124,7 @@ public class MHQInternationalization {
      * @return the localized string
      */
     public static String getFormattedText(String key, Object... args) {
-        return MessageFormat.format(getTextAt(getInstance().defaultBundle, key), args);
+        return getFormattedTextAt(getInstance().defaultBundle, key, args);
     }
 
     /**

--- a/MekHQ/src/mekhq/utilities/MHQInternationalization.java
+++ b/MekHQ/src/mekhq/utilities/MHQInternationalization.java
@@ -124,7 +124,7 @@ public class MHQInternationalization {
      * @return the localized string
      */
     public static String getFormattedText(String key, Object... args) {
-        return MessageFormat.format(getFormattedTextAt(getInstance().defaultBundle, key), args);
+        return MessageFormat.format(getTextAt(getInstance().defaultBundle, key), args);
     }
 
     /**


### PR DESCRIPTION
`getFormattedText` calls `getFormattedTextAt`, both parse the text through `MessageFormat.format` which causes anything with an apostrophe to get mangled. Normally you need to double an apostrophe, to escape it, however due to this bug developers would have actually needed to escape apostrophe _twice_ with `'''` appearing as `'`, whereas missing the third apostrophe would cause html to break formatting.