### PR TITLE
Close #9251: Increased Size of 'Current Location' Rings in Interstellar Tab

### DIFF
--- a/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
+++ b/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
@@ -766,16 +766,16 @@ public class InterstellarMapPanel extends JPanel {
                         if (system.equals(InterstellarMapPanel.this.campaign.getCurrentSystem())) {
                             // let's try rings
                             g2.setPaint(Color.ORANGE);
-                            arc.setArcByCenter(x, y, size * 1.8, 0, 360, Arc2D.OPEN);
+                            arc.setArcByCenter(x, y, size * 3.4, 0, 360, Arc2D.OPEN);
                             g2.fill(arc);
                             g2.setPaint(Color.BLACK);
-                            arc.setArcByCenter(x, y, size * 1.6, 0, 360, Arc2D.OPEN);
+                            arc.setArcByCenter(x, y, size * 2.9, 0, 360, Arc2D.OPEN);
                             g2.fill(arc);
                             g2.setPaint(Color.ORANGE);
-                            arc.setArcByCenter(x, y, size * 1.4, 0, 360, Arc2D.OPEN);
+                            arc.setArcByCenter(x, y, size * 2.4, 0, 360, Arc2D.OPEN);
                             g2.fill(arc);
                             g2.setPaint(Color.BLACK);
-                            arc.setArcByCenter(x, y, size * 1.2, 0, 360, Arc2D.OPEN);
+                            arc.setArcByCenter(x, y, size * 1.9, 0, 360, Arc2D.OPEN);
                             g2.fill(arc);
                         }
                         if ((null != selectedSystem) && selectedSystem.equals(system)) {
@@ -1366,8 +1366,8 @@ public class InterstellarMapPanel extends JPanel {
      */
 
     /**
-    * Opens the GM-only planetary system editor pre-selected on the given system. Refreshes and repaints the map after
-    * the dialog closes so saved planetary overrides are drawn from the campaign overlay.
+     * Opens the GM-only planetary system editor pre-selected on the given system. Refreshes and repaints the map after
+     * the dialog closes so saved planetary overrides are drawn from the campaign overlay.
      */
     private void openPlanetarySystemEditor(PlanetarySystem system) {
         if ((system == null) || !campaign.isGM()) {


### PR DESCRIPTION
Close #9251

This would be a good addition to 51.0, if we can wing it.

# Before
<img width="537" height="328" alt="image" src="https://github.com/user-attachments/assets/90f99385-b219-4b67-abfc-bbea6b56b73b" />


# After
<img width="636" height="402" alt="image" src="https://github.com/user-attachments/assets/d787ed88-076d-451f-9c1e-996002262ef6" />
