### PR TITLE
Fixed Salvage Accident Edge Trigger Settings

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -3599,6 +3599,13 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     menuItem.addActionListener(this);
                     submenu.add(menuItem);
 
+                    menuItem = new JMenuItem(resources.getString("edgeTriggerFatalAccident.text"));
+                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER,
+                          PersonnelOptions.EDGE_SALVAGE_ACCIDENTS,
+                          TRUE));
+                    menuItem.addActionListener(this);
+                    submenu.add(menuItem);
+
                     menuItem = new JMenuItem(resources.getString("edgeTriggerAcquireCheck.text"));
                     menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER,
                           PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL,
@@ -3681,6 +3688,13 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     menuItem = new JMenuItem(resources.getString("edgeTriggerFailedRefit.text"));
                     menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER,
                           PersonnelOptions.EDGE_REPAIR_FAILED_REFIT,
+                          FALSE));
+                    menuItem.addActionListener(this);
+                    submenu.add(menuItem);
+
+                    menuItem = new JMenuItem(resources.getString("edgeTriggerFatalAccident.text"));
+                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER,
+                          PersonnelOptions.EDGE_SALVAGE_ACCIDENTS,
                           FALSE));
                     menuItem.addActionListener(this);
                     submenu.add(menuItem);


### PR DESCRIPTION
# Requires https://github.com/MegaMek/mm-data/pull/383

The 'Reroll with Edge to Avoid Salvage Accidents' Edge Trigger wasn't fully configured. This PR finishes it off.