### PR TITLE
Minor Adjustment to How Prefab Names Are Constructed by Company Name Generator

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/backgrounds/BackgroundsController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/backgrounds/BackgroundsController.java
@@ -100,7 +100,7 @@ public class BackgroundsController {
                 yield name + newWordSuggestion;
             }
             // Pre-Fab
-            case 3 -> name + getWeightedPreFab().randomItem();
+            case 3 -> getWeightedPreFab().randomItem();
             default -> throw new IllegalStateException(
                   "Unexpected value in mekhq/campaign/personnel/backgrounds/BackgroundsController.java/getNameBody: "
                         + roll


### PR DESCRIPTION
Isolated prefab names so that we don't place prefixes before them. This is done to expand the variety of prefab names we can use, as we no longer need to factor in the possibility of the name having a random prefix.