### PR TITLE
Fix #8639: Fixed Faction Standing Incorrectly Reporting Positive Regard Gain as Negative When Regard is Already at Maximum Value

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionStandings.java
+++ b/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionStandings.java
@@ -1070,7 +1070,7 @@ public class FactionStandings {
 
         // Build final report
         String deltaDirection;
-        if (newRegard > originalRegard) {
+        if (newRegard >= originalRegard) {
             reportingColor = getPositiveColor();
             deltaDirection = getTextAt(RESOURCE_BUNDLE, "factionStandings.change.increased");
         } else {


### PR DESCRIPTION
Fix #8639

I do love a single-character fix!

If the player received Regard for a faction and their Regard is already maxed out they wouldn't see any improvement. This would cause the polarity of the report to incorrectly call it a loss. Now it doesn't

This was a visual bug only.