### PR TITLE
Refactor isTryingToConceive to isWantsChildren (fixes #7849)

### DIFF
--- a/MekHQ/resources/mekhq/resources/AbstractProcreation.properties
+++ b/MekHQ/resources/mekhq/resources/AbstractProcreation.properties
@@ -1,4 +1,4 @@
-# Copyright (C) 2005-2025 The MegaMek Team. All Rights Reserved.
+# Copyright (C) 2005-2026 The MegaMek Team. All Rights Reserved.
 #
 # This file is part of MekHQ.
 #

--- a/MekHQ/resources/mekhq/resources/AbstractProcreation.properties
+++ b/MekHQ/resources/mekhq/resources/AbstractProcreation.properties
@@ -32,6 +32,7 @@
 ## Procreation
 # AbstractProcreation Class
 cannotProcreate.Gender.text=MekHQ procreation is female-based, and thus males cannot procreate.
+cannotProcreate.DoesNotWantChildren.text=He does not want children.
 cannotProcreate.NotTryingForABaby.text=She is not trying for a baby.
 cannotProcreate.AlreadyPregnant.text=She is already pregnant.
 cannotProcreate.Inactive.text=She is currently inactive.

--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1320,13 +1320,13 @@ lblDetermineFatherAtBirth.tooltip=The father of a child will be determined based
 lblDisplayTrueDueDate.text=Display True Due Date
 lblDisplayTrueDueDate.tooltip=This displays the actual date the baby will be delivered on the\
   \ mother's personnel sheet instead of an estimated due date.
-lblNoInterestInChildrenDiceSize.text=No Interest in Children Chance : 1 in
+lblNoInterestInChildrenDiceSize.text=Does Not Want Children Chance : 1 in
 lblNoInterestInChildrenDiceSize.tooltip=This is the number of sides on the die rolled to determine\
-  \ whether a character has no interest in children. This die is rolled when creating the\
-  \ character, with no interest occurring on a roll of 1. The results of this roll can be changed\
-  \ by right-clicking on the character and changing the 'Interested in Children' flag.\
+  \ whether a character does not want children. This die is rolled when creating the\
+  \ character, with not wanting children occurring on a roll of 1. The results of this roll can be changed\
+  \ by right-clicking on the character and changing the 'Wants Children' flag.\
   <br>\
-  <br>Changing this value to 1 will mean all characters are interested in children.
+  <br>Changing this value to 1 will mean all characters want children.
 lblUseMaternityLeave.text=Enable Automatic Maternity Leave
 lblUseMaternityLeave.tooltip=If enabled, pregnant personnel will be placed on maternity leave 20\
   \ weeks before they give birth and will not return to active duty until after they have given\

--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -345,8 +345,8 @@ miPrefersWomen.text=Prefers Women
 miPrefersWomen.toolTipText=If this is selected, then the person will be included as a potential spouse for marriages to\
   \ female (including Other - Female) characters (married personnel will not be included even if this flag is \
   selected, nor will characters under 18 years old)
-miTryingToConceive.text=Trying to Conceive
-miTryingToConceive.toolTipText=If this is selected, the person has a chance to have children created through random procreation (this flag is ignored for personnel under 18 years old).
+miWantsChildren.text=Wants Chtldren
+miWantsChildren.toolTipText=If this is selected, the person has a chance to have children created through random procreation (this flag is ignored for personnel under 18 years old).
 miHidePersonality.text=Hide Personality
 miHidePersonality.toolTipText=If this is selected, the character's personality description will be hidden. This is useful\
   \ if you want to write your own description.
@@ -1394,7 +1394,7 @@ PersonnelTableModelColumn.FOUNDER.text=Founder
 PersonnelTableModelColumn.CLAN_PERSONNEL.text=Clan Personnel
 PersonnelTableModelColumn.MARRIAGEABLE.text=Interested in Marriage
 PersonnelTableModelColumn.DIVORCEABLE.text=Divorceable
-PersonnelTableModelColumn.TRYING_TO_CONCEIVE.text=Wants Children
+PersonnelTableModelColumn.WANTS_CHILDREN.text=Wants Children
 PersonnelTableModelColumn.IMMORTAL.text=Excluded from Random Death
 PersonnelTableModelColumn.EMPLOYED.text=Employed by the Unit
 PersonnelTableModelColumn.HIDE_PERSONALITY.text=Hide Personality

--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -345,7 +345,7 @@ miPrefersWomen.text=Prefers Women
 miPrefersWomen.toolTipText=If this is selected, then the person will be included as a potential spouse for marriages to\
   \ female (including Other - Female) characters (married personnel will not be included even if this flag is \
   selected, nor will characters under 18 years old)
-miWantsChildren.text=Wants Chtldren
+miWantsChildren.text=Wants Children
 miWantsChildren.toolTipText=If this is selected, the person has a chance to have children created through random procreation (this flag is ignored for personnel under 18 years old).
 miHidePersonality.text=Hide Personality
 miHidePersonality.toolTipText=If this is selected, the character's personality description will be hidden. This is useful\

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -428,7 +428,7 @@ public class Person {
     private boolean prefersWomen;
     // this is a flag used in random procreation to determine whether to attempt to
     // procreate
-    private boolean tryingToConceive;
+    private boolean wantsChildren;
     private boolean hidePersonality;
     // endregion Flags
 
@@ -666,7 +666,7 @@ public class Person {
         setQuickTrainIgnore(false);
         setPrefersMen(false);
         setPrefersWomen(false);
-        setTryingToConceive(true);
+        setWantsChildren(true);
         // endregion Flags
 
         extraData = new ExtraData();
@@ -3240,13 +3240,9 @@ public class Person {
         this.prefersWomen = prefersWomen;
     }
 
-    public boolean isTryingToConceive() {
-        return tryingToConceive;
-    }
+    public boolean isWantsChildren() {return wantsChildren;}
 
-    public void setTryingToConceive(final boolean tryingToConceive) {
-        this.tryingToConceive = tryingToConceive;
-    }
+    public void setWantsChildren(final boolean wantsChildren) {this.wantsChildren = wantsChildren;}
 
     public boolean isHidePersonality() {
         return hidePersonality;
@@ -3827,7 +3823,7 @@ public class Person {
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "marriageable", marriageable);
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "prefersMen", prefersMen);
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "prefersWomen", prefersWomen);
-            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "tryingToConceive", tryingToConceive);
+            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "wantsChildren", wantsChildren);
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "hidePersonality", hidePersonality);
             // endregion Flags
 
