### PR TITLE
Fixed Parts in Use Failing to Correctly Set Minimum Stock Percentage for Missing Parts

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/PartsInUseManager.java
+++ b/MekHQ/src/mekhq/campaign/market/PartsInUseManager.java
@@ -159,10 +159,10 @@ public class PartsInUseManager {
      * The values for each part type are retrieved from the campaign options.</p>
      *
      * <p>If the provided {@link Part} is a {@link MissingPart} we use {@link MissingPart#getNewPart()} to fetch the
-     * right part. We do this here to avoid an issue with inheritance. Chiefly missing parts can be a type of part, but
+     * right part. We do this here to avoid an issue with inheritance. Chiefly, missing parts can be a type of part, but
      * most parts aren't missing parts.</p>
      *
-     * <p></p>We could filter earlier in the pipeline, but that would rely on all future developers knowing about
+     * <p>We could filter earlier in the pipeline, but that would rely on all future developers knowing about
      * this risk and accounting for it. By self-correcting here, we avoid that issue entirely.</p>
      *
      * @param part The {@link Part} for which the default stock percentage is to be determined. The part must not be

--- a/MekHQ/src/mekhq/campaign/market/PartsInUseManager.java
+++ b/MekHQ/src/mekhq/campaign/market/PartsInUseManager.java
@@ -158,6 +158,13 @@ public class PartsInUseManager {
      * <p>This method uses the type of the provided {@link Part} to decide which default stock percentage to return.
      * The values for each part type are retrieved from the campaign options.</p>
      *
+     * <p>If the provided {@link Part} is a {@link MissingPart} we use {@link MissingPart#getNewPart()} to fetch the
+     * right part. We do this here to avoid an issue with inheritance. Chiefly missing parts can be a type of part, but
+     * most parts aren't missing parts.</p>
+     *
+     * <p></p>We could filter earlier in the pipeline, but that would rely on all future developers knowing about
+     * this risk and accounting for it. By self-correcting here, we avoid that issue entirely.</p>
+     *
      * @param part The {@link Part} for which the default stock percentage is to be determined. The part must not be
      *             {@code null}.
      *
@@ -165,6 +172,10 @@ public class PartsInUseManager {
      *       campaign options.
      */
     private int getDefaultStockPercent(Part part) {
+        if (part instanceof MissingPart missingPart) {
+            part = missingPart.getNewPart();
+        }
+
         if (part instanceof HeatSink) {
             return campaignOptions.getAutoLogisticsHeatSink();
         } else if (part instanceof MekLocation) {


### PR DESCRIPTION
If a player salvaged a number any missing parts would be placed in the Parts in Use dialog with 0% minimum stock. This would only happen if that part had not been present on another unit earlier in the campaign.

The issue was caused by an inheritance issue which this PR fixes.