### PR TITLE
Add a new "Filter by current month" option for scenarios in the briefin…

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignGUI.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignGUI.properties
@@ -29,12 +29,10 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 # Resources for the CampaignGUI class
-
 # Menus
 mekSelectorDialog.unsupported.gunEmplacement=Gun Emplacements are %s<b>not supported</b>%s by MekHQ.
 mekSelectorDialog.unsupported.droneOs=Drone units are %s<b>not supported</b>%s by MekHQ.
 mekSelectorDialog.unsupported.null=Unit does not have an entity.
-
 # Dynamic Buttons
 pnlMarkets.title=Marketplace
 btnContractMarket.market=<html><center>Contract Market</center></html>
@@ -44,7 +42,6 @@ btnUnitMarket.market=<html><center>Unit Market</center></html>
 btnUnitMarket.toolTipText=<html>Opens the Unit Market to purchase new 'Mechs, vehicles, aerospace assets, etc.</html>
 btnUnitMarket.manual=<html><center>Purchase Units</center></html>
 btnPartsMarket.manual=<html><center>Purchase Parts</center></html>
-
 ## Unsorted Resources
 btnMassTraining.text=Mass Personnel Training
 btnMassTraining.toolTipText=This launches the Mass Personnel Training Dialog, which allows you to train large numbers of personnel at the same time.
@@ -77,6 +74,7 @@ briefingTab.scenarioFilter.turningPoint=Turning Point
 briefingTab.scenarioFilter.assigned=Assigned
 briefingTab.scenarioFilter.unassigned=Unassigned
 briefingTab.scenarioFilter.allResolved=Resolved
+briefingTab.scenarioFilter.currentMonth=Current Month
 briefingTab.selectedScenario.button.deploy=Deploy...
 briefingTab.selectedScenario.button.deploy.toolTipText=Assign a force to the selected StratCon scenario.
 briefingTab.assignments.coverage.title=Deployment Coverage
@@ -225,7 +223,6 @@ lblTransportCapacity.text=<html><nobr><b>Transport Capacity:</b></nobr></html>;
 lblCargoSummary.text=<html><nobr><b>Cargo Summary:</b></nobr></html>;
 lblFacilityCapacities.text=<html><nobr><b>Facility Capacities:</b></nobr></html>;
 panLog.title=Daily Activity Log
-
 # New Day Blockers: Overdue Loans
 dialogOverdueLoans.ic={0}, we're unable to meet an upcoming loan payment as we lack the funds to cover our obligations.\
   \ This is a critical issue that requires immediate attention. Without addressing it, we risk defaulting, which would\
@@ -240,7 +237,6 @@ dialogOverdueLoans.ooc=This is a critical situation, and you will be unable to p
   <br>- Take out another loan.\
   <br>- Default on the loan. Though you will be required to sell units to the bank, based on the loan's collateral.\
   <br>- Use GM Mode to delete the loan.</p>
-
 # New Day Blockers: Invalid Faction
 dialogInvalidFaction.ic={0}, our parent faction has gone dark. All attempts at communication have failed, and we have\
   \ received no orders, updates, or logistical support. This is a serious situation that requires immediate attention.\
@@ -256,7 +252,6 @@ dialogScenarioAcceptance.button.accept=Commence Drop
 dialogScenarioAcceptance.button.cancel=Return to the Launch Bay
 cadreReassignment.text=One or more formations were assigned to Cadre duties. With the contract now concluded, they have \
   been reassigned to Frontline.
-
 # Status Bar - Temp Personnel
 statusBar.pnlTempPersonnel.title=Temp
 statusBar.pnlVehicleCrew.title=Vehicle Crew

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -203,7 +203,8 @@ public final class BriefingTab extends CampaignGuiTab {
         TURNING_POINT("briefingTab.scenarioFilter.turningPoint"),
         ASSIGNED("briefingTab.scenarioFilter.assigned"),
         UNASSIGNED("briefingTab.scenarioFilter.unassigned"),
-        ALL_RESOLVED("briefingTab.scenarioFilter.allResolved");
+        ALL_RESOLVED("briefingTab.scenarioFilter.allResolved"),
+        CURRENT_MONTH("briefingTab.scenarioFilter.currentMonth");
 
         private final String resourceKey;
 
@@ -327,7 +328,8 @@ public final class BriefingTab extends CampaignGuiTab {
               ScenarioQueueFilter.TURNING_POINT,
               ScenarioQueueFilter.ASSIGNED,
               ScenarioQueueFilter.UNASSIGNED,
-              ScenarioQueueFilter.ALL_RESOLVED
+              ScenarioQueueFilter.ALL_RESOLVED,
+              ScenarioQueueFilter.CURRENT_MONTH
         });
 
         panScenarioActions = BriefingStyle.createSectionPanel(
@@ -708,6 +710,7 @@ public final class BriefingTab extends CampaignGuiTab {
             case TURNING_POINT -> scenarioModel.isTurningPointScenario(scenario);
             case ASSIGNED -> !scenario.getForces(getCampaign()).getAllUnits(false).isEmpty();
             case UNASSIGNED -> scenario.getForces(getCampaign()).getAllUnits(false).isEmpty();
+            case CURRENT_MONTH -> scenario.getDate().getMonth() == getCampaign().getLocalDate().getMonth();
         };
     }
 
@@ -2603,6 +2606,10 @@ public final class BriefingTab extends CampaignGuiTab {
                 filteredScenarios.add(scenario);
             } else if (selectedFilter == ScenarioQueueFilter.ALL_RESOLVED) {
                 if (!scenario.getStatus().isCurrent()) {
+                    filteredScenarios.add(scenario);
+                }
+            } else if (selectedFilter == ScenarioQueueFilter.CURRENT_MONTH) {
+                if (matchesScenarioFilter(scenario, selectedFilter)) {
                     filteredScenarios.add(scenario);
                 }
             } else if (scenario.getStatus().isCurrent() && matchesScenarioFilter(scenario, selectedFilter)) {


### PR DESCRIPTION
The new briefing tab introduces various filters for scenarios in the current contract.

This PR adds a new option, namely to only show those scenarios (present, past and future) that happen/have happened in the current month.

The reasoning for this is that the win-loss ratio of scenarios in the current month has an impact on morale.