### PR TITLE
Added Mek Head Components to Parts in Use Campaign Options

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -256,9 +256,15 @@ lblAutoLogisticsActuators.tooltip=autoLogistics counts the number of 'Mek actuat
 lblAutoLogisticsJumpJets.text=Jump Jets Restock Percent
 lblAutoLogisticsJumpJets.tooltip=autoLogistics counts the number of jump jets in use and then\
   \ automatically orders replacement spares equal to the percentage set in this option.
+lblAutoLogisticsHeadComponents.text=Mek Head Component Restock Percent
+lblAutoLogisticsHeadComponents.tooltip=autoLogistics counts how many cockpits, sensors, and life support \
+  equipment are in use and then automatically orders replacement spares equal to the percentage set in this option.
 lblAutoLogisticsEngines.text=Engine Restock Percent
 lblAutoLogisticsEngines.tooltip=autoLogistics counts the number of engines in use and then\
   \ automatically orders replacement spares equal to the percentage set in this option.
+lblAutoLogisticsGyros.text=Mek Gyro Restock Percent
+lblAutoLogisticsGyros.tooltip=autoLogistics counts the number of gyros in use and then automatically orders \
+  replacement spares equal to the percentage set in this option.
 lblAutoLogisticsWeapons.text=Weapon Restock Percent
 lblAutoLogisticsWeapons.tooltip=autoLogistics counts the number of weapons in use and then\
   \ automatically orders replacement spares equal to the percentage set in this option.

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
@@ -188,6 +188,8 @@ public class CampaignOptions {
     private int autoLogisticsJumpJets;
     private int autoLogisticsEngines;
     private int autoLogisticsWeapons;
+    private int autoLogisticsGyros;
+    private int autoLogisticsHeadComponents;
     private int autoLogisticsOther;
 
     // Delivery
@@ -792,6 +794,8 @@ public class CampaignOptions {
         autoLogisticsJumpJets = 50;
         autoLogisticsEngines = 0;
         autoLogisticsWeapons = 50;
+        autoLogisticsGyros = 0;
+        autoLogisticsHeadComponents = 15;
         autoLogisticsOther = 0;
 
         // Delivery
@@ -4944,6 +4948,22 @@ public class CampaignOptions {
 
     public void setAutoLogisticsWeapons(int autoLogisticsWeapons) {
         this.autoLogisticsWeapons = autoLogisticsWeapons;
+    }
+
+    public int getAutoLogisticsGyros() {
+        return autoLogisticsGyros;
+    }
+
+    public void setAutoLogisticsGyros(int autoLogisticsGyros) {
+        this.autoLogisticsGyros = autoLogisticsGyros;
+    }
+
+    public int getAutoLogisticsHeadComponents() {
+        return autoLogisticsHeadComponents;
+    }
+
+    public void setAutoLogisticsHeadComponents(int autoLogisticsHeadComponents) {
+        this.autoLogisticsHeadComponents = autoLogisticsHeadComponents;
     }
 
     public int getAutoLogisticsOther() {

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
@@ -256,6 +256,11 @@ public class CampaignOptionsMarshaller {
               campaignOptions.getAutoLogisticsJumpJets());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "autoLogisticsEngines", campaignOptions.getAutoLogisticsEngines());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "autoLogisticsWeapons", campaignOptions.getAutoLogisticsWeapons());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "autoLogisticsGyros", campaignOptions.getAutoLogisticsGyros());
+        MHQXMLUtility.writeSimpleXMLTag(pw,
+              indent,
+              "autoLogisticsHeadComponents",
+              campaignOptions.getAutoLogisticsHeadComponents());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "autoLogisticsOther", campaignOptions.getAutoLogisticsOther());
 
         // region Personnel Tab

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
@@ -321,6 +321,9 @@ public class CampaignOptionsUnmarshaller {
             case "autoLogisticsJumpJets" -> campaignOptions.setAutoLogisticsJumpJets(parseInt(nodeContents));
             case "autoLogisticsEngines" -> campaignOptions.setAutoLogisticsEngines(parseInt(nodeContents));
             case "autoLogisticsWeapons" -> campaignOptions.setAutoLogisticsWeapons(parseInt(nodeContents));
+            case "autoLogisticsGyros" -> campaignOptions.setAutoLogisticsGyros(parseInt(nodeContents));
+            case "autoLogisticsHeadComponents" ->
+                  campaignOptions.setAutoLogisticsHeadComponents(parseInt(nodeContents));
             case "autoLogisticsOther" -> campaignOptions.setAutoLogisticsOther(parseInt(nodeContents));
             case "useTactics" -> campaignOptions.setUseTactics(parseBoolean(nodeContents));
             case "useInitiativeBonus" -> campaignOptions.setUseInitiativeBonus(parseBoolean(nodeContents));

--- a/MekHQ/src/mekhq/campaign/market/PartsInUseManager.java
+++ b/MekHQ/src/mekhq/campaign/market/PartsInUseManager.java
@@ -61,7 +61,11 @@ import mekhq.campaign.parts.equipment.EquipmentPart;
 import mekhq.campaign.parts.equipment.HeatSink;
 import mekhq.campaign.parts.equipment.JumpJet;
 import mekhq.campaign.parts.meks.MekActuator;
+import mekhq.campaign.parts.meks.MekCockpit;
+import mekhq.campaign.parts.meks.MekGyro;
+import mekhq.campaign.parts.meks.MekLifeSupport;
 import mekhq.campaign.parts.meks.MekLocation;
+import mekhq.campaign.parts.meks.MekSensor;
 import mekhq.campaign.parts.missing.MissingPart;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.work.IAcquisitionWork;
@@ -189,6 +193,10 @@ public class PartsInUseManager {
             return campaignOptions.getAutoLogisticsJumpJets();
         } else if (part instanceof EnginePart) {
             return campaignOptions.getAutoLogisticsEngines();
+        } else if (part instanceof MekGyro) {
+            return campaignOptions.getAutoLogisticsGyros();
+        } else if (part instanceof MekCockpit || part instanceof MekSensor || part instanceof MekLifeSupport) {
+            return campaignOptions.getAutoLogisticsHeadComponents();
         } else if (part instanceof EquipmentPart equipmentPart) {
             if (equipmentPart.getType() instanceof WeaponType) {
                 return campaignOptions.getAutoLogisticsWeapons();

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/EquipmentAndSuppliesTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/EquipmentAndSuppliesTab.java
@@ -51,6 +51,7 @@ import javax.swing.JSpinner;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingConstants;
 
+import megamek.Version;
 import megamek.client.ui.comboBoxes.MMComboBox;
 import megamek.client.ui.util.UIUtil;
 import megamek.common.annotations.Nullable;
@@ -127,6 +128,10 @@ public class EquipmentAndSuppliesTab {
     private JSpinner spnAutoLogisticsJumpJets;
     private JLabel lblAutoLogisticsEngines;
     private JSpinner spnAutoLogisticsEngines;
+    private JLabel lblAutoLogisticsHeadComponents;
+    private JSpinner spnAutoLogisticsHeadComponents;
+    private JLabel lblAutoLogisticsGyros;
+    private JSpinner spnAutoLogisticsGyros;
     private JLabel lblAutoLogisticsOther;
     private JSpinner spnAutoLogisticsOther;
     //end autoLogistics Tab
@@ -316,6 +321,10 @@ public class EquipmentAndSuppliesTab {
         spnAutoLogisticsJumpJets = new JSpinner();
         lblAutoLogisticsEngines = new JLabel();
         spnAutoLogisticsEngines = new JSpinner();
+        lblAutoLogisticsHeadComponents = new JLabel();
+        spnAutoLogisticsHeadComponents = new JSpinner();
+        lblAutoLogisticsGyros = new JLabel();
+        spnAutoLogisticsGyros = new JSpinner();
         lblAutoLogisticsOther = new JLabel();
         spnAutoLogisticsOther = new JSpinner();
     }
@@ -545,10 +554,23 @@ public class EquipmentAndSuppliesTab {
         spnAutoLogisticsJumpJets = new CampaignOptionsSpinner("AutoLogisticsJumpJets", 250, 0, 10000, 1);
         spnAutoLogisticsJumpJets.addMouseListener(createTipPanelUpdater(acquisitionHeader, "AutoLogisticsJumpJets"));
 
+        lblAutoLogisticsHeadComponents = new CampaignOptionsLabel("AutoLogisticsHeadComponents",
+              getMetadata(new Version(0, 51, 1)));
+        lblAutoLogisticsHeadComponents.addMouseListener(createTipPanelUpdater(acquisitionHeader,
+              "AutoLogisticsHeadComponents"));
+        spnAutoLogisticsHeadComponents = new CampaignOptionsSpinner("AutoLogisticsHeadComponents", 15, 0, 10000, 1);
+        spnAutoLogisticsHeadComponents.addMouseListener(createTipPanelUpdater(acquisitionHeader,
+              "AutoLogisticsHeadComponents"));
+
         lblAutoLogisticsEngines = new CampaignOptionsLabel("AutoLogisticsEngines");
         lblAutoLogisticsEngines.addMouseListener(createTipPanelUpdater(acquisitionHeader, "AutoLogisticsEngines"));
         spnAutoLogisticsEngines = new CampaignOptionsSpinner("AutoLogisticsEngines", 250, 0, 10000, 1);
         spnAutoLogisticsEngines.addMouseListener(createTipPanelUpdater(acquisitionHeader, "AutoLogisticsEngines"));
+
+        lblAutoLogisticsGyros = new CampaignOptionsLabel("AutoLogisticsGyros", getMetadata(new Version(0, 51, 1)));
+        lblAutoLogisticsGyros.addMouseListener(createTipPanelUpdater(acquisitionHeader, "AutoLogisticsGyros"));
+        spnAutoLogisticsGyros = new CampaignOptionsSpinner("AutoLogisticsGyros", 0, 0, 10000, 1);
+        spnAutoLogisticsGyros.addMouseListener(createTipPanelUpdater(acquisitionHeader, "AutoLogisticsGyros"));
 
         lblAutoLogisticsOther = new CampaignOptionsLabel("AutoLogisticsOther");
         lblAutoLogisticsOther.addMouseListener(createTipPanelUpdater(acquisitionHeader, "AutoLogisticsOther"));
@@ -570,7 +592,9 @@ public class EquipmentAndSuppliesTab {
         addSpinnerToPanel(panel, layout, lblAutoLogisticsAmmunition, spnAutoLogisticsAmmunition);
         addSpinnerToPanel(panel, layout, lblAutoLogisticsActuators, spnAutoLogisticsActuators);
         addSpinnerToPanel(panel, layout, lblAutoLogisticsJumpJets, spnAutoLogisticsJumpJets);
+        addSpinnerToPanel(panel, layout, lblAutoLogisticsHeadComponents, spnAutoLogisticsHeadComponents);
         addSpinnerToPanel(panel, layout, lblAutoLogisticsEngines, spnAutoLogisticsEngines);
+        addSpinnerToPanel(panel, layout, lblAutoLogisticsGyros, spnAutoLogisticsGyros);
         addSpinnerToPanel(panel, layout, lblAutoLogisticsWeapons, spnAutoLogisticsWeapons);
         addSpinnerToPanel(panel, layout, lblAutoLogisticsOther, spnAutoLogisticsOther);
 
@@ -1132,6 +1156,8 @@ public class EquipmentAndSuppliesTab {
         options.setAutoLogisticsActuators((int) spnAutoLogisticsActuators.getValue());
         options.setAutoLogisticsJumpJets((int) spnAutoLogisticsJumpJets.getValue());
         options.setAutoLogisticsEngines((int) spnAutoLogisticsEngines.getValue());
+        options.setAutoLogisticsHeadComponents((int) spnAutoLogisticsHeadComponents.getValue());
+        options.setAutoLogisticsGyros((int) spnAutoLogisticsGyros.getValue());
         options.setAutoLogisticsHeatSink((int) spnAutoLogisticsHeatSink.getValue());
         options.setAutoLogisticsWeapons((int) spnAutoLogisticsWeapons.getValue());
         options.setAutoLogisticsOther((int) spnAutoLogisticsOther.getValue());
@@ -1215,6 +1241,8 @@ public class EquipmentAndSuppliesTab {
         spnAutoLogisticsActuators.setValue(options.getAutoLogisticsActuators());
         spnAutoLogisticsJumpJets.setValue(options.getAutoLogisticsJumpJets());
         spnAutoLogisticsEngines.setValue(options.getAutoLogisticsEngines());
+        spnAutoLogisticsHeadComponents.setValue(options.getAutoLogisticsHeadComponents());
+        spnAutoLogisticsGyros.setValue(options.getAutoLogisticsGyros());
         spnAutoLogisticsHeatSink.setValue(options.getAutoLogisticsHeatSink());
         spnAutoLogisticsWeapons.setValue(options.getAutoLogisticsWeapons());
         spnAutoLogisticsOther.setValue(options.getAutoLogisticsOther());

--- a/MekHQ/unittests/mekhq/campaign/market/PartsInUseManagerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/market/PartsInUseManagerTest.java
@@ -64,8 +64,8 @@ import mekhq.campaign.parts.equipment.EquipmentPart;
 import mekhq.campaign.parts.equipment.HeatSink;
 import mekhq.campaign.parts.equipment.JumpJet;
 import mekhq.campaign.parts.meks.MekActuator;
+import mekhq.campaign.parts.meks.MekCockpit;
 import mekhq.campaign.parts.meks.MekGyro;
-import mekhq.campaign.parts.meks.MekLifeSupport;
 import mekhq.campaign.parts.meks.MekLocation;
 import mekhq.campaign.parts.meks.MekSensor;
 import org.junit.jupiter.api.BeforeAll;
@@ -249,6 +249,36 @@ class PartsInUseManagerTest {
             }
 
             @Test
+            public void testGetSetStockPercentGyros() {
+                // Act
+                campaign.getCampaignOptions().setAutoLogisticsGyros(FIRST_DESIRED_STOCK);
+                int firstStockLevel = campaign.getCampaignOptions().getAutoLogisticsGyros();
+
+                // Let's change the stock level to something else so we can make sure it properly changes
+                campaign.getCampaignOptions().setAutoLogisticsGyros(SECOND_DESIRED_STOCK);
+                int secondStockLevel = campaign.getCampaignOptions().getAutoLogisticsGyros();
+
+                // Assert
+                assertEquals(FIRST_DESIRED_STOCK, firstStockLevel);
+                assertEquals(SECOND_DESIRED_STOCK, secondStockLevel);
+            }
+
+            @Test
+            public void testGetSetStockPercentCockpits() {
+                // Act
+                campaign.getCampaignOptions().setAutoLogisticsHeadComponents(FIRST_DESIRED_STOCK);
+                int firstStockLevel = campaign.getCampaignOptions().getAutoLogisticsHeadComponents();
+
+                // Let's change the stock level to something else so we can make sure it properly changes
+                campaign.getCampaignOptions().setAutoLogisticsHeadComponents(SECOND_DESIRED_STOCK);
+                int secondStockLevel = campaign.getCampaignOptions().getAutoLogisticsHeadComponents();
+
+                // Assert
+                assertEquals(FIRST_DESIRED_STOCK, firstStockLevel);
+                assertEquals(SECOND_DESIRED_STOCK, secondStockLevel);
+            }
+
+            @Test
             public void testGetSetStockPercentOther() {
                 // Act
                 campaign.getCampaignOptions().setAutoLogisticsOther(FIRST_DESIRED_STOCK);
@@ -306,7 +336,7 @@ class PartsInUseManagerTest {
              * @return parts that are not explicitly handled by {@code PartsInUseManager#getDefaultStockPercent(Part)}
              */
             public static Stream<Part> otherUnhandledDefaultStockPercentParts() {
-                return Stream.of(new MekGyro(), new Cubicle(), new MekSensor(), new MekLifeSupport());
+                return Stream.of(new Cubicle());
             }
 
             @BeforeEach
@@ -321,6 +351,8 @@ class PartsInUseManagerTest {
                 when(mockCampaignOptions.getAutoLogisticsJumpJets()).thenReturn(INCORRECT_STOCK_LEVEL);
                 when(mockCampaignOptions.getAutoLogisticsEngines()).thenReturn(INCORRECT_STOCK_LEVEL);
                 when(mockCampaignOptions.getAutoLogisticsWeapons()).thenReturn(INCORRECT_STOCK_LEVEL);
+                when(mockCampaignOptions.getAutoLogisticsGyros()).thenReturn(INCORRECT_STOCK_LEVEL);
+                when(mockCampaignOptions.getAutoLogisticsHeadComponents()).thenReturn(INCORRECT_STOCK_LEVEL);
                 when(mockCampaignOptions.getAutoLogisticsOther()).thenReturn(INCORRECT_STOCK_LEVEL);
             }
 
@@ -686,6 +718,96 @@ class PartsInUseManagerTest {
                 assertEquals(1, afterChangeAllPercents.stream().filter(i -> i == DESIRED_STOCK_LEVEL).toArray().length);
             }
 
+            @Test
+            public void testGetDefaultStockPercentCockpits() {
+                // Arrange
+                part = new MekCockpit(100, Mek.COCKPIT_STANDARD, false, campaign);
+
+                // Act
+                try {
+                    initialStockPercent = (int) method.invoke(partsInUseManager, part);
+                    initialAllPercents = getAllDefaultStockPercents();
+
+                    // Let's change it and make sure that it uses the new value
+                    when(mockCampaignOptions.getAutoLogisticsHeadComponents()).thenReturn(DESIRED_STOCK_LEVEL);
+
+                    desiredStockPercent = (int) method.invoke(partsInUseManager, part);
+                    afterChangeAllPercents = getAllDefaultStockPercents();
+                } catch (IllegalAccessException | InvocationTargetException e) {
+                    throw new RuntimeException(e);
+                }
+
+                // Assert
+                assertEquals(INCORRECT_STOCK_LEVEL, initialStockPercent);
+                assertEquals(DESIRED_STOCK_LEVEL, desiredStockPercent);
+
+                // None of the initial defaults should contain the desired stock percent
+                assertFalse(initialAllPercents.contains(desiredStockPercent));
+
+                // Only one of these should be the desired stock percent
+                assertEquals(1, afterChangeAllPercents.stream().filter(i -> i == DESIRED_STOCK_LEVEL).toArray().length);
+            }
+
+            @Test
+            public void testGetDefaultStockPercentMekSensors() {
+                // Arrange
+                part = new MekSensor(100, campaign);
+
+                // Act
+                try {
+                    initialStockPercent = (int) method.invoke(partsInUseManager, part);
+                    initialAllPercents = getAllDefaultStockPercents();
+
+                    // Let's change it and make sure that it uses the new value
+                    when(mockCampaignOptions.getAutoLogisticsHeadComponents()).thenReturn(DESIRED_STOCK_LEVEL);
+
+                    desiredStockPercent = (int) method.invoke(partsInUseManager, part);
+                    afterChangeAllPercents = getAllDefaultStockPercents();
+                } catch (IllegalAccessException | InvocationTargetException e) {
+                    throw new RuntimeException(e);
+                }
+
+                // Assert
+                assertEquals(INCORRECT_STOCK_LEVEL, initialStockPercent);
+                assertEquals(DESIRED_STOCK_LEVEL, desiredStockPercent);
+
+                // None of the initial defaults should contain the desired stock percent
+                assertFalse(initialAllPercents.contains(desiredStockPercent));
+
+                // Only one of these should be the desired stock percent
+                assertEquals(1, afterChangeAllPercents.stream().filter(i -> i == DESIRED_STOCK_LEVEL).toArray().length);
+            }
+
+            @Test
+            public void testGetDefaultStockPercentGyros() {
+                // Arrange
+                part = new MekGyro(100, Mek.GYRO_STANDARD, 5, false, campaign);
+
+                // Act
+                try {
+                    initialStockPercent = (int) method.invoke(partsInUseManager, part);
+                    initialAllPercents = getAllDefaultStockPercents();
+
+                    // Let's change it and make sure that it uses the new value
+                    when(mockCampaignOptions.getAutoLogisticsGyros()).thenReturn(DESIRED_STOCK_LEVEL);
+
+                    desiredStockPercent = (int) method.invoke(partsInUseManager, part);
+                    afterChangeAllPercents = getAllDefaultStockPercents();
+                } catch (IllegalAccessException | InvocationTargetException e) {
+                    throw new RuntimeException(e);
+                }
+
+                // Assert
+                assertEquals(INCORRECT_STOCK_LEVEL, initialStockPercent);
+                assertEquals(DESIRED_STOCK_LEVEL, desiredStockPercent);
+
+                // None of the initial defaults should contain the desired stock percent
+                assertFalse(initialAllPercents.contains(desiredStockPercent));
+
+                // Only one of these should be the desired stock percent
+                assertEquals(1, afterChangeAllPercents.stream().filter(i -> i == DESIRED_STOCK_LEVEL).toArray().length);
+            }
+
             @ParameterizedTest
             @MethodSource(value = "otherUnhandledDefaultStockPercentParts")
             public void testGetDefaultStockPercentOtherUnhandled(Part otherPart) {
@@ -732,8 +854,8 @@ class PartsInUseManagerTest {
     }
 
     /**
-     * Tests for the private {@code PartsInUseManager#updatePartInUseData} method to verify that
-     * refit-reserved parts are counted as in-use rather than stored.
+     * Tests for the private {@code PartsInUseManager#updatePartInUseData} method to verify that refit-reserved parts
+     * are counted as in-use rather than stored.
      */
     @Nested
     public class TestUpdatePartInUseData {
@@ -767,14 +889,20 @@ class PartsInUseManagerTest {
             when(spare.getQuality()).thenReturn(PartQuality.QUALITY_D);
 
             PartInUse partInUse = mock(PartInUse.class);
-            int[] useCount = {0};
-            int[] storeCount = {0};
+            int[] useCount = { 0 };
+            int[] storeCount = { 0 };
             when(partInUse.getUseCount()).thenAnswer(inv -> useCount[0]);
             when(partInUse.getStoreCount()).thenAnswer(inv -> storeCount[0]);
             // setUseCount / setStoreCount capture the values
-            org.mockito.Mockito.doAnswer(inv -> { useCount[0] = inv.getArgument(0); return null; })
+            org.mockito.Mockito.doAnswer(inv -> {
+                      useCount[0] = inv.getArgument(0);
+                      return null;
+                  })
                   .when(partInUse).setUseCount(org.mockito.ArgumentMatchers.anyInt());
-            org.mockito.Mockito.doAnswer(inv -> { storeCount[0] = inv.getArgument(0); return null; })
+            org.mockito.Mockito.doAnswer(inv -> {
+                      storeCount[0] = inv.getArgument(0);
+                      return null;
+                  })
                   .when(partInUse).setStoreCount(org.mockito.ArgumentMatchers.anyInt());
 
             // Act
@@ -798,13 +926,19 @@ class PartsInUseManagerTest {
             when(reserved.getQuality()).thenReturn(PartQuality.QUALITY_D);
 
             PartInUse partInUse = mock(PartInUse.class);
-            int[] useCount = {0};
-            int[] storeCount = {0};
+            int[] useCount = { 0 };
+            int[] storeCount = { 0 };
             when(partInUse.getUseCount()).thenAnswer(inv -> useCount[0]);
             when(partInUse.getStoreCount()).thenAnswer(inv -> storeCount[0]);
-            org.mockito.Mockito.doAnswer(inv -> { useCount[0] = inv.getArgument(0); return null; })
+            org.mockito.Mockito.doAnswer(inv -> {
+                      useCount[0] = inv.getArgument(0);
+                      return null;
+                  })
                   .when(partInUse).setUseCount(org.mockito.ArgumentMatchers.anyInt());
-            org.mockito.Mockito.doAnswer(inv -> { storeCount[0] = inv.getArgument(0); return null; })
+            org.mockito.Mockito.doAnswer(inv -> {
+                      storeCount[0] = inv.getArgument(0);
+                      return null;
+                  })
                   .when(partInUse).setStoreCount(org.mockito.ArgumentMatchers.anyInt());
 
             // Act
@@ -845,13 +979,19 @@ class PartsInUseManagerTest {
             when(reserved2.getQuality()).thenReturn(PartQuality.QUALITY_D);
 
             PartInUse partInUse = mock(PartInUse.class);
-            int[] useCount = {0};
-            int[] storeCount = {0};
+            int[] useCount = { 0 };
+            int[] storeCount = { 0 };
             when(partInUse.getUseCount()).thenAnswer(inv -> useCount[0]);
             when(partInUse.getStoreCount()).thenAnswer(inv -> storeCount[0]);
-            org.mockito.Mockito.doAnswer(inv -> { useCount[0] = inv.getArgument(0); return null; })
+            org.mockito.Mockito.doAnswer(inv -> {
+                      useCount[0] = inv.getArgument(0);
+                      return null;
+                  })
                   .when(partInUse).setUseCount(org.mockito.ArgumentMatchers.anyInt());
-            org.mockito.Mockito.doAnswer(inv -> { storeCount[0] = inv.getArgument(0); return null; })
+            org.mockito.Mockito.doAnswer(inv -> {
+                      storeCount[0] = inv.getArgument(0);
+                      return null;
+                  })
                   .when(partInUse).setStoreCount(org.mockito.ArgumentMatchers.anyInt());
 
             // Act: process the spare and both reserved parts
@@ -879,17 +1019,26 @@ class PartsInUseManagerTest {
             when(inTransitReserved.getQuality()).thenReturn(PartQuality.QUALITY_D);
 
             PartInUse partInUse = mock(PartInUse.class);
-            int[] useCount = {0};
-            int[] storeCount = {0};
-            int[] transferCount = {0};
+            int[] useCount = { 0 };
+            int[] storeCount = { 0 };
+            int[] transferCount = { 0 };
             when(partInUse.getUseCount()).thenAnswer(inv -> useCount[0]);
             when(partInUse.getStoreCount()).thenAnswer(inv -> storeCount[0]);
             when(partInUse.getTransferCount()).thenAnswer(inv -> transferCount[0]);
-            org.mockito.Mockito.doAnswer(inv -> { useCount[0] = inv.getArgument(0); return null; })
+            org.mockito.Mockito.doAnswer(inv -> {
+                      useCount[0] = inv.getArgument(0);
+                      return null;
+                  })
                   .when(partInUse).setUseCount(org.mockito.ArgumentMatchers.anyInt());
-            org.mockito.Mockito.doAnswer(inv -> { storeCount[0] = inv.getArgument(0); return null; })
+            org.mockito.Mockito.doAnswer(inv -> {
+                      storeCount[0] = inv.getArgument(0);
+                      return null;
+                  })
                   .when(partInUse).setStoreCount(org.mockito.ArgumentMatchers.anyInt());
-            org.mockito.Mockito.doAnswer(inv -> { transferCount[0] = inv.getArgument(0); return null; })
+            org.mockito.Mockito.doAnswer(inv -> {
+                      transferCount[0] = inv.getArgument(0);
+                      return null;
+                  })
                   .when(partInUse).setTransferCount(org.mockito.ArgumentMatchers.anyInt());
 
             // Act


### PR DESCRIPTION
While working on #9276 I spotted a couple of common equipment types that weren't covered by Parts in Use and were therefore using the 'Other' catch-all.

With this PR two new campaign options are added allowing players to specify the default Parts in Use percentiles for mek gyros and mek head equipment (specifically the cockpit, sensors, and life support crit locations).

Gyros have a default percentile of 0%, due to their cost, similar to engines. We don't want to bankrupt players. Head equipment is 15%.