### PR TITLE
Optimized How Contract Difficulty is Calculated to Reduce Load Times on New Month.

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -2285,9 +2285,9 @@ public class AtBContract extends Contract {
                 // Removing this check will break things, see the other comments.
                 continue;
             }
-            // TODO implement getGBV(int index) in UnitTable to simplify this?
+
             // getMekSummary(int index) is NULL for salvage.
-            int genericBattleValue = unitTable.getMekSummary(i).loadEntity().getGenericBattleValue();
+            int genericBattleValue = unitTable.getMekSummary(i).getGenericBattleValue();
             int weight = unitTable.getEntryWeight(i); // NOT 0 for salvage
 
             totalBattleValue += battleValue * weight;


### PR DESCRIPTION
Currently, when calculating the difficulty of a contract we are forced to instantiate the entire entity object. This is an expensive process, especially when we're doing this for a _lot_ of units (as we are during difficulty estimations).

Now, thanks to https://github.com/MegaMek/megamek/pull/8309, we're going to store GBV in MekSummary. This can then be fetched by MekHQ, at will, without needing to instantiate the entire Entity class just for a single integer.

I've done numerous tests (even found an unrelated bug) and _on average_ when a campaign is transitioning from one month to the next I am seeing savings of around 23 seconds. The more contracts generated the higher the savings.