### PR TITLE
Added Faction Standing Annual Decay Notice to Try and Reduce Player Confusion

### DIFF
--- a/MekHQ/resources/mekhq/resources/FactionStandings.properties
+++ b/MekHQ/resources/mekhq/resources/FactionStandings.properties
@@ -173,3 +173,4 @@ factionStandings.change.completed=completed
 factionStandings.change.employer=employer
 factionStandings.change.enemy=enemy
 factionStandings.change.faction=faction
+factionStandings.change.decay=<b>Annual Faction Standing Decay</b>

--- a/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionStandings.java
+++ b/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionStandings.java
@@ -1186,6 +1186,13 @@ public class FactionStandings {
             }
         }
 
+        // We saw a lot of player confusion with players not realizing that annual regard decay was a thing. This
+        // notice was added to try and mitigate that.
+        if (!regardChangeReports.isEmpty()) {
+            String decayNotice = getTextAt(RESOURCE_BUNDLE, "factionStandings.change.decay");
+            regardChangeReports.addFirst(decayNotice);
+        }
+
         return regardChangeReports;
     }
 


### PR DESCRIPTION
I noticed many players are getting confused by the annual degradation of faction standing points (regard). I opted to include a little notice to clarify that this is annual decay in an attempt to mitigate this confusion.