### PR TITLE
Fixed Inverted Polarity in Veterancy Award Eligibility

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/PersonUtility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonUtility.java
@@ -215,9 +215,9 @@ public class PersonUtility {
         boolean excludeInjuryEffects = true;
         int experienceLevel = person.getExperienceLevel(campaign, useSecondaryProfession, excludeInjuryEffects);
 
-        boolean isEligibleForVeterancyAward = experienceLevel < EXP_VETERAN;
+        boolean isIneligibleForVeterancyAward = experienceLevel >= EXP_VETERAN;
 
-        person.setHasGainedVeterancySPA(isEligibleForVeterancyAward);
+        person.setHasGainedVeterancySPA(isIneligibleForVeterancyAward);
     }
 
     /**


### PR DESCRIPTION
This conditional was incorrectly flagging characters as ineligible to receive Veterancy Awards. Now it isn't.

Marking this as critical, not because it's game breaking, but because if we don't fix this before release we will never hear the end of it :D