@@ -4467,8 +4463,10 @@ public class Person {
                     person.setPrefersMen(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (nodeName.equalsIgnoreCase("prefersWomen")) {
                     person.setPrefersWomen(Boolean.parseBoolean(wn2.getTextContent().trim()));
-                } else if (nodeName.equalsIgnoreCase("tryingToConceive")) {
-                    person.setTryingToConceive(Boolean.parseBoolean(wn2.getTextContent().trim()));
+                } else if (nodeName.equalsIgnoreCase("tryingToConceive")) { // <51.0 compatibility handler
+                    person.setWantsChildren(Boolean.parseBoolean(wn2.getTextContent().trim()));
+                } else if (nodeName.equalsIgnoreCase("wantsChildren")) {
+                    person.setWantsChildren(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (nodeName.equalsIgnoreCase("hidePersonality")) {
                     person.setHidePersonality(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (nodeName.equalsIgnoreCase("extraData")) {

--- a/MekHQ/src/mekhq/campaign/personnel/generator/DefaultPersonnelGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/generator/DefaultPersonnelGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2019-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/campaign/personnel/generator/DefaultPersonnelGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/generator/DefaultPersonnelGenerator.java
@@ -144,7 +144,7 @@ public class DefaultPersonnelGenerator extends AbstractPersonnelGenerator {
               campaignOptions.getInterestedInSameSexDiceSize(), campaignOptions.getInterestedInBothSexesDiceSize());
 
         int interestInChildren = campaignOptions.getNoInterestInChildrenDiceSize();
-        person.setTryingToConceive(((interestInChildren != 0) && (randomInt(interestInChildren)) != 0));
+        person.setWantsChildren(((interestInChildren != 0) && (randomInt(interestInChildren)) != 0));
 
         //check for Bloodname
         campaign.checkBloodnameAdd(person, false);

--- a/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
+++ b/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
@@ -234,12 +234,12 @@ public abstract class AbstractProcreation {
      * @return null if they can, otherwise the reason why they cannot
      */
     public @Nullable String canProcreate(final LocalDate today, final Person person, final boolean randomProcreation) {
-        if (person.getGender().isMale()) {
-            return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.Gender.text");
-        }
-
-        if (!person.isTryingToConceive()) {
-            return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.NotTryingForABaby.text");
+        if (!person.isWantsChildren()) {
+            if (person.getGender().isMale()) {
+                return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.DoesNotWantChildren.text");
+            } else {
+                return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.NotTryingForABaby.text");
+            }
         }
 
         if (person.isPregnant()) {
@@ -289,7 +289,7 @@ public abstract class AbstractProcreation {
                     return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.FemaleSpouse.text");
                 }
 
-                if (!person.getGenealogy().getSpouse().isTryingToConceive()) {
+                if (!person.getGenealogy().getSpouse().isWantsChildren()) {
                     return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.SpouseNotTryingForABaby.text");
                 }
 
@@ -533,7 +533,7 @@ public abstract class AbstractProcreation {
 
         // check desire for children
         if (Compute.d6(1) <= 2) {
-            mother.setTryingToConceive(false);
+            mother.setWantsChildren(false);
         }
 
         // Cleanup Data
@@ -637,7 +637,7 @@ public abstract class AbstractProcreation {
         }
 
         if (Compute.d6(1) <= 2) {
-            mother.setTryingToConceive(false);
+            mother.setWantsChildren(false);
         }
 
         // Cleanup Data

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -487,6 +487,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
             case CMD_ADD_PREGNANCY: {
                 Stream.of(people)
+                      .filter(person -> person.getGender().isFemale())
                       .filter(person -> (getCampaign().getProcreation()
                                                .canProcreate(getCampaign().getLocalDate(), person, false) == null))
                       .forEach(person -> {
@@ -3900,8 +3901,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
               Person::setQuickTrainIgnore);
         addFlagMenuItem(menu, selected, "miSalvageSupervisor", null, Person::isSalvageSupervisor,
               Person::setSalvageSupervisor);
-        addFlagMenuItem(menu, selected, "miTryingToConceive", null, Person::isTryingToConceive,
-              Person::setTryingToConceive);
+        addFlagMenuItem(menu, selected, "miWantsChildren", null, Person::isWantsChildren,
+              Person::setWantsChildren);
         addFlagMenuItem(menu, selected, "neverAssignMaintenanceAutomatically", null,
               Person::isNeverAssignMaintenanceAutomatically, Person::setNeverAssignMaintenanceAutomatically);
 
@@ -4191,6 +4192,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
             if (getCampaignOptions().isUseManualProcreation()) {
                 if (Stream.of(selected)
+                          .filter(p -> p.getGender().isFemale())
                           .anyMatch(p -> getCampaign().getProcreation()
                                                .canProcreate(getCampaign().getLocalDate(), p, false) == null)) {
                     menuItem = new JMenuItem(resources.getString(oneSelected ?

--- a/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
@@ -171,7 +171,7 @@ public enum PersonnelTableModelColumn {
     QUICK_TRAIN_IGNORE("PersonnelTableModelColumn.QUICK_TRAIN_IGNORE.text"),
     SALVAGE_SUPERVISOR("PersonnelTableModelColumn.SALVAGE_SUPERVISOR.text"),
     SECOND_IN_COMMAND("PersonnelTableModelColumn.SECOND_IN_COMMAND.text"),
-    TRYING_TO_CONCEIVE("PersonnelTableModelColumn.TRYING_TO_CONCEIVE.text"),
+    WANTS_CHILDREN("PersonnelTableModelColumn.WANTS_CHILDREN.text"),
     UNDER_PROTECTION("PersonnelTableModelColumn.UNDER_PROTECTION.text"),
     COVER_MEDICAL_EXPENSES("PersonnelTableModelColumn.COVER_MEDICAL_EXPENSES.text"),
     BLOCK_MATERNITY_LEAVE("PersonnelTableModelColumn.BLOCK_MATERNITY_LEAVE.text"),
@@ -504,9 +504,7 @@ public enum PersonnelTableModelColumn {
         return this == DIVORCEABLE;
     }
 
-    public boolean isTryingToConceive() {
-        return this == TRYING_TO_CONCEIVE;
-    }
+    public boolean isWantsChildren() {return this == WANTS_CHILDREN;}
 
     public boolean isImmortal() {
         return this == IMMORTAL;
@@ -881,10 +879,8 @@ public enum PersonnelTableModelColumn {
             case TECH_VESSEL -> skillValue.apply(SkillType.S_TECH_VESSEL);
             case TOUGHNESS -> Integer.toString(person.getAdjustedToughness());
             case TRAINING -> skillValue.apply(SkillType.S_TRAINING);
-            case TRYING_TO_CONCEIVE -> resources.getString(person.isChild(campaign.getLocalDate()) ? "NA.text" :
-                                                                 person.getGender().isFemale() ?
-                                                                 (convertBooleanToYesNo(person.isTryingToConceive())) :
-                                                                 "NA.text");
+            case WANTS_CHILDREN -> resources.getString(person.isChild(campaign.getLocalDate()) ? "NA.text" :
+                                                             convertBooleanToYesNo(person.isWantsChildren()));
             case UNDER_PROTECTION -> resources.getString(convertBooleanToYesNo(person.isUnderProtection()));
             case COVER_MEDICAL_EXPENSES ->
                   resources.getString(convertBooleanToYesNo(person.isCoverIllicitMedicalExpenses()));
@@ -1333,7 +1329,7 @@ public enum PersonnelTableModelColumn {
                      PREFERS_MEN,
                      PREFERS_WOMEN,
                      COVER_MEDICAL_EXPENSES,
-                     TRYING_TO_CONCEIVE,
+                     WANTS_CHILDREN,
                      BLOCK_MATERNITY_LEAVE -> true;
                 default -> false;
             };

--- a/MekHQ/unittests/mekhq/campaign/personnel/procreation/AbstractProcreationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/procreation/AbstractProcreationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2022-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/unittests/mekhq/campaign/personnel/procreation/AbstractProcreationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/procreation/AbstractProcreationTest.java
@@ -164,7 +164,7 @@ public class AbstractProcreationTest {
     //endregion Determination Methods
 
     @Test
-    public void testIsMale() {
+    public void testNotInterestInChildrenMale() {
         // Arrange
         AbstractProcreation procreation = new RandomProcreation(mockCampaignOptions);
 
@@ -172,6 +172,7 @@ public class AbstractProcreationTest {
         LocalDate date = LocalDate.of(3025, 1, 1);
 
         when(person.getGender()).thenReturn(Gender.MALE);
+        when(person.isWantsChildren()).thenReturn(false);
 
         // Act
         String result = procreation.canProcreate(date, person, false);
@@ -181,7 +182,7 @@ public class AbstractProcreationTest {
     }
 
     @Test
-    public void testNotInterestInChildren() {
+    public void testNotInterestInChildrenFemale() {
         // Arrange
         AbstractProcreation procreation = new RandomProcreation(mockCampaignOptions);
 
@@ -189,7 +190,7 @@ public class AbstractProcreationTest {
         LocalDate date = LocalDate.of(3025, 1, 1);
 
         when(person.getGender()).thenReturn(Gender.FEMALE);
-        when(person.isTryingToConceive()).thenReturn(false);
+        when(person.isWantsChildren()).thenReturn(false);
 
         // Act
         String result = procreation.canProcreate(date, person, false);
@@ -206,8 +207,7 @@ public class AbstractProcreationTest {
         Person person = mock(Person.class);
         LocalDate date = LocalDate.of(3025, 1, 1);
 
-        when(person.getGender()).thenReturn(Gender.FEMALE);
-        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isWantsChildren()).thenReturn(true);
         when(person.isPregnant()).thenReturn(true);
 
         // Act
@@ -225,8 +225,7 @@ public class AbstractProcreationTest {
         Person person = mock(Person.class);
         LocalDate date = LocalDate.of(3025, 1, 1);
 
-        when(person.getGender()).thenReturn(Gender.FEMALE);
-        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isWantsChildren()).thenReturn(true);
         when(person.isPregnant()).thenReturn(false);
         when(person.getStatus()).thenReturn(PersonnelStatus.STUDENT);
 
@@ -245,8 +244,7 @@ public class AbstractProcreationTest {
         Person person = mock(Person.class);
         LocalDate date = LocalDate.of(3025, 1, 1);
 
-        when(person.getGender()).thenReturn(Gender.FEMALE);
-        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isWantsChildren()).thenReturn(true);
         when(person.isPregnant()).thenReturn(false);
         when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
         when(person.isDeployed()).thenReturn(true);
@@ -266,8 +264,7 @@ public class AbstractProcreationTest {
         Person person = mock(Person.class);
         LocalDate date = LocalDate.of(3025, 1, 1);
 
-        when(person.getGender()).thenReturn(Gender.FEMALE);
-        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isWantsChildren()).thenReturn(true);
         when(person.isPregnant()).thenReturn(false);
         when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
         when(person.isDeployed()).thenReturn(false);
@@ -288,8 +285,7 @@ public class AbstractProcreationTest {
         Person person = mock(Person.class);
         LocalDate date = LocalDate.of(3025, 1, 1);
 
-        when(person.getGender()).thenReturn(Gender.FEMALE);
-        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isWantsChildren()).thenReturn(true);
         when(person.isPregnant()).thenReturn(false);
         when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
         when(person.isDeployed()).thenReturn(false);
@@ -311,8 +307,7 @@ public class AbstractProcreationTest {
         Person person = mock(Person.class);
         LocalDate date = LocalDate.of(3025, 1, 1);
 
-        when(person.getGender()).thenReturn(Gender.FEMALE);
-        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isWantsChildren()).thenReturn(true);
         when(person.isPregnant()).thenReturn(false);
         when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
         when(person.isDeployed()).thenReturn(false);
@@ -335,8 +330,7 @@ public class AbstractProcreationTest {
         Person person = mock(Person.class);
         LocalDate date = LocalDate.of(3025, 1, 1);
 
-        when(person.getGender()).thenReturn(Gender.FEMALE);
-        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isWantsChildren()).thenReturn(true);
         when(person.isPregnant()).thenReturn(false);
         when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
         when(person.isDeployed()).thenReturn(false);
@@ -360,8 +354,7 @@ public class AbstractProcreationTest {
         Person person = mock(Person.class);
         LocalDate date = LocalDate.of(3025, 1, 1);
 
-        when(person.getGender()).thenReturn(Gender.FEMALE);
-        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isWantsChildren()).thenReturn(true);
         when(person.isPregnant()).thenReturn(false);
         when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
         when(person.isDeployed()).thenReturn(false);
@@ -386,8 +379,7 @@ public class AbstractProcreationTest {
         Genealogy genealogy = mock(Genealogy.class);
         LocalDate date = LocalDate.of(3025, 1, 1);
 
-        when(person.getGender()).thenReturn(Gender.FEMALE);
-        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isWantsChildren()).thenReturn(true);
         when(person.isPregnant()).thenReturn(false);
         when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
         when(person.isDeployed()).thenReturn(false);
@@ -415,8 +407,7 @@ public class AbstractProcreationTest {
         Genealogy genealogy = mock(Genealogy.class);
         LocalDate date = LocalDate.of(3025, 1, 1);
 
-        when(person.getGender()).thenReturn(Gender.FEMALE);
-        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isWantsChildren()).thenReturn(true);
         when(person.isPregnant()).thenReturn(false);
         when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
         when(person.isDeployed()).thenReturn(false);
@@ -446,8 +437,7 @@ public class AbstractProcreationTest {
         Genealogy genealogy = mock(Genealogy.class);
         LocalDate date = LocalDate.of(3025, 1, 1);
 
-        when(person.getGender()).thenReturn(Gender.FEMALE);
-        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isWantsChildren()).thenReturn(true);
         when(person.isPregnant()).thenReturn(false);
         when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
         when(person.isDeployed()).thenReturn(false);
@@ -459,7 +449,7 @@ public class AbstractProcreationTest {
         when(genealogy.hasSpouse()).thenReturn(true);
         when(genealogy.getSpouse()).thenReturn(spouse);
         when(spouse.getGender()).thenReturn(Gender.MALE);
-        when(spouse.isTryingToConceive()).thenReturn(false);
+        when(spouse.isWantsChildren()).thenReturn(false);
 
         // Act
         String result = procreation.canProcreate(date, person, true);
@@ -478,8 +468,7 @@ public class AbstractProcreationTest {
         Genealogy genealogy = mock(Genealogy.class);
         LocalDate date = LocalDate.of(3025, 1, 1);
 
-        when(person.getGender()).thenReturn(Gender.FEMALE);
-        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isWantsChildren()).thenReturn(true);
         when(person.isPregnant()).thenReturn(false);
         when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
         when(person.isDeployed()).thenReturn(false);
@@ -491,7 +480,7 @@ public class AbstractProcreationTest {
         when(genealogy.hasSpouse()).thenReturn(true);
         when(genealogy.getSpouse()).thenReturn(spouse);
         when(spouse.getGender()).thenReturn(Gender.MALE);
-        when(spouse.isTryingToConceive()).thenReturn(true);
+        when(spouse.isWantsChildren()).thenReturn(true);
         when(spouse.getStatus()).thenReturn(PersonnelStatus.STUDENT);
 
         // Act
@@ -511,8 +500,7 @@ public class AbstractProcreationTest {
         Genealogy genealogy = mock(Genealogy.class);
         LocalDate date = LocalDate.of(3025, 1, 1);
 
-        when(person.getGender()).thenReturn(Gender.FEMALE);
-        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isWantsChildren()).thenReturn(true);
         when(person.isPregnant()).thenReturn(false);
         when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
         when(person.isDeployed()).thenReturn(false);
@@ -524,7 +512,7 @@ public class AbstractProcreationTest {
         when(genealogy.hasSpouse()).thenReturn(true);
         when(genealogy.getSpouse()).thenReturn(spouse);
         when(spouse.getGender()).thenReturn(Gender.MALE);
-        when(spouse.isTryingToConceive()).thenReturn(true);
+        when(spouse.isWantsChildren()).thenReturn(true);
         when(spouse.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
         when(spouse.isDeployed()).thenReturn(true);
 
@@ -545,8 +533,7 @@ public class AbstractProcreationTest {
         Genealogy genealogy = mock(Genealogy.class);
         LocalDate date = LocalDate.of(3025, 1, 1);
 
-        when(person.getGender()).thenReturn(Gender.FEMALE);
-        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isWantsChildren()).thenReturn(true);
         when(person.isPregnant()).thenReturn(false);
         when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
         when(person.isDeployed()).thenReturn(false);
@@ -558,7 +545,7 @@ public class AbstractProcreationTest {
         when(genealogy.hasSpouse()).thenReturn(true);
         when(genealogy.getSpouse()).thenReturn(spouse);
         when(spouse.getGender()).thenReturn(Gender.MALE);
-        when(spouse.isTryingToConceive()).thenReturn(true);
+        when(spouse.isWantsChildren()).thenReturn(true);
         when(spouse.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
         when(spouse.isDeployed()).thenReturn(false);
         when(spouse.isChild(date, true)).thenReturn(true);
@@ -580,8 +567,7 @@ public class AbstractProcreationTest {
         Genealogy genealogy = mock(Genealogy.class);
         LocalDate date = LocalDate.of(3025, 1, 1);
 
-        when(person.getGender()).thenReturn(Gender.FEMALE);
-        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isWantsChildren()).thenReturn(true);
         when(person.isPregnant()).thenReturn(false);
         when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
         when(person.isDeployed()).thenReturn(false);
@@ -593,7 +579,7 @@ public class AbstractProcreationTest {
         when(genealogy.hasSpouse()).thenReturn(true);
         when(genealogy.getSpouse()).thenReturn(spouse);
         when(spouse.getGender()).thenReturn(Gender.MALE);
-        when(spouse.isTryingToConceive()).thenReturn(true);
+        when(spouse.isWantsChildren()).thenReturn(true);
         when(spouse.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
         when(spouse.isDeployed()).thenReturn(false);
         when(spouse.isChild(date, true)).thenReturn(false);
@@ -616,8 +602,7 @@ public class AbstractProcreationTest {
         Genealogy genealogy = mock(Genealogy.class);
         LocalDate date = LocalDate.of(3025, 1, 1);
 
-        when(person.getGender()).thenReturn(Gender.FEMALE);
-        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isWantsChildren()).thenReturn(true);
         when(person.isPregnant()).thenReturn(false);
         when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
         when(person.isDeployed()).thenReturn(false);
@@ -629,7 +614,7 @@ public class AbstractProcreationTest {
         when(genealogy.hasSpouse()).thenReturn(true);
         when(genealogy.getSpouse()).thenReturn(spouse);
         when(spouse.getGender()).thenReturn(Gender.MALE);
-        when(spouse.isTryingToConceive()).thenReturn(true);
+        when(spouse.isWantsChildren()).thenReturn(true);
         when(spouse.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
         when(spouse.isDeployed()).thenReturn(false);
         when(spouse.isChild(date, true)).thenReturn(false);
@@ -653,8 +638,7 @@ public class AbstractProcreationTest {
         Genealogy genealogy = mock(Genealogy.class);
         LocalDate date = LocalDate.of(3025, 1, 1);
 
-        when(person.getGender()).thenReturn(Gender.FEMALE);
-        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isWantsChildren()).thenReturn(true);
         when(person.isPregnant()).thenReturn(false);
         when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
         when(person.isDeployed()).thenReturn(false);
@@ -666,7 +650,7 @@ public class AbstractProcreationTest {
         when(genealogy.hasSpouse()).thenReturn(true);
         when(genealogy.getSpouse()).thenReturn(spouse);
         when(spouse.getGender()).thenReturn(Gender.MALE);
-        when(spouse.isTryingToConceive()).thenReturn(true);
+        when(spouse.isWantsChildren()).thenReturn(true);
         when(spouse.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
         when(spouse.isDeployed()).thenReturn(false);
         when(spouse.isChild(date, true)).thenReturn(false);
@@ -690,8 +674,7 @@ public class AbstractProcreationTest {
         Genealogy genealogy = mock(Genealogy.class);
         LocalDate date = LocalDate.of(3025, 1, 1);
 
-        when(person.getGender()).thenReturn(Gender.FEMALE);
-        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isWantsChildren()).thenReturn(true);
         when(person.isPregnant()).thenReturn(false);
         when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
         when(person.isDeployed()).thenReturn(false);
@@ -703,7 +686,7 @@ public class AbstractProcreationTest {
         when(genealogy.hasSpouse()).thenReturn(true);
         when(genealogy.getSpouse()).thenReturn(spouse);
         when(spouse.getGender()).thenReturn(Gender.MALE);
-        when(spouse.isTryingToConceive()).thenReturn(true);
+        when(spouse.isWantsChildren()).thenReturn(true);
         when(spouse.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
         when(spouse.isDeployed()).thenReturn(false);
         when(spouse.isChild(date, true)).thenReturn(false);

--- a/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
+++ b/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2022-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
+++ b/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
@@ -683,12 +683,12 @@ public class PersonnelTableModelColumnTest {
     }
 
     @Test
-    public void testIsTryingToConceive() {
+    public void testIsWantsChildren() {
         for (final PersonnelTableModelColumn personnelTableModelColumn : columns) {
-            if (personnelTableModelColumn == PersonnelTableModelColumn.TRYING_TO_CONCEIVE) {
-                assertTrue(personnelTableModelColumn.isTryingToConceive());
+            if (personnelTableModelColumn == PersonnelTableModelColumn.WANTS_CHILDREN) {
+                assertTrue(personnelTableModelColumn.isWantsChildren());
             } else {
-                assertFalse(personnelTableModelColumn.isTryingToConceive());
+                assertFalse(personnelTableModelColumn.isWantsChildren());
             }
         }
     }


### PR DESCRIPTION
There is a property for persons named 'Trying to conceive'. Although it would seem this should only apply to female personnel, it is also used to determine if male personnel want children or not, but this currently does not work properly.

This PR fixes this by changing the internal name to 'wants children', and also using that everywhere that it is used. It also fixes the issue with determining if male personnel want children or not, which factors in for the tests for pregnancy for female characters that have a male spouse.

Closes #7849 

**Note**
A comment in #7849 calls for 

_We'd also likely need additional campaign options, one set for male procreation interest and another for female._

This is not included in this PR, and I'm not sure if it is really needed. But it would not be very difficult to add it.