### PR TITLE
Update AtTech pool minutes info on overtime mode changes

### DIFF
--- a/MekHQ/src/mekhq/gui/RepairTab.java
+++ b/MekHQ/src/mekhq/gui/RepairTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2017-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/gui/RepairTab.java
+++ b/MekHQ/src/mekhq/gui/RepairTab.java
@@ -984,7 +984,7 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
      * Updates the AsTech pool statistics (minutes, overtime availability, and AsTech count) in the UI label.
      */
     public void refreshAsTechPool() {
-        String astechString = "<html><b>AsTech Pool Minutes:</> " + getCampaign().getAsTechPoolMinutes();
+        String astechString = "<html><b>AsTech Pool Minutes:</b> " + getCampaign().getAsTechPoolMinutes();
         if (getCampaign().isOvertimeAllowed()) {
             astechString += " [" + getCampaign().getAsTechPoolOvertime() + " overtime]";
         }

--- a/MekHQ/src/mekhq/gui/RepairTab.java
+++ b/MekHQ/src/mekhq/gui/RepairTab.java
@@ -462,8 +462,10 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
         btnOvertime.setSelected(getCampaign().isOvertimeAllowed());
         btnOvertime.addActionListener(evt -> {
             getCampaign().setOvertime(btnOvertime.isSelected());
+            refreshAsTechPool();
             WarehouseTab warehouseTab = getCampaignGui().getWarehouseTab();
             if (warehouseTab != null) {
+                warehouseTab.refreshAsTechPool();
                 warehouseTab.refreshOvertimeStatus();
             }
         });
@@ -473,11 +475,7 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         panTechs.add(btnOvertime, gridBagConstraints);
 
-        asTechPoolLabel = new JLabel("<html><b>AsTech Pool Minutes:</> " +
-                                           getCampaign().getAsTechPoolMinutes() +
-                                           " (" +
-                                           getCampaign().getNumberAsTechs() +
-                                           " AsTechs)</html>");
+        asTechPoolLabel = new JLabel();
         asTechPoolLabel.setName("asTechPoolLabel");
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 1;
@@ -500,6 +498,7 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
         add(pnlTutorial, BorderLayout.SOUTH);
 
         filterTechs();
+        refreshAsTechPool();
     }
 
     private RoundedJButton getBtnMRMSInstantAll() {
@@ -946,19 +945,14 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
      * @throws IllegalArgumentException if an invalid row index is provided to the selection methods. This exception is
      *                                  prevented by validating indices against updated row counts.
      */
-    public void refreshTechsList() {
+    private void refreshTechsList() {
         int selected = techTable.getSelectedRow();
         // Get all techs who have more than 0 minutes free, and sort by skill descending (elites at bottom)
         List<Person> techs = getCampaign().getTechs(true);
         techsModel.setData(techs);
         filterTechs();
 
-        String astechString = "<html><b>AsTech Pool Minutes:</> " + getCampaign().getAsTechPoolMinutes();
-        if (getCampaign().isOvertimeAllowed()) {
-            astechString += " [" + getCampaign().getAsTechPoolOvertime() + " overtime]";
-        }
-        astechString += " (" + getCampaign().getNumberAsTechs() + " AsTechs)</html>";
-        asTechPoolLabel.setText(astechString);
+        refreshAsTechPool();
 
         // Ensuring valid row selection after refresh
         if (getCampaignOptions().isResetToFirstTech() && (techTable.getRowCount() > 0)) {
@@ -984,6 +978,18 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
         } else {
             techTable.clearSelection(); // Clear selection if there's no valid option
         }
+    }
+
+    /**
+     * Updates the AsTech pool statistics (minutes, overtime availability, and AsTech count) in the UI label.
+     */
+    public void refreshAsTechPool() {
+        String astechString = "<html><b>AsTech Pool Minutes:</> " + getCampaign().getAsTechPoolMinutes();
+        if (getCampaign().isOvertimeAllowed()) {
+            astechString += " [" + getCampaign().getAsTechPoolOvertime() + " overtime]";
+        }
+        astechString += " (" + getCampaign().getNumberAsTechs() + " AsTechs)</html>";
+        asTechPoolLabel.setText(astechString);
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/WarehouseTab.java
+++ b/MekHQ/src/mekhq/gui/WarehouseTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2017-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/gui/WarehouseTab.java
+++ b/MekHQ/src/mekhq/gui/WarehouseTab.java
@@ -679,7 +679,7 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
      * Updates the AsTech pool statistics (minutes, overtime availability, and AsTech count) in the UI label.
      */
     public void refreshAsTechPool() {
-        String astechString = "<html><b>AsTech Pool Minutes:</> " + getCampaign().getAsTechPoolMinutes();
+        String astechString = "<html><b>AsTech Pool Minutes:</b> " + getCampaign().getAsTechPoolMinutes();
         if (getCampaign().isOvertimeAllowed()) {
             astechString += " [" + getCampaign().getAsTechPoolOvertime() + " overtime]";
         }

--- a/MekHQ/src/mekhq/gui/WarehouseTab.java
+++ b/MekHQ/src/mekhq/gui/WarehouseTab.java
@@ -400,9 +400,11 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
         btnOvertime.setSelected(getCampaign().isOvertimeAllowed());
         btnOvertime.addActionListener(evt -> {
             getCampaign().setOvertime(btnOvertime.isSelected());
+            refreshAsTechPool();
             RepairTab repairBayTab = getCampaignGui().getRepairBayTab();
             if (repairBayTab != null) {
                 repairBayTab.refreshOvertimeStatus();
+                repairBayTab.refreshAsTechPool();
             }
         });
         gridBagConstraints = new GridBagConstraints();
@@ -412,12 +414,7 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         panelDoTask.add(btnOvertime, gridBagConstraints);
 
-        asTechPoolLabel = new JLabel("<html><b>AsTech Pool Minutes:</> " +
-                                           getCampaign().getAsTechPoolMinutes() +
-                                           " (" +
-                                           getCampaign().getNumberAsTechs() +
-                                           " AsTechs)</html>");
-        asTechPoolLabel.setHorizontalAlignment(SwingConstants.CENTER);
+        asTechPoolLabel = new JLabel();
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 6;
@@ -435,6 +432,8 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
         setLayout(new BorderLayout());
         add(splitWarehouse, BorderLayout.CENTER);
         add(pnlTutorial, BorderLayout.SOUTH);
+
+        refreshAsTechPool();
     }
 
     /**
@@ -654,16 +653,11 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
         }
     }
 
-    public void refreshTechsList() {
+    private void refreshTechsList() {
         // The next gets all techs who have more than 0 minutes free, and sorted by
         // skill descending (elites at bottom)
         techsModel.setData(getCampaign().getTechs(true));
-        String astechString = "<html><b>AsTech Pool Minutes:</> " + getCampaign().getAsTechPoolMinutes();
-        if (getCampaign().isOvertimeAllowed()) {
-            astechString += " [" + getCampaign().getAsTechPoolOvertime() + " overtime]";
-        }
-        astechString += " (" + getCampaign().getNumberAsTechs() + " AsTechs)</html>";
-        refreshAsTechPool(astechString);
+        refreshAsTechPool();
 
         // If requested, switch to top entry
         if ((null == selectedTech || getCampaign().getCampaignOptions().isResetToFirstTech()) &&
@@ -679,6 +673,18 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
                 }
             }
         }
+    }
+
+    /**
+     * Updates the AsTech pool statistics (minutes, overtime availability, and AsTech count) in the UI label.
+     */
+    public void refreshAsTechPool() {
+        String astechString = "<html><b>AsTech Pool Minutes:</> " + getCampaign().getAsTechPoolMinutes();
+        if (getCampaign().isOvertimeAllowed()) {
+            astechString += " [" + getCampaign().getAsTechPoolOvertime() + " overtime]";
+        }
+        astechString += " (" + getCampaign().getNumberAsTechs() + " AsTechs)</html>";
+        asTechPoolLabel.setText(astechString);
     }
 
     /**
@@ -759,10 +765,6 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
             return null;
         }
         return partsModel.getPartAt(partsTable.convertRowIndexToModel(row));
-    }
-
-    public void refreshAsTechPool(String astechString) {
-        asTechPoolLabel.setText(astechString);
     }
 
     private final ActionScheduler partsScheduler = new ActionScheduler(this::refreshPartsList);


### PR DESCRIPTION
Changes include:
- Add wiring for 'Allow Overtime' buttons in the Repair Bay and Warehouse tabs and corresponding AsTech pool info labels
- Make `refreshTechsList` private in both tabs
- Extract AsTech pool info update logic into a separate method and reuse it during tab initialization to remove duplicate code

PR in action:

https://github.com/user-attachments/assets/6fafdbb5-f735-41b2-9785-a42577eadee7
