### PR TITLE
Fix #9095: Fixed Missing Conditional Causing Refit Tech Assessment to Misreport Automatic Success When Tech Has 0 Minutes Available

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6515,9 +6515,6 @@ public class Campaign implements ITechManager, ILocation {
         if (target.getValue() == TargetRoll.IMPOSSIBLE) {
             return target;
         }
-        if (target.getValue() == TargetRoll.AUTOMATIC_SUCCESS) {
-            return target;
-        }
 
         target.append(partWork.getAllMods(tech));
 
@@ -6534,9 +6531,9 @@ public class Campaign implements ITechManager, ILocation {
         }
 
         final int minutes = Math.min(partWork.getTimeLeft(), techTime);
-        if (minutes <= 0) {
+        if (!(partWork instanceof Refit) && minutes <= 0) {
             LOGGER.error("Attempting to get the target number for a part with zero time left.");
-            return new TargetRoll(TargetRoll.AUTOMATIC_SUCCESS, "No part repair time remaining.");
+            return new TargetRoll(TargetRoll.AUTOMATIC_FAIL, "No part repair time remaining.");
         }
 
         int helpMod;

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6484,7 +6484,7 @@ public class Campaign implements ITechManager, ILocation {
         final int techTime = isOvertimeAllowed() ?
                                    tech.getMinutesLeft() + tech.getOvertimeLeft() :
                                    tech.getMinutesLeft();
-        if (techTime <= 0) {
+        if (!(partWork instanceof Refit) && (techTime <= 0)) {
             return new TargetRoll(TargetRoll.IMPOSSIBLE, "The tech has no time left.");
         }
 
@@ -6513,6 +6513,9 @@ public class Campaign implements ITechManager, ILocation {
         }
         final TargetRoll target = new TargetRoll(value, SkillType.getExperienceLevelName(effectiveSkillLevel));
         if (target.getValue() == TargetRoll.IMPOSSIBLE) {
+            return target;
+        }
+        if (target.getValue() == TargetRoll.AUTOMATIC_SUCCESS) {
             return target;
         }
 

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6484,7 +6484,7 @@ public class Campaign implements ITechManager, ILocation {
         final int techTime = isOvertimeAllowed() ?
                                    tech.getMinutesLeft() + tech.getOvertimeLeft() :
                                    tech.getMinutesLeft();
-        if (!(partWork instanceof Refit) && (techTime <= 0)) {
+        if (techTime <= 0) {
             return new TargetRoll(TargetRoll.IMPOSSIBLE, "The tech has no time left.");
         }
 


### PR DESCRIPTION
Fix #9095

The 'refit target number' method is used by a few different sources. Including parts repair.

As part of its functioning it rejects attempts made to repair parts with 0 time left.

However it was incorrectly performing this test for refits which, by their nature, are not restricted to a single day's time allotment.

Furthermore, this was misreporting such instances as 'automatic success' and not 'automatic failure'.

This PR resolves both issues.