### PR TITLE
Fix #9268: Mass Training Dialog Can Now Train Skills a Character Did Not Previously Possess

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
@@ -286,7 +286,7 @@ public final class BatchXPDialog extends JDialog {
                     skillLevel.setEnabled(true);
                     ((SpinnerNumberModel) skillLevel.getModel()).setMaximum(maxSkillLevel);
                     skillLevel.getModel()
-                          .setValue(Math.clamp((Integer) skillLevel.getModel().getValue(), 1, maxSkillLevel));
+                          .setValue(Math.clamp((Integer) skillLevel.getModel().getValue(), 0, maxSkillLevel));
                     buttonSpendXP.setEnabled(true);
                 }
             }


### PR DESCRIPTION
Fix #9268

Removed clamp lower band of `1`, replaced with `0`. Tested in game with no issues.