### PR TITLE
Fixed Null Protection Reporting False-Positive Events

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/generator/SingleSpecialAbilityGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/generator/SingleSpecialAbilityGenerator.java
@@ -305,7 +305,8 @@ public class SingleSpecialAbilityGenerator extends AbstractSpecialAbilityGenerat
             if (!ability.booleanValue()) {
                 SpecialAbility spa = SpecialAbility.getAbility(ability.getName());
                 if (spa == null) {
-                    LOGGER.error("Missing ability: {}", ability.getName());
+                    // Generally we hit this null protection if the ability exists, but is not enabled in the
+                    // player's campaign. No need to spam up the log reporting on this, it's working as intended.
                     continue;
                 }
 


### PR DESCRIPTION
My earlier fix to a faulty `null` guard was a little too paranoid miss-reporting missing SPA data, when this is in fact working as intended. The bug was the faulty guard and not an issue with how we were handling data.