### PR TITLE
Add enemy morale gauge to the briefing room and Morale Update dialog

### DIFF
--- a/MekHQ/resources/mekhq/resources/ContractViewPanel.properties
+++ b/MekHQ/resources/mekhq/resources/ContractViewPanel.properties
@@ -45,7 +45,6 @@ none=None
 lblEnemy.text=<html><nobr><b>Enemy:</b></nobr></html>
 lblAllyRating.text=<html><nobr><b>Ally Experience & Equipment:</b></nobr></html>
 lblEnemyRating.text=<html><nobr><b>Enemy Experience & Equipment:</b></nobr></html>
-lblMorale.text=<html><nobr><b>Enemy Morale:</b></nobr></html>
 lblScore.text=<html><nobr><b>Victory Points:</b></nobr></html>
 lblSupportPoints.text=<html><nobr><b>Support Points:</b></nobr></html>
 lblNoEarlyEnd.text=(No Early Contract End)

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -147,6 +147,7 @@ import mekhq.campaign.universe.factionStanding.FactionStandings;
 import mekhq.campaign.universe.factionStanding.PerformBatchall;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogNotification;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
+import mekhq.gui.view.MoraleBar;
 import mekhq.utilities.MHQXMLUtility;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -192,7 +193,6 @@ public class AtBContract extends Contract {
     protected int requiredCombatTeams;
     protected int requiredCombatElements;
     protected AtBMoraleLevel moraleLevel;
-    protected AtBMoraleLevel previousMoraleLevel = null;
     protected LocalDate routEnd;
     protected int partsAvailabilityLevel;
     protected int sharesPct;
@@ -459,7 +459,6 @@ public class AtBContract extends Contract {
                     }
                 }
 
-                previousMoraleLevel = moraleLevel;
                 moraleLevel = newMoraleLevel;
                 routEnd = null;
 
@@ -491,8 +490,9 @@ public class AtBContract extends Contract {
               campaignOptions.getMoraleDecisiveDefeatEffect(), campaignOptions.getMoraleDefeatEffect());
         String flavorText = MHQMorale.getFormattedTitle()
                                   + "<h2 style='text-align:center;'>" + getName() + "</h2>"
-                                  + moraleLevel.getToolTipText();
-        new ImmersiveDialogNotification(campaign, flavorText, moraleReport, true);
+                + MoraleBar.getMoraleDisplay(this).tooltip();
+        new ImmersiveDialogNotification(campaign, flavorText, moraleReport, MoraleBar.createDialogPanel(this),
+                true);
 
         MHQMorale.routedMoraleUpdate(campaign, this);
 
@@ -1108,10 +1108,6 @@ public class AtBContract extends Contract {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "requiredCombatElements", getRequiredCombatElements());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "moraleLevel", getMoraleLevel().name());
 
-        if (previousMoraleLevel != null) {
-            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "previousMoraleLevel", previousMoraleLevel.name());
-        }
-
         if (routEnd != null) {
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "routEnd", routEnd);
         }
@@ -1212,8 +1208,6 @@ public class AtBContract extends Contract {
                     requiredCombatElements = Integer.parseInt(item.getTextContent());
                 } else if (item.getNodeName().equalsIgnoreCase("moraleLevel")) {
                     setMoraleLevel(AtBMoraleLevel.parseFromString(item.getTextContent().trim()));
-                } else if (item.getNodeName().equalsIgnoreCase("previousMoraleLevel")) {
-                    setPreviousMoraleLevel(AtBMoraleLevel.parseFromString(item.getTextContent().trim()));
                 } else if (item.getNodeName().equalsIgnoreCase("routEnd")) {
                     routEnd = MHQXMLUtility.parseDate(item.getTextContent().trim());
                 } else if (item.getNodeName().equalsIgnoreCase("routedPayout")) {
@@ -1553,45 +1547,6 @@ public class AtBContract extends Contract {
 
     public void setMoraleLevel(final AtBMoraleLevel moraleLevel) {
         this.moraleLevel = moraleLevel;
-    }
-
-    /**
-     * Returns the enemy morale level recorded immediately before the most recent
-     * morale check, or {@code null} if no
-     * prior morale level has been captured yet (e.g. for a freshly generated
-     * contract or a campaign saved before this
-     * information was tracked).
-     *
-     * @return the previous {@link AtBMoraleLevel}, or {@code null} if unknown
-     */
-    public @Nullable AtBMoraleLevel getPreviousMoraleLevel() {
-        return previousMoraleLevel;
-    }
-
-    public void setPreviousMoraleLevel(final @Nullable AtBMoraleLevel previousMoraleLevel) {
-        this.previousMoraleLevel = previousMoraleLevel;
-    }
-
-    /**
-     * Reports the direction in which enemy morale moved during the most recent
-     * morale check.
-     *
-     * <p>
-     * The value is expressed from the morale scale's point of view: a positive
-     * value means enemy morale rose
-     * (better for the enemy, worse for the player), a negative value means it fell,
-     * and zero means it was unchanged or
-     * the trend is unknown.
-     * </p>
-     *
-     * @return {@code 1} if morale rose, {@code -1} if it fell, or {@code 0} if
-     *         unchanged or unknown
-     */
-    public int getMoraleTrend() {
-        if ((previousMoraleLevel == null) || (moraleLevel == null)) {
-            return 0;
-        }
-        return Integer.signum(moraleLevel.getLevel() - previousMoraleLevel.getLevel());
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -192,6 +192,7 @@ public class AtBContract extends Contract {
     protected int requiredCombatTeams;
     protected int requiredCombatElements;
     protected AtBMoraleLevel moraleLevel;
+    protected AtBMoraleLevel previousMoraleLevel = null;
     protected LocalDate routEnd;
     protected int partsAvailabilityLevel;
     protected int sharesPct;
@@ -458,6 +459,7 @@ public class AtBContract extends Contract {
                     }
                 }
 
+                previousMoraleLevel = moraleLevel;
                 moraleLevel = newMoraleLevel;
                 routEnd = null;
 
@@ -1106,6 +1108,10 @@ public class AtBContract extends Contract {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "requiredCombatElements", getRequiredCombatElements());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "moraleLevel", getMoraleLevel().name());
 
+        if (previousMoraleLevel != null) {
+            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "previousMoraleLevel", previousMoraleLevel.name());
+        }
+
         if (routEnd != null) {
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "routEnd", routEnd);
         }
