### PR TITLE
Removed References to Education System from Training Combat Formations Code

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
@@ -277,8 +277,7 @@ public class TrainingCombatTeams {
                           commander.getFullTitle(),
                           spanOpeningWithCustomColor(ReportingUtilities.getNegativeColor()),
                           CLOSING_SPAN_TAG));
-                    trainee.setEduAcademyName("");
-                    trainee.setEduEducationTime(0);
+                    trainee.setTrainingForceEducationTime(0);
                     continue;
                 }
 


### PR DESCRIPTION
Early in the redesign of Combat Training Formations (CTF) we hooked into the education system, so that we could use some of its components. At some point I realized that was dumb and gave CTFs a bespoke implementation. However, while I refactored away most of the education code I missed one instance. This PR corrects that oversight.

While this is a bug, it is largely benign. All it means is that a character who joins a CTF, stops being able to train any more, but later rejoins a CTF where they _can_ train will remember their past progress.