### PR TITLE
Fixed NPE in AutoRank System

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -1331,7 +1331,7 @@ public class AtBContract extends Contract {
             clanOpponent.setBloodname(bloodname.getName());
         }
 
-        AutoAssignRankForCompanyGenerator.assignAscendingRank(employerLiaison, RO_MIN);
+        AutoAssignRankForCompanyGenerator.assignAscendingRank(clanOpponent, RO_MIN);
 
         final RankSystem rankSystem = Ranks.getRankSystemFromCode("CLAN");
 

--- a/MekHQ/src/mekhq/campaign/personnel/ranks/AutoAssignRankForCompanyGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/ranks/AutoAssignRankForCompanyGenerator.java
@@ -127,6 +127,10 @@ public final class AutoAssignRankForCompanyGenerator {
         }
 
         for (Person person : crew) {
+            if (person == null) {
+                continue;
+            }
+
             // Skip anyone who already has a rank
             if (!hasNoRank(person)) {
                 continue;
@@ -239,7 +243,7 @@ public final class AutoAssignRankForCompanyGenerator {
      * @author Illiani
      * @since 0.51.0
      */
-    private static int assignNormalRank(Person person, int startIndex) {
+    private static int assignNormalRank(@Nullable Person person, int startIndex) {
         if (startIndex <= RE_MIN) {
             return RE_MIN;
         }
@@ -272,7 +276,7 @@ public final class AutoAssignRankForCompanyGenerator {
      * @author Illiani
      * @since 0.51.0
      */
-    public static void assignAscendingRank(Person person, int startIndex) {
+    public static void assignAscendingRank(@Nullable Person person, int startIndex) {
         if (person == null) {
             return;
         }
@@ -309,7 +313,11 @@ public final class AutoAssignRankForCompanyGenerator {
                      rankName.equalsIgnoreCase(MISSING_RANK);
     }
 
-    public static void assignRankSystemFromFaction(Person person, int rankLevel) {
+    public static void assignRankSystemFromFaction(@Nullable Person person, int rankLevel) {
+        if (person == null) {
+            return;
+        }
+
         RankSystem rankSystem = person.getOriginFaction().getRankSystem();
         final RankValidator rankValidator = new RankValidator();
         if (!rankValidator.validate(rankSystem, false)) {

--- a/MekHQ/src/mekhq/campaign/personnel/ranks/AutoAssignRankForCompanyGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/ranks/AutoAssignRankForCompanyGenerator.java
@@ -269,9 +269,9 @@ public final class AutoAssignRankForCompanyGenerator {
      * @since 0.51.0
      */
     public static void assignAscendingRank(@Nullable Person person, int startIndex) {
-        //        if (person == null) {
-        //            return;
-        //        }
+        if (person == null) {
+            return;
+        }
 
         int rankIndex = startIndex;
         person.setRank(rankIndex);

--- a/MekHQ/src/mekhq/campaign/personnel/ranks/AutoAssignRankForCompanyGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/ranks/AutoAssignRankForCompanyGenerator.java
@@ -127,10 +127,6 @@ public final class AutoAssignRankForCompanyGenerator {
         }
 
         for (Person person : crew) {
-            if (person == null) {
-                continue;
-            }
-
             // Skip anyone who already has a rank
             if (!hasNoRank(person)) {
                 continue;
@@ -243,13 +239,9 @@ public final class AutoAssignRankForCompanyGenerator {
      * @author Illiani
      * @since 0.51.0
      */
-    private static int assignNormalRank(@Nullable Person person, int startIndex) {
+    private static int assignNormalRank(Person person, int startIndex) {
         if (startIndex <= RE_MIN) {
             return RE_MIN;
-        }
-
-        if (person == null) {
-            return startIndex;
         }
 
         int rankIndex = startIndex;
@@ -277,9 +269,9 @@ public final class AutoAssignRankForCompanyGenerator {
      * @since 0.51.0
      */
     public static void assignAscendingRank(@Nullable Person person, int startIndex) {
-        if (person == null) {
-            return;
-        }
+        //        if (person == null) {
+        //            return;
+        //        }
 
         int rankIndex = startIndex;
         person.setRank(rankIndex);

--- a/MekHQ/src/mekhq/campaign/personnel/ranks/AutoAssignRankForCompanyGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/ranks/AutoAssignRankForCompanyGenerator.java
@@ -244,6 +244,10 @@ public final class AutoAssignRankForCompanyGenerator {
             return RE_MIN;
         }
 
+        if (person == null) {
+            return startIndex;
+        }
+
         int rankIndex = startIndex;
         person.setRank(rankIndex);
 
@@ -269,6 +273,10 @@ public final class AutoAssignRankForCompanyGenerator {
      * @since 0.51.0
      */
     public static void assignAscendingRank(Person person, int startIndex) {
+        if (person == null) {
+            return;
+        }
+
         int rankIndex = startIndex;
         person.setRank(rankIndex);
 


### PR DESCRIPTION
Added `null` protections to autoranks ranks system. While a `null` person _shouldn't_ be passed in it's entirely possible that it could happen (and has) so let's protect ourselves.

Marked as critical as this can cause several systems to brick, it turns out.