### PR TITLE
Refactor CampaignGUI tab management

### DIFF
--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -222,7 +222,6 @@ public final class BriefingTab extends CampaignGuiTab {
     public BriefingTab(CampaignGUI gui, String tabName) {
         super(gui, tabName);
         selectedScenario = -1;
-        MekHQ.registerHandler(this);
     }
     // endregion Constructors
 
@@ -742,8 +741,8 @@ public final class BriefingTab extends CampaignGuiTab {
         }
 
         boolean stratConScenario = isStratConScenario(scenario);
-        btnDeploySelectedScenario.setEnabled(stratConScenario &&
-                                                   (getCampaignGui().getTab(MHQTabType.STRAT_CON) instanceof StratConTab));
+        btnDeploySelectedScenario.setEnabled(
+              stratConScenario && getCampaignGui().getStratConTab().isPresent());
         refreshScenarioActionButtonEmphasis();
     }
 
@@ -760,9 +759,8 @@ public final class BriefingTab extends CampaignGuiTab {
             return;
         }
 
-        if (getCampaignGui().getTab(MHQTabType.STRAT_CON) instanceof StratConTab stratConTab) {
-            MaplessStratCon.deployWithoutMap(stratConTab.getStratconPanel(), getCampaign(), scenario);
-        }
+        getCampaignGui().getStratConTab().ifPresent(
+              tab -> MaplessStratCon.deployWithoutMap(tab.getStratconPanel(), getCampaign(), scenario));
     }
 
     private void addMission() {

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -39,7 +39,6 @@ import static mekhq.campaign.force.Formation.NO_ASSIGNED_SCENARIO;
 import static mekhq.campaign.market.personnelMarket.enums.PersonnelMarketStyle.PERSONNEL_MARKET_DISABLED;
 import static mekhq.campaign.personnel.skills.SkillType.getExperienceLevelName;
 import static mekhq.gui.dialog.nagDialogs.NagController.triggerDailyNags;
-import static mekhq.gui.enums.MHQTabType.COMMAND_CENTER;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 import java.awt.*;
@@ -60,15 +59,7 @@ import java.util.*;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.zip.GZIPOutputStream;
-import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JTable;
-import javax.swing.SwingConstants;
+import javax.swing.*;
 import javax.swing.border.Border;
 
 import megamek.client.ui.dialogs.UnitLoadingDialog;
@@ -164,7 +155,18 @@ public class CampaignGUI extends JPanel {
 
     private MekHQMenuBar windowMenu;
 
-    private final EnumMap<MHQTabType, CampaignGuiTab> standardTabs;
+    private final CommandCenterTab commandCenterTab;
+    private final TOETab toeTab;
+    private final BriefingTab briefingRoomTab;
+    private final StratConTab stratConTab;
+    private final MapTab interstellarMapTab;
+    private final PersonnelTab personnelTab;
+    private final HangarTab hangarTab;
+    private final WarehouseTab warehouseTab;
+    private final RepairTab repairBayTab;
+    private final InfirmaryTab infirmaryTab;
+    private final MekLabTab mekLabTab;
+    private final FinancesTab financesTab;
 
     /* Components for the status panel */
     private JPanel statusPanel;
@@ -200,10 +202,37 @@ public class CampaignGUI extends JPanel {
     public CampaignGUI(MekHQ app) {
         this.app = app;
         reportHLL = new ReportHyperlinkListener(this);
-        standardTabs = new EnumMap<>(MHQTabType.class);
         initComponents();
         MekHQ.registerHandler(this);
         setUserPreferences();
+
+        commandCenterTab = new CommandCenterTab(this, MHQTabType.COMMAND_CENTER.toString());
+        toeTab = new TOETab(this, MHQTabType.TOE.toString());
+        briefingRoomTab = new BriefingTab(this, MHQTabType.BRIEFING_ROOM.toString());
+        stratConTab = new StratConTab(this, MHQTabType.STRAT_CON.toString());
+        interstellarMapTab = new MapTab(this, MHQTabType.INTERSTELLAR_MAP.toString());
+        personnelTab = new PersonnelTab(this, MHQTabType.PERSONNEL.toString());
+        hangarTab = new HangarTab(this, MHQTabType.HANGAR.toString());
+        warehouseTab = new WarehouseTab(this, MHQTabType.WAREHOUSE.toString());
+        repairBayTab = new RepairTab(this, MHQTabType.REPAIR_BAY.toString());
+        infirmaryTab = new InfirmaryTab(this, MHQTabType.INFIRMARY.toString());
+        mekLabTab = new MekLabTab(this, MHQTabType.MEK_LAB.toString());
+        financesTab = new FinancesTab(this, MHQTabType.FINANCES.toString());
+
+        activateTab(commandCenterTab);
+        activateTab(toeTab);
+        activateTab(briefingRoomTab);
+        if (getCampaign().getCampaignOptions().isUseStratCon()) {
+            activateTab(stratConTab);
+        }
+        activateTab(interstellarMapTab);
+        activateTab(personnelTab);
+        activateTab(hangarTab);
+        activateTab(warehouseTab);
+        activateTab(repairBayTab);
+        activateTab(infirmaryTab);
+        activateTab(mekLabTab);
+        activateTab(financesTab);
     }
     // endregion Constructors
 
@@ -262,21 +291,6 @@ public class CampaignGUI extends JPanel {
         tabMain.setMinimumSize(new Dimension(600, 200));
         tabMain.setPreferredSize(new Dimension(900, 300));
 
-        addStandardTab(COMMAND_CENTER);
-        addStandardTab(MHQTabType.TOE);
-        addStandardTab(MHQTabType.BRIEFING_ROOM);
-        if (getCampaign().getCampaignOptions().isUseStratCon()) {
-            addStandardTab(MHQTabType.STRAT_CON);
-        }
-        addStandardTab(MHQTabType.INTERSTELLAR_MAP);
-        addStandardTab(MHQTabType.PERSONNEL);
-        addStandardTab(MHQTabType.HANGAR);
-        addStandardTab(MHQTabType.WAREHOUSE);
-        addStandardTab(MHQTabType.REPAIR_BAY);
-        addStandardTab(MHQTabType.INFIRMARY);
-        addStandardTab(MHQTabType.MEK_LAB);
-        addStandardTab(MHQTabType.FINANCES);
-
         boolean isMaplessMode = getCampaign().getCampaignOptions().isUseStratConMaplessMode();
         int stratConTabIndex = tabMain.indexOfTab(MHQTabType.STRAT_CON.toString());
 
@@ -301,8 +315,6 @@ public class CampaignGUI extends JPanel {
         add(tabMain, BorderLayout.CENTER);
         add(pnlTop, BorderLayout.PAGE_START);
         add(statusPanel, BorderLayout.PAGE_END);
-
-        standardTabs.values().forEach(CampaignGuiTab::refreshAll);
 
         refreshWindowTitle();
         refreshCampaignControlButtons();
@@ -355,10 +367,6 @@ public class CampaignGUI extends JPanel {
             });
         }
 
-        CommandCenterTab commandCenter = getCommandCenterTab();
-        for (DailyReportType type : DailyReportType.values()) {
-            commandCenter.clearDailyReportNag(type.getTabIndex());
-        }
     }
 
     /**
@@ -547,40 +555,62 @@ public class CampaignGUI extends JPanel {
 
     // endregion Initialization
 
-    public @Nullable CampaignGuiTab getTab(final MHQTabType tabType) {
-        return standardTabs.get(tabType);
+    public CommandCenterTab getCommandCenterTab() {
+        return commandCenterTab;
     }
 
-    public @Nullable CommandCenterTab getCommandCenterTab() {
-        return (CommandCenterTab) getTab(COMMAND_CENTER);
+    public TOETab getTOETab() {
+        return toeTab;
     }
 
-    public @Nullable TOETab getTOETab() {
-        return (TOETab) getTab(MHQTabType.TOE);
+    public Optional<StratConTab> getStratConTab() {
+        return tabMain.indexOfComponent(stratConTab) >= 0 ? Optional.of(stratConTab) : Optional.empty();
     }
 
-    public @Nullable MapTab getMapTab() {
-        return (MapTab) getTab(MHQTabType.INTERSTELLAR_MAP);
+    public MapTab getMapTab() {
+        return interstellarMapTab;
     }
 
-    public @Nullable PersonnelTab getPersonnelTab() {
-        return (PersonnelTab) getTab(MHQTabType.PERSONNEL);
+    public PersonnelTab getPersonnelTab() {
+        return personnelTab;
     }
 
-    public @Nullable WarehouseTab getWarehouseTab() {
-        return (WarehouseTab) getTab(MHQTabType.WAREHOUSE);
+    public WarehouseTab getWarehouseTab() {
+        return warehouseTab;
     }
 
-    public @Nullable RepairTab getRepairBayTab() {
-        return (RepairTab) getTab(MHQTabType.REPAIR_BAY);
+    public RepairTab getRepairBayTab() {
+        return repairBayTab;
     }
 
-    public @Nullable HangarTab getHangarTab() {
-        return (HangarTab) getTab(MHQTabType.HANGAR);
+    public BriefingTab getBriefingRoomTab() {
+        return briefingRoomTab;
     }
 
-    public boolean hasTab(MHQTabType tabType) {
-        return standardTabs.containsKey(tabType);
+    public HangarTab getHangarTab() {
+        return hangarTab;
+    }
+
+    public MekLabTab getMekLabTab() {
+        return mekLabTab;
+    }
+
+    public InfirmaryTab getInfirmaryTab() {
+        return infirmaryTab;
+    }
+
+    public FinancesTab getFinancesTab() {
+        return financesTab;
+    }
+
+    /**
+     * Sets the selected tab.
+     */
+    public void setSelectedTab(CampaignGuiTab tab) {
+        IntStream.range(0, tabMain.getTabCount())
+              .filter(ii -> Objects.equals(tabMain.getComponentAt(ii), tab))
+              .findFirst()
+              .ifPresent(ii -> tabMain.setSelectedIndex(ii));
     }
 
     /**
@@ -589,69 +619,54 @@ public class CampaignGUI extends JPanel {
      * @param tabType The type of tab to select.
      */
     public void setSelectedTab(MHQTabType tabType) {
-        if (standardTabs.containsKey(tabType)) {
-            final CampaignGuiTab tab = standardTabs.get(tabType);
-            IntStream.range(0, tabMain.getTabCount())
-                  .filter(ii -> Objects.equals(tabMain.getComponentAt(ii), tab))
-                  .findFirst()
-                  .ifPresent(ii -> tabMain.setSelectedIndex(ii));
-        }
+        Optional<? extends CampaignGuiTab> tab = switch (tabType) {
+            case COMMAND_CENTER -> Optional.of(getCommandCenterTab());
+            case INTERSTELLAR_MAP -> Optional.of(getMapTab());
+            case TOE -> Optional.of(getTOETab());
+            case BRIEFING_ROOM -> Optional.of(getBriefingRoomTab());
+            case STRAT_CON -> getStratConTab();
+            case PERSONNEL -> Optional.of(getPersonnelTab());
+            case HANGAR -> Optional.of(getHangarTab());
+            case REPAIR_BAY -> Optional.of(getRepairBayTab());
+            case WAREHOUSE -> Optional.of(getWarehouseTab());
+            case INFIRMARY -> Optional.of(getInfirmaryTab());
+            case FINANCES -> Optional.of(getFinancesTab());
+            case MEK_LAB -> Optional.of(getMekLabTab());
+        };
+        tab.ifPresent(this::setSelectedTab);
     }
 
     /**
-     * Adds one of the built-in tabs to the gui, if it is not already present.
+     * Checks if tab is present in the tab panel. If not, adds it to the panel and activates it.
      *
-     * @param tab The type of tab to add
+     * @param tab The tab to activate
      */
-    public void addStandardTab(MHQTabType tab) {
-        if (!standardTabs.containsKey(tab)) {
-            CampaignGuiTab campaignGuiTab = tab.createTab(this);
-            standardTabs.put(tab, campaignGuiTab);
-            int index = IntStream.range(0, tabMain.getTabCount())
-                              .filter(i -> ((CampaignGuiTab) tabMain.getComponentAt(i)).tabType().ordinal() >
-                                                 tab.ordinal())
-                              .findFirst()
-                              .orElse(tabMain.getTabCount());
-            tabMain.insertTab(campaignGuiTab.getTabName(), null, campaignGuiTab, null, index);
-            tabMain.setMnemonicAt(index, tab.getMnemonic());
+    public void activateTab(CampaignGuiTab tab) {
+        if (tabMain.indexOfComponent(tab) >= 0) {
+            return;
         }
+        int index =
+              IntStream.range(0, tabMain.getTabCount()).filter(
+                          i -> ((CampaignGuiTab) tabMain.getComponentAt(i)).tabType().ordinal() >
+                                     tab.tabType().ordinal())
+                    .findFirst()
+                    .orElse(tabMain.getTabCount());
+        tabMain.insertTab(tab.getTabName(), null, tab, null, index);
+        tabMain.setMnemonicAt(index, tab.tabType().getMnemonic());
+        SwingUtilities.invokeLater(() -> {
+            tab.refreshAll();
+            tab.activateTab();
+        });
     }
 
     /**
-     * Removes one of the built-in tabs from the gui.
+     * Removes a tab from the tab panel and deactivates it.
      *
-     * @param tabType The tab to remove
+     * @param tab The tab to deactivate
      */
-    public void removeStandardTab(MHQTabType tabType) {
-        CampaignGuiTab tab = standardTabs.get(tabType);
-        if (tab != null) {
-            MekHQ.unregisterHandler(tab);
-            removeTab(tab);
-        }
-    }
-
-    /**
-     * Removes a tab from the gui.
-     *
-     * @param tab The tab to remove
-     */
-    public void removeTab(CampaignGuiTab tab) {
-        tab.disposeTab();
-        removeTab(tab.getTabName());
-    }
-
-    /**
-     * Removes a tab from the gui.
-     *
-     * @param tabName The name of the tab to remove
-     */
-    public void removeTab(String tabName) {
-        int index = tabMain.indexOfTab(tabName);
-        if (index >= 0) {
-            CampaignGuiTab tab = (CampaignGuiTab) tabMain.getComponentAt(index);
-            standardTabs.remove(tab.tabType());
-            tabMain.removeTabAt(index);
-        }
+    private void deactivateTab(CampaignGuiTab tab) {
+        tab.deactivateTab();
+        tabMain.remove(tab);
     }
 
     public boolean showRetirementDefectionDialog() {
@@ -690,11 +705,10 @@ public class CampaignGUI extends JPanel {
     }
 
     public void focusOnUnit(UUID id) {
-        HangarTab ht = (HangarTab) getTab(MHQTabType.HANGAR);
-        if (null == id || null == ht) {
+        if (null == id) {
             return;
         }
-        ht.focusOnUnit(id);
+        getHangarTab().focusOnUnit(id);
         tabMain.setSelectedIndex(getTabIndexByName(resourceMap.getString("panHangar.TabConstraints.tabTitle")));
     }
 
@@ -717,11 +731,7 @@ public class CampaignGUI extends JPanel {
      * @since 0.50.05
      */
     public void focusOnScenario(int targetId) {
-        BriefingTab briefingTab = (BriefingTab) getTab(MHQTabType.BRIEFING_ROOM);
-        if (briefingTab == null) {
-            return;
-        }
-        briefingTab.focusOnScenario(targetId);
+        getBriefingRoomTab().focusOnScenario(targetId);
         tabMain.setSelectedIndex(getTabIndexByName(resourceMap.getString("panBriefing.TabConstraints.tabTitle")));
     }
 
@@ -744,11 +754,7 @@ public class CampaignGUI extends JPanel {
      * @since 0.50.05
      */
     public void focusOnMission(int targetId) {
-        BriefingTab briefingTab = (BriefingTab) getTab(MHQTabType.BRIEFING_ROOM);
-        if (briefingTab == null) {
-            return;
-        }
-        briefingTab.focusOnMission(targetId);
+        getBriefingRoomTab().focusOnMission(targetId);
         tabMain.setSelectedIndex(getTabIndexByName(resourceMap.getString("panBriefing.TabConstraints.tabTitle")));
     }
 
@@ -756,10 +762,8 @@ public class CampaignGUI extends JPanel {
         if (null == id) {
             return;
         }
-        if (getTab(MHQTabType.REPAIR_BAY) != null) {
-            ((RepairTab) getTab(MHQTabType.REPAIR_BAY)).focusOnUnit(id);
-            tabMain.setSelectedComponent(getTab(MHQTabType.REPAIR_BAY));
-        }
+        getRepairBayTab().focusOnUnit(id);
+        tabMain.setSelectedComponent(getRepairBayTab());
     }
 
     public void focusOnPerson(Person person) {
@@ -772,12 +776,8 @@ public class CampaignGUI extends JPanel {
         if (id == null) {
             return;
         }
-        PersonnelTab pt = (PersonnelTab) getTab(MHQTabType.PERSONNEL);
-        if (pt == null) {
-            return;
-        }
-        pt.focusOnPerson(id);
-        tabMain.setSelectedComponent(pt);
+        getPersonnelTab().focusOnPerson(id);
+        tabMain.setSelectedComponent(getPersonnelTab());
     }
 
     public void showNews(int id) {
@@ -1066,9 +1066,7 @@ public class CampaignGUI extends JPanel {
             return;
         }
         getCampaign().refit(r);
-        if (hasTab(MHQTabType.MEK_LAB)) {
-            ((MekLabTab) getTab(MHQTabType.MEK_LAB)).clearUnit();
-        }
+        getMekLabTab().clearUnit();
     }
 
     private static String getRefitRefurbish(Refit r) {
@@ -1173,10 +1171,6 @@ public class CampaignGUI extends JPanel {
         }
 
         PersonnelTab pt = getPersonnelTab();
-        if (pt == null) {
-            logger.error("Cannot export person if there's not a personnel tab");
-            return;
-        }
         int row = pt.getPersonnelTable().getSelectedRow();
         if (row < 0) {
             logger.warn("Cannot export person if no one is selected! Ignoring.");
@@ -1389,10 +1383,7 @@ public class CampaignGUI extends JPanel {
     }
 
     public void refreshLab() {
-        MekLabTab lab = (MekLabTab) getTab(MHQTabType.MEK_LAB);
-        if (null == lab) {
-            return;
-        }
+        MekLabTab lab = getMekLabTab();
         Unit u = lab.getUnit();
         if (null == u) {
             return;
@@ -1870,10 +1861,10 @@ public class CampaignGUI extends JPanel {
      */
     @Subscribe
     public void handle(final OptionsChangedEvent optionsChangedEvent) {
-        if (!getCampaign().getCampaignOptions().isUseStratCon() && (getTab(MHQTabType.STRAT_CON) != null)) {
-            removeStandardTab(MHQTabType.STRAT_CON);
-        } else if (getCampaign().getCampaignOptions().isUseStratCon() && (getTab(MHQTabType.STRAT_CON) == null)) {
-            addStandardTab(MHQTabType.STRAT_CON);
+        if (!getCampaign().getCampaignOptions().isUseStratCon() && getStratConTab().isPresent()) {
+            deactivateTab(stratConTab);
+        } else if (getCampaign().getCampaignOptions().isUseStratCon() && getStratConTab().isEmpty()) {
+            activateTab(stratConTab);
         }
 
         // Update blob crew label visibility

--- a/MekHQ/src/mekhq/gui/CampaignGuiTab.java
+++ b/MekHQ/src/mekhq/gui/CampaignGuiTab.java
@@ -90,9 +90,15 @@ public abstract class CampaignGuiTab extends JPanel {
     abstract public MHQTabType tabType();
 
     /**
-     * Called when tab is removed from gui.
+     * Called when tab is activated.
      */
-    public void disposeTab() {
+    public void activateTab() {
+        MekHQ.registerHandler(this);
+    }
+    /**
+     * Called when tab is deactivated.
+     */
+    public void deactivateTab() {
         MekHQ.unregisterHandler(this);
     }
 }

--- a/MekHQ/src/mekhq/gui/CommandCenterTab.java
+++ b/MekHQ/src/mekhq/gui/CommandCenterTab.java
@@ -192,7 +192,6 @@ public final class CommandCenterTab extends CampaignGuiTab {
      */
     public CommandCenterTab(CampaignGUI gui, String name) {
         super(gui, name);
-        MekHQ.registerHandler(this);
     }
 
     //region Getters/Setters

--- a/MekHQ/src/mekhq/gui/FinancesTab.java
+++ b/MekHQ/src/mekhq/gui/FinancesTab.java
@@ -124,7 +124,6 @@ public final class FinancesTab extends CampaignGuiTab {
     //region Constructors
     public FinancesTab(CampaignGUI gui, String name) {
         super(gui, name);
-        MekHQ.registerHandler(this);
     }
     //endregion Constructors
 

--- a/MekHQ/src/mekhq/gui/HangarTab.java
+++ b/MekHQ/src/mekhq/gui/HangarTab.java
@@ -134,9 +134,7 @@ public final class HangarTab extends CampaignGuiTab {
     // region Constructors
     public HangarTab(CampaignGUI gui, String name) {
         super(gui, name);
-        MekHQ.registerHandler(this);
         setUserPreferences();
-        GUIPreferences.getInstance().addPreferenceChangeListener(scalingChangeListener);
     }
     // endregion Constructors
 
@@ -605,8 +603,14 @@ public final class HangarTab extends CampaignGuiTab {
     }
 
     @Override
-    public void disposeTab() {
-        super.disposeTab();
+    public void activateTab() {
+        super.activateTab();
+        GUIPreferences.getInstance().addPreferenceChangeListener(scalingChangeListener);
+    }
+
+    @Override
+    public void deactivateTab() {
+        super.deactivateTab();
         GUIPreferences.getInstance().removePreferenceChangeListener(scalingChangeListener);
     }
 

--- a/MekHQ/src/mekhq/gui/InfirmaryTab.java
+++ b/MekHQ/src/mekhq/gui/InfirmaryTab.java
@@ -101,7 +101,6 @@ public final class InfirmaryTab extends CampaignGuiTab {
     //region Constructors
     public InfirmaryTab(CampaignGUI gui, String name) {
         super(gui, name);
-        MekHQ.registerHandler(this);
     }
     //endregion Constructors
 

--- a/MekHQ/src/mekhq/gui/MapTab.java
+++ b/MekHQ/src/mekhq/gui/MapTab.java
@@ -100,7 +100,6 @@ public final class MapTab extends CampaignGuiTab implements ActionListener {
     //region Constructors
     public MapTab(CampaignGUI gui, String tabName) {
         super(gui, tabName);
-        MekHQ.registerHandler(this);
     }
     //endregion Constructors
 

--- a/MekHQ/src/mekhq/gui/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/PersonnelTab.java
@@ -118,9 +118,7 @@ public final class PersonnelTab extends CampaignGuiTab {
     // region Constructors
     public PersonnelTab(CampaignGUI gui, String name) {
         super(gui, name);
-        MekHQ.registerHandler(this);
         setUserPreferences();
-        GUIPreferences.getInstance().addPreferenceChangeListener(scalingChangeListener);
     }
     // endregion Constructors
 
@@ -361,8 +359,14 @@ public final class PersonnelTab extends CampaignGuiTab {
     }
 
     @Override
-    public void disposeTab() {
-        super.disposeTab();
+    public void activateTab() {
+        super.activateTab();
+        GUIPreferences.getInstance().addPreferenceChangeListener(scalingChangeListener);
+    }
+
+    @Override
+    public void deactivateTab() {
+        super.deactivateTab();
         GUIPreferences.getInstance().removePreferenceChangeListener(scalingChangeListener);
     }
 

--- a/MekHQ/src/mekhq/gui/RepairTab.java
+++ b/MekHQ/src/mekhq/gui/RepairTab.java
@@ -145,7 +145,6 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
     // region Constructors
     public RepairTab(CampaignGUI gui, String name) {
         super(gui, name);
-        MekHQ.registerHandler(this);
         setUserPreferences();
     }
     // endregion Constructors
@@ -459,15 +458,12 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
 
         btnOvertime = new RoundedMMToggleButton(resourceMap.getString("btnOvertime.text"));
         btnOvertime.setToolTipText(resourceMap.getString("btnOvertime.toolTipText"));
-        btnOvertime.setSelected(getCampaign().isOvertimeAllowed());
         btnOvertime.addActionListener(evt -> {
             getCampaign().setOvertime(btnOvertime.isSelected());
             refreshAsTechPool();
             WarehouseTab warehouseTab = getCampaignGui().getWarehouseTab();
-            if (warehouseTab != null) {
-                warehouseTab.refreshAsTechPool();
-                warehouseTab.refreshOvertimeStatus();
-            }
+            warehouseTab.refreshAsTechPool();
+            warehouseTab.refreshOvertimeStatus();
         });
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;

--- a/MekHQ/src/mekhq/gui/StratConTab.java
+++ b/MekHQ/src/mekhq/gui/StratConTab.java
@@ -167,8 +167,6 @@ public class StratConTab extends CampaignGuiTab {
         infoScrollPane.setMaximumSize(new Dimension(UIUtil.scaleForGUI(UIUtil.scaleForGUI(600),
               infoScrollPane.getHeight())));
         this.add(infoScrollPane, BorderLayout.EAST);
-
-        MekHQ.registerHandler(this);
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/TOETab.java
+++ b/MekHQ/src/mekhq/gui/TOETab.java
@@ -95,7 +95,6 @@ public final class TOETab extends CampaignGuiTab {
     //region Constructors
     public TOETab(CampaignGUI gui, String name) {
         super(gui, name);
-        MekHQ.registerHandler(this);
     }
     //endregion Constructors
 
@@ -221,9 +220,9 @@ public final class TOETab extends CampaignGuiTab {
      * @since 0.50.10
      */
     private void deployToStratCon(Scenario selectedScenario) {
-        if (getCampaignGui().getTab(MHQTabType.STRAT_CON) instanceof StratConTab stratConTab) {
-            MaplessStratCon.deployWithoutMap(stratConTab.getStratconPanel(), getCampaign(), selectedScenario);
-        }
+        getCampaignGui().getStratConTab().ifPresent(
+              tab -> MaplessStratCon.deployWithoutMap(tab.getStratconPanel(),
+                    getCampaign(), selectedScenario));
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/WarehouseTab.java
+++ b/MekHQ/src/mekhq/gui/WarehouseTab.java
@@ -164,7 +164,6 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
     // region Constructors
     public WarehouseTab(CampaignGUI gui, String name) {
         super(gui, name);
-        MekHQ.registerHandler(this);
         setUserPreferences();
     }
     // endregion Constructors
@@ -441,15 +440,12 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
 
         btnOvertime = new RoundedMMToggleButton(resourceMap.getString("btnOvertime.text"));
         btnOvertime.setToolTipText(resourceMap.getString("btnOvertime.toolTipText"));
-        btnOvertime.setSelected(getCampaign().isOvertimeAllowed());
         btnOvertime.addActionListener(evt -> {
             getCampaign().setOvertime(btnOvertime.isSelected());
             refreshAsTechPool();
             RepairTab repairBayTab = getCampaignGui().getRepairBayTab();
-            if (repairBayTab != null) {
-                repairBayTab.refreshOvertimeStatus();
-                repairBayTab.refreshAsTechPool();
-            }
+            repairBayTab.refreshOvertimeStatus();
+            repairBayTab.refreshAsTechPool();
         });
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;

--- a/MekHQ/src/mekhq/gui/adapter/ScenarioTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/ScenarioTableMouseAdapter.java
@@ -86,12 +86,12 @@ public class ScenarioTableMouseAdapter extends JPopupMenuAdapter {
         JMenu menu;
 
         // let's fill the pop-up menu
-        if (gui.getTab(MHQTabType.STRAT_CON) instanceof StratConTab stratConTab
-                  && scenario instanceof AtBDynamicScenario) {
+        if (gui.getStratConTab().isPresent() && scenario instanceof AtBDynamicScenario) {
             menuItem = new JMenuItem("Deploy...");
-            menuItem.addActionListener(evt -> MaplessStratCon.deployWithoutMap(stratConTab.getStratconPanel(),
-                  gui.getCampaign(),
-                  scenario));
+            menuItem.addActionListener(
+                  event -> gui.getStratConTab().ifPresent(
+                        tab -> MaplessStratCon.deployWithoutMap(tab.getStratconPanel(), gui.getCampaign(), scenario))
+            );
             popup.add(menuItem);
         }
 

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -546,8 +546,8 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
                 }
             }
         } else if (command.equals(COMMAND_CUSTOMIZE)) { // Single Unit only
-            ((MekLabTab) gui.getTab(MHQTabType.MEK_LAB)).loadUnit(selectedUnit);
-            gui.getTabMain().setSelectedIndex(gui.getTabMain().getTabCount() - 1);
+            gui.getMekLabTab().loadUnit(selectedUnit);
+            gui.setSelectedTab(gui.getMekLabTab());
         } else if (command.equals(COMMAND_CANCEL_CUSTOMIZE)) {
             Stream.of(units).filter(Unit::isRefitting).forEach(unit -> unit.getRefit().cancel());
         } else if (command.equals(COMMAND_REFIT_GM_COMPLETE)) {
@@ -1142,7 +1142,7 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
                     menu.add(menuItem);
                 }
 
-                if (oneSelected && gui.hasTab(MHQTabType.MEK_LAB)) {
+                if (oneSelected) {
                     menuItem = new JMenuItem("Customize in Mek Lab...");
                     menuItem.setActionCommand(COMMAND_CUSTOMIZE);
                     menuItem.addActionListener(this);

--- a/MekHQ/src/mekhq/gui/dialog/AcquisitionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AcquisitionsDialog.java
@@ -155,9 +155,7 @@ public class AcquisitionsDialog extends JDialog {
 
             btnSummary.firePropertyChange("missingCount", -1, PartsAcquisitionService.getMissingCount());
 
-            if (campaignGUI.getTab(MHQTabType.REPAIR_BAY) != null) {
-                ((RepairTab) campaignGUI.getTab(MHQTabType.REPAIR_BAY)).refreshPartsAcquisitionService(false);
-            }
+            campaignGUI.getRepairBayTab().refreshPartsAcquisitionService(false);
         });
 
         GridBagConstraints gbc = new GridBagConstraints();

--- a/MekHQ/src/mekhq/gui/enums/MHQTabType.java
+++ b/MekHQ/src/mekhq/gui/enums/MHQTabType.java
@@ -132,23 +132,6 @@ public enum MHQTabType {
     }
     //endregion Boolean Comparison Methods
 
-    public @Nullable CampaignGuiTab createTab(final CampaignGUI gui) {
-        return switch (this) {
-            case COMMAND_CENTER -> new CommandCenterTab(gui, toString());
-            case TOE -> new TOETab(gui, toString());
-            case BRIEFING_ROOM -> new BriefingTab(gui, toString());
-            case INTERSTELLAR_MAP -> new MapTab(gui, toString());
-            case PERSONNEL -> new PersonnelTab(gui, toString());
-            case HANGAR -> new HangarTab(gui, toString());
-            case WAREHOUSE -> new WarehouseTab(gui, toString());
-            case REPAIR_BAY -> new RepairTab(gui, toString());
-            case INFIRMARY -> new InfirmaryTab(gui, toString());
-            case FINANCES -> new FinancesTab(gui, toString());
-            case MEK_LAB -> new MekLabTab(gui, toString());
-            case STRAT_CON -> new StratConTab(gui, toString());
-        };
-    }
-
     @Override
     public String toString() {
         return name;

--- a/MekHQ/src/mekhq/gui/menus/MekHQMenuBar.java
+++ b/MekHQ/src/mekhq/gui/menus/MekHQMenuBar.java
@@ -229,7 +229,7 @@ public class MekHQMenuBar extends JMenuBar {
             // Unregister event handlers for CampaignGUI and tabs
             for (int i = 0; i < getTabMain().getTabCount(); i++) {
                 if (getTabMain().getComponentAt(i) instanceof CampaignGuiTab) {
-                    ((CampaignGuiTab) getTabMain().getComponentAt(i)).disposeTab();
+                    ((CampaignGuiTab) getTabMain().getComponentAt(i)).deactivateTab();
                 }
             }
             MekHQ.unregisterHandler(this);
@@ -1022,9 +1022,6 @@ public class MekHQMenuBar extends JMenuBar {
      * Exports Personnel to a CSV file.
      */
     private void exportPersonnel() {
-        if (getGui().getPersonnelTab() == null) {
-            return;
-        }
         JTable table = getGui().getPersonnelTab().getPersonnelTable();
         if (table.getRowCount() == 0) {
             JOptionPane.showMessageDialog(getFrame(), resourceMap.getString("dlgNoPersonnel.text"));
@@ -1039,9 +1036,6 @@ public class MekHQMenuBar extends JMenuBar {
      * Exports Units to a CSV file.
      */
     private void exportUnits() {
-        if (getGui().getHangarTab() == null) {
-            return;
-        }
         JTable table = getGui().getHangarTab().getUnitTable();
         if (table.getRowCount() == 0) {
             JOptionPane.showMessageDialog(getFrame(), resourceMap.getString("dlgNoUnits.text"));
@@ -1220,7 +1214,7 @@ public class MekHQMenuBar extends JMenuBar {
         for (int i = 0; i < getTabMain().getTabCount(); i++) {
             Component tab = getTabMain().getComponentAt(i);
             if (tab instanceof CampaignGuiTab) {
-                ((CampaignGuiTab) tab).disposeTab();
+                ((CampaignGuiTab) tab).deactivateTab();
             }
         }
 

--- a/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
@@ -64,6 +64,7 @@ import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Systems;
 import mekhq.campaign.universe.factionStanding.FactionStandingUtilities;
+import mekhq.gui.CampaignGUI;
 import mekhq.gui.enums.MHQTabType;
 
 /**
@@ -269,8 +270,9 @@ public class ContractSummaryPanel extends JPanel {
             @Override
             public void mouseClicked(MouseEvent e) {
                 // Display where it is on the interstellar map
-                campaign.getApp().getCampaigngui().getMapTab().switchSystemsMap(contract.getSystem());
-                campaign.getApp().getCampaigngui().setSelectedTab(MHQTabType.INTERSTELLAR_MAP);
+                CampaignGUI gui = campaign.getApp().getCampaigngui();
+                gui.getMapTab().switchSystemsMap(contract.getSystem());
+                gui.setSelectedTab(gui.getMapTab());
             }
         });
         gridBagConstraintsText.gridy = y;

--- a/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
@@ -212,7 +212,7 @@ public class MissionViewPanel extends JScrollablePanel {
                 public void mouseClicked(MouseEvent e) {
                     // Display where it is on the interstellar map
                     gui.getMapTab().switchSystemsMap(mission.getSystem());
-                    gui.setSelectedTab(MHQTabType.INTERSTELLAR_MAP);
+                    gui.setSelectedTab(gui.getMapTab());
                 }
             });
             gridBagConstraints = new GridBagConstraints();
@@ -307,7 +307,7 @@ public class MissionViewPanel extends JScrollablePanel {
                 public void mouseClicked(MouseEvent e) {
                     // Display where it is on the interstellar map
                     gui.getMapTab().switchSystemsMap(contract.getSystem());
-                    gui.setSelectedTab(MHQTabType.INTERSTELLAR_MAP);
+                    gui.setSelectedTab(gui.getMapTab());
                 }
             });
             gridBagConstraints = new GridBagConstraints();
@@ -638,7 +638,7 @@ public class MissionViewPanel extends JScrollablePanel {
             public void mouseClicked(MouseEvent e) {
                 // Display where it is on the interstellar map
                 gui.getMapTab().switchSystemsMap(contract.getSystem());
-                gui.setSelectedTab(MHQTabType.INTERSTELLAR_MAP);
+                gui.setSelectedTab(gui.getMapTab());
             }
         });
         gridBagConstraints = new GridBagConstraints();

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -1187,7 +1187,7 @@ public class PersonViewPanel extends JScrollablePanel {
                             // ...otherwise, dive on in to the system view!
                             gui.getMapTab().switchPlanetaryMap(person.getOriginPlanet());
                         }
-                        gui.setSelectedTab(MHQTabType.INTERSTELLAR_MAP);
+                        gui.setSelectedTab(gui.getMapTab());
                     }
                 });
             } else {

--- a/MekHQ/unittests/mekhq/gui/enums/MHQTabTypeTest.java
+++ b/MekHQ/unittests/mekhq/gui/enums/MHQTabTypeTest.java
@@ -199,61 +199,6 @@ public class MHQTabTypeTest {
     }
     //endregion Boolean Comparison Methods
 
-    /**
-     * This test is disabled because it will run through all the GUI tabs and initialize them, which is not a quick
-     * process. This also requires lots more mock handling to actually go through the initializations too.
-     */
-    @Disabled
-    @Test
-    public void testCreateTab() {
-        final MekHQ mockMekHQ = mock(MekHQ.class);
-        final CampaignGUI gui = new CampaignGUI(mockMekHQ);
-        for (final MHQTabType mhqTabType : types) {
-            final CampaignGuiTab tab = mhqTabType.createTab(gui);
-            switch (mhqTabType) {
-                case COMMAND_CENTER:
-                    assertInstanceOf(CommandCenterTab.class, tab);
-                    break;
-                case TOE:
-                    assertInstanceOf(TOETab.class, tab);
-                    break;
-                case BRIEFING_ROOM:
-                    assertInstanceOf(BriefingTab.class, tab);
-                    break;
-                case INTERSTELLAR_MAP:
-                    assertInstanceOf(MapTab.class, tab);
-                    break;
-                case PERSONNEL:
-                    assertInstanceOf(PersonnelTab.class, tab);
-                    break;
-                case HANGAR:
-                    assertInstanceOf(HangarTab.class, tab);
-                    break;
-                case WAREHOUSE:
-                    assertInstanceOf(WarehouseTab.class, tab);
-                    break;
-                case REPAIR_BAY:
-                    assertInstanceOf(RepairTab.class, tab);
-                    break;
-                case INFIRMARY:
-                    assertInstanceOf(InfirmaryTab.class, tab);
-                    break;
-                case FINANCES:
-                    assertInstanceOf(FinancesTab.class, tab);
-                    break;
-                case MEK_LAB:
-                    assertInstanceOf(MekLabTab.class, tab);
-                    break;
-                case STRAT_CON:
-                    assertInstanceOf(StratConTab.class, tab);
-                    break;
-                default:
-                    assertNull(tab);
-                    break;
-            }
-        }
-    }
-
     @Test
     public void testToStringOverride() {
         assertEquals(resources.getString("MHQTabType.COMMAND_CENTER.text"), MHQTabType.COMMAND_CENTER.toString());


### PR DESCRIPTION
- Replace `EnumMap` tab storage in `CampaignGUI` with explicit final fields and dedicated getter methods for each tab type
- Change `getXyzTab` signatures to reflect their conditionality
- Introduce `activateTab` and `deactivateTab` lifecycle methods for `CampaignGuiTab` to better manage tab state
- Remove manual event bus registration from individual tab constructors and centralized it in the new `activateTab` method
- Update all views, dialogs, adapters, and menus to use the new type-safe getters instead of generic `getTab` calls and casting
- Move GUI preference listener registrations for `HangarTab` and `PersonnelTab` into the new `activateTab` and `deactivateTab` methods
- Change `setSelectedTab` across multiple view panels to take the specific tab object rather than the tab enum type