### PR TITLE
Refactor StratCon scouting logic to properly evaluate modifiers

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratCon/ScoutRecord.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/ScoutRecord.java
@@ -32,8 +32,30 @@
  */
 package mekhq.campaign.stratCon;
 
+import megamek.common.TargetRollModifier;
+import megamek.common.rolls.TargetRoll;
 import mekhq.campaign.personnel.Person;
 
-public record ScoutRecord(Person scout, String skillName, int scoutSkillLevel, double entityWeight,
-      int unitAtBSpeed, boolean hasEquipmentOrRelevantSPA) {
+import java.util.List;
+
+public record ScoutRecord(
+      Person scout,
+      TargetRoll targetNumber,
+      String bestScoutSkillName,
+      boolean scoutHasEagleEyes,
+      double unitWeight,
+      int unitSpeed,
+      boolean unitHasSensorEquipment
+) {
+
+    /**
+     * Returns the full list of {@link TargetRollModifier}s affecting scouting.
+     *
+     * @return a list of {@link TargetRollModifier} reflecting all bonuses scout has
+     */
+    public List<TargetRollModifier> getAllScoutRollModifiers() {
+        return StratConRulesManager.getAllScoutRollModifiers(unitWeight, unitSpeed,
+              scoutHasEagleEyes, unitHasSensorEquipment);
+    }
+
 }

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -66,6 +66,8 @@ import static mekhq.campaign.stratCon.StratConRulesManager.ReinforcementResultsT
 import static mekhq.campaign.stratCon.StratConRulesManager.ReinforcementResultsType.INTERCEPTED;
 import static mekhq.campaign.stratCon.StratConRulesManager.ReinforcementResultsType.SUCCESS;
 import static mekhq.campaign.stratCon.StratConScenarioFactory.convertSpecificUnitTypeToGeneral;
+import static mekhq.utilities.EntityUtilities.hasActiveProbe;
+import static mekhq.utilities.EntityUtilities.hasImprovedSensors;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
 import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
@@ -125,7 +127,6 @@ import mekhq.campaign.stratCon.StratConScenario.ScenarioState;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Planet;
 import mekhq.gui.dialog.nagDialogs.CombatChallengeNagDialog;
-import mekhq.utilities.EntityUtilities;
 import mekhq.utilities.ReportingUtilities;
 import org.apache.commons.math3.util.Pair;
 
@@ -1609,14 +1610,13 @@ public class StratConRulesManager {
         CampaignOptions campaignOptions = campaign.getCampaignOptions();
         Formation formation = campaign.getFormation(forceID);
         Hangar hangar = campaign.getAllHangar();
-        List<ScoutRecord> scouts = formation == null ? new ArrayList<>() : buildScoutMap(formation, hangar,
-              campaignOptions);
+        List<ScoutRecord> scouts = buildScoutMap(formation, hangar, campaignOptions);
 
         boolean useAdvancedScouting = campaignOptions.isUseAdvancedScouting();
         // Each scout may scan up to scanMultiplier hexes
         // Each scout may scan up to a radius of individualScanRange hexes
         for (ScoutRecord scoutData : scouts) {
-            int individualScanRange = useAdvancedScouting && scoutData.entityWeight() <= 35 ?
+            int individualScanRange = useAdvancedScouting && scoutData.unitWeight() <= 35 ?
                                             scanRangeIncrease + 1 :
                                             scanRangeIncrease;
             int remainingScans = useAdvancedScouting ? 1 : Integer.MAX_VALUE;
@@ -1629,12 +1629,6 @@ public class StratConRulesManager {
 
             scoutQueue.add(new Pair<>(coords, 0));
             scoutVisited.add(coords); // starting hex is already processed separately
-
-            TargetRollModifier weightModifier = getUnitWeightModifier(scoutData.entityWeight());
-            TargetRollModifier speedModifier = getUnitSpeedModifier(scoutData.unitAtBSpeed());
-            TargetRollModifier skillModifier = getScoutComplementarySPAModifier(scout);
-            TargetRollModifier sensorsModifier = new TargetRollModifier(
-                  scoutData.hasEquipmentOrRelevantSPA() ? -1 : 0, "Unit Sensors");
 
             while (!scoutQueue.isEmpty() && remainingScans > 0) {
                 Pair<StratConCoords, Integer> current = scoutQueue.poll();
@@ -1681,8 +1675,8 @@ public class StratConRulesManager {
                         skillCheck = new SkillCheckUtility(
                               getTextAt(RESOURCE_BUNDLE, "StratConRulesManager.scoutingSkillCheck"),
                               scout,
-                              scoutData.skillName(),
-                              List.of(weightModifier, speedModifier, sensorsModifier, skillModifier),
+                              scoutData.bestScoutSkillName(),
+                              scoutData.getAllScoutRollModifiers(),
                               0,
                               false,
                               false,
@@ -1743,7 +1737,7 @@ public class StratConRulesManager {
      * @author Illiani
      * @since 0.50.07
      */
-    private static TargetRollModifier getUnitWeightModifier(double unitWeight) {
+    static TargetRollModifier getUnitWeightModifier(double unitWeight) {
         int modifier = 6; // default for anything greater than 100t
 
         if (unitWeight <= 55) {
@@ -1777,7 +1771,7 @@ public class StratConRulesManager {
      * @author Illiani
      * @since 0.50.07
      */
-    private static TargetRollModifier getUnitSpeedModifier(int unitSpeed) {
+    static TargetRollModifier getUnitSpeedModifier(int unitSpeed) {
         int modifier;
         if (unitSpeed <= 3) {
             modifier = 1;
@@ -1791,9 +1785,23 @@ public class StratConRulesManager {
     }
 
     /**
+     * Generates a {@link TargetRollModifier} representing the effect of unit sensor equipment.
+     *
+     * @param unitHasSensorEquipment flag signifying presence of sensor equipment
+     *
+     * @return a {@link TargetRollModifier} reflecting bonuses from unit sensor equipment; will have a modifier
+     *       value of 0 if no qualifying equipment is present
+     */
+    static TargetRollModifier getUnitEquipmentModifier(boolean unitHasSensorEquipment) {
+        int modifier = unitHasSensorEquipment ? -1 : 0;
+        return new TargetRollModifier(modifier, "Unit Sensor Equipment Modifier");
+    }
+
+    /**
      * Generates a {@link TargetRollModifier} representing the effect of complementary SPAs skills for a given scout.
      *
-     * @param scout the {@link Person} whose scouting SPAs are being evaluated
+     * @param scoutHasEagleEyes      flag signifying if the scout has Eagle Eyes SPA
+     * @param unitHasSensorEquipment flag signifying presence of sensor equipment
      *
      * @return a {@link TargetRollModifier} reflecting bonuses from complementary scouting skills; will have a modifier
      *       value of 0 if no qualifying skills are present
@@ -1801,11 +1809,31 @@ public class StratConRulesManager {
      * @author Illiani
      * @since 0.50.10
      */
-    private static TargetRollModifier getScoutComplementarySPAModifier(Person scout) {
-        PersonnelOptions options = scout.getOptions();
-        int complementaryModifier = options.booleanOption(OptionsConstants.MISC_EAGLE_EYES) ? -1 : 0;
+    static TargetRollModifier getScoutComplementarySPAModifier(boolean scoutHasEagleEyes,
+          boolean unitHasSensorEquipment) {
+        // Eagle Eyes adds +1 to the effective scout skill but does not stack with sensor equipment
+        int modifier = (scoutHasEagleEyes && !unitHasSensorEquipment) ? -1 : 0;
+        return new TargetRollModifier(modifier, "Scout Complementary SPA Modifier");
+    }
 
-        return new TargetRollModifier(complementaryModifier, "Complementary SPA Modifier");
+    /**
+     * Returns the full list of {@link TargetRollModifier}s for a given scout.
+     *
+     * @param unitWeight             the unit's weight in tons
+     * @param unitSpeed              the unit's speed
+     * @param scoutHasEagleEyes      flag signifying if the scout has Eagle Eyes SPA
+     * @param unitHasSensorEquipment flag signifying presence of sensor equipment
+     *
+     * @return a list of {@link TargetRollModifier} reflecting all bonuses scout has
+     */
+    static List<TargetRollModifier> getAllScoutRollModifiers(double unitWeight, int unitSpeed,
+          boolean scoutHasEagleEyes, boolean unitHasSensorEquipment) {
+        TargetRollModifier weightModifier = getUnitWeightModifier(unitWeight);
+        TargetRollModifier speedModifier = getUnitSpeedModifier(unitSpeed);
+        TargetRollModifier sensorEquipmentModifier = getUnitEquipmentModifier(unitHasSensorEquipment);
+        TargetRollModifier scoutModifier =
+              getScoutComplementarySPAModifier(scoutHasEagleEyes, unitHasSensorEquipment);
+        return List.of(weightModifier, speedModifier, sensorEquipmentModifier, scoutModifier);
     }
 
     /**
@@ -1814,7 +1842,7 @@ public class StratConRulesManager {
      *
      * <p>For each unit retrieved from the {@code Force}, this method examines all crew members to determine which
      * has the highest scouting-related skill (as evaluated by
-     * {@link ScoutingSkills#getBestScoutingSkill(Person)}).</p>
+     * {@link ScoutingSkills#getBestScoutingSkill(Person)}) in combination with scouting roll modifiers</p>
      *
      * <p>The crew member with the highest skill level becomes the designated scout for that unit. The method also
      * determines whether each unit is a "light unit" based on its weight class.</p>
@@ -1832,7 +1860,11 @@ public class StratConRulesManager {
      * @author Illiani
      * @since 0.50.07
      */
-    private static List<ScoutRecord> buildScoutMap(Formation formation, Hangar hangar, CampaignOptions campaignOptions) {
+    static List<ScoutRecord> buildScoutMap(Formation formation, Hangar hangar, CampaignOptions campaignOptions) {
+        if (formation == null) {
+            return new ArrayList<>();
+        }
+
         List<ScoutRecord> scouts = new ArrayList<>();
         for (Unit unit : formation.getAllUnitsAsUnits(hangar, false)) {
             List<Person> unitCrew = unit.getCrew();
@@ -1841,70 +1873,69 @@ public class StratConRulesManager {
                 continue;
             }
 
+            // defaults
+            double unitWeight = 200.0;
+            int unitSpeed = 0;
             boolean hasSensorEquipment = false;
+
             Entity entity = unit.getEntity();
             if (entity != null) {
-                boolean hasImprovedSensors = EntityUtilities.hasImprovedSensors(entity);
-                boolean hasActiveProbe = EntityUtilities.hasActiveProbe(entity);
-                hasSensorEquipment = hasImprovedSensors || hasActiveProbe;
+                unitWeight = entity.getWeight();
+                unitSpeed = AtBDynamicScenarioFactory.calculateAtBSpeed(entity);
+                hasSensorEquipment = hasImprovedSensors(entity) || hasActiveProbe(entity);
 
                 if (unit.isOnlyCommandersMatter(campaignOptions)) {
                     Person commander = unit.getCommander();
                     if (commander == null) {
                         LOGGER.info("No commander for unit: {} {}", unit.getName(), unit.getId());
-                        continue;
+                        continue; // skip unit, because commander-only is enforced but no commander exists
                     }
                     unitCrew = Collections.singletonList(commander);
                 }
             }
 
             // Find the best scout in this unit, if any
-            Person bestScout = null;
-            String bestScoutSkillName = SkillType.S_SENSOR_OPERATIONS;
-            int bestScoutSkillLevel = -1;
+            ScoutRecord bestScout = null;
+            int bestScoutTargetNumber = Integer.MAX_VALUE;
             for (Person crewMember : unitCrew) {
-                if (bestScout == null) {
-                    bestScout = crewMember;
-                }
-
+                boolean hasEagleEyes = crewMember.getOptions().booleanOption(OptionsConstants.MISC_EAGLE_EYES);
                 String scoutSkillName = ScoutingSkills.getBestScoutingSkill(crewMember);
                 if (scoutSkillName == null) {
                     continue;
                 }
 
-                SkillModifierData skillModifierData = crewMember.getSkillModifierData();
+                // StratConRules manager passes useAgingEffects == false, so we use a deprecated method version for now
+                TargetRoll targetNumber = SkillCheckUtility.determineTargetNumber(crewMember,
+                      SkillType.getType(scoutSkillName), 0);
+                LOGGER.error("Target number: " + targetNumber.getValue());
+                List<TargetRollModifier> modifiers = getAllScoutRollModifiers(unitWeight,
+                      unitSpeed,
+                      hasEagleEyes,
+                      hasSensorEquipment);
 
-                Skill scoutSkill = crewMember.getSkill(scoutSkillName);
-                PersonnelOptions options = crewMember.getOptions();
-                int complementaryModifier = !hasSensorEquipment && // Doesn't stack with Sensor Equipment
-                                                  options.booleanOption(OptionsConstants.MISC_EAGLE_EYES) ?
-                                                  1 : 0;
+                modifiers.forEach(targetNumber::addModifier);
+                modifiers.forEach(m ->
+                    LOGGER.error("Modifier: " + m.value()));
 
-                int scoutSkillLevel = (scoutSkill == null) ? -1 : scoutSkill.getTotalSkillLevel(skillModifierData);
-                scoutSkillLevel += complementaryModifier;
-                if (scoutSkillLevel > bestScoutSkillLevel) {
-                    bestScout = crewMember;
-                    bestScoutSkillName = scoutSkillName;
-                    bestScoutSkillLevel = scoutSkillLevel;
+                if (bestScout == null || targetNumber.getValue() < bestScoutTargetNumber) {
+                    bestScout = new ScoutRecord(crewMember, targetNumber, scoutSkillName,
+                        hasEagleEyes, unitWeight, unitSpeed, hasSensorEquipment);
+                    bestScoutTargetNumber = targetNumber.getValue();
                 }
             }
 
-            double weight = 200.0;
-            if (entity != null) {
-                weight = entity.getWeight();
+            if (bestScout == null) {
+                continue;
             }
 
-            int unitSpeed = entity == null ? 0 : AtBDynamicScenarioFactory.calculateAtBSpeed(entity);
-
-            ScoutRecord scoutRecord = new ScoutRecord(bestScout, bestScoutSkillName, bestScoutSkillLevel, weight,
-                  unitSpeed, hasSensorEquipment);
-            LOGGER.info("Unit {} has best scout: {} with skill {} at level {} and is weight: {}t",
-                  unit.getId(), bestScout, bestScoutSkillName, bestScoutSkillLevel, weight);
-            scouts.add(scoutRecord);
+            LOGGER.info("Unit {} (weight: {}t, speed: {}) has best scout: {} with skill {} at TN {}",
+                  unit.getId(), unitWeight, unitSpeed, bestScout.scout(), bestScout.bestScoutSkillName(),
+                  bestScout.targetNumber().getValue());
+            scouts.add(bestScout);
         }
 
-        // Sort scouts by the skill level of their best scout skill, the highest first
-        scouts.sort(Comparator.comparingInt(ScoutRecord::scoutSkillLevel).reversed());
+        // Sort scouts by the target number of their best scout skill, the lowest first
+        scouts.sort(Comparator.comparingInt(a -> a.targetNumber().getValue()));
         return scouts;
     }
 

--- a/MekHQ/unittests/mekhq/campaign/stratCon/StratConRulesManagerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/stratCon/StratConRulesManagerTest.java
@@ -32,6 +32,7 @@
  */
 package mekhq.campaign.stratCon;
 
+import static mekhq.campaign.personnel.skills.SkillType.S_SENSOR_OPERATIONS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -43,22 +44,16 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Hashtable;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.Vector;
+import java.util.*;
 
+import megamek.common.TargetRollModifier;
 import megamek.common.options.OptionsConstants;
 import megamek.common.units.Entity;
 import megamek.common.units.UnitType;
@@ -70,19 +65,29 @@ import mekhq.campaign.force.CombatTeam;
 import mekhq.campaign.force.Formation;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.AtBDynamicScenario;
+import mekhq.campaign.mission.AtBDynamicScenarioFactory;
 import mekhq.campaign.mission.ScenarioForceTemplate;
 import mekhq.campaign.mission.ScenarioMapParameters.MapLocation;
 import mekhq.campaign.mission.ScenarioTemplate;
 import mekhq.campaign.mission.enums.CombatRole;
 import mekhq.campaign.mission.enums.ScenarioType;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.PersonnelOptions;
+import mekhq.campaign.personnel.skills.ScoutingSkills;
+import mekhq.campaign.personnel.skills.Skill;
+import mekhq.campaign.personnel.skills.SkillModifierData;
+import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.stratCon.StratConContractDefinition.StrategicObjectiveType;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Atmosphere;
 import mekhq.campaign.universe.Planet;
+import mekhq.utilities.EntityUtilities;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 /**
  * Tests for {@link StratConRulesManager}
@@ -161,9 +166,9 @@ class StratConRulesManagerTest {
         ScenarioTemplate template = mock(ScenarioTemplate.class);
         StratConFacility facility = new StratConFacility();
 
-        try (MockedStatic<StratConScenarioFactory> scenarioFactory = Mockito.mockStatic(StratConScenarioFactory.class);
-              MockedStatic<StratConFacilityFactory> facilityFactory = Mockito.mockStatic(StratConFacilityFactory.class);
-              MockedStatic<StratConRulesManager> rulesManager = Mockito.mockStatic(StratConRulesManager.class,
+        try (MockedStatic<StratConScenarioFactory> scenarioFactory = mockStatic(StratConScenarioFactory.class);
+              MockedStatic<StratConFacilityFactory> facilityFactory = mockStatic(StratConFacilityFactory.class);
+              MockedStatic<StratConRulesManager> rulesManager = mockStatic(StratConRulesManager.class,
                     CALLS_REAL_METHODS)) {
             scenarioFactory.when(() -> StratConScenarioFactory.getSpecificScenario("objective-template.xml"))
                   .thenReturn(template);
@@ -225,8 +230,8 @@ class StratConRulesManagerTest {
         facility.setOwner(ScenarioForceTemplate.ForceAlignment.Allied);
         track.addFacility(coords, facility);
 
-        try (MockedStatic<StratConScenarioFactory> scenarioFactory = Mockito.mockStatic(StratConScenarioFactory.class);
-              MockedStatic<StratConRulesManager> rulesManager = Mockito.mockStatic(StratConRulesManager.class,
+        try (MockedStatic<StratConScenarioFactory> scenarioFactory = mockStatic(StratConScenarioFactory.class);
+              MockedStatic<StratConRulesManager> rulesManager = mockStatic(StratConRulesManager.class,
                     CALLS_REAL_METHODS)) {
             scenarioFactory.when(() -> StratConScenarioFactory.getFacilityScenario(true)).thenReturn(null);
 
@@ -454,7 +459,7 @@ class StratConRulesManagerTest {
         Set<Integer> forceIDs = new LinkedHashSet<>(List.of(42));
 
         try (MockedStatic<StratConRulesManager> mockedManager =
-                   Mockito.mockStatic(StratConRulesManager.class, CALLS_REAL_METHODS)) {
+                   mockStatic(StratConRulesManager.class, CALLS_REAL_METHODS)) {
             // Mock setupScenario to return our controlled Official Challenge scenario
             mockedManager.when(() -> StratConRulesManager.setupScenario(
                   any(), any(), any(), any(), any(), any(), anyBoolean(), any()
@@ -496,7 +501,7 @@ class StratConRulesManagerTest {
         Set<Integer> forceIDs = new LinkedHashSet<>(List.of(42));
 
         try (MockedStatic<StratConRulesManager> mockedManager =
-                   Mockito.mockStatic(StratConRulesManager.class, CALLS_REAL_METHODS)) {
+                   mockStatic(StratConRulesManager.class, CALLS_REAL_METHODS)) {
             mockedManager.when(() -> StratConRulesManager.setupScenario(
                   any(), any(), any(), any(), any(), any(), anyBoolean(), any()
             )).thenReturn(mockScenario);
@@ -660,5 +665,252 @@ class StratConRulesManagerTest {
               (Campaign) mocks[2], MapLocation.AllGroundTerrain);
 
         assertFalse(result);
+    }
+
+    @Nested
+    class ScoutingRules {
+
+        @BeforeAll
+        static void beforeAll() {
+            SkillType.initializeTypes();
+        }
+
+        @ParameterizedTest
+        @CsvSource({ "20.0, 0", "55.0, 0", "55.1, 2", "75.0, 2", "75.1, 4", "100.0, 4", "100.1, 6", "150.0, 6" })
+        void testGetUnitWeightModifier(double weight, int expectedModifier) {
+            TargetRollModifier modifier = StratConRulesManager.getUnitWeightModifier(weight);
+            assertEquals(expectedModifier, modifier.value());
+            assertEquals("Unit Weight Modifier", modifier.description());
+        }
+
+        @ParameterizedTest
+        @CsvSource({ "0, 1", "3, 1", "4, 0", "7, 0", "8, -1", "15, -1" })
+        void testGetUnitSpeedModifier(int speed, int expectedModifier) {
+            TargetRollModifier modifier = StratConRulesManager.getUnitSpeedModifier(speed);
+            assertEquals(expectedModifier, modifier.value());
+            assertEquals("Unit Speed Modifier", modifier.description());
+        }
+
+        @ParameterizedTest
+        @CsvSource({ "true, -1", "false, 0" })
+        void testGetUnitEquipmentModifier(boolean hasSensorEquipment, int expectedModifier) {
+            TargetRollModifier modifier = StratConRulesManager.getUnitEquipmentModifier(hasSensorEquipment);
+            assertEquals(expectedModifier, modifier.value());
+            assertEquals("Unit Sensor Equipment Modifier", modifier.description());
+        }
+
+        @ParameterizedTest
+        @CsvSource({ "false, false, 0", "true, false, -1",  "false, true, 0",  "true, true, 0" })
+        void testGetScoutComplementarySPAModifier(boolean hasEagleEyes, boolean hasSensorEquipment,
+              int expectedModifier) {
+            TargetRollModifier modifier =
+                  StratConRulesManager.getScoutComplementarySPAModifier(hasEagleEyes, hasSensorEquipment);
+            assertEquals(expectedModifier, modifier.value());
+            assertEquals("Scout Complementary SPA Modifier", modifier.description());
+        }
+
+        @Test
+        void testGetAllScoutRollModifiers() {
+            // 60t (weight mod: 2), speed 8 (speed mod: -1)
+            // has sensor quipment (equip mod: -1), Eagle Eyes (SPA mod: 0 since it doesn't stack)
+            List<TargetRollModifier> modifiers = StratConRulesManager.getAllScoutRollModifiers(60, 8, true, true);
+
+            assertEquals(4, modifiers.size());
+            assertEquals(2, modifiers.get(0).value());  // weight
+            assertEquals(-1, modifiers.get(1).value()); // speed
+            assertEquals(-1, modifiers.get(2).value()); // equipment
+            assertEquals(0, modifiers.get(3).value());  // SPA
+        }
+
+        @Test
+        void testBuildScoutMap_NullFormation() {
+            List<ScoutRecord> scouts = StratConRulesManager.buildScoutMap(
+                  null, mock(Hangar.class), mock(CampaignOptions.class));
+            assertNotNull(scouts);
+            assertTrue(scouts.isEmpty());
+        }
+
+        @Test
+        void testBuildScoutMap_SingleCrewMember() {
+            Person person = mockPerson(4, true);
+            ScoutRecord bestScout = getBestScoutForUnit(List.of(person), 45, 5, true, false);
+
+            assertEquals(person, bestScout.scout());
+            assertEquals(S_SENSOR_OPERATIONS, bestScout.bestScoutSkillName());
+            assertEquals(3, bestScout.targetNumber().getValue());
+            assertEquals(45.0, bestScout.unitWeight());
+            assertEquals(5, bestScout.unitSpeed());
+            assertTrue(bestScout.scoutHasEagleEyes());
+            assertTrue(bestScout.unitHasSensorEquipment());
+        }
+
+        @Test
+        void testBuildScoutMap_Sorting_EqualTN() {
+            Person person1 = mockPerson(1, false);
+            Person person2 = mockPerson(1, false);
+            Person person3 = mockPerson(1, false);
+            ScoutRecord bestScout = getBestScoutForUnit(List.of(person1, person2, person3), 45, 5, false, false);
+            assertEquals(person1, bestScout.scout()); // choose first
+        }
+
+        @Test
+        void testBuildScoutMap_Sorting_DifferentTNs() {
+            Person person1 = mockPerson(3, false);
+            Person person2 = mockPerson(2, false);
+            Person person3 = mockPerson(1, false);
+            ScoutRecord bestScout = getBestScoutForUnit(List.of(person1, person2, person3), 45, 5, false, false);
+            assertEquals(person3, bestScout.scout()); // choose highest
+        }
+
+        @Test
+        void testBuildScoutMap_UnitSorting() {
+            Person person1 = mockPerson(3, false);
+            Person person2 = mockPerson(1, false);
+            Person person3 = mockPerson(2, false);
+            List<ScoutRecord> bestScouts = getBestScoutsForUnits(List.of(person1, person2, person3), false, false);
+            // sort according to TNs
+            assertEquals(3, bestScouts.size());
+            assertEquals(person2, bestScouts.get(0).scout());
+            assertEquals(person3, bestScouts.get(1).scout());
+            assertEquals(person1, bestScouts.get(2).scout());
+        }
+
+        @Test
+        void testBuildScoutMap_TN_NoEagleEyes() {
+            ScoutRecord bestScout = getBestScoutForUnit(List.of(mockPerson(4, false)), 45, 5, false, false);
+            assertEquals(4, bestScout.targetNumber().getValue());
+        }
+
+        @Test
+        void testBuildScoutMap_TN_EagleEyes() {
+            ScoutRecord bestScout = getBestScoutForUnit(List.of(mockPerson(4, true)), 45, 5, false, false);
+            assertEquals(3, bestScout.targetNumber().getValue());
+        }
+
+        @Test
+        void testBuildScoutMap_TN_EagleEyes_AP() {
+            ScoutRecord bestScout = getBestScoutForUnit(List.of(mockPerson(4, true)), 45, 5, false, true);
+            assertEquals(3, bestScout.targetNumber().getValue());
+        }
+
+        @Test
+        void testBuildScoutMap_TN_EagleEyes_IS() {
+            ScoutRecord bestScout = getBestScoutForUnit(List.of(mockPerson(4, true)), 45, 5, true, false);
+            assertEquals(3, bestScout.targetNumber().getValue());
+        }
+
+        @Test
+        void testBuildScoutMap_TN_EagleEyes_IS_AP() {
+            ScoutRecord bestScout = getBestScoutForUnit(List.of(mockPerson(4, true)), 45, 5, true, true);
+            assertEquals(3, bestScout.targetNumber().getValue());
+        }
+
+        @Test
+        void testBuildScoutMap_TN_UnitSpeed() {
+            ScoutRecord bestScout = getBestScoutForUnit(List.of(mockPerson(4, false)), 45, 9, false, false);
+            assertEquals(3, bestScout.targetNumber().getValue());
+        }
+
+        @Test
+        void testBuildScoutMap_EmptyCrewSkipsUnit() {
+            Formation formation = mock(Formation.class);
+            Hangar hangar = mock(Hangar.class);
+            Unit unit = mock(Unit.class);
+
+            when(formation.getAllUnitsAsUnits(hangar, false)).thenReturn(Collections.singletonList(unit));
+            when(unit.getCrew()).thenReturn(new ArrayList<>());
+
+            List<ScoutRecord> scouts = StratConRulesManager.buildScoutMap(
+                  formation, hangar, mock(CampaignOptions.class));
+            assertTrue(scouts.isEmpty());
+        }
+
+        private Person mockPerson(int sensorOperationsSkill, boolean hasEagleEye) {
+            Person person = mock(Person.class);
+            PersonnelOptions options = mock(PersonnelOptions.class);
+            Skill skill = mock(Skill.class);
+            SkillModifierData skillModData = mock(SkillModifierData.class);
+
+            when(person.hasSkill(S_SENSOR_OPERATIONS)).thenReturn(true);
+            when(person.getSkill(S_SENSOR_OPERATIONS)).thenReturn(skill);
+            when(person.getSkillModifierData()).thenReturn(skillModData);
+            when(person.getSkillModifierData(anyBoolean())).thenReturn(skillModData);
+            when(person.getSkillModifierData(
+                  anyBoolean(), anyBoolean(), any(LocalDate.class))).thenReturn(skillModData);
+            when(person.getSkillModifierData(
+                  anyBoolean(), anyBoolean(), any(LocalDate.class), anyBoolean())).thenReturn(skillModData);
+            when(skill.getFinalSkillValue(skillModData)).thenReturn(sensorOperationsSkill);
+            when(person.getOptions()).thenReturn(options);
+            when(options.booleanOption(OptionsConstants.MISC_EAGLE_EYES)).thenReturn(hasEagleEye);
+
+            return person;
+        }
+
+        /**
+         * Mocks a single unit with multiple crew members and gets the best scout
+         */
+        private ScoutRecord getBestScoutForUnit(List<Person> crew,
+              double unitWeight, int unitSpeed, boolean hasImprovedSensors, boolean hasActiveProbe) {
+            Formation formation = mock(Formation.class);
+            Hangar hangar = mock(Hangar.class);
+            Unit unit = mock(Unit.class);
+            Entity entity = mock(Entity.class);
+
+            when(formation.getAllUnitsAsUnits(hangar, false)).thenReturn(Collections.singletonList(unit));
+            when(unit.getCrew()).thenReturn(crew);
+            when(unit.getEntity()).thenReturn(entity);
+            when(entity.getWeight()).thenReturn(unitWeight);
+
+            try (MockedStatic<AtBDynamicScenarioFactory> scenarioFactory = mockStatic(AtBDynamicScenarioFactory.class);
+                  MockedStatic<EntityUtilities> entityUtils = mockStatic(EntityUtilities.class);
+                  MockedStatic<ScoutingSkills> scoutingSkills = mockStatic(ScoutingSkills.class)) {
+
+                scenarioFactory.when(() -> AtBDynamicScenarioFactory.calculateAtBSpeed(entity)).thenReturn(unitSpeed);
+                entityUtils.when(() -> EntityUtilities.hasImprovedSensors(entity)).thenReturn(hasImprovedSensors);
+                entityUtils.when(() -> EntityUtilities.hasActiveProbe(entity)).thenReturn(hasActiveProbe);
+                crew.forEach(crewMember -> scoutingSkills.when(() ->
+                                                                     ScoutingSkills.getBestScoutingSkill(crewMember))
+                                                 .thenReturn(S_SENSOR_OPERATIONS));
+
+                List<ScoutRecord> scouts =
+                      StratConRulesManager.buildScoutMap(formation, hangar, mock(CampaignOptions.class));
+                assertEquals(1, scouts.size());
+
+                return scouts.getFirst();
+            }
+        }
+
+        /**
+         * Mocks multiple units with a single crew member each and gets the best scouts
+         */
+        private List<ScoutRecord> getBestScoutsForUnits(List<Person> crews,
+              boolean hasImprovedSensors, boolean hasActiveProbe) {
+            Formation formation = mock(Formation.class);
+            Hangar hangar = mock(Hangar.class);
+
+            try (MockedStatic<AtBDynamicScenarioFactory> scenarioFactory = mockStatic(AtBDynamicScenarioFactory.class);
+                  MockedStatic<EntityUtilities> entityUtils = mockStatic(EntityUtilities.class);
+                  MockedStatic<ScoutingSkills> scoutingSkills = mockStatic(ScoutingSkills.class)) {
+
+                List<Unit> units = crews.stream().map(crew -> {
+                    Unit unit = mock(Unit.class);
+                    Entity entity = mock(Entity.class);
+                    when(unit.getCrew()).thenReturn(List.of(crew));
+                    when(unit.getEntity()).thenReturn(entity);
+                    when(entity.getWeight()).thenReturn(45.0);
+                    scenarioFactory.when(() -> AtBDynamicScenarioFactory.calculateAtBSpeed(entity)).thenReturn(5);
+                    entityUtils.when(() -> EntityUtilities.hasImprovedSensors(entity)).thenReturn(hasImprovedSensors);
+                    entityUtils.when(() -> EntityUtilities.hasActiveProbe(entity)).thenReturn(hasActiveProbe);
+                    scoutingSkills.when(() -> ScoutingSkills.getBestScoutingSkill(crew)).thenReturn(S_SENSOR_OPERATIONS);
+                    return unit;
+                }).toList();
+                when(formation.getAllUnitsAsUnits(hangar, false)).thenReturn(units);
+
+                List<ScoutRecord> scouts =
+                      StratConRulesManager.buildScoutMap(formation, hangar, mock(CampaignOptions.class));
+
+                return scouts;
+            }
+        }
     }
 }


### PR DESCRIPTION
StratCon scouting skill calculations are incorrectly stacking Eagle Eye SPA and unit sensor equipment bonuses. Rules for the Eagle Eyes SPA and unit sensor equipment were handled inconsistently, leading to fragmented logic where modifiers were applied in different places, leading to incorrect calculations for target rolls modifiers.

This PR overhauls the scout evaluation process to be outcome-driven rather than skill level-driven. Modifier calculations are extracted into centralized methods. Instead of comparing skill levels, the system now calculates the actual `TargetRoll` value for every eligible scout. The `ScoutRecord` is then built using the crew member who provides the highest effective skill level. Additionally, the stacking logic has only one implementation ensuring that it's applied consistently.

Exact Changes:
- Expand `ScoutRecord` fields to explicitly store unit and scout characteristics (scoutHasEagleEyes, unitWeight, unitSpeed, unitHasSensorEquipment), decoupling it from raw bonus lookups downstream
- Refactor the final modifier calculations into static methods in `StratConRulesManager` (adding `getUnitEquipmentModifier` and `getAllScoutRollModifiers`)
- Improve `buildScoutMap` to evaluate scouts based on their lowest total `TargetRollModifier` score, rather than their kill level
- Fix Eagle Eyes SPA stacking
- Add extensive test coverage for scout skill calculations