### PR TITLE
Fixed Marriage Gender Selection for Extra Unit Marriages

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/marriage/AbstractMarriage.java
+++ b/MekHQ/src/mekhq/campaign/personnel/marriage/AbstractMarriage.java
@@ -353,9 +353,6 @@ public abstract class AbstractMarriage {
      */
     protected void marryRandomSpouse(final Campaign campaign, final LocalDate today, final Person person,
           boolean isInterUnit, boolean isBackground) {
-        boolean prefersMen = person.isPrefersMen();
-        boolean prefersWomen = person.isPrefersWomen();
-
         List<Person> potentialSpouses;
         Person spouse = null;
 
@@ -375,12 +372,11 @@ public abstract class AbstractMarriage {
         }
 
         if (!isInterUnit && campaign.getCurrentLocation().isOnPlanet()) {
-            List<Gender> possibleGenders = new ArrayList<>();
-            if (prefersMen) {
-                possibleGenders.add(Gender.MALE);
-            } else {
-                possibleGenders.add(Gender.FEMALE);
+            List<Gender> possibleGenders = getPossibleGenders(person);
+            if (possibleGenders.isEmpty()) {
+                return;
             }
+
             Gender spouseGender = ObjectUtility.getRandomItem(possibleGenders);
             spouse = createExternalSpouse(campaign, today, person, spouseGender);
         }
@@ -390,6 +386,19 @@ public abstract class AbstractMarriage {
         }
 
         marry(campaign, today, person, spouse, MergingSurnameStyle.WEIGHTED, isBackground);
+    }
+
+    private static List<Gender> getPossibleGenders(Person person) {
+        List<Gender> possibleGenders = new ArrayList<>();
+        if (person.isPrefersMen()) {
+            possibleGenders.add(Gender.MALE);
+        }
+
+        if (person.isPrefersWomen()) {
+            possibleGenders.add(Gender.FEMALE);
+        }
+
+        return possibleGenders;
     }
 
     /**

--- a/MekHQ/unittests/mekhq/campaign/personnel/marriage/AbstractMarriageTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/marriage/AbstractMarriageTest.java
@@ -515,9 +515,6 @@ public class AbstractMarriageTest {
         doCallRealMethod().when(mockMarriage).marryRandomSpouse(any(), any(), any(), eq(true), eq(true));
 
         final Person mockPerson = mock(Person.class);
-        when(mockPerson.isPrefersMen()).thenReturn(false);
-        when(mockPerson.isPrefersWomen()).thenReturn(true);
-
         final List<Person> mockPersonnel = new ArrayList<>();
         when(mockCampaign.getActivePersonnel(true, true)).thenReturn(mockPersonnel);
 


### PR DESCRIPTION
While working on something unrelated I spotted a logical error in how we handled marriage gender selection. Specifically for characters choosing to marry outside the unit.

The logical error is an artifact from prior to our implementation of asexual characters. Essentially, when picking spouse gender, we tested whether the character was attracted to male (or non-binary with male organs) characters and if they weren't we incorrectly assumed they were attracted to female (or non-binary with female organs) characters.

Now we correctly check for both gender preferences separately and early exit if the character is asexual.

It is possible we have a filter early in the pipeline that filters out asexual characters, but this change makes things more robust.