### PR TITLE
Fixed Disease & BioWeapon Attack Warning from Triggering Every Day While On Approach to Planet; Fixed Dialog Incorrectly Using Wrong Values in Text

### DIFF
--- a/MekHQ/resources/mekhq/resources/CurrentLocation.properties
+++ b/MekHQ/resources/mekhq/resources/CurrentLocation.properties
@@ -28,7 +28,6 @@
 # Microsoft's "Game Content Usage Rules"
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
-
 # Arrived Early Dialog
 # suppress inspection "UnusedProperty"
 contract.arrivedEarly.ic.0={0}, we''ve completed atmospheric insertion and offloading without incident. All transports\
@@ -109,15 +108,14 @@ bioweaponAttack.outOfCharacter={0} is currently affected by {1}. This is a canon
   bioweapons vary, some are debilitating, others are deadly.\
   <p>If you make planetfall, your personnel <b>will</b> be exposed. Infection is not immediate, but it is unavoidable \
   over time. Withdrawal from the system remains the only reliable means of avoiding contamination.</p>
-diseaseOutbreak.inCharacter=Medical surveillance confirms that this system is currently experiencing an active \
-  disease outbreak.\
-  <p>{0} is currently affected by {1}. This is a canonical event. The effects of diseases vary, some are debilitating,\
+diseaseOutbreak.inCharacter={0}, medical surveillance confirms that this system is currently experiencing \
+  an active disease outbreak.
+diseaseOutbreak.outOfCharacter={0} is currently affected by {1}. This is a canonical event. The effects of diseases vary, some are debilitating,\
   \ others are deadly.\
   <p>If you make planetfall, your personnel <b>will</b> be exposed. Infection is not immediate, but it is unavoidable \
   over time. Withdrawal from the system remains the only reliable means of avoiding contamination.</p>
 disease.outOfCharacter.vaccineStatus.none=<p><b>Currently, no cure is available for this pathogen.</b></p>
 disease.outOfCharacter.vaccineStatus.available=<p><b>A vaccine will be available if you land.</b></p>
-
 # Current Location Panel UI
 title.onPlanet=On {0}
 title.chargingImpossible=In {0}, {1}

--- a/MekHQ/src/mekhq/campaign/AbstractLocation.java
+++ b/MekHQ/src/mekhq/campaign/AbstractLocation.java
@@ -33,7 +33,6 @@
 
 package mekhq.campaign;
 
-import static java.lang.Math.ceil;
 import static megamek.common.compute.Compute.randomInt;
 import static mekhq.campaign.Campaign.AdministratorSpecialization.TRANSPORT;
 import static mekhq.campaign.enums.DailyReportType.GENERAL;
@@ -48,7 +47,6 @@ import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import java.io.PrintWriter;
 import java.time.LocalDate;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 
@@ -59,11 +57,9 @@ import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import megamek.common.annotations.Nullable;
 import megamek.logging.MMLogger;
 import mekhq.campaign.campaignOptions.CampaignOptions;
-import mekhq.campaign.finances.Money;
 import mekhq.campaign.location.ILocation;
 import mekhq.campaign.location.LocationNode;
 import mekhq.campaign.mission.Contract;
-import mekhq.campaign.mission.TransportCostCalculations;
 import mekhq.campaign.personnel.Injury;
 import mekhq.campaign.personnel.InjuryType;
 import mekhq.campaign.personnel.Person;
@@ -73,7 +69,6 @@ import mekhq.campaign.universe.Planet;
 import mekhq.campaign.universe.PlanetarySystem;
 import mekhq.campaign.universe.Systems;
 import mekhq.campaign.universe.factionStanding.FactionStandingUtilities;
-import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogNotification;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogWidth;
 
@@ -226,11 +221,14 @@ public abstract class AbstractLocation implements ILocation {
         for (InjuryType disease : activeDiseases) {
             String centerMessage = getFormattedTextAt(RESOURCE_BUNDLE, "diseaseOutbreak.inCharacter",
                   campaign.getCommanderAddress());
+            String bottomMessage = getFormattedTextAt(RESOURCE_BUNDLE, "diseaseOutbreak.outOfCharacter",
+                  currentSystem.getName(today), disease.getSimpleName());
             centerMessage += availableCures.contains(disease)
                                    ? getTextAt(RESOURCE_BUNDLE, "disease.outOfCharacter.vaccineStatus.available")
                                    : getTextAt(RESOURCE_BUNDLE, "disease.outOfCharacter.vaccineStatus.none");
 
-            new ImmersiveDialogNotification(campaign, centerMessage, true);
+            new ImmersiveDialogSimple(campaign, campaign.getSeniorMedicalPerson(), null,
+                  centerMessage, null, bottomMessage, null, false, ImmersiveDialogWidth.LARGE);
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/AbstractLocation.java
+++ b/MekHQ/src/mekhq/campaign/AbstractLocation.java
@@ -223,7 +223,7 @@ public abstract class AbstractLocation implements ILocation {
                   campaign.getCommanderAddress());
             String bottomMessage = getFormattedTextAt(RESOURCE_BUNDLE, "diseaseOutbreak.outOfCharacter",
                   currentSystem.getName(today), disease.getSimpleName());
-            centerMessage += availableCures.contains(disease)
+            bottomMessage += availableCures.contains(disease)
                                    ? getTextAt(RESOURCE_BUNDLE, "disease.outOfCharacter.vaccineStatus.available")
                                    : getTextAt(RESOURCE_BUNDLE, "disease.outOfCharacter.vaccineStatus.none");
 

--- a/MekHQ/src/mekhq/campaign/CurrentLocation.java
+++ b/MekHQ/src/mekhq/campaign/CurrentLocation.java
@@ -267,10 +267,6 @@ public class CurrentLocation extends AbstractLocation {
                 jumpPath = null;
                 MekHQ.triggerEvent(new TransitCompleteEvent(this));
             }
-
-            if (campaignOptions.isUseRandomDiseases() && campaignOptions.isUseAlternativeAdvancedMedical()) {
-                checkForDiseaseOrBioweaponOutbreaks(campaign, today);
-            }
         }
 
         if (wasTraveling || jumpPath != null) {
@@ -284,6 +280,10 @@ public class CurrentLocation extends AbstractLocation {
             // This should be before inoculations so that we can correctly read the TO&E
             if (!campaign.getAutomatedMothballUnits().isEmpty()) {
                 performAutomatedActivation(campaign);
+            }
+
+            if (campaignOptions.isUseRandomDiseases() && campaignOptions.isUseAlternativeAdvancedMedical()) {
+                checkForDiseaseOrBioweaponOutbreaks(campaign, today);
             }
 
             if (campaignOptions.isUseRandomDiseases() && campaignOptions.isUseAlternativeAdvancedMedical()) {


### PR DESCRIPTION
Due to the placement of this warning dialog it was unintentionally repeating every day while the campaign is in-transit to a disease or bioweapon affected planet.

While fixing that, I also adjusted and fixed the dialog itself.

Marking this bug as 'medium' due to how annoying the daily spam is