### PR TITLE
Unify `onlyCommanderMatters` option check logic

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -1607,13 +1607,10 @@ public class StratConRulesManager {
 
         // Build a map of scouts and their information
         CampaignOptions campaignOptions = campaign.getCampaignOptions();
-        boolean isCommandersOnlyVehicles = campaignOptions.isOnlyCommandersMatterVehicles();
-        boolean isCommandersOnlyInfantry = campaignOptions.isOnlyCommandersMatterInfantry();
-        boolean isCommandersOnlyBattleArmor = campaignOptions.isOnlyCommandersMatterBattleArmor();
         Formation formation = campaign.getFormation(forceID);
         Hangar hangar = campaign.getHangar();
         List<ScoutRecord> scouts = formation == null ? new ArrayList<>() : buildScoutMap(formation, hangar,
-              isCommandersOnlyVehicles, isCommandersOnlyInfantry, isCommandersOnlyBattleArmor);
+              campaignOptions);
 
         boolean useAdvancedScouting = campaignOptions.isUseAdvancedScouting();
         // Each scout may scan up to scanMultiplier hexes
@@ -1825,14 +1822,9 @@ public class StratConRulesManager {
      * <p>All such {@link ScoutRecord} entries are collected, sorted in descending order of scout skill level, and
      * returned as a list. Units with no crew are logged and skipped.</p>
      *
-     * @param formation                   the {@link Formation} containing units to evaluate
-     * @param hangar                      the {@link Hangar} used to help retrieve units from the force
-     * @param isCommandersOnlyVehicles    {@code true} to only use the skills possessed by the unit commander (if
-     *                                    vehicle)
-     * @param isCommandersOnlyInfantry    {@code true} to only use the skills possessed by the unit commander (if
-     *                                    conventional infantry)
-     * @param isCommandersOnlyBattleArmor {@code true} to only use the skills possessed by the unit commander (if battle
-     *                                    armor)
+     * @param formation       the {@link Formation} containing units to evaluate
+     * @param hangar          the {@link Hangar} used to help retrieve units from the force
+     * @param campaignOptions {@link CampaignOptions}, used to check useCommanderOnly options
      *
      * @return a list of {@link ScoutRecord} objects, each representing the best scout and their skill details for a
      *       unit, sorted from the highest to lowest scout skill level
@@ -1840,8 +1832,7 @@ public class StratConRulesManager {
      * @author Illiani
      * @since 0.50.07
      */
-    private static List<ScoutRecord> buildScoutMap(Formation formation, Hangar hangar, boolean isCommandersOnlyVehicles,
-          boolean isCommandersOnlyInfantry, boolean isCommandersOnlyBattleArmor) {
+    private static List<ScoutRecord> buildScoutMap(Formation formation, Hangar hangar, CampaignOptions campaignOptions) {
         List<ScoutRecord> scouts = new ArrayList<>();
         for (Unit unit : formation.getAllUnitsAsUnits(hangar, false)) {
             List<Person> unitCrew = unit.getCrew();
@@ -1857,16 +1848,7 @@ public class StratConRulesManager {
                 boolean hasActiveProbe = EntityUtilities.hasActiveProbe(entity);
                 hasSensorEquipment = hasImprovedSensors || hasActiveProbe;
 
-                boolean useCommanderOnly = false;
-                if (entity.isVehicle() && isCommandersOnlyVehicles) {
-                    useCommanderOnly = true;
-                } else if (entity.isConventionalInfantry() && isCommandersOnlyInfantry) {
-                    useCommanderOnly = true;
-                } else if (entity.isBattleArmor() && isCommandersOnlyBattleArmor) {
-                    useCommanderOnly = true;
-                }
-
-                if (useCommanderOnly) {
+                if (unit.isOnlyCommandersMatter(campaignOptions)) {
                     Person commander = unit.getCommander();
                     if (commander == null) {
                         LOGGER.info("No commander for unit: {} {}", unit.getName(), unit.getId());

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -4851,14 +4851,6 @@ public class Unit implements ITechnology {
 
     public void resetPilotAndEntity() {
         final CampaignOptions campaignOptions = getCampaign().getCampaignOptions();
-        boolean commanderOnlyVehicles = campaignOptions.isOnlyCommandersMatterVehicles() &&
-                                              (entity instanceof Tank || entity instanceof ConvFighter);
-        boolean commanderOnlyInfantry = campaignOptions.isOnlyCommandersMatterInfantry() &&
-                                              entity instanceof Infantry &&
-                                              !(entity instanceof BattleArmor);
-        boolean commanderOnlyBattleArmor = campaignOptions.isOnlyCommandersMatterBattleArmor() &&
-                                                 entity instanceof BattleArmor;
-        boolean isOnlyCommandersMatter = commanderOnlyVehicles || commanderOnlyInfantry || commanderOnlyBattleArmor;
 
         // Reset transient data
         getCampaign().clearGameData(entity);
@@ -4870,7 +4862,7 @@ public class Unit implements ITechnology {
         entity.setStartingPos(START_NONE);
 
         // Update crew data
-        updateCrew(isOnlyCommandersMatter);
+        updateCrew(isOnlyCommandersMatter(campaignOptions));
 
         // commander can be null at this point, but that's ok because both of the following calls include null
         // handling built into their methods.
@@ -4883,6 +4875,12 @@ public class Unit implements ITechnology {
         if (campaignOptions.isUseAbilities() || campaignOptions.isUseEdge() || campaignOptions.isUseImplants()) {
             processUnitSPAs(commander);
         }
+    }
+
+    public boolean isOnlyCommandersMatter(CampaignOptions campaignOptions) {
+        return (isVehicle() && campaignOptions.isOnlyCommandersMatterVehicles()) ||
+                     (isConventionalInfantry() && campaignOptions.isOnlyCommandersMatterInfantry()) ||
+                     (isBattleArmor() && campaignOptions.isOnlyCommandersMatterBattleArmor());
     }
 
     private void updateCrew(boolean isOnlyCommandersMatter) {
@@ -5026,19 +5024,12 @@ public class Unit implements ITechnology {
             }
         }
 
-        boolean commanderOnlyVehicles = campaignOptions.isOnlyCommandersMatterVehicles() &&
-                                              (entity instanceof Tank || entity instanceof ConvFighter);
-        boolean commanderOnlyInfantry = campaignOptions.isOnlyCommandersMatterInfantry() &&
-                                              entity instanceof Infantry &&
-                                              !(entity instanceof BattleArmor);
-        boolean commanderOnlyBattleArmor = campaignOptions.isOnlyCommandersMatterBattleArmor() &&
-                                                 entity instanceof BattleArmor;
-        boolean commanderOnly = commanderOnlyVehicles || commanderOnlyInfantry || commanderOnlyBattleArmor;
+        boolean onlyCommandersMatter = isOnlyCommandersMatter(campaignOptions);
 
         // For crew-served units, let's look at the abilities of the group. If more than half the crew (gunners
         // and pilots only, for spacecraft) have an ability, grant the benefit to the unit
         // TODO : Mobile structures, large naval support vehicles
-        if (!commanderOnly &&
+        if (!onlyCommandersMatter &&
                   (entity.hasETypeFlag(Entity.ETYPE_SMALL_CRAFT) ||
                          entity.hasETypeFlag(Entity.ETYPE_JUMPSHIP) ||
                          entity.hasETypeFlag(Entity.ETYPE_TANK) ||
@@ -5121,7 +5112,7 @@ public class Unit implements ITechnology {
             // Assign edge points to spacecraft and vehicle crews and infantry units. This overwrites the Edge value
             // assigned above (which will always be 0 in 0.50.10+).
             if (campaignOptions.isUseEdge()) {
-                setEdgeForCrew(crewSize, commanderOnly);
+                setEdgeForCrew(crewSize, onlyCommandersMatter);
             }
 
             // Reset the composite technician used by spacecraft and infantry
@@ -5160,7 +5151,7 @@ public class Unit implements ITechnology {
             // Assign edge points to spacecraft and vehicle crews and infantry units. This overwrites the Edge value
             // assigned above (which will always be 0 in 0.50.10+).
             if (campaignOptions.isUseEdge()) {
-                setEdgeForCrew(usesSoloPilot() ? 1 : getCrew().size(), commanderOnly);
+                setEdgeForCrew(usesSoloPilot() ? 1 : getCrew().size(), onlyCommandersMatter);
             }
         }
     }
@@ -7140,6 +7131,13 @@ public class Unit implements ITechnology {
      */
     public boolean isConventionalInfantry() {
         return (getEntity() != null) && getEntity().isConventionalInfantry();
+    }
+
+    /**
+     * @return true if the unit is vehicle, otherwise false
+     */
+    public boolean isVehicle() {
+        return (getEntity() != null) && getEntity().isVehicle();
     }
 
     /**

--- a/MekHQ/unittests/mekhq/campaign/unit/UnitCommandersMatterOptionTest.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/UnitCommandersMatterOptionTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package mekhq.campaign.unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+
+import megamek.common.battleArmor.BattleArmor;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.units.*;
+import mekhq.campaign.campaignOptions.CampaignOptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class UnitCommandersMatterOptionTest {
+
+    // not static because we want @BeforeAll to run first
+    private final List<Entity> allEntities = List.of(
+          new AeroSpaceFighter(), new BattleArmor(), new BipedMek(), new CombatVehicleEscapePod(), new ConvFighter(),
+          new ConvInfantry(), new Dropship(), new EjectedCrew(), new FighterSquadron(), new FixedWingSupport(),
+          new Jumpship(), new LandAirMek(0, 0, 0), new LargeSupportTank(), new MekWarrior(), new ProtoMek(),
+          new QuadMek(), new QuadVee(), new SmallCraft(), new SpaceStation(), new SuperHeavyTank(), new Tank(),
+          new TripodMek(), new VTOL(), new Warship()
+    );
+
+    @BeforeAll
+    static void beforeAll() {
+        EquipmentType.initializeTypes();
+    }
+
+    private void runTest(CampaignOptions options, Set<Class<? extends Entity>> expectedTrueClasses) {
+        for (Entity entity : allEntities) {
+            boolean expected = expectedTrueClasses.contains(entity.getClass());
+            assertEquals(expected,
+                  new Unit(entity, null).isOnlyCommandersMatter(options),
+                  String.format("Unexpected isOnlyCommandersMatter for %s", entity.getClass().getSimpleName())
+            );
+        }
+    }
+
+    @Test
+    public void testIsOnlyCommandersMatter_Vehicles() {
+        CampaignOptions options = mock(CampaignOptions.class);
+        when(options.isOnlyCommandersMatterVehicles()).thenReturn(true);
+        Set<Class<? extends Entity>> expectedTrue = Set.of(
+              LargeSupportTank.class, SuperHeavyTank.class, Tank.class, VTOL.class);
+        runTest(options, expectedTrue);
+    }
+
+    @Test
+    public void testIsOnlyCommandersMatter_Infantry() {
+        CampaignOptions options = mock(CampaignOptions.class);
+        when(options.isOnlyCommandersMatterInfantry()).thenReturn(true);
+        Set<Class<? extends Entity>> expectedTrue = Set.of(ConvInfantry.class, EjectedCrew.class, MekWarrior.class);
+        runTest(options, expectedTrue);
+    }
+
+    @Test
+    public void testIsOnlyCommandersMatter_BA() {
+        CampaignOptions options = mock(CampaignOptions.class);
+        when(options.isOnlyCommandersMatterBattleArmor()).thenReturn(true);
+        Set<Class<? extends Entity>> expectedTrue = Set.of(BattleArmor.class);
+        runTest(options, expectedTrue);
+    }
+}


### PR DESCRIPTION
Previously `Unit` and `StratConRulesManager` had slightly different implementations for such option checks. This change makes sure that we apply rules consistently.

Effectively it means that the settings will stop working for `ConvFighter` and `FixedWingSuppor` when the vehicle setting is on and for `CombatVehicleEscapePod` when the infantry setting is on.