### PR TITLE
Fix #9192: Extra Income Now Visible on Character Sheet if Not Equal to Rank 0 (None)

### DIFF
--- a/MekHQ/resources/mekhq/resources/PersonViewPanel.properties
+++ b/MekHQ/resources/mekhq/resources/PersonViewPanel.properties
@@ -60,6 +60,8 @@ lblWealth.text=Wealth
 lblWealth.tooltip=Raising this trait to at least rank 7 will improve unit Reputation by 1 if this character is the\
   \ campaign commander. If this character is the campaign commander, they will reinvest funds back into the unit at the\
   \ beginning of each month based on their Wealth score.
+lblExtraIncome.text=<html>Extra Income: {0} C-Bills</html>
+lblExtraIncome.tooltip=Personal funds or debts. Please see the Glossary for more information.
 lblReputation.text=Reputation
 lblReputation.tooltip=If this character is the campaign commander, the unit's Reputation will be modified by their\
   \ Reputation score. Also modifies all Negotiation, Protocols, and Streetwise skills.\

--- a/MekHQ/resources/mekhq/resources/PersonViewPanel.properties
+++ b/MekHQ/resources/mekhq/resources/PersonViewPanel.properties
@@ -60,7 +60,7 @@ lblWealth.text=Wealth
 lblWealth.tooltip=Raising this trait to at least rank 7 will improve unit Reputation by 1 if this character is the\
   \ campaign commander. If this character is the campaign commander, they will reinvest funds back into the unit at the\
   \ beginning of each month based on their Wealth score.
-lblExtraIncome.text=<html>Extra Income: {0}  {1} C-Bills</html>
+lblExtraIncome.text=<html>Extra Income: {0} ({1} C-Bills)</html>
 lblExtraIncome.tooltip=Personal funds or debts. Please see the Glossary for more information.
 lblReputation.text=Reputation
 lblReputation.tooltip=If this character is the campaign commander, the unit's Reputation will be modified by their\

--- a/MekHQ/resources/mekhq/resources/PersonViewPanel.properties
+++ b/MekHQ/resources/mekhq/resources/PersonViewPanel.properties
@@ -60,7 +60,7 @@ lblWealth.text=Wealth
 lblWealth.tooltip=Raising this trait to at least rank 7 will improve unit Reputation by 1 if this character is the\
   \ campaign commander. If this character is the campaign commander, they will reinvest funds back into the unit at the\
   \ beginning of each month based on their Wealth score.
-lblExtraIncome.text=<html>Extra Income: {0} C-Bills</html>
+lblExtraIncome.text=<html>Extra Income: {0}  {1} C-Bills</html>
 lblExtraIncome.tooltip=Personal funds or debts. Please see the Glossary for more information.
 lblReputation.text=Reputation
 lblReputation.tooltip=If this character is the campaign commander, the unit's Reputation will be modified by their\

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -114,6 +114,7 @@ import mekhq.campaign.personnel.SpecialAbility;
 import mekhq.campaign.personnel.education.Academy;
 import mekhq.campaign.personnel.education.EducationController;
 import mekhq.campaign.personnel.enums.BloodmarkLevel;
+import mekhq.campaign.personnel.enums.ExtraIncome;
 import mekhq.campaign.personnel.enums.GenderDescriptors;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
@@ -2376,6 +2377,18 @@ public class PersonViewPanel extends JScrollablePanel {
             lblWealth.setToolTipText(wordWrap(resourceMap.getString("lblWealth.tooltip")));
         }
 
+        JLabel lblExtraIncome = null;
+        ExtraIncome extraIncome = person.getExtraIncome();
+        int traitLevel = extraIncome.getTraitLevel();
+        boolean isUseBetterExtraIncome = campaignOptions.isUseBetterExtraIncome();
+        Money incomeAmount = extraIncome.getMonthlyIncomeAdjusted(isUseBetterExtraIncome);
+        if (traitLevel != 0) {
+            String extraIncomeLabel = getFormattedTextAt(RESOURCE_BUNDLE, "lblExtraIncome.text",
+                  traitLevel, incomeAmount.toAmountString());
+            lblExtraIncome = new JLabel(extraIncomeLabel);
+            lblExtraIncome.setToolTipText(wordWrap(resourceMap.getString("lblExtraIncome.tooltip")));
+        }
+
         JLabel lblReputation = null;
         int baseReputation = person.getReputation();
         int adjustedReputation = person.getAdjustedReputation(campaignOptions.isUseAgeEffects(),
@@ -2517,6 +2530,9 @@ public class PersonViewPanel extends JScrollablePanel {
         }
         if (lblWealth != null) {
             components.add(lblWealth);
+        }
+        if (lblExtraIncome != null) {
+            components.add(lblExtraIncome);
         }
         if (lblReputation != null) {
             components.add(lblReputation);


### PR DESCRIPTION
Fix #9192

As per title

<img width="560" height="177" alt="image" src="https://github.com/user-attachments/assets/e389a7b5-8bc2-4c73-8d60-625ee239c9fc" />
