### PR TITLE
Show 'Allow Overtime' button only in the Repair Bay and Warehouse tabs

### DIFF
--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -391,11 +391,6 @@ public class CampaignGUI extends JPanel {
         lblTempVesselCrew = new JLabel();
         lblPartsAvailabilityRating = new JLabel();
 
-        RoundedMMToggleButton btnOvertime = new RoundedMMToggleButton(resourceMap.getString("btnOvertime.text"));
-        btnOvertime.setToolTipText(resourceMap.getString("btnOvertime.toolTipText"));
-        btnOvertime.setSelected(getCampaign().isOvertimeAllowed());
-        btnOvertime.addActionListener(evt -> getCampaign().setOvertime(btnOvertime.isSelected()));
-
         Border innerBorder = BorderFactory.createCompoundBorder(
               new RoundedLineBorder(UIUtil.uiIndependentGray(), 1, 8),
               BorderFactory.createEmptyBorder(1, 3, 1, 3));
@@ -424,7 +419,6 @@ public class CampaignGUI extends JPanel {
         pnlTempPersonnel.add(pnlVehicleCrew);
         pnlTempPersonnel.add(pnlVesselCrew);
 
-        statusPanel.add(btnOvertime);
         statusPanel.add(pnlTempPersonnel);
         statusPanel.add(lblPartsAvailabilityRating);
     }
@@ -575,6 +569,10 @@ public class CampaignGUI extends JPanel {
 
     public @Nullable WarehouseTab getWarehouseTab() {
         return (WarehouseTab) getTab(MHQTabType.WAREHOUSE);
+    }
+
+    public @Nullable RepairTab getRepairBayTab() {
+        return (RepairTab) getTab(MHQTabType.REPAIR_BAY);
     }
 
     public boolean hasTab(MHQTabType tabType) {

--- a/MekHQ/src/mekhq/gui/RepairTab.java
+++ b/MekHQ/src/mekhq/gui/RepairTab.java
@@ -463,7 +463,9 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
         btnOvertime.addActionListener(evt -> {
             getCampaign().setOvertime(btnOvertime.isSelected());
             WarehouseTab warehouseTab = getCampaignGui().getWarehouseTab();
-            warehouseTab.refreshOvertimeStatus();
+            if (warehouseTab != null) {
+                warehouseTab.refreshOvertimeStatus();
+            }
         });
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;

--- a/MekHQ/src/mekhq/gui/RepairTab.java
+++ b/MekHQ/src/mekhq/gui/RepairTab.java
@@ -122,6 +122,7 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
     private JTextPane txtServicedUnitView;
     private JTextArea textTarget;
     private JTextPane txtResult;
+    private RoundedMMToggleButton btnOvertime;
     private JLabel asTechPoolLabel;
     private JComboBox<String> choiceLocation;
     private RoundedJButton btnAcquisitions;
@@ -456,18 +457,30 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
         gridBagConstraints.weighty = 1.0;
         panTechs.add(scrollTechTable, gridBagConstraints);
 
+        btnOvertime = new RoundedMMToggleButton(resourceMap.getString("btnOvertime.text"));
+        btnOvertime.setToolTipText(resourceMap.getString("btnOvertime.toolTipText"));
+        btnOvertime.setSelected(getCampaign().isOvertimeAllowed());
+        btnOvertime.addActionListener(evt -> {
+            getCampaign().setOvertime(btnOvertime.isSelected());
+            WarehouseTab warehouseTab = getCampaignGui().getWarehouseTab();
+            warehouseTab.refreshOvertimeStatus();
+        });
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 2;
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
+        panTechs.add(btnOvertime, gridBagConstraints);
+
         asTechPoolLabel = new JLabel("<html><b>AsTech Pool Minutes:</> " +
                                            getCampaign().getAsTechPoolMinutes() +
                                            " (" +
                                            getCampaign().getNumberAsTechs() +
                                            " AsTechs)</html>");
-        asTechPoolLabel.setHorizontalAlignment(SwingConstants.CENTER);
         asTechPoolLabel.setName("asTechPoolLabel");
         gridBagConstraints = new GridBagConstraints();
-        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 2;
         gridBagConstraints.gridwidth = 2;
-        gridBagConstraints.insets = new Insets(0, 10, 0, 0);
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         panTechs.add(asTechPoolLabel, gridBagConstraints);
 
@@ -568,6 +581,7 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
         refreshTaskList();
         refreshPartsAcquisition();
         refreshTechsList();
+        refreshOvertimeStatus();
     }
 
     /*
@@ -969,6 +983,14 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
             techTable.clearSelection(); // Clear selection if there's no valid option
         }
     }
+
+    /**
+     * Updates 'Overtime Allowed' button state.
+     */
+    public void refreshOvertimeStatus() {
+        btnOvertime.setSelected(getCampaign().isOvertimeAllowed());
+    }
+
 
     public void refreshPartsAcquisition() {
         refreshPartsAcquisitionService(true);

--- a/MekHQ/src/mekhq/gui/WarehouseTab.java
+++ b/MekHQ/src/mekhq/gui/WarehouseTab.java
@@ -401,7 +401,9 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
         btnOvertime.addActionListener(evt -> {
             getCampaign().setOvertime(btnOvertime.isSelected());
             RepairTab repairBayTab = getCampaignGui().getRepairBayTab();
-            repairBayTab.refreshOvertimeStatus();
+            if (repairBayTab != null) {
+                repairBayTab.refreshOvertimeStatus();
+            }
         });
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;

--- a/MekHQ/src/mekhq/gui/WarehouseTab.java
+++ b/MekHQ/src/mekhq/gui/WarehouseTab.java
@@ -139,6 +139,7 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
     private RoundedMMToggleButton btnShowAllTechsWarehouse;
     private JLabel lblTargetNumWarehouse;
     private JTextArea textTargetWarehouse;
+    private RoundedMMToggleButton btnOvertime;
     private JLabel asTechPoolLabel;
     private JComboBox<String> choiceParts;
     private JComboBox<String> choicePartsView;
@@ -394,6 +395,21 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
         gridBagConstraints.insets = new Insets(2, 2, 2, 2);
         panelDoTask.add(scrollTechTable, gridBagConstraints);
 
+        btnOvertime = new RoundedMMToggleButton(resourceMap.getString("btnOvertime.text"));
+        btnOvertime.setToolTipText(resourceMap.getString("btnOvertime.toolTipText"));
+        btnOvertime.setSelected(getCampaign().isOvertimeAllowed());
+        btnOvertime.addActionListener(evt -> {
+            getCampaign().setOvertime(btnOvertime.isSelected());
+            RepairTab repairBayTab = getCampaignGui().getRepairBayTab();
+            repairBayTab.refreshOvertimeStatus();
+        });
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 5;
+        gridBagConstraints.gridwidth = 2;
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
+        panelDoTask.add(btnOvertime, gridBagConstraints);
+
         asTechPoolLabel = new JLabel("<html><b>AsTech Pool Minutes:</> " +
                                            getCampaign().getAsTechPoolMinutes() +
                                            " (" +
@@ -402,10 +418,10 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
         asTechPoolLabel.setHorizontalAlignment(SwingConstants.CENTER);
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 5;
+        gridBagConstraints.gridy = 6;
         gridBagConstraints.gridwidth = 2;
-        gridBagConstraints.insets = new Insets(0, 10, 0, 0);
         gridBagConstraints.anchor = GridBagConstraints.WEST;
+        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;;
         panelDoTask.add(asTechPoolLabel, gridBagConstraints);
 
         JSplitPane splitWarehouse = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, panSupplies, panelDoTask);
@@ -457,6 +473,7 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
     public void refreshAll() {
         refreshTechsList();
         refreshPartsList();
+        refreshOvertimeStatus();
     }
 
     /*
@@ -660,6 +677,13 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
                 }
             }
         }
+    }
+
+    /**
+     * Updates 'Overtime Allowed' button state.
+     */
+    public void refreshOvertimeStatus() {
+        btnOvertime.setSelected(getCampaign().isOvertimeAllowed());
     }
 
     public void refreshPartsList() {


### PR DESCRIPTION
The button is now present only in places where we show AsTech pool instead of being in the status bar. Wiring that synchronizes button state across the tabs was also added.

Before:
<img width="387" height="167" alt="Screenshot 2026-06-01 at 19 03 16" src="https://github.com/user-attachments/assets/73894296-59c1-4f44-a110-025398baddac" />

After:
<img width="536" height="585" alt="Screenshot 2026-06-01 at 19 04 51" src="https://github.com/user-attachments/assets/3149c282-6d48-42c2-afe3-98fe093bfee5" />
<img width="436" height="581" alt="Screenshot 2026-06-01 at 19 05 08" src="https://github.com/user-attachments/assets/589774f3-9e48-4fec-94c3-a16aaa5173cf" />

