### PR TITLE
Fix `MHQOptions.getNewDayMRMS` reading incorrect config key

### DIFF
--- a/MekHQ/src/mekhq/MHQOptions.java
+++ b/MekHQ/src/mekhq/MHQOptions.java
@@ -1034,7 +1034,7 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public boolean getNewDayMRMS() {
-        return userPreferences.node(MHQConstants.NEW_DAY_NODE).getBoolean(MHQConstants.NEW_DAY_AUTO_LOGISTICS, true);
+        return userPreferences.node(MHQConstants.NEW_DAY_NODE).getBoolean(MHQConstants.NEW_DAY_MRMS, true);
     }
 
     public void setNewDayMRMS(final boolean value) {


### PR DESCRIPTION
`MHQOptions` was reading `NEW_DAY_AUTO_LOGISTICS` setting instead of `NEW_DAY_MRMS` resulting in unexpected behavior during new day processing and in the Client Setting dialog.