@@ -1206,6 +1212,8 @@ public class AtBContract extends Contract {
                     requiredCombatElements = Integer.parseInt(item.getTextContent());
                 } else if (item.getNodeName().equalsIgnoreCase("moraleLevel")) {
                     setMoraleLevel(AtBMoraleLevel.parseFromString(item.getTextContent().trim()));
+                } else if (item.getNodeName().equalsIgnoreCase("previousMoraleLevel")) {
+                    setPreviousMoraleLevel(AtBMoraleLevel.parseFromString(item.getTextContent().trim()));
                 } else if (item.getNodeName().equalsIgnoreCase("routEnd")) {
                     routEnd = MHQXMLUtility.parseDate(item.getTextContent().trim());
                 } else if (item.getNodeName().equalsIgnoreCase("routedPayout")) {
@@ -1545,6 +1553,45 @@ public class AtBContract extends Contract {
 
     public void setMoraleLevel(final AtBMoraleLevel moraleLevel) {
         this.moraleLevel = moraleLevel;
+    }
+
+    /**
+     * Returns the enemy morale level recorded immediately before the most recent
+     * morale check, or {@code null} if no
+     * prior morale level has been captured yet (e.g. for a freshly generated
+     * contract or a campaign saved before this
+     * information was tracked).
+     *
+     * @return the previous {@link AtBMoraleLevel}, or {@code null} if unknown
+     */
+    public @Nullable AtBMoraleLevel getPreviousMoraleLevel() {
+        return previousMoraleLevel;
+    }
+
+    public void setPreviousMoraleLevel(final @Nullable AtBMoraleLevel previousMoraleLevel) {
+        this.previousMoraleLevel = previousMoraleLevel;
+    }
+
+    /**
+     * Reports the direction in which enemy morale moved during the most recent
+     * morale check.
+     *
+     * <p>
+     * The value is expressed from the morale scale's point of view: a positive
+     * value means enemy morale rose
+     * (better for the enemy, worse for the player), a negative value means it fell,
+     * and zero means it was unchanged or
+     * the trend is unknown.
+     * </p>
+     *
+     * @return {@code 1} if morale rose, {@code -1} if it fell, or {@code 0} if
+     *         unchanged or unknown
+     */
+    public int getMoraleTrend() {
+        if ((previousMoraleLevel == null) || (moraleLevel == null)) {
+            return 0;
+        }
+        return Integer.signum(moraleLevel.getLevel() - previousMoraleLevel.getLevel());
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/mission/MHQMorale.java
+++ b/MekHQ/src/mekhq/campaign/mission/MHQMorale.java
@@ -237,6 +237,10 @@ public class MHQMorale {
         AtBMoraleLevel updatedMoraleLevel = currentMoraleLevel;
         MoraleOutcome moraleOutcome;
 
+        // Record the morale level prior to this check so the briefing room can display
+        // the morale trend.
+        contract.setPreviousMoraleLevel(currentMoraleLevel);
+
         if (roll <= RALLYING_TARGET_NUMBER) {
             moraleOutcome = MoraleOutcome.RALLYING;
             updatedMoraleLevel = switch (currentMoraleLevel) {

--- a/MekHQ/src/mekhq/campaign/mission/MHQMorale.java
+++ b/MekHQ/src/mekhq/campaign/mission/MHQMorale.java
@@ -237,10 +237,6 @@ public class MHQMorale {
         AtBMoraleLevel updatedMoraleLevel = currentMoraleLevel;
         MoraleOutcome moraleOutcome;
 
-        // Record the morale level prior to this check so the briefing room can display
-        // the morale trend.
-        contract.setPreviousMoraleLevel(currentMoraleLevel);
-
         if (roll <= RALLYING_TARGET_NUMBER) {
             moraleOutcome = MoraleOutcome.RALLYING;
             updatedMoraleLevel = switch (currentMoraleLevel) {

--- a/MekHQ/src/mekhq/gui/baseComponents/SegmentedBar.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/SegmentedBar.java
@@ -42,12 +42,14 @@ import java.awt.RenderingHints;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import javax.swing.JComponent;
 import javax.swing.ToolTipManager;
 import javax.swing.UIManager;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import megamek.client.ui.util.UIUtil;
-import megamek.common.annotations.Nullable;
 
 /**
  * A compact, reusable gauge that draws a row of equally-sized colored segments.
@@ -76,7 +78,7 @@ public class SegmentedBar extends JComponent {
      * @param color   the fill color used when the segment is active
      * @param tooltip the tooltip to show when hovering this segment, or {@code null} for no tooltip
      */
-    public record Segment(Color color, @Nullable String tooltip) {
+    public record Segment(@Nonnull Color color, @Nullable String tooltip) {
     }
 
     private static final int DEFAULT_GAP = 2;
@@ -268,7 +270,7 @@ public class SegmentedBar extends JComponent {
      * @param g2     the graphics context to paint on
      * @param filled the effective number of filled segments
      */
-    private void paintActiveLabel(final Graphics2D g2, final int filled) {
+    private void paintActiveLabel(@Nonnull final Graphics2D g2, final int filled) {
         if ((activeLabel == null) || activeLabel.isBlank() || (filled <= 0)) {
             return;
         }
@@ -288,7 +290,7 @@ public class SegmentedBar extends JComponent {
     }
 
     @Override
-    public @Nullable String getToolTipText(final MouseEvent event) {
+    public @Nullable String getToolTipText(@Nonnull final MouseEvent event) {
         for (int i = 0; i < segments.size(); i++) {
             final Rectangle bounds = segmentBounds(i);
             if ((bounds != null) && bounds.contains(event.getPoint())) {
@@ -307,21 +309,34 @@ public class SegmentedBar extends JComponent {
      *
      * @return the neutral color
      */
-    private static Color neutralColor() {
+    private static @Nonnull Color neutralColor() {
         final Color foreground = UIManager.getColor("Label.foreground");
         return (foreground == null) ? Color.GRAY : foreground;
     }
 
     /**
      * Builds a list of segments whose colors are interpolated across the given gradient anchors. The number of
-     * segments equals the number of tooltips; anchor colors are spread evenly across that range.
+     * segments equals the number of tooltips; anchor colors are spread evenly across that range. An empty
+     * {@code tooltips} array yields an empty segment list (a bar with nothing to draw).
      *
-     * @param anchors  two or more colors to interpolate across, from first segment to last
-     * @param tooltips one tooltip per segment (its length determines the number of segments)
+     * @param anchors  one or more colors to interpolate across, from first segment to last; must not be {@code null}
+     *                 or empty
+     * @param tooltips one tooltip per segment (its length determines the number of segments); must not be
+     *                 {@code null}, though individual entries may be {@code null} for a segment with no tooltip
      *
      * @return the generated segments
+     *
+     * @throws NullPointerException     if {@code anchors} or {@code tooltips} is {@code null}
+     * @throws IllegalArgumentException if {@code anchors} is empty
      */
-    public static List<Segment> gradientSegments(final Color[] anchors, final String[] tooltips) {
+    public static @Nonnull List<Segment> gradientSegments(@Nonnull final Color[] anchors,
+          @Nonnull final String[] tooltips) {
+        Objects.requireNonNull(anchors, "anchors must not be null");
+        Objects.requireNonNull(tooltips, "tooltips must not be null");
+        if (anchors.length == 0) {
+            throw new IllegalArgumentException("anchors must contain at least one color");
+        }
+
         final int count = tooltips.length;
         final List<Segment> result = new ArrayList<>(count);
         for (int i = 0; i < count; i++) {
@@ -333,26 +348,42 @@ public class SegmentedBar extends JComponent {
     /**
      * Convenience overload that interpolates between a single start and end color.
      *
-     * @param start    the color of the first segment
-     * @param end      the color of the last segment
-     * @param tooltips one tooltip per segment (its length determines the number of segments)
+     * @param start    the color of the first segment; must not be {@code null}
+     * @param end      the color of the last segment; must not be {@code null}
+     * @param tooltips one tooltip per segment (its length determines the number of segments); must not be {@code null}
      *
      * @return the generated segments
+     *
+     * @throws NullPointerException if {@code start}, {@code end}, or {@code tooltips} is {@code null}
      */
-    public static List<Segment> gradientSegments(final Color start, final Color end, final String[] tooltips) {
+    public static @Nonnull List<Segment> gradientSegments(@Nonnull final Color start, @Nonnull final Color end,
+          @Nonnull final String[] tooltips) {
+        Objects.requireNonNull(start, "start must not be null");
+        Objects.requireNonNull(end, "end must not be null");
         return gradientSegments(new Color[] { start, end }, tooltips);
     }
 
     /**
      * Computes a single interpolated color for a segment index within a gradient.
      *
-     * @param anchors two or more colors to interpolate across
+     * @param anchors one or more colors to interpolate across; must not be {@code null} or empty
      * @param count   the total number of segments
-     * @param index   the zero-based index of the segment to color
+     * @param index   the zero-based index of the segment to color; must be in the range {@code [0, count)}
      *
      * @return the interpolated color for the segment
+     *
+     * @throws NullPointerException     if {@code anchors} is {@code null}
+     * @throws IllegalArgumentException if {@code anchors} is empty, or if {@code index} is outside {@code [0, count)}
      */
-    public static Color interpolatedColor(final Color[] anchors, final int count, final int index) {
+    public static @Nonnull Color interpolatedColor(@Nonnull final Color[] anchors, final int count, final int index) {
+        Objects.requireNonNull(anchors, "anchors must not be null");
+        if (anchors.length == 0) {
+            throw new IllegalArgumentException("anchors must contain at least one color");
+        }
+        if ((index < 0) || (index >= count)) {
+            throw new IllegalArgumentException("index must be in the range [0, " + count + "), but was " + index);
+        }
+
         if ((count <= 1) || (anchors.length == 1)) {
             return anchors[0];
         }
@@ -364,7 +395,7 @@ public class SegmentedBar extends JComponent {
         return interpolate(anchors[lower], anchors[upper], scaled - lower);
     }
 
-    private static Color interpolate(final Color from, final Color to, final float t) {
+    private static @Nonnull Color interpolate(@Nonnull final Color from, @Nonnull final Color to, final float t) {
         final int red = Math.round(from.getRed() + (to.getRed() - from.getRed()) * t);
         final int green = Math.round(from.getGreen() + (to.getGreen() - from.getGreen()) * t);
         final int blue = Math.round(from.getBlue() + (to.getBlue() - from.getBlue()) * t);

--- a/MekHQ/src/mekhq/gui/baseComponents/SegmentedBar.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/SegmentedBar.java
@@ -53,26 +53,18 @@ import megamek.common.annotations.Nullable;
  * A compact, reusable gauge that draws a row of equally-sized colored segments.
  *
  * <p>
- * Each segment carries its own fill {@link Color} and an optional tooltip shown
- * when the mouse hovers over that
- * segment. A subset of leading segments can be marked as "filled" (drawn in
- * full color) while the remainder are drawn
- * as neutral, hueless empty slots; this lets the component act either as a
- * static colored scale (all segments filled)
- * or as a level/progress indicator (filled up to the current value). Rendering
- * is intentionally flat: segments are
- * solid rounded rectangles with no borders or bevels. An optional thin outline
- * can highlight the last filled segment to
+ * Each segment carries its own fill {@link Color} and an optional tooltip shown when the mouse hovers over that
+ * segment. A subset of leading segments can be marked as "filled" (drawn in full color) while the remainder are drawn
+ * as neutral, hueless empty slots; this lets the component act either as a static colored scale (all segments filled)
+ * or as a level/progress indicator (filled up to the current value). Rendering is intentionally flat: segments are
+ * solid rounded rectangles with no borders or bevels. An optional thin outline can highlight the last filled segment to
  * call out the current level.
  * </p>
  *
  * <p>
- * The component is value-agnostic. Callers describe what to show by supplying a
- * list of {@link Segment Segments};
- * helper factory methods are provided to build those segments from a color
- * gradient. This makes the same control usable
- * for very different concepts (morale, reputation, readiness, ...) simply by
- * changing the segments and tooltips.
+ * The component is value-agnostic. Callers describe what to show by supplying a list of {@link Segment Segments};
+ * helper factory methods are provided to build those segments from a color gradient. This makes the same control usable
+ * for very different concepts (morale, reputation, readiness, ...) simply by changing the segments and tooltips.
  * </p>
  *
  * @author The MegaMek Team
@@ -82,17 +74,14 @@ public class SegmentedBar extends JComponent {
      * A single segment of the bar.
      *
      * @param color   the fill color used when the segment is active
-     * @param tooltip the tooltip to show when hovering this segment, or
-     *                {@code null} for no tooltip
+     * @param tooltip the tooltip to show when hovering this segment, or {@code null} for no tooltip
      */
     public record Segment(Color color, @Nullable String tooltip) {
     }
 
     private static final int DEFAULT_GAP = 2;
     private static final int DEFAULT_ARC = 4;
-    /**
-     * Vertical gap between the segment row and the active label drawn beneath it.
-     */
+    /** Vertical gap between the segment row and the active label drawn beneath it. */
     private static final int DEFAULT_LABEL_GAP = 3;
     /** Alpha applied to the neutral fill of inactive ("empty slot") segments. */
     private static final int INACTIVE_FILL_ALPHA = 28;
@@ -109,16 +98,14 @@ public class SegmentedBar extends JComponent {
      */
     public SegmentedBar() {
         setOpaque(false);
-        // Register so that per-segment tooltips returned from
-        // getToolTipText(MouseEvent) are displayed.
+        // Register so that per-segment tooltips returned from getToolTipText(MouseEvent) are displayed.
         ToolTipManager.sharedInstance().registerComponent(this);
     }
 
     /**
      * Sets the segments to display, left to right.
      *
-     * @param segments the segments to draw; {@code null} is treated as an empty
-     *                 list
+     * @param segments the segments to draw; {@code null} is treated as an empty list
      */
     public void setSegments(final @Nullable List<Segment> segments) {
         this.segments = (segments == null) ? List.of() : List.copyOf(segments);
@@ -127,12 +114,10 @@ public class SegmentedBar extends JComponent {
     }
 
     /**
-     * Sets how many leading segments are drawn in full color. Segments at or beyond
-     * this count are drawn as neutral
+     * Sets how many leading segments are drawn in full color. Segments at or beyond this count are drawn as neutral
      * empty slots.
      *
-     * @param filledCount the number of active segments, or a negative value to
-     *                    treat every segment as filled
+     * @param filledCount the number of active segments, or a negative value to treat every segment as filled
      */
     public void setFilledCount(final int filledCount) {
         this.filledCount = filledCount;
@@ -140,11 +125,9 @@ public class SegmentedBar extends JComponent {
     }
 
     /**
-     * Controls whether a thin outline highlights the last filled segment to
-     * emphasise the current level.
+     * Controls whether a thin outline highlights the last filled segment to emphasise the current level.
      *
-     * @param showEdgeMarker {@code true} to draw the highlight (the default),
-     *                       {@code false} to hide it
+     * @param showEdgeMarker {@code true} to draw the highlight (the default), {@code false} to hide it
      */
     public void setShowEdgeMarker(final boolean showEdgeMarker) {
         this.showEdgeMarker = showEdgeMarker;
@@ -152,15 +135,11 @@ public class SegmentedBar extends JComponent {
     }
 
     /**
-     * Sets an optional text label drawn, centered, beneath the last filled
-     * ("active") segment. The label may be wider
-     * than the segment it labels; it is centered on that segment's center and only
-     * nudged inward to stay within the
-     * component's bounds. Passing {@code null} or a blank string hides the label
-     * and reclaims its vertical space.
+     * Sets an optional text label drawn, centered, beneath the last filled ("active") segment. The label may be wider
+     * than the segment it labels; it is centered on that segment's center and only nudged inward to stay within the
+     * component's bounds. Passing {@code null} or a blank string hides the label and reclaims its vertical space.
      *
-     * @param activeLabel the text to draw under the active segment, or {@code null}
-     *                    for none
+     * @param activeLabel the text to draw under the active segment, or {@code null} for none
      */
     public void setActiveLabel(final @Nullable String activeLabel) {
         this.activeLabel = activeLabel;
@@ -200,9 +179,8 @@ public class SegmentedBar extends JComponent {
     }
 
     /**
-     * @return the vertical space reserved beneath the segment row for the active
-     *         label, or {@code 0} when no label is
-     *         set
+     * @return the vertical space reserved beneath the segment row for the active label, or {@code 0} when no label is
+     *       set
      */
     private int labelAreaHeight() {
         if ((activeLabel == null) || activeLabel.isBlank()) {
@@ -212,22 +190,19 @@ public class SegmentedBar extends JComponent {
     }
 
     /**
-     * @return the height available for the colored segment row, excluding any
-     *         active-label area
+     * @return the height available for the colored segment row, excluding any active-label area
      */
     private int barHeight() {
         return Math.max(getHeight() - labelAreaHeight(), 1);
     }
 
     /**
-     * Computes the pixel bounds of the segment at the given index. Both painting
-     * and tooltip hit-testing use this so
+     * Computes the pixel bounds of the segment at the given index. Both painting and tooltip hit-testing use this so
      * they stay in sync.
      *
      * @param index the zero-based segment index
      *
-     * @return the bounds of the segment, or {@code null} if the index is out of
-     *         range
+     * @return the bounds of the segment, or {@code null} if the index is out of range
      */
     protected @Nullable Rectangle segmentBounds(final int index) {
         final int count = segments.size();
@@ -327,8 +302,7 @@ public class SegmentedBar extends JComponent {
     }
 
     /**
-     * Returns a theme-aware neutral color used for empty slots and the edge marker.
-     * Derived from the label foreground
+     * Returns a theme-aware neutral color used for empty slots and the edge marker. Derived from the label foreground
      * color so it reads correctly on both light and dark themes.
      *
      * @return the neutral color
@@ -339,15 +313,11 @@ public class SegmentedBar extends JComponent {
     }
 
     /**
-     * Builds a list of segments whose colors are interpolated across the given
-     * gradient anchors. The number of segments
-     * equals the number of tooltips; anchor colors are spread evenly across that
-     * range.
+     * Builds a list of segments whose colors are interpolated across the given gradient anchors. The number of
+     * segments equals the number of tooltips; anchor colors are spread evenly across that range.
      *
-     * @param anchors  two or more colors to interpolate across, from first segment
-     *                 to last
-     * @param tooltips one tooltip per segment (its length determines the number of
-     *                 segments)
+     * @param anchors  two or more colors to interpolate across, from first segment to last
+     * @param tooltips one tooltip per segment (its length determines the number of segments)
      *
      * @return the generated segments
      */
@@ -365,8 +335,7 @@ public class SegmentedBar extends JComponent {
      *
      * @param start    the color of the first segment
      * @param end      the color of the last segment
-     * @param tooltips one tooltip per segment (its length determines the number of
-     *                 segments)
+     * @param tooltips one tooltip per segment (its length determines the number of segments)
      *
      * @return the generated segments
      */

--- a/MekHQ/src/mekhq/gui/baseComponents/SegmentedBar.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/SegmentedBar.java
@@ -1,0 +1,404 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.baseComponents;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.JComponent;
+import javax.swing.ToolTipManager;
+import javax.swing.UIManager;
+
+import megamek.client.ui.util.UIUtil;
+import megamek.common.annotations.Nullable;
+
+/**
+ * A compact, reusable gauge that draws a row of equally-sized colored segments.
+ *
+ * <p>
+ * Each segment carries its own fill {@link Color} and an optional tooltip shown
+ * when the mouse hovers over that
+ * segment. A subset of leading segments can be marked as "filled" (drawn in
+ * full color) while the remainder are drawn
+ * as neutral, hueless empty slots; this lets the component act either as a
+ * static colored scale (all segments filled)
+ * or as a level/progress indicator (filled up to the current value). Rendering
+ * is intentionally flat: segments are
+ * solid rounded rectangles with no borders or bevels. An optional thin outline
+ * can highlight the last filled segment to
+ * call out the current level.
+ * </p>
+ *
+ * <p>
+ * The component is value-agnostic. Callers describe what to show by supplying a
+ * list of {@link Segment Segments};
+ * helper factory methods are provided to build those segments from a color
+ * gradient. This makes the same control usable
+ * for very different concepts (morale, reputation, readiness, ...) simply by
+ * changing the segments and tooltips.
+ * </p>
+ *
+ * @author The MegaMek Team
+ */
+public class SegmentedBar extends JComponent {
+    /**
+     * A single segment of the bar.
+     *
+     * @param color   the fill color used when the segment is active
+     * @param tooltip the tooltip to show when hovering this segment, or
+     *                {@code null} for no tooltip
+     */
+    public record Segment(Color color, @Nullable String tooltip) {
+    }
+
+    private static final int DEFAULT_GAP = 2;
+    private static final int DEFAULT_ARC = 4;
+    /**
+     * Vertical gap between the segment row and the active label drawn beneath it.
+     */
+    private static final int DEFAULT_LABEL_GAP = 3;
+    /** Alpha applied to the neutral fill of inactive ("empty slot") segments. */
+    private static final int INACTIVE_FILL_ALPHA = 28;
+    /** Alpha applied to the outline that highlights the last filled segment. */
+    private static final int MARKER_ALPHA = 210;
+
+    private List<Segment> segments = List.of();
+    private int filledCount = -1;
+    private boolean showEdgeMarker = true;
+    private String activeLabel;
+
+    /**
+     * Creates an empty bar. Use {@link #setSegments(List)} to populate it.
+     */
+    public SegmentedBar() {
+        setOpaque(false);
+        // Register so that per-segment tooltips returned from
+        // getToolTipText(MouseEvent) are displayed.
+        ToolTipManager.sharedInstance().registerComponent(this);
+    }
+
+    /**
+     * Sets the segments to display, left to right.
+     *
+     * @param segments the segments to draw; {@code null} is treated as an empty
+     *                 list
+     */
+    public void setSegments(final @Nullable List<Segment> segments) {
+        this.segments = (segments == null) ? List.of() : List.copyOf(segments);
+        revalidate();
+        repaint();
+    }
+
+    /**
+     * Sets how many leading segments are drawn in full color. Segments at or beyond
+     * this count are drawn as neutral
+     * empty slots.
+     *
+     * @param filledCount the number of active segments, or a negative value to
+     *                    treat every segment as filled
+     */
+    public void setFilledCount(final int filledCount) {
+        this.filledCount = filledCount;
+        repaint();
+    }
+
+    /**
+     * Controls whether a thin outline highlights the last filled segment to
+     * emphasise the current level.
+     *
+     * @param showEdgeMarker {@code true} to draw the highlight (the default),
+     *                       {@code false} to hide it
+     */
+    public void setShowEdgeMarker(final boolean showEdgeMarker) {
+        this.showEdgeMarker = showEdgeMarker;
+        repaint();
+    }
+
+    /**
+     * Sets an optional text label drawn, centered, beneath the last filled
+     * ("active") segment. The label may be wider
+     * than the segment it labels; it is centered on that segment's center and only
+     * nudged inward to stay within the
+     * component's bounds. Passing {@code null} or a blank string hides the label
+     * and reclaims its vertical space.
+     *
+     * @param activeLabel the text to draw under the active segment, or {@code null}
+     *                    for none
+     */
+    public void setActiveLabel(final @Nullable String activeLabel) {
+        this.activeLabel = activeLabel;
+        revalidate();
+        repaint();
+    }
+
+    /**
+     * @return the effective number of filled segments, clamped to the segment count
+     */
+    protected int effectiveFilledCount() {
+        return (filledCount < 0) ? segments.size() : Math.min(filledCount, segments.size());
+    }
+
+    @Override
+    public Dimension getPreferredSize() {
+        final Dimension base = UIUtil.scaleForGUI(140, 14);
+        return new Dimension(base.width, base.height + labelAreaHeight());
+    }
+
+    @Override
+    public Dimension getMinimumSize() {
+        final Dimension base = UIUtil.scaleForGUI(84, 10);
+        return new Dimension(base.width, base.height + labelAreaHeight());
+    }
+
+    private int gap() {
+        return Math.max(UIUtil.scaleForGUI(DEFAULT_GAP), 1);
+    }
+
+    private int arc() {
+        return Math.max(UIUtil.scaleForGUI(DEFAULT_ARC), 2);
+    }
+
+    private int labelGap() {
+        return Math.max(UIUtil.scaleForGUI(DEFAULT_LABEL_GAP), 1);
+    }
+
+    /**
+     * @return the vertical space reserved beneath the segment row for the active
+     *         label, or {@code 0} when no label is
+     *         set
+     */
+    private int labelAreaHeight() {
+        if ((activeLabel == null) || activeLabel.isBlank()) {
+            return 0;
+        }
+        return labelGap() + getFontMetrics(getFont()).getHeight();
+    }
+
+    /**
+     * @return the height available for the colored segment row, excluding any
+     *         active-label area
+     */
+    private int barHeight() {
+        return Math.max(getHeight() - labelAreaHeight(), 1);
+    }
+
+    /**
+     * Computes the pixel bounds of the segment at the given index. Both painting
+     * and tooltip hit-testing use this so
+     * they stay in sync.
+     *
+     * @param index the zero-based segment index
+     *
+     * @return the bounds of the segment, or {@code null} if the index is out of
+     *         range
+     */
+    protected @Nullable Rectangle segmentBounds(final int index) {
+        final int count = segments.size();
+        if ((count == 0) || (index < 0) || (index >= count)) {
+            return null;
+        }
+        final int gap = gap();
+        final int totalGap = gap * (count - 1);
+        final int segmentWidth = Math.max((getWidth() - totalGap) / count, 1);
+        final int usedWidth = segmentWidth * count + totalGap;
+        final int xStart = Math.max((getWidth() - usedWidth) / 2, 0);
+        final int x = xStart + index * (segmentWidth + gap);
+        return new Rectangle(x, 0, segmentWidth, barHeight());
+    }
+
+    @Override
+    protected void paintComponent(final Graphics g) {
+        super.paintComponent(g);
+        if (segments.isEmpty()) {
+            return;
+        }
+
+        final Graphics2D g2 = (Graphics2D) g.create();
+        try {
+            g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+            final int arc = arc();
+            final int filled = effectiveFilledCount();
+            final Color neutral = neutralColor();
+
+            for (int i = 0; i < segments.size(); i++) {
+                final Rectangle bounds = segmentBounds(i);
+                if (bounds == null) {
+                    continue;
+                }
+
+                if (i < filled) {
+                    g2.setColor(segments.get(i).color());
+                } else {
+                    g2.setColor(new Color(neutral.getRed(), neutral.getGreen(), neutral.getBlue(),
+                            INACTIVE_FILL_ALPHA));
+                }
+                g2.fillRoundRect(bounds.x, bounds.y, bounds.width, bounds.height, arc, arc);
+            }
+
+            if (showEdgeMarker && (filled > 0)) {
+                final Rectangle bounds = segmentBounds(filled - 1);
+                if (bounds != null) {
+                    g2.setColor(new Color(neutral.getRed(), neutral.getGreen(), neutral.getBlue(), MARKER_ALPHA));
+                    g2.drawRoundRect(bounds.x, bounds.y, bounds.width - 1, bounds.height - 1, arc, arc);
+                }
+            }
+
+            paintActiveLabel(g2, filled);
+        } finally {
+            g2.dispose();
+        }
+    }
+
+    /**
+     * Draws the active label, if set, centered beneath the last filled segment.
+     *
+     * @param g2     the graphics context to paint on
+     * @param filled the effective number of filled segments
+     */
+    private void paintActiveLabel(final Graphics2D g2, final int filled) {
+        if ((activeLabel == null) || activeLabel.isBlank() || (filled <= 0)) {
+            return;
+        }
+        final Rectangle active = segmentBounds(filled - 1);
+        if (active == null) {
+            return;
+        }
+        g2.setColor(neutralColor());
+        final FontMetrics metrics = g2.getFontMetrics(getFont());
+        final int textWidth = metrics.stringWidth(activeLabel);
+        final int centerX = active.x + (active.width / 2);
+        int textX = centerX - (textWidth / 2);
+        // Keep the (potentially wider) label within the component bounds.
+        textX = Math.max(0, Math.min(textX, getWidth() - textWidth));
+        final int textY = active.height + labelGap() + metrics.getAscent();
+        g2.drawString(activeLabel, textX, textY);
+    }
+
+    @Override
+    public @Nullable String getToolTipText(final MouseEvent event) {
+        for (int i = 0; i < segments.size(); i++) {
+            final Rectangle bounds = segmentBounds(i);
+            if ((bounds != null) && bounds.contains(event.getPoint())) {
+                final String tooltip = segments.get(i).tooltip();
+                if (tooltip != null) {
+                    return tooltip;
+                }
+            }
+        }
+        return super.getToolTipText(event);
+    }
+
+    /**
+     * Returns a theme-aware neutral color used for empty slots and the edge marker.
+     * Derived from the label foreground
+     * color so it reads correctly on both light and dark themes.
+     *
+     * @return the neutral color
+     */
+    private static Color neutralColor() {
+        final Color foreground = UIManager.getColor("Label.foreground");
+        return (foreground == null) ? Color.GRAY : foreground;
+    }
+
+    /**
+     * Builds a list of segments whose colors are interpolated across the given
+     * gradient anchors. The number of segments
+     * equals the number of tooltips; anchor colors are spread evenly across that
+     * range.
+     *
+     * @param anchors  two or more colors to interpolate across, from first segment
+     *                 to last
+     * @param tooltips one tooltip per segment (its length determines the number of
+     *                 segments)
+     *
+     * @return the generated segments
+     */
+    public static List<Segment> gradientSegments(final Color[] anchors, final String[] tooltips) {
+        final int count = tooltips.length;
+        final List<Segment> result = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            result.add(new Segment(interpolatedColor(anchors, count, i), tooltips[i]));
+        }
+        return result;
+    }
+
+    /**
+     * Convenience overload that interpolates between a single start and end color.
+     *
+     * @param start    the color of the first segment
+     * @param end      the color of the last segment
+     * @param tooltips one tooltip per segment (its length determines the number of
+     *                 segments)
+     *
+     * @return the generated segments
+     */
+    public static List<Segment> gradientSegments(final Color start, final Color end, final String[] tooltips) {
+        return gradientSegments(new Color[] { start, end }, tooltips);
+    }
+
+    /**
+     * Computes a single interpolated color for a segment index within a gradient.
+     *
+     * @param anchors two or more colors to interpolate across
+     * @param count   the total number of segments
+     * @param index   the zero-based index of the segment to color
+     *
+     * @return the interpolated color for the segment
+     */
+    public static Color interpolatedColor(final Color[] anchors, final int count, final int index) {
+        if ((count <= 1) || (anchors.length == 1)) {
+            return anchors[0];
+        }
+
+        final float fraction = (float) index / (count - 1);
+        final float scaled = fraction * (anchors.length - 1);
+        final int lower = (int) Math.floor(scaled);
+        final int upper = Math.min(lower + 1, anchors.length - 1);
+        return interpolate(anchors[lower], anchors[upper], scaled - lower);
+    }
+
+    private static Color interpolate(final Color from, final Color to, final float t) {
+        final int red = Math.round(from.getRed() + (to.getRed() - from.getRed()) * t);
+        final int green = Math.round(from.getGreen() + (to.getGreen() - from.getGreen()) * t);
+        final int blue = Math.round(from.getBlue() + (to.getBlue() - from.getBlue()) * t);
+        return new Color(red, green, blue);
+    }
+}

--- a/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogNotification.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogNotification.java
@@ -35,7 +35,9 @@ package mekhq.gui.baseComponents.immersiveDialogs;
 import static mekhq.utilities.MHQInternationalization.getText;
 
 import java.util.List;
+import javax.swing.JPanel;
 
+import megamek.common.annotations.Nullable;
 import mekhq.campaign.Campaign;
 
 /**
@@ -122,6 +124,40 @@ public class ImmersiveDialogNotification extends ImmersiveDialogCore {
               null,
               null,
               isModal);
+    }
+
+    /**
+     * Constructs a notification dialog with the specified campaign context,
+     * message, bottom message, a supplemental
+     * panel shown between the message and the buttons, and modality.
+     *
+     * @param campaign          the current campaign context
+     * @param centerMessage     the main message to display in the center of the
+     *                          dialog
+     * @param bottomMessage     the message to display in the bottom of the dialog,
+     *                          or {@code null} for none
+     * @param supplementalPanel an optional panel (for example a gauge or chart)
+     *                          rendered between the message and the
+     *                          buttons, or {@code null} for none
+     * @param isModal           {@code true} if the dialog should be modal,
+     *                          {@code false} otherwise
+     *
+     * @author VicenteCartas
+     * @since 0.51.01
+     */
+    public ImmersiveDialogNotification(Campaign campaign, String centerMessage, @Nullable String bottomMessage,
+            @Nullable JPanel supplementalPanel, boolean isModal) {
+        super(campaign,
+                null,
+                null,
+                centerMessage,
+                createButtons(),
+                bottomMessage,
+                ImmersiveDialogWidth.MEDIUM.getWidth(),
+                false,
+                supplementalPanel,
+                null,
+                isModal);
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogNotification.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogNotification.java
@@ -37,7 +37,7 @@ import static mekhq.utilities.MHQInternationalization.getText;
 import java.util.List;
 import javax.swing.JPanel;
 
-import megamek.common.annotations.Nullable;
+import jakarta.annotation.Nullable;
 import mekhq.campaign.Campaign;
 
 /**

--- a/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
@@ -576,8 +576,6 @@ public class MissionViewPanel extends JScrollablePanel {
         JLabel txtAllyRating = new JLabel();
         JLabel lblEnemyRating = new JLabel();
         JLabel txtEnemyRating = new JLabel();
-        JLabel lblMorale = new JLabel();
-        JLabel txtMorale = new JLabel();
         JLabel lblSharePct = new JLabel();
         JLabel txtSharePct = new JLabel();
         JLabel lblCargoRequirement = new JLabel();
@@ -1050,44 +1048,16 @@ public class MissionViewPanel extends JScrollablePanel {
 
         addDescriptionPane(contract.getDescription(), y++, 0.0);
 
-        // Enemy morale (text, trend arrow, and gauge) is intentionally shown at the
-        // very bottom of the panel, after
-        // the contract description.
-        final String moraleText;
-        final String moraleTooltip;
-        if ((contract.getContractType().isGarrisonDuty() || contract.getContractType().isRetainer()) &&
-                contract.getMoraleLevel().isRouted()) {
-            moraleText = resourceMap.getString("txtGarrisonMoraleRouted.text");
-            moraleTooltip = resourceMap.getString("txtGarrisonMoraleRouted.tooltip");
-        } else {
-            moraleText = contract.getMoraleLevel().toString();
-            moraleTooltip = contract.getMoraleLevel().getToolTipText();
-        }
+        // Enemy morale is shown at the very bottom of the panel, after the contract
+        // description, as a labelled gauge.
+        // The bar's own label (which honours the special "Peaceful" wording for routed
+        // garrison/retainer contracts) is
+        // self-explanatory, so no separate "Enemy Morale:" caption is needed.
+        final MoraleBar.MoraleDisplay moraleDisplay = MoraleBar.getMoraleDisplay(contract);
+        final String moraleText = moraleDisplay.label();
+        final String moraleTooltip = moraleDisplay.tooltip();
 
-        lblMorale.setName("lblMorale");
-        lblMorale.setText(resourceMap.getString("lblMorale.text"));
-        lblMorale.setToolTipText(wordWrap(moraleTooltip));
-        gridBagConstraints = new GridBagConstraints();
-        gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = y;
-        gridBagConstraints.insets = new Insets(6, 0, 0, 0);
-        gridBagConstraints.fill = GridBagConstraints.NONE;
-        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-        pnlStats.add(lblMorale, gridBagConstraints);
-
-        txtMorale.setName("txtMorale");
-        txtMorale.setText("<html>" + moraleText + getMoraleTrendArrow(contract.getMoraleTrend()) + "</html>");
-        txtMorale.setToolTipText(wordWrap(moraleTooltip));
-        gridBagConstraints = new GridBagConstraints();
-        gridBagConstraints.gridx = 1;
-        gridBagConstraints.gridy = y++;
-        gridBagConstraints.weightx = 0.5;
-        gridBagConstraints.insets = new Insets(6, 10, 0, 0);
-        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
-        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-        pnlStats.add(txtMorale, gridBagConstraints);
-
-        MoraleBar moraleBar = new MoraleBar(contract.getMoraleLevel());
+        MoraleBar moraleBar = new MoraleBar(contract.getMoraleLevel(), moraleText);
         moraleBar.setToolTipText(wordWrap(moraleTooltip));
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
@@ -1095,37 +1065,10 @@ public class MissionViewPanel extends JScrollablePanel {
         gridBagConstraints.gridwidth = 2;
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.weighty = 1.0;
-        gridBagConstraints.insets = new Insets(2, 0, 2, 0);
+        gridBagConstraints.insets = new Insets(UIUtil.scaleForGUI(6), 0, 2, 0);
         gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         pnlStats.add(moraleBar, gridBagConstraints);
-    }
-
-    /**
-     * Builds the small HTML snippet used to show the enemy morale trend next to the
-     * morale value.
-     *
-     * <p>
-     * The trend is shown from the player's perspective: rising enemy morale is
-     * dangerous and shown with a red up
-     * arrow, while falling enemy morale is favourable and shown with a green down
-     * arrow. No arrow is shown when the
-     * trend is unchanged or unknown.
-     * </p>
-     *
-     * @param trend a positive value if enemy morale rose, negative if it fell, or
-     *              zero if unchanged/unknown
-     *
-     * @return an HTML fragment containing the colored trend arrow, or an empty
-     *         string if there is no trend to show
-     */
-    private String getMoraleTrendArrow(int trend) {
-        if (trend > 0) {
-            return " <span style='color:" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + ";'>&#9650;</span>";
-        } else if (trend < 0) {
-            return " <span style='color:" + MekHQ.getMHQOptions().getFontColorPositiveHexColor() + ";'>&#9660;</span>";
-        }
-        return "";
     }
 
     private void addDescriptionPane(String description, int gridY) {

--- a/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
@@ -1048,7 +1048,10 @@ public class MissionViewPanel extends JScrollablePanel {
 
         addDescriptionPane(contract.getDescription(), y++, 0.0);
 
-        // Enemy morale is shown at the very bottom of the panel, as a labelled gauge.
+        // Enemy morale is shown as a labelled gauge at the very bottom of the panel, after the contract description.
+        // This (always-present) row carries the panel's vertical weight so the contract stats stay anchored to the top
+        // rather than centering; SOUTHWEST anchoring keeps the fixed-height gauge pinned to the bottom of that row, so
+        // any extra vertical space falls above the gauge instead of below it.
         final MoraleBar.MoraleDisplay moraleDisplay = MoraleBar.getMoraleDisplay(contract);
         final String moraleText = moraleDisplay.label();
         final String moraleTooltip = moraleDisplay.tooltip();
@@ -1063,7 +1066,7 @@ public class MissionViewPanel extends JScrollablePanel {
         gridBagConstraints.weighty = 1.0;
         gridBagConstraints.insets = new Insets(UIUtil.scaleForGUI(6), 0, 2, 0);
         gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
-        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
+        gridBagConstraints.anchor = GridBagConstraints.SOUTHWEST;
         pnlStats.add(moraleBar, gridBagConstraints);
     }
 

--- a/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
@@ -247,7 +247,7 @@ public class MissionViewPanel extends JScrollablePanel {
             pnlStats.add(txtType, gridBagConstraints);
         }
 
-        addDescriptionPane(mission.getDescription(), 3);
+        addDescriptionPane(mission.getDescription(), 3, 1.0);
     }
 
     private void fillStatsContract() {
@@ -542,7 +542,7 @@ public class MissionViewPanel extends JScrollablePanel {
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         pnlStats.add(lblSalvagePct2, gridBagConstraints);
         i++;
-        addDescriptionPane(contract.getDescription(), i);
+        addDescriptionPane(contract.getDescription(), i, 1.0);
 
     }
 
@@ -1048,11 +1048,7 @@ public class MissionViewPanel extends JScrollablePanel {
 
         addDescriptionPane(contract.getDescription(), y++, 0.0);
 
-        // Enemy morale is shown at the very bottom of the panel, after the contract
-        // description, as a labelled gauge.
-        // The bar's own label (which honours the special "Peaceful" wording for routed
-        // garrison/retainer contracts) is
-        // self-explanatory, so no separate "Enemy Morale:" caption is needed.
+        // Enemy morale is shown at the very bottom of the panel, as a labelled gauge.
         final MoraleBar.MoraleDisplay moraleDisplay = MoraleBar.getMoraleDisplay(contract);
         final String moraleText = moraleDisplay.label();
         final String moraleTooltip = moraleDisplay.tooltip();
@@ -1069,10 +1065,6 @@ public class MissionViewPanel extends JScrollablePanel {
         gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         pnlStats.add(moraleBar, gridBagConstraints);
-    }
-
-    private void addDescriptionPane(String description, int gridY) {
-        addDescriptionPane(description, gridY, 1.0);
     }
 
     private void addDescriptionPane(String description, int gridY, double weighty) {

--- a/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
@@ -923,35 +923,6 @@ public class MissionViewPanel extends JScrollablePanel {
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         pnlStats.add(txtSalvagePct, gridBagConstraints);
 
-        lblMorale.setName("lblMorale");
-        lblMorale.setText(resourceMap.getString("lblMorale.text"));
-        lblMorale.setToolTipText(wordWrap(contract.getMoraleLevel().getToolTipText()));
-        gridBagConstraints = new GridBagConstraints();
-        gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = y;
-        gridBagConstraints.fill = GridBagConstraints.NONE;
-        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-        pnlStats.add(lblMorale, gridBagConstraints);
-
-        txtMorale.setName("txtMorale");
-
-        if ((contract.getContractType().isGarrisonDuty() || contract.getContractType().isRetainer()) &&
-                  contract.getMoraleLevel().isRouted()) {
-            txtMorale.setText(resourceMap.getString("txtGarrisonMoraleRouted.text"));
-            txtMorale.setToolTipText(wordWrap(resourceMap.getString("txtGarrisonMoraleRouted.tooltip")));
-        } else {
-            txtMorale.setText(contract.getMoraleLevel().toString());
-            txtMorale.setToolTipText(wordWrap(contract.getMoraleLevel().getToolTipText()));
-        }
-        gridBagConstraints = new GridBagConstraints();
-        gridBagConstraints.gridx = 1;
-        gridBagConstraints.gridy = y++;
-        gridBagConstraints.weightx = 0.5;
-        gridBagConstraints.insets = new Insets(0, 10, 0, 0);
-        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
-        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-        pnlStats.add(txtMorale, gridBagConstraints);
-
         if (campaign.getCampaignOptions().isUseShareSystem()) {
             lblSharePct.setName("lblSharePct");
             lblSharePct.setText(resourceMap.getString("lblSharePct.text"));
@@ -1077,10 +1048,91 @@ public class MissionViewPanel extends JScrollablePanel {
             pnlStats.add(txtSupport, gridBagConstraints);
         }
 
-        addDescriptionPane(contract.getDescription(), y);
+        addDescriptionPane(contract.getDescription(), y++, 0.0);
+
+        // Enemy morale (text, trend arrow, and gauge) is intentionally shown at the
+        // very bottom of the panel, after
+        // the contract description.
+        final String moraleText;
+        final String moraleTooltip;
+        if ((contract.getContractType().isGarrisonDuty() || contract.getContractType().isRetainer()) &&
+                contract.getMoraleLevel().isRouted()) {
+            moraleText = resourceMap.getString("txtGarrisonMoraleRouted.text");
+            moraleTooltip = resourceMap.getString("txtGarrisonMoraleRouted.tooltip");
+        } else {
+            moraleText = contract.getMoraleLevel().toString();
+            moraleTooltip = contract.getMoraleLevel().getToolTipText();
+        }
+
+        lblMorale.setName("lblMorale");
+        lblMorale.setText(resourceMap.getString("lblMorale.text"));
+        lblMorale.setToolTipText(wordWrap(moraleTooltip));
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = y;
+        gridBagConstraints.insets = new Insets(6, 0, 0, 0);
+        gridBagConstraints.fill = GridBagConstraints.NONE;
+        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
+        pnlStats.add(lblMorale, gridBagConstraints);
+
+        txtMorale.setName("txtMorale");
+        txtMorale.setText("<html>" + moraleText + getMoraleTrendArrow(contract.getMoraleTrend()) + "</html>");
+        txtMorale.setToolTipText(wordWrap(moraleTooltip));
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = y++;
+        gridBagConstraints.weightx = 0.5;
+        gridBagConstraints.insets = new Insets(6, 10, 0, 0);
+        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
+        pnlStats.add(txtMorale, gridBagConstraints);
+
+        MoraleBar moraleBar = new MoraleBar(contract.getMoraleLevel());
+        moraleBar.setToolTipText(wordWrap(moraleTooltip));
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = y;
+        gridBagConstraints.gridwidth = 2;
+        gridBagConstraints.weightx = 1.0;
+        gridBagConstraints.weighty = 1.0;
+        gridBagConstraints.insets = new Insets(2, 0, 2, 0);
+        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
+        pnlStats.add(moraleBar, gridBagConstraints);
+    }
+
+    /**
+     * Builds the small HTML snippet used to show the enemy morale trend next to the
+     * morale value.
+     *
+     * <p>
+     * The trend is shown from the player's perspective: rising enemy morale is
+     * dangerous and shown with a red up
+     * arrow, while falling enemy morale is favourable and shown with a green down
+     * arrow. No arrow is shown when the
+     * trend is unchanged or unknown.
+     * </p>
+     *
+     * @param trend a positive value if enemy morale rose, negative if it fell, or
+     *              zero if unchanged/unknown
+     *
+     * @return an HTML fragment containing the colored trend arrow, or an empty
+     *         string if there is no trend to show
+     */
+    private String getMoraleTrendArrow(int trend) {
+        if (trend > 0) {
+            return " <span style='color:" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + ";'>&#9650;</span>";
+        } else if (trend < 0) {
+            return " <span style='color:" + MekHQ.getMHQOptions().getFontColorPositiveHexColor() + ";'>&#9660;</span>";
+        }
+        return "";
     }
 
     private void addDescriptionPane(String description, int gridY) {
+        addDescriptionPane(description, gridY, 1.0);
+    }
+
+    private void addDescriptionPane(String description, int gridY, double weighty) {
         if ((description == null) || description.isBlank()) {
             return;
         }
@@ -1095,7 +1147,7 @@ public class MissionViewPanel extends JScrollablePanel {
         gridBagConstraints.gridy = gridY;
         gridBagConstraints.gridwidth = 2;
         gridBagConstraints.weightx = 1.0;
-        gridBagConstraints.weighty = 1.0;
+        gridBagConstraints.weighty = weighty;
         gridBagConstraints.insets = new Insets(0, 0, 5, 0);
         gridBagConstraints.fill = GridBagConstraints.BOTH;
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;

--- a/MekHQ/src/mekhq/gui/view/MoraleBar.java
+++ b/MekHQ/src/mekhq/gui/view/MoraleBar.java
@@ -63,13 +63,15 @@ import mekhq.gui.baseComponents.SegmentedBar;
  * </p>
  *
  * <p>
- * This is a thin configuration of the reusable {@link SegmentedBar}; all
- * rendering and tooltip handling live there.
+ * This wraps a private {@link SegmentedBar} (composition rather than
+ * inheritance) so that only the morale-specific API is exposed; callers cannot
+ * reconfigure the underlying segments and break the "one segment per morale
+ * level" invariant.
  * </p>
  *
  * @author The MegaMek Team
  */
-public class MoraleBar extends SegmentedBar {
+public class MoraleBar extends JPanel {
     /**
      * Anchor colors for the morale gradient, ordered from the lowest enemy morale
      * to the highest. Low enemy morale is
@@ -91,13 +93,19 @@ public class MoraleBar extends SegmentedBar {
     };
 
     /**
+     * The wrapped gauge. Kept private so the segment-level API is not exposed to
+     * callers.
+     */
+    private final SegmentedBar bar = new SegmentedBar();
+
+    /**
      * Creates a morale bar for the given morale level.
      *
      * @param moraleLevel the enemy morale level to display; may be {@code null}, in
      *                    which case nothing is painted
      */
     public MoraleBar(final @Nullable AtBMoraleLevel moraleLevel) {
-        setMoraleLevel(moraleLevel);
+        this(moraleLevel, (moraleLevel == null) ? null : moraleLevel.toString());
     }
 
     /**
@@ -112,6 +120,9 @@ public class MoraleBar extends SegmentedBar {
      *                    name
      */
     public MoraleBar(final @Nullable AtBMoraleLevel moraleLevel, final @Nullable String labelText) {
+        super(new BorderLayout());
+        setOpaque(false);
+        add(bar, BorderLayout.CENTER);
         setMoraleLevel(moraleLevel, labelText);
     }
 
@@ -138,9 +149,9 @@ public class MoraleBar extends SegmentedBar {
      */
     public void setMoraleLevel(final @Nullable AtBMoraleLevel moraleLevel, final @Nullable String labelText) {
         if (moraleLevel == null) {
-            setSegments(List.of());
-            setFilledCount(0);
-            setActiveLabel(null);
+            bar.setSegments(List.of());
+            bar.setFilledCount(0);
+            bar.setActiveLabel(null);
             return;
         }
 
@@ -150,9 +161,22 @@ public class MoraleBar extends SegmentedBar {
             tooltips[i] = wordWrap(levels[i] + " \u2014 " + levels[i].getToolTipText());
         }
 
-        setSegments(gradientSegments(MORALE_GRADIENT, tooltips));
-        setFilledCount(moraleLevel.getLevel() - AtBMoraleLevel.MINIMUM_MORALE_LEVEL + 1);
-        setActiveLabel(labelText);
+        bar.setSegments(SegmentedBar.gradientSegments(MORALE_GRADIENT, tooltips));
+        bar.setFilledCount(moraleLevel.getLevel() - AtBMoraleLevel.MINIMUM_MORALE_LEVEL + 1);
+        bar.setActiveLabel(labelText);
+    }
+
+    /**
+     * Forwards the tooltip to the wrapped gauge so that the area around the
+     * segments (gaps and the label) shows this
+     * fallback tooltip, while individual segments keep their own per-level
+     * tooltips.
+     *
+     * @param text the tooltip text, or {@code null} for none
+     */
+    @Override
+    public void setToolTipText(final @Nullable String text) {
+        bar.setToolTipText(text);
     }
 
     /**
@@ -179,9 +203,9 @@ public class MoraleBar extends SegmentedBar {
                 horizontalPadding));
 
         final MoraleDisplay display = getMoraleDisplay(contract);
-        final MoraleBar bar = new MoraleBar(contract.getMoraleLevel(), display.label());
-        bar.setToolTipText(wordWrap(display.tooltip()));
-        panel.add(bar, BorderLayout.CENTER);
+        final MoraleBar moraleBar = new MoraleBar(contract.getMoraleLevel(), display.label());
+        moraleBar.setToolTipText(wordWrap(display.tooltip()));
+        panel.add(moraleBar, BorderLayout.CENTER);
         return panel;
     }
 

--- a/MekHQ/src/mekhq/gui/view/MoraleBar.java
+++ b/MekHQ/src/mekhq/gui/view/MoraleBar.java
@@ -32,65 +32,63 @@
  */
 package mekhq.gui.view;
 
-import java.awt.BasicStroke;
+import static megamek.client.ui.WrapLayout.wordWrap;
+
+import java.awt.BorderLayout;
 import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Graphics;
-import java.awt.Graphics2D;
-import java.awt.RenderingHints;
-import javax.swing.JComponent;
-import javax.swing.UIManager;
+import java.util.List;
+import java.util.ResourceBundle;
+import javax.swing.BorderFactory;
+import javax.swing.JPanel;
 
 import megamek.client.ui.util.UIUtil;
 import megamek.common.annotations.Nullable;
+import mekhq.MekHQ;
+import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.enums.AtBMoraleLevel;
+import mekhq.gui.baseComponents.SegmentedBar;
 
 /**
  * A compact, segmented gauge that visualizes enemy {@link AtBMoraleLevel}.
  *
  * <p>
  * The bar has one segment per possible morale level, ordered from the morale
- * scale's minimum to its maximum. Each
- * segment is colored on a fixed green-to-red gradient and the colors are
- * presented from the <em>player's</em>
- * perspective: low enemy morale (e.g. {@code ROUTED}) is green because it is
- * favourable for the player, while high
- * enemy morale (e.g. {@code OVERWHELMING}) is red because it is dangerous.
- * Segments up to and including the current
- * morale level are drawn at full strength; the remaining segments are faded, so
- * the lit length communicates how high
- * the enemy's morale currently is while the lit "tip" colour communicates its
- * severity.
+ * scale's minimum to its maximum. The gauge reads like the enemy's morale
+ * meter: the more segments that are lit, the higher the enemy's morale. The
+ * colors are presented from the <em>player's</em> perspective: low enemy morale
+ * (a routed enemy) is green because it is favourable for the player, climbing
+ * through orange and into red at the highest morale (a dangerous,
+ * fully-committed enemy). Hovering a segment shows the name and description of
+ * that morale level.
+ * </p>
+ *
+ * <p>
+ * This is a thin configuration of the reusable {@link SegmentedBar}; all
+ * rendering and tooltip handling live there.
  * </p>
  *
  * @author The MegaMek Team
  */
-public class MoraleBar extends JComponent {
-    private static final int SEGMENT_COUNT = AtBMoraleLevel.MAXIMUM_MORALE_LEVEL - AtBMoraleLevel.MINIMUM_MORALE_LEVEL
-            + 1;
-    private static final int FADED_ALPHA = 55;
-    private static final int BORDER_ALPHA = 60;
-
+public class MoraleBar extends SegmentedBar {
     /**
-     * Anchor colors for the morale gradient, ordered from the most favourable
-     * morale for the player (deep green) to the
-     * most dangerous (deep red). The colors are deliberately deep and well
-     * separated so that adjacent segments remain
-     * easy to tell apart. Segment colors are interpolated across these anchors, so
-     * the gauge works for any number of
-     * morale levels.
+     * Anchor colors for the morale gradient, ordered from the lowest enemy morale
+     * to the highest. Low enemy morale is
+     * green (favourable for the player) and high enemy morale is red (dangerous for
+     * the player), so the gauge reads as
+     * an enemy-strength meter from the player's perspective: a short green bar is
+     * good news, a long red bar is bad. The
+     * colors are deliberately deep and well separated so that adjacent segments
+     * remain easy to tell apart.
      */
     private static final Color[] MORALE_GRADIENT = {
-            new Color(0x12, 0x7C, 0x1E), // deep green - most favourable for the player
+            new Color(0x12, 0x7C, 0x1E), // deep green - lowest enemy morale, most favourable for the player
             new Color(0x36, 0xB3, 0x2B), // green
             new Color(0x8C, 0xC6, 0x1A), // lime
             new Color(0xE8, 0xC4, 0x0A), // gold
             new Color(0xF2, 0x86, 0x00), // orange
             new Color(0xD2, 0x44, 0x10), // red-orange
-            new Color(0xA8, 0x12, 0x12) // deep red - most dangerous for the player
+            new Color(0xA8, 0x12, 0x12) // deep red - highest enemy morale, most dangerous for the player
     };
-
-    private AtBMoraleLevel moraleLevel;
 
     /**
      * Creates a morale bar for the given morale level.
@@ -99,117 +97,125 @@ public class MoraleBar extends JComponent {
      *                    which case nothing is painted
      */
     public MoraleBar(final @Nullable AtBMoraleLevel moraleLevel) {
-        this.moraleLevel = moraleLevel;
-        setOpaque(false);
+        setMoraleLevel(moraleLevel);
     }
 
     /**
-     * Updates the displayed morale level and repaints the bar.
+     * Creates a morale bar for the given morale level with a custom label drawn
+     * beneath the active segment.
      *
-     * @param moraleLevel the new enemy morale level to display
+     * @param moraleLevel the enemy morale level to display; may be {@code null}, in
+     *                    which case nothing is painted
+     * @param labelText   the text to show beneath the current level (for example a
+     *                    contract-specific name such as
+     *                    "Peaceful"), or {@code null} to use the morale level's own
+     *                    name
+     */
+    public MoraleBar(final @Nullable AtBMoraleLevel moraleLevel, final @Nullable String labelText) {
+        setMoraleLevel(moraleLevel, labelText);
+    }
+
+    /**
+     * Updates the displayed morale level and repaints the bar. The label beneath
+     * the active segment defaults to the
+     * morale level's own name.
+     *
+     * @param moraleLevel the new enemy morale level to display, or {@code null} to
+     *                    clear the bar
      */
     public void setMoraleLevel(final @Nullable AtBMoraleLevel moraleLevel) {
-        this.moraleLevel = moraleLevel;
-        repaint();
+        setMoraleLevel(moraleLevel, (moraleLevel == null) ? null : moraleLevel.toString());
     }
 
-    @Override
-    public Dimension getPreferredSize() {
-        return UIUtil.scaleForGUI(140, 14);
-    }
-
-    @Override
-    public Dimension getMinimumSize() {
-        return UIUtil.scaleForGUI(84, 10);
-    }
-
-    @Override
-    protected void paintComponent(final Graphics g) {
-        super.paintComponent(g);
+    /**
+     * Updates the displayed morale level and the label drawn beneath the active
+     * segment, then repaints the bar.
+     *
+     * @param moraleLevel the new enemy morale level to display, or {@code null} to
+     *                    clear the bar
+     * @param labelText   the text to show beneath the current level, or
+     *                    {@code null} for no label
+     */
+    public void setMoraleLevel(final @Nullable AtBMoraleLevel moraleLevel, final @Nullable String labelText) {
         if (moraleLevel == null) {
+            setSegments(List.of());
+            setFilledCount(0);
+            setActiveLabel(null);
             return;
         }
 
-        final Graphics2D g2 = (Graphics2D) g.create();
-        try {
-            g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-
-            final int width = getWidth();
-            final int height = getHeight();
-            final int gap = Math.max(UIUtil.scaleForGUI(2), 1);
-            final int arc = Math.max(UIUtil.scaleForGUI(4), 2);
-            final int totalGap = gap * (SEGMENT_COUNT - 1);
-            final int segmentWidth = Math.max((width - totalGap) / SEGMENT_COUNT, 1);
-            final int usedWidth = segmentWidth * SEGMENT_COUNT + totalGap;
-            final int xStart = Math.max((width - usedWidth) / 2, 0);
-
-            final int filledIndex = moraleLevel.getLevel() - AtBMoraleLevel.MINIMUM_MORALE_LEVEL;
-
-            for (int i = 0; i < SEGMENT_COUNT; i++) {
-                final int x = xStart + i * (segmentWidth + gap);
-                final Color base = segmentColor(i);
-
-                if (i <= filledIndex) {
-                    g2.setColor(base);
-                } else {
-                    g2.setColor(new Color(base.getRed(), base.getGreen(), base.getBlue(), FADED_ALPHA));
-                }
-                g2.fillRoundRect(x, 0, segmentWidth, height, arc, arc);
-
-                g2.setColor(new Color(0, 0, 0, BORDER_ALPHA));
-                g2.drawRoundRect(x, 0, segmentWidth - 1, height - 1, arc, arc);
-            }
-
-            // Outline the current level so the exact morale value is unambiguous.
-            final int markerX = xStart + filledIndex * (segmentWidth + gap);
-            Color markerColor = UIManager.getColor("Label.foreground");
-            if (markerColor == null) {
-                markerColor = Color.WHITE;
-            }
-            g2.setColor(markerColor);
-            g2.setStroke(new BasicStroke(Math.max(UIUtil.scaleForGUI(2), 1)));
-            g2.drawRoundRect(markerX, 0, segmentWidth - 1, height - 1, arc, arc);
-        } finally {
-            g2.dispose();
+        final AtBMoraleLevel[] levels = AtBMoraleLevel.values();
+        final String[] tooltips = new String[levels.length];
+        for (int i = 0; i < levels.length; i++) {
+            tooltips[i] = wordWrap(levels[i] + " \u2014 " + levels[i].getToolTipText());
         }
+
+        setSegments(gradientSegments(MORALE_GRADIENT, tooltips));
+        setFilledCount(moraleLevel.getLevel() - AtBMoraleLevel.MINIMUM_MORALE_LEVEL + 1);
+        setActiveLabel(labelText);
     }
 
     /**
-     * Computes the color for the segment at the given index by interpolating across
-     * the deep, well-separated
-     * {@link #MORALE_GRADIENT} anchors, from green (favorable for the player) at
-     * the lowest morale to red (dangerous
-     * for the player) at the highest.
+     * Builds a self-contained panel wrapping a {@link MoraleBar}, suitable for
+     * embedding in dialogs such as the
+     * immersive "Morale Update" notification. The bar is given generous horizontal
+     * padding so it reads as a centered
+     * gauge rather than spanning the full dialog width. The label beneath the
+     * active
+     * segment honours the contract's
+     * special "Peaceful" wording for routed garrison/retainer contracts, matching
+     * the briefing-room contract panel.
      *
-     * @param index the zero-based segment index, from lowest to highest morale
+     * @param contract the contract whose enemy morale should be displayed
      *
-     * @return the color for the segment
+     * @return a transparent panel containing the configured morale bar
      */
-    private static Color segmentColor(final int index) {
-        if (SEGMENT_COUNT <= 1) {
-            return MORALE_GRADIENT[0];
-        }
+    public static JPanel createDialogPanel(final AtBContract contract) {
+        final JPanel panel = new JPanel(new BorderLayout());
+        panel.setOpaque(false);
+        final int horizontalPadding = UIUtil.scaleForGUI(40);
+        final int verticalPadding = UIUtil.scaleForGUI(6);
+        panel.setBorder(BorderFactory.createEmptyBorder(verticalPadding, horizontalPadding, verticalPadding,
+                horizontalPadding));
 
-        final float fraction = (float) index / (SEGMENT_COUNT - 1);
-        final float scaled = fraction * (MORALE_GRADIENT.length - 1);
-        final int lower = (int) Math.floor(scaled);
-        final int upper = Math.min(lower + 1, MORALE_GRADIENT.length - 1);
-        return interpolate(MORALE_GRADIENT[lower], MORALE_GRADIENT[upper], scaled - lower);
+        final MoraleDisplay display = getMoraleDisplay(contract);
+        final MoraleBar bar = new MoraleBar(contract.getMoraleLevel(), display.label());
+        bar.setToolTipText(wordWrap(display.tooltip()));
+        panel.add(bar, BorderLayout.CENTER);
+        return panel;
     }
 
     /**
-     * Linearly interpolates between two colors.
+     * The display text and tooltip used to describe a contract's enemy morale.
      *
-     * @param from the color at {@code t == 0}
-     * @param to   the color at {@code t == 1}
-     * @param t    the interpolation factor, in the range {@code [0, 1]}
-     *
-     * @return the interpolated color
+     * @param label   the short morale name to show (e.g. a morale level name, or
+     *                "Peaceful")
+     * @param tooltip the descriptive tooltip for that morale state
      */
-    private static Color interpolate(final Color from, final Color to, final float t) {
-        final int red = Math.round(from.getRed() + (to.getRed() - from.getRed()) * t);
-        final int green = Math.round(from.getGreen() + (to.getGreen() - from.getGreen()) * t);
-        final int blue = Math.round(from.getBlue() + (to.getBlue() - from.getBlue()) * t);
-        return new Color(red, green, blue);
+    public record MoraleDisplay(String label, String tooltip) {
+    }
+
+    /**
+     * Computes the morale label and tooltip for a contract, applying the special
+     * "Peaceful" wording used for routed
+     * garrison-duty and retainer contracts. This is the single source of truth
+     * shared by the briefing-room contract
+     * panel and the morale dialog so the two never diverge.
+     *
+     * @param contract the contract whose enemy morale should be described
+     *
+     * @return the label and tooltip to display
+     */
+    public static MoraleDisplay getMoraleDisplay(final AtBContract contract) {
+        final AtBMoraleLevel level = contract.getMoraleLevel();
+        if ((contract.getContractType().isGarrisonDuty() || contract.getContractType().isRetainer()) &&
+                level.isRouted()) {
+            final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.ContractViewPanel",
+                    MekHQ.getMHQOptions().getLocale());
+            return new MoraleDisplay(resources.getString("txtGarrisonMoraleRouted.text"),
+                    resources.getString("txtGarrisonMoraleRouted.tooltip"));
+        }
+        return new MoraleDisplay(level.toString(), level.getToolTipText());
     }
 }
+

--- a/MekHQ/src/mekhq/gui/view/MoraleBar.java
+++ b/MekHQ/src/mekhq/gui/view/MoraleBar.java
@@ -52,35 +52,27 @@ import mekhq.gui.baseComponents.SegmentedBar;
  * A compact, segmented gauge that visualizes enemy {@link AtBMoraleLevel}.
  *
  * <p>
- * The bar has one segment per possible morale level, ordered from the morale
- * scale's minimum to its maximum. The gauge reads like the enemy's morale
- * meter: the more segments that are lit, the higher the enemy's morale. The
- * colors are presented from the <em>player's</em> perspective: low enemy morale
- * (a routed enemy) is green because it is favourable for the player, climbing
- * through orange and into red at the highest morale (a dangerous,
- * fully-committed enemy). Hovering a segment shows the name and description of
- * that morale level.
+ * The bar has one segment per possible morale level, ordered from the morale scale's minimum to its maximum. The gauge
+ * reads like the enemy's morale meter: the more segments that are lit, the higher the enemy's morale. The colors are
+ * presented from the <em>player's</em> perspective: low enemy morale (a routed enemy) is green because it is favourable
+ * for the player, climbing through orange and into red at the highest morale (a dangerous, fully-committed enemy).
+ * Hovering a segment shows the name and description of that morale level.
  * </p>
  *
  * <p>
- * This wraps a private {@link SegmentedBar} (composition rather than
- * inheritance) so that only the morale-specific API is exposed; callers cannot
- * reconfigure the underlying segments and break the "one segment per morale
- * level" invariant.
+ * This wraps a private {@link SegmentedBar} (composition rather than inheritance) so that only the morale-specific API
+ * is exposed; callers cannot reconfigure the underlying segments and break the "one segment per morale level"
+ * invariant.
  * </p>
  *
  * @author The MegaMek Team
  */
 public class MoraleBar extends JPanel {
     /**
-     * Anchor colors for the morale gradient, ordered from the lowest enemy morale
-     * to the highest. Low enemy morale is
-     * green (favourable for the player) and high enemy morale is red (dangerous for
-     * the player), so the gauge reads as
-     * an enemy-strength meter from the player's perspective: a short green bar is
-     * good news, a long red bar is bad. The
-     * colors are deliberately deep and well separated so that adjacent segments
-     * remain easy to tell apart.
+     * Anchor colors for the morale gradient, ordered from the lowest enemy morale to the highest. Low enemy morale is
+     * green (favourable for the player) and high enemy morale is red (dangerous for the player), so the gauge reads as
+     * an enemy-strength meter from the player's perspective: a short green bar is good news, a long red bar is bad. The
+     * colors are deliberately deep and well separated so that adjacent segments remain easy to tell apart.
      */
     private static final Color[] MORALE_GRADIENT = {
             new Color(0x12, 0x7C, 0x1E), // deep green - lowest enemy morale, most favourable for the player
@@ -93,31 +85,25 @@ public class MoraleBar extends JPanel {
     };
 
     /**
-     * The wrapped gauge. Kept private so the segment-level API is not exposed to
-     * callers.
+     * The wrapped gauge. Kept private so the segment-level API is not exposed to callers.
      */
     private final SegmentedBar bar = new SegmentedBar();
 
     /**
      * Creates a morale bar for the given morale level.
      *
-     * @param moraleLevel the enemy morale level to display; may be {@code null}, in
-     *                    which case nothing is painted
+     * @param moraleLevel the enemy morale level to display; may be {@code null}, in which case nothing is painted
      */
     public MoraleBar(final @Nullable AtBMoraleLevel moraleLevel) {
         this(moraleLevel, (moraleLevel == null) ? null : moraleLevel.toString());
     }
 
     /**
-     * Creates a morale bar for the given morale level with a custom label drawn
-     * beneath the active segment.
+     * Creates a morale bar for the given morale level with a custom label drawn beneath the active segment.
      *
-     * @param moraleLevel the enemy morale level to display; may be {@code null}, in
-     *                    which case nothing is painted
-     * @param labelText   the text to show beneath the current level (for example a
-     *                    contract-specific name such as
-     *                    "Peaceful"), or {@code null} to use the morale level's own
-     *                    name
+     * @param moraleLevel the enemy morale level to display; may be {@code null}, in which case nothing is painted
+     * @param labelText   the text to show beneath the current level (for example a contract-specific name such as
+     *                    "Peaceful"), or {@code null} to use the morale level's own name
      */
     public MoraleBar(final @Nullable AtBMoraleLevel moraleLevel, final @Nullable String labelText) {
         super(new BorderLayout());
@@ -127,25 +113,20 @@ public class MoraleBar extends JPanel {
     }
 
     /**
-     * Updates the displayed morale level and repaints the bar. The label beneath
-     * the active segment defaults to the
+     * Updates the displayed morale level and repaints the bar. The label beneath the active segment defaults to the
      * morale level's own name.
      *
-     * @param moraleLevel the new enemy morale level to display, or {@code null} to
-     *                    clear the bar
+     * @param moraleLevel the new enemy morale level to display, or {@code null} to clear the bar
      */
     public void setMoraleLevel(final @Nullable AtBMoraleLevel moraleLevel) {
         setMoraleLevel(moraleLevel, (moraleLevel == null) ? null : moraleLevel.toString());
     }
 
     /**
-     * Updates the displayed morale level and the label drawn beneath the active
-     * segment, then repaints the bar.
+     * Updates the displayed morale level and the label drawn beneath the active segment, then repaints the bar.
      *
-     * @param moraleLevel the new enemy morale level to display, or {@code null} to
-     *                    clear the bar
-     * @param labelText   the text to show beneath the current level, or
-     *                    {@code null} for no label
+     * @param moraleLevel the new enemy morale level to display, or {@code null} to clear the bar
+     * @param labelText   the text to show beneath the current level, or {@code null} for no label
      */
     public void setMoraleLevel(final @Nullable AtBMoraleLevel moraleLevel, final @Nullable String labelText) {
         if (moraleLevel == null) {
@@ -167,10 +148,8 @@ public class MoraleBar extends JPanel {
     }
 
     /**
-     * Forwards the tooltip to the wrapped gauge so that the area around the
-     * segments (gaps and the label) shows this
-     * fallback tooltip, while individual segments keep their own per-level
-     * tooltips.
+     * Forwards the tooltip to the wrapped gauge so that the area around the segments (gaps and the label) shows this
+     * fallback tooltip, while individual segments keep their own per-level tooltips.
      *
      * @param text the tooltip text, or {@code null} for none
      */
@@ -180,15 +159,10 @@ public class MoraleBar extends JPanel {
     }
 
     /**
-     * Builds a self-contained panel wrapping a {@link MoraleBar}, suitable for
-     * embedding in dialogs such as the
-     * immersive "Morale Update" notification. The bar is given generous horizontal
-     * padding so it reads as a centered
-     * gauge rather than spanning the full dialog width. The label beneath the
-     * active
-     * segment honours the contract's
-     * special "Peaceful" wording for routed garrison/retainer contracts, matching
-     * the briefing-room contract panel.
+     * Builds a self-contained panel wrapping a {@link MoraleBar}, suitable for embedding in dialogs such as the
+     * immersive "Morale Update" notification. The bar is given generous horizontal padding so it reads as a centered
+     * gauge rather than spanning the full dialog width. The label beneath the active segment honours the contract's
+     * special "Peaceful" wording for routed garrison/retainer contracts, matching the briefing-room contract panel.
      *
      * @param contract the contract whose enemy morale should be displayed
      *
@@ -212,18 +186,15 @@ public class MoraleBar extends JPanel {
     /**
      * The display text and tooltip used to describe a contract's enemy morale.
      *
-     * @param label   the short morale name to show (e.g. a morale level name, or
-     *                "Peaceful")
+     * @param label   the short morale name to show (e.g. a morale level name, or "Peaceful")
      * @param tooltip the descriptive tooltip for that morale state
      */
     public record MoraleDisplay(String label, String tooltip) {
     }
 
     /**
-     * Computes the morale label and tooltip for a contract, applying the special
-     * "Peaceful" wording used for routed
-     * garrison-duty and retainer contracts. This is the single source of truth
-     * shared by the briefing-room contract
+     * Computes the morale label and tooltip for a contract, applying the special "Peaceful" wording used for routed
+     * garrison-duty and retainer contracts. This is the single source of truth shared by the briefing-room contract
      * panel and the morale dialog so the two never diverge.
      *
      * @param contract the contract whose enemy morale should be described

--- a/MekHQ/src/mekhq/gui/view/MoraleBar.java
+++ b/MekHQ/src/mekhq/gui/view/MoraleBar.java
@@ -71,6 +71,25 @@ public class MoraleBar extends JComponent {
     private static final int FADED_ALPHA = 55;
     private static final int BORDER_ALPHA = 60;
 
+    /**
+     * Anchor colors for the morale gradient, ordered from the most favourable
+     * morale for the player (deep green) to the
+     * most dangerous (deep red). The colors are deliberately deep and well
+     * separated so that adjacent segments remain
+     * easy to tell apart. Segment colors are interpolated across these anchors, so
+     * the gauge works for any number of
+     * morale levels.
+     */
+    private static final Color[] MORALE_GRADIENT = {
+            new Color(0x12, 0x7C, 0x1E), // deep green - most favourable for the player
+            new Color(0x36, 0xB3, 0x2B), // green
+            new Color(0x8C, 0xC6, 0x1A), // lime
+            new Color(0xE8, 0xC4, 0x0A), // gold
+            new Color(0xF2, 0x86, 0x00), // orange
+            new Color(0xD2, 0x44, 0x10), // red-orange
+            new Color(0xA8, 0x12, 0x12) // deep red - most dangerous for the player
+    };
+
     private AtBMoraleLevel moraleLevel;
 
     /**
@@ -156,18 +175,41 @@ public class MoraleBar extends JComponent {
     }
 
     /**
-     * Computes the fixed gradient color for the segment at the given index,
-     * interpolating the hue from green (favorable
-     * for the player) at the lowest morale to red (dangerous for the player) at the
-     * highest.
+     * Computes the color for the segment at the given index by interpolating across
+     * the deep, well-separated
+     * {@link #MORALE_GRADIENT} anchors, from green (favorable for the player) at
+     * the lowest morale to red (dangerous
+     * for the player) at the highest.
      *
      * @param index the zero-based segment index, from lowest to highest morale
      *
      * @return the color for the segment
      */
     private static Color segmentColor(final int index) {
-        final float fraction = (SEGMENT_COUNT <= 1) ? 0f : (float) index / (SEGMENT_COUNT - 1);
-        final float hue = (120f * (1f - fraction)) / 360f; // 120 degrees (green) down to 0 degrees (red)
-        return Color.getHSBColor(hue, 0.85f, 0.80f);
+        if (SEGMENT_COUNT <= 1) {
+            return MORALE_GRADIENT[0];
+        }
+
+        final float fraction = (float) index / (SEGMENT_COUNT - 1);
+        final float scaled = fraction * (MORALE_GRADIENT.length - 1);
+        final int lower = (int) Math.floor(scaled);
+        final int upper = Math.min(lower + 1, MORALE_GRADIENT.length - 1);
+        return interpolate(MORALE_GRADIENT[lower], MORALE_GRADIENT[upper], scaled - lower);
+    }
+
+    /**
+     * Linearly interpolates between two colors.
+     *
+     * @param from the color at {@code t == 0}
+     * @param to   the color at {@code t == 1}
+     * @param t    the interpolation factor, in the range {@code [0, 1]}
+     *
+     * @return the interpolated color
+     */
+    private static Color interpolate(final Color from, final Color to, final float t) {
+        final int red = Math.round(from.getRed() + (to.getRed() - from.getRed()) * t);
+        final int green = Math.round(from.getGreen() + (to.getGreen() - from.getGreen()) * t);
+        final int blue = Math.round(from.getBlue() + (to.getBlue() - from.getBlue()) * t);
+        return new Color(red, green, blue);
     }
 }

--- a/MekHQ/src/mekhq/gui/view/MoraleBar.java
+++ b/MekHQ/src/mekhq/gui/view/MoraleBar.java
@@ -33,17 +33,16 @@
 package mekhq.gui.view;
 
 import static megamek.client.ui.WrapLayout.wordWrap;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
-import java.util.List;
-import java.util.ResourceBundle;
 import javax.swing.BorderFactory;
 import javax.swing.JPanel;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import megamek.client.ui.util.UIUtil;
-import megamek.common.annotations.Nullable;
-import mekhq.MekHQ;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.enums.AtBMoraleLevel;
 import mekhq.gui.baseComponents.SegmentedBar;
@@ -59,15 +58,11 @@ import mekhq.gui.baseComponents.SegmentedBar;
  * Hovering a segment shows the name and description of that morale level.
  * </p>
  *
- * <p>
- * This wraps a private {@link SegmentedBar} (composition rather than inheritance) so that only the morale-specific API
- * is exposed; callers cannot reconfigure the underlying segments and break the "one segment per morale level"
- * invariant.
- * </p>
- *
  * @author The MegaMek Team
  */
 public class MoraleBar extends JPanel {
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.ContractViewPanel";
+
     /**
      * Anchor colors for the morale gradient, ordered from the lowest enemy morale to the highest. Low enemy morale is
      * green (favourable for the player) and high enemy morale is red (dangerous for the player), so the gauge reads as
@@ -90,51 +85,16 @@ public class MoraleBar extends JPanel {
     private final SegmentedBar bar = new SegmentedBar();
 
     /**
-     * Creates a morale bar for the given morale level.
+     * Creates a morale bar for the given morale level, with a label drawn beneath the active segment.
      *
-     * @param moraleLevel the enemy morale level to display; may be {@code null}, in which case nothing is painted
+     * @param moraleLevel the enemy morale level to display
+     * @param labelText   the text to show beneath the current level (for example the morale level's name, or a
+     *                    contract-specific name such as "Peaceful"). Pass a blank string to show no label.
      */
-    public MoraleBar(final @Nullable AtBMoraleLevel moraleLevel) {
-        this(moraleLevel, (moraleLevel == null) ? null : moraleLevel.toString());
-    }
-
-    /**
-     * Creates a morale bar for the given morale level with a custom label drawn beneath the active segment.
-     *
-     * @param moraleLevel the enemy morale level to display; may be {@code null}, in which case nothing is painted
-     * @param labelText   the text to show beneath the current level (for example a contract-specific name such as
-     *                    "Peaceful"), or {@code null} to use the morale level's own name
-     */
-    public MoraleBar(final @Nullable AtBMoraleLevel moraleLevel, final @Nullable String labelText) {
+    public MoraleBar(@Nonnull final AtBMoraleLevel moraleLevel, @Nonnull final String labelText) {
         super(new BorderLayout());
         setOpaque(false);
         add(bar, BorderLayout.CENTER);
-        setMoraleLevel(moraleLevel, labelText);
-    }
-
-    /**
-     * Updates the displayed morale level and repaints the bar. The label beneath the active segment defaults to the
-     * morale level's own name.
-     *
-     * @param moraleLevel the new enemy morale level to display, or {@code null} to clear the bar
-     */
-    public void setMoraleLevel(final @Nullable AtBMoraleLevel moraleLevel) {
-        setMoraleLevel(moraleLevel, (moraleLevel == null) ? null : moraleLevel.toString());
-    }
-
-    /**
-     * Updates the displayed morale level and the label drawn beneath the active segment, then repaints the bar.
-     *
-     * @param moraleLevel the new enemy morale level to display, or {@code null} to clear the bar
-     * @param labelText   the text to show beneath the current level, or {@code null} for no label
-     */
-    public void setMoraleLevel(final @Nullable AtBMoraleLevel moraleLevel, final @Nullable String labelText) {
-        if (moraleLevel == null) {
-            bar.setSegments(List.of());
-            bar.setFilledCount(0);
-            bar.setActiveLabel(null);
-            return;
-        }
 
         final AtBMoraleLevel[] levels = AtBMoraleLevel.values();
         final String[] tooltips = new String[levels.length];
@@ -168,7 +128,7 @@ public class MoraleBar extends JPanel {
      *
      * @return a transparent panel containing the configured morale bar
      */
-    public static JPanel createDialogPanel(final AtBContract contract) {
+    public static @Nonnull JPanel createDialogPanel(@Nonnull final AtBContract contract) {
         final JPanel panel = new JPanel(new BorderLayout());
         panel.setOpaque(false);
         final int horizontalPadding = UIUtil.scaleForGUI(40);
@@ -189,7 +149,7 @@ public class MoraleBar extends JPanel {
      * @param label   the short morale name to show (e.g. a morale level name, or "Peaceful")
      * @param tooltip the descriptive tooltip for that morale state
      */
-    public record MoraleDisplay(String label, String tooltip) {
+    public record MoraleDisplay(@Nonnull String label, @Nonnull String tooltip) {
     }
 
     /**
@@ -201,14 +161,12 @@ public class MoraleBar extends JPanel {
      *
      * @return the label and tooltip to display
      */
-    public static MoraleDisplay getMoraleDisplay(final AtBContract contract) {
+    public static @Nonnull MoraleDisplay getMoraleDisplay(@Nonnull final AtBContract contract) {
         final AtBMoraleLevel level = contract.getMoraleLevel();
         if ((contract.getContractType().isGarrisonDuty() || contract.getContractType().isRetainer()) &&
                 level.isRouted()) {
-            final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.ContractViewPanel",
-                    MekHQ.getMHQOptions().getLocale());
-            return new MoraleDisplay(resources.getString("txtGarrisonMoraleRouted.text"),
-                    resources.getString("txtGarrisonMoraleRouted.tooltip"));
+            return new MoraleDisplay(getTextAt(RESOURCE_BUNDLE, "txtGarrisonMoraleRouted.text"),
+                    getTextAt(RESOURCE_BUNDLE, "txtGarrisonMoraleRouted.tooltip"));
         }
         return new MoraleDisplay(level.toString(), level.getToolTipText());
     }

--- a/MekHQ/src/mekhq/gui/view/MoraleBar.java
+++ b/MekHQ/src/mekhq/gui/view/MoraleBar.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.view;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import javax.swing.JComponent;
+import javax.swing.UIManager;
+
+import megamek.client.ui.util.UIUtil;
+import megamek.common.annotations.Nullable;
+import mekhq.campaign.mission.enums.AtBMoraleLevel;
+
+/**
+ * A compact, segmented gauge that visualizes enemy {@link AtBMoraleLevel}.
+ *
+ * <p>
+ * The bar has one segment per possible morale level, ordered from the morale
+ * scale's minimum to its maximum. Each
+ * segment is colored on a fixed green-to-red gradient and the colors are
+ * presented from the <em>player's</em>
+ * perspective: low enemy morale (e.g. {@code ROUTED}) is green because it is
+ * favourable for the player, while high
+ * enemy morale (e.g. {@code OVERWHELMING}) is red because it is dangerous.
+ * Segments up to and including the current
+ * morale level are drawn at full strength; the remaining segments are faded, so
+ * the lit length communicates how high
+ * the enemy's morale currently is while the lit "tip" colour communicates its
+ * severity.
+ * </p>
+ *
+ * @author The MegaMek Team
+ */
+public class MoraleBar extends JComponent {
+    private static final int SEGMENT_COUNT = AtBMoraleLevel.MAXIMUM_MORALE_LEVEL - AtBMoraleLevel.MINIMUM_MORALE_LEVEL
+            + 1;
+    private static final int FADED_ALPHA = 55;
+    private static final int BORDER_ALPHA = 60;
+
+    private AtBMoraleLevel moraleLevel;
+
+    /**
+     * Creates a morale bar for the given morale level.
+     *
+     * @param moraleLevel the enemy morale level to display; may be {@code null}, in
+     *                    which case nothing is painted
+     */
+    public MoraleBar(final @Nullable AtBMoraleLevel moraleLevel) {
+        this.moraleLevel = moraleLevel;
+        setOpaque(false);
+    }
+
+    /**
+     * Updates the displayed morale level and repaints the bar.
+     *
+     * @param moraleLevel the new enemy morale level to display
+     */
+    public void setMoraleLevel(final @Nullable AtBMoraleLevel moraleLevel) {
+        this.moraleLevel = moraleLevel;
+        repaint();
+    }
+
+    @Override
+    public Dimension getPreferredSize() {
+        return UIUtil.scaleForGUI(140, 14);
+    }
+
+    @Override
+    public Dimension getMinimumSize() {
+        return UIUtil.scaleForGUI(84, 10);
+    }
+
+    @Override
+    protected void paintComponent(final Graphics g) {
+        super.paintComponent(g);
+        if (moraleLevel == null) {
+            return;
+        }
+
+        final Graphics2D g2 = (Graphics2D) g.create();
+        try {
+            g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+            final int width = getWidth();
+            final int height = getHeight();
+            final int gap = Math.max(UIUtil.scaleForGUI(2), 1);
+            final int arc = Math.max(UIUtil.scaleForGUI(4), 2);
+            final int totalGap = gap * (SEGMENT_COUNT - 1);
+            final int segmentWidth = Math.max((width - totalGap) / SEGMENT_COUNT, 1);
+            final int usedWidth = segmentWidth * SEGMENT_COUNT + totalGap;
+            final int xStart = Math.max((width - usedWidth) / 2, 0);
+
+            final int filledIndex = moraleLevel.getLevel() - AtBMoraleLevel.MINIMUM_MORALE_LEVEL;
+
+            for (int i = 0; i < SEGMENT_COUNT; i++) {
+                final int x = xStart + i * (segmentWidth + gap);
+                final Color base = segmentColor(i);
+
+                if (i <= filledIndex) {
+                    g2.setColor(base);
+                } else {
+                    g2.setColor(new Color(base.getRed(), base.getGreen(), base.getBlue(), FADED_ALPHA));
+                }
+                g2.fillRoundRect(x, 0, segmentWidth, height, arc, arc);
+
+                g2.setColor(new Color(0, 0, 0, BORDER_ALPHA));
+                g2.drawRoundRect(x, 0, segmentWidth - 1, height - 1, arc, arc);
+            }
+
+            // Outline the current level so the exact morale value is unambiguous.
+            final int markerX = xStart + filledIndex * (segmentWidth + gap);
+            Color markerColor = UIManager.getColor("Label.foreground");
+            if (markerColor == null) {
+                markerColor = Color.WHITE;
+            }
+            g2.setColor(markerColor);
+            g2.setStroke(new BasicStroke(Math.max(UIUtil.scaleForGUI(2), 1)));
+            g2.drawRoundRect(markerX, 0, segmentWidth - 1, height - 1, arc, arc);
+        } finally {
+            g2.dispose();
+        }
+    }
+
+    /**
+     * Computes the fixed gradient color for the segment at the given index,
+     * interpolating the hue from green (favorable
+     * for the player) at the lowest morale to red (dangerous for the player) at the
+     * highest.
+     *
+     * @param index the zero-based segment index, from lowest to highest morale
+     *
+     * @return the color for the segment
+     */
+    private static Color segmentColor(final int index) {
+        final float fraction = (SEGMENT_COUNT <= 1) ? 0f : (float) index / (SEGMENT_COUNT - 1);
+        final float hue = (120f * (1f - fraction)) / 360f; // 120 degrees (green) down to 0 degrees (red)
+        return Color.getHSBColor(hue, 0.85f, 0.80f);
+    }
+}

--- a/MekHQ/unittests/mekhq/gui/baseComponents/SegmentedBarTest.java
+++ b/MekHQ/unittests/mekhq/gui/baseComponents/SegmentedBarTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.baseComponents;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Color;
+import java.util.List;
+
+import mekhq.gui.baseComponents.SegmentedBar.Segment;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the pure static factory and color helpers of {@link SegmentedBar}, with an emphasis on the argument
+ * validation those public methods are expected to perform.
+ */
+class SegmentedBarTest {
+    private static final Color[] BLACK_TO_WHITE = { Color.BLACK, Color.WHITE };
+    private static final String[] THREE_TOOLTIPS = { "a", "b", "c" };
+
+    // region gradientSegments(Color[], String[])
+
+    @Test
+    void gradientSegmentsRejectsNullAnchors() {
+        assertThrows(NullPointerException.class, () -> SegmentedBar.gradientSegments(null, THREE_TOOLTIPS));
+    }
+
+    @Test
+    void gradientSegmentsRejectsNullTooltips() {
+        assertThrows(NullPointerException.class, () -> SegmentedBar.gradientSegments(BLACK_TO_WHITE, null));
+    }
+
+    @Test
+    void gradientSegmentsRejectsEmptyAnchors() {
+        assertThrows(IllegalArgumentException.class,
+              () -> SegmentedBar.gradientSegments(new Color[0], THREE_TOOLTIPS));
+    }
+
+    @Test
+    void gradientSegmentsWithEmptyTooltipsReturnsEmptyList() {
+        final List<Segment> segments = SegmentedBar.gradientSegments(BLACK_TO_WHITE, new String[0]);
+        assertTrue(segments.isEmpty());
+    }
+
+    @Test
+    void gradientSegmentsProducesOneSegmentPerTooltipAtEndpoints() {
+        final List<Segment> segments = SegmentedBar.gradientSegments(BLACK_TO_WHITE, THREE_TOOLTIPS);
+
+        assertEquals(THREE_TOOLTIPS.length, segments.size());
+        // The first and last segments land exactly on the gradient endpoints.
+        assertEquals(Color.BLACK, segments.get(0).color());
+        assertEquals(Color.WHITE, segments.get(segments.size() - 1).color());
+        // The midpoint of black -> white is mid-gray.
+        assertEquals(new Color(128, 128, 128), segments.get(1).color());
+    }
+
+    @Test
+    void gradientSegmentsPreservesTooltipsIncludingNullEntries() {
+        final String[] tooltips = { "first", null, "third" };
+        final List<Segment> segments = SegmentedBar.gradientSegments(BLACK_TO_WHITE, tooltips);
+
+        assertEquals("first", segments.get(0).tooltip());
+        assertNull(segments.get(1).tooltip());
+        assertEquals("third", segments.get(2).tooltip());
+    }
+
+    @Test
+    void gradientSegmentsWithSingleAnchorUsesThatColorForEverySegment() {
+        final List<Segment> segments = SegmentedBar.gradientSegments(new Color[] { Color.RED }, THREE_TOOLTIPS);
+
+        for (final Segment segment : segments) {
+            assertEquals(Color.RED, segment.color());
+        }
+    }
+
+    // endregion gradientSegments(Color[], String[])
+
+    // region gradientSegments(Color, Color, String[])
+
+    @Test
+    void gradientSegmentsStartEndRejectsNullStart() {
+        assertThrows(NullPointerException.class,
+              () -> SegmentedBar.gradientSegments(null, Color.WHITE, THREE_TOOLTIPS));
+    }
+
+    @Test
+    void gradientSegmentsStartEndRejectsNullEnd() {
+        assertThrows(NullPointerException.class,
+              () -> SegmentedBar.gradientSegments(Color.BLACK, null, THREE_TOOLTIPS));
+    }
+
+    @Test
+    void gradientSegmentsStartEndRejectsNullTooltips() {
+        assertThrows(NullPointerException.class,
+              () -> SegmentedBar.gradientSegments(Color.BLACK, Color.WHITE, null));
+    }
+
+    @Test
+    void gradientSegmentsStartEndInterpolatesBetweenTheTwoColors() {
+        final List<Segment> segments = SegmentedBar.gradientSegments(Color.BLACK, Color.WHITE, THREE_TOOLTIPS);
+
+        assertEquals(Color.BLACK, segments.get(0).color());
+        assertEquals(new Color(128, 128, 128), segments.get(1).color());
+        assertEquals(Color.WHITE, segments.get(2).color());
+    }
+
+    // endregion gradientSegments(Color, Color, String[])
+
+    // region interpolatedColor
+
+    @Test
+    void interpolatedColorRejectsNullAnchors() {
+        assertThrows(NullPointerException.class, () -> SegmentedBar.interpolatedColor(null, 3, 0));
+    }
+
+    @Test
+    void interpolatedColorRejectsEmptyAnchors() {
+        assertThrows(IllegalArgumentException.class, () -> SegmentedBar.interpolatedColor(new Color[0], 3, 0));
+    }
+
+    @Test
+    void interpolatedColorRejectsNegativeIndex() {
+        assertThrows(IllegalArgumentException.class, () -> SegmentedBar.interpolatedColor(BLACK_TO_WHITE, 3, -1));
+    }
+
+    @Test
+    void interpolatedColorRejectsIndexEqualToCount() {
+        assertThrows(IllegalArgumentException.class, () -> SegmentedBar.interpolatedColor(BLACK_TO_WHITE, 3, 3));
+    }
+
+    @Test
+    void interpolatedColorWithSingleSegmentReturnsFirstAnchor() {
+        assertEquals(Color.BLACK, SegmentedBar.interpolatedColor(BLACK_TO_WHITE, 1, 0));
+    }
+
+    @Test
+    void interpolatedColorReturnsEndpointsAndMidpoint() {
+        assertEquals(Color.BLACK, SegmentedBar.interpolatedColor(BLACK_TO_WHITE, 3, 0));
+        assertEquals(new Color(128, 128, 128), SegmentedBar.interpolatedColor(BLACK_TO_WHITE, 3, 1));
+        assertEquals(Color.WHITE, SegmentedBar.interpolatedColor(BLACK_TO_WHITE, 3, 2));
+    }
+
+    // endregion interpolatedColor
+}


### PR DESCRIPTION
<img width="882" height="995" alt="image" src="https://github.com/user-attachments/assets/9884db49-eabe-40a1-84ae-78ff30686902" />

## Summary

Replaces the plain "Enemy Morale: <level>" text in the briefing-room contract panel with a compact, color-coded **segmented gauge**, and shows the same gauge in the immersive **Morale Update** dialog.

This also introduces a reusable `SegmentedBar` base component that other features can use for any "level on a colored scale" display.

## What it looks like

- One segment per enemy morale level (`Routed` → `Overwhelming`).
- Colors are from the **player's perspective**: low enemy morale is deep green (good for you), climbing through orange to deep red at the highest morale (dangerous for you).
- Lit segments fill up to the current level; higher segments render as neutral "empty slots", so the lit length communicates how high morale is.
- The current level's name is drawn, centered, beneath the active segment (honoring the special **"Peaceful"** wording for routed garrison/retainer contracts).
- Hovering a segment shows that level's name and description.

## Testing

- `./gradlew :MekHQ:compileJava :MekHQ:checkstyleMain` — passes, no checkstyle violations.
- Verified in-app on the briefing-room contract panel and the Morale Update dialog across multiple morale levels, including the routed garrison "Peaceful" case (panel and dialog match).