### PR TITLE
Always add free units to the default formation, even without ranks

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/FatigueTrackingCampaignOptionsChangedConfirmationDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/FatigueTrackingCampaignOptionsChangedConfirmationDialog.java
@@ -211,12 +211,11 @@ public class FatigueTrackingCampaignOptionsChangedConfirmationDialog extends JDi
                 quality = UnitOrder.getRandomUnitQuality(0);
             }
             Unit unit = campaign.addNewUnit(mekSummary.loadEntity(), true, 0, quality);
-            if (isAutomaticallyAssignRanks) {
-                if (unit != null) {
+            if (unit != null) {
+                if (isAutomaticallyAssignRanks) {
                     AutoAssignRankForCompanyGenerator.assignRanks(campaign, unit, faction);
-
-                    units.add(unit);
                 }
+                units.add(unit);
             }
         } catch (Exception e) {
             LOGGER.error(e, "Unable to load entity: {}: {}. Returning none.",

--- a/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/MASHTheaterTrackingCampaignOptionsChangedConfirmationDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/MASHTheaterTrackingCampaignOptionsChangedConfirmationDialog.java
@@ -212,11 +212,11 @@ public class MASHTheaterTrackingCampaignOptionsChangedConfirmationDialog extends
             }
             Unit unit = campaign.addNewUnit(mekSummary.loadEntity(), true, 0, quality);
 
-            if (isAutomaticallyAssignRanks) {
-                if (unit != null) {
+            if (unit != null) {
+                if (isAutomaticallyAssignRanks) {
                     AutoAssignRankForCompanyGenerator.assignRanks(campaign, unit, faction);
-                    units.add(unit);
                 }
+                units.add(unit);
             }
         } catch (Exception e) {
             LOGGER.error(e, "Unable to load entity: {}: {}. Returning none.",

--- a/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/PrisonerTrackingCampaignOptionsChangedConfirmationDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/PrisonerTrackingCampaignOptionsChangedConfirmationDialog.java
@@ -218,12 +218,11 @@ public class PrisonerTrackingCampaignOptionsChangedConfirmationDialog extends JD
                 quality = UnitOrder.getRandomUnitQuality(0);
             }
             Unit unit = campaign.addNewUnit(mekSummary.loadEntity(), true, 0, quality);
-            if (automaticallyAssignRanks) {
-                if (unit != null) {
+            if (unit != null) {
+                if (automaticallyAssignRanks) {
                     AutoAssignRankForCompanyGenerator.assignRanks(campaign, unit, faction);
-
-                    units.add(unit);
                 }
+                units.add(unit);
             }
         } catch (Exception e) {
             LOGGER.error(e, "Unable to load entity: {}: {}. Returning none.",

--- a/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/SalvageCampaignOptionsChangedConfirmationDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/SalvageCampaignOptionsChangedConfirmationDialog.java
@@ -220,11 +220,11 @@ public class SalvageCampaignOptionsChangedConfirmationDialog extends JDialog {
                     quality = UnitOrder.getRandomUnitQuality(0);
                 }
                 Unit unit = campaign.addNewUnit(mekSummary.loadEntity(), true, 0, quality);
-                if (isAutomaticallyAssignRanks) {
-                    if (unit != null) {
+                if (unit != null) {
+                    if (isAutomaticallyAssignRanks) {
                         AutoAssignRankForCompanyGenerator.assignRanks(campaign, unit, faction);
-                        units.add(unit);
                     }
+                    units.add(unit);
                 }
             } catch (Exception e) {
                 LOGGER.error(e, "Unable to load entity: {}: {}. Returning none.",

--- a/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/StratConConvoyCampaignOptionsChangedConfirmationDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/StratConConvoyCampaignOptionsChangedConfirmationDialog.java
@@ -218,11 +218,11 @@ public class StratConConvoyCampaignOptionsChangedConfirmationDialog extends JDia
                 }
                 Unit unit = campaign.addNewUnit(mekSummary.loadEntity(), true, 0, quality);
 
-                if (isAutomaticallyAssignRanks) {
-                    if (unit != null) {
+                if (unit != null) {
+                    if (isAutomaticallyAssignRanks) {
                         AutoAssignRankForCompanyGenerator.assignRanks(campaign, unit, faction);
-                        units.add(unit);
                     }
+                    units.add(unit);
                 }
             } catch (Exception e) {
                 LOGGER.error(e, "Unable to load entity: {}: {}. Returning none.",


### PR DESCRIPTION
When generating a company with the company generator, it is possible to receive free units (for supply, salvage and so on). These free units should be automatically added to default formations in the TOE.

However, if generating the company without automatically assigning ranks to the new personnel, the free units were added to the roster, but they were not added to the default formations in the TOE.

This PR fixes this by always adding the free units to the default formations in the TOE, even when no ranks are generated.