### PR TITLE
Unsubscribe CommandGUI from the event bus on campaign creation and loading

### DIFF
--- a/MekHQ/src/mekhq/gui/menus/MekHQMenuBar.java
+++ b/MekHQ/src/mekhq/gui/menus/MekHQMenuBar.java
@@ -226,6 +226,7 @@ public class MekHQMenuBar extends JMenuBar {
                 }
             }
             MekHQ.unregisterHandler(this);
+            MekHQ.unregisterHandler(getGui());
             // check for a loaded story arc and unregister that handler as well
             if (null != getCampaign().getStoryArc()) {
                 MekHQ.unregisterHandler(getCampaign().getStoryArc());
@@ -1315,6 +1316,7 @@ public class MekHQMenuBar extends JMenuBar {
 
         // Unregister other handlers
         MekHQ.unregisterHandler(this);
+        MekHQ.unregisterHandler(getGui());
 
         if (getCampaign().getStoryArc() != null) {
             MekHQ.unregisterHandler(getCampaign().getStoryArc());


### PR DESCRIPTION
A regression was introduced in #9135 because `MekHQ.unregisterHandler(this)` was moved as is and it did not break the build. This change ensures that `CampaignGUI` is correctly unsubscribed.