### PR TITLE
Show a message when a part is damaged beyond repair

### DIFF
--- a/MekHQ/resources/mekhq/resources/Parts.properties
+++ b/MekHQ/resources/mekhq/resources/Parts.properties
@@ -1,4 +1,4 @@
-# Copyright (C) 2005-2025 The MegaMek Team. All Rights Reserved.
+# Copyright (C) 2005-2026 The MegaMek Team. All Rights Reserved.
 #
 # This file is part of MekHQ.
 #
@@ -51,3 +51,4 @@ PartRepairType.POD_SPACE.text=Pod
 PartRepairType.UNKNOWN_LOCATION.text=Error: Unknown Repair Type
 # Modifier descriptions
 Part.modifier.obsolete=obsolete
+Part.damaged.beyond.repair=Damaged beyond repair

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -34,6 +34,7 @@
 package mekhq.campaign.parts;
 
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.MHQInternationalization.getText;
 
 import java.io.PrintWriter;
 import java.text.DecimalFormat;
@@ -472,10 +473,10 @@ public abstract class Part implements IPartWork, ITechnology {
             }
             String inStockText = inStock == 0 ?
                                        ReportingUtilities.messageSurroundedBySpanWithColor(MekHQ.getMHQOptions()
-                                                                                                 .getFontColorNegativeHexColor(),
+                                                                                           .getFontColorNegativeHexColor(),
                                              "None in stock") :
                                        ReportingUtilities.messageSurroundedBySpanWithColor(MekHQ.getMHQOptions()
-                                                                                                 .getFontColorPositiveHexColor(),
+                                                                                           .getFontColorPositiveHexColor(),
                                              inStock + " in stock");
 
             toReturn.append("<br>").append(inStockText).append("<br>");
@@ -493,6 +494,10 @@ public abstract class Part implements IPartWork, ITechnology {
             if (getMode() != WorkTime.NORMAL) {
                 toReturn.append(" <i>").append(getCurrentModeName()).append("</i>");
             }
+        } else {
+            toReturn.append(ReportingUtilities.messageSurroundedBySpanWithColor(
+                  MekHQ.getMHQOptions().getFontColorNegativeHexColor(),
+                  getText("Part.damaged.beyond.repair")));
         }
         toReturn.append("</html>");
         return toReturn.toString();
@@ -1495,8 +1500,8 @@ public abstract class Part implements IPartWork, ITechnology {
     }
 
     /**
-     * Returns the base quantity of this part for Parts In Use reporting, without checking whether the part
-     * is reserved or in use.
+     * Returns the base quantity of this part for Parts In Use reporting, without checking whether the part is reserved
+     * or in use.
      *
      * <p>Returns {@code 1} if the part is assigned to a unit, or the part's stored quantity otherwise.</p>
      *


### PR DESCRIPTION
As seen in #8871 when a part is no longer repairable, the list of Techs is empty, but there is no indication why.

This PR fixes this by showing a 'Damaged beyond repair' message for the part.

<img width="1258" height="312" alt="Damaged" src="https://github.com/user-attachments/assets/28dee070-5425-4314-9ad7-77e22eff3295" />

Closes #8871 
(Probably) Closes #7359