### PR TITLE
Fixed Null Protection in `getSpecialAbilities`

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/generator/SingleSpecialAbilityGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/generator/SingleSpecialAbilityGenerator.java
@@ -304,14 +304,21 @@ public class SingleSpecialAbilityGenerator extends AbstractSpecialAbilityGenerat
             IOption ability = i.nextElement();
             if (!ability.booleanValue()) {
                 SpecialAbility spa = SpecialAbility.getAbility(ability.getName());
+                if (spa == null) {
+                    LOGGER.error("Missing ability: {}", ability.getName());
+                    continue;
+                }
+
                 if (isVeterancyAward && spa.getOriginOnly()) {
                     continue;
                 }
 
-                if ((spa == null) || (spa.getWeight() <= 0)
-                          || (!spa.isEligible(person.isClanPersonnel(), person.getSkills(), person.getOptions()))) {
+                boolean isIneligible = !spa.isEligible(person.isClanPersonnel(), person.getSkills(),
+                      person.getOptions());
+                if (spa.getWeight() <= 0 || isIneligible) {
                     continue;
                 }
+
                 eligible.add(spa);
             }
         }


### PR DESCRIPTION
This PR is in response to MegaMek/megamek#8311 but does not directly fix the root cause of that PR.

The goal of this PR is to fix the underlying failure that led to MegaMek/megamek#8311, so that we don't have a broken Nightly, tonight. I can then, tomorrow, go through and find the root cause.