### PR TITLE
Respect `isClanCampaign` and `isUseAgingEffects` in advanced scouting checks

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -1611,7 +1611,8 @@ public class StratConRulesManager {
         CampaignOptions campaignOptions = campaign.getCampaignOptions();
         Formation formation = campaign.getFormation(forceID);
         Hangar hangar = campaign.getAllHangar();
-        List<ScoutRecord> scouts = buildScoutMap(formation, hangar, campaignOptions);
+        List<ScoutRecord> scouts = buildScoutMap(formation, hangar, campaignOptions,
+              campaign.isClanCampaign(), campaign.getLocalDate());
 
         boolean useAdvancedScouting = campaignOptions.isUseAdvancedScouting();
         // Each scout may scan up to scanMultiplier hexes
@@ -1682,8 +1683,8 @@ boolean isUseEdge = campaignOptions.isUseEdge() && scout.getOptions().booleanOpt
                               0,
                               isUseEdge,
                               false,
-                              false, // Irrelevant
-                              false, // Irrelevant
+                              campaignOptions.isUseAgeEffects(),
+                              campaign.isClanCampaign(),
                               campaign.getLocalDate()
                         );
                         campaign.addReport(SKILL_CHECKS, skillCheck.getResultsText());
@@ -1855,6 +1856,8 @@ boolean isUseEdge = campaignOptions.isUseEdge() && scout.getOptions().booleanOpt
      * @param formation       the {@link Formation} containing units to evaluate
      * @param hangar          the {@link Hangar} used to help retrieve units from the force
      * @param campaignOptions {@link CampaignOptions}, used to check useCommanderOnly options
+     * @param isClanCampaign  if {@code true}, applies rules specific to clan campaigns
+     * @param date            the current date, used for time-dependent logic
      *
      * @return a list of {@link ScoutRecord} objects, each representing the best scout and their skill details for a
      *       unit, sorted from the highest to lowest scout skill level
@@ -1862,7 +1865,8 @@ boolean isUseEdge = campaignOptions.isUseEdge() && scout.getOptions().booleanOpt
      * @author Illiani
      * @since 0.50.07
      */
-    static List<ScoutRecord> buildScoutMap(Formation formation, Hangar hangar, CampaignOptions campaignOptions) {
+    static List<ScoutRecord> buildScoutMap(Formation formation, Hangar hangar, CampaignOptions campaignOptions,
+          boolean isClanCampaign, LocalDate date) {
         if (formation == null) {
             return new ArrayList<>();
         }
@@ -1906,18 +1910,10 @@ boolean isUseEdge = campaignOptions.isUseEdge() && scout.getOptions().booleanOpt
                     continue;
                 }
 
-                // StratConRules manager passes useAgingEffects == false, so we use a deprecated method version for now
                 TargetRoll targetNumber = SkillCheckUtility.determineTargetNumber(crewMember,
-                      SkillType.getType(scoutSkillName), 0);
-                LOGGER.error("Target number: " + targetNumber.getValue());
-                List<TargetRollModifier> modifiers = getAllScoutRollModifiers(unitWeight,
-                      unitSpeed,
-                      hasEagleEyes,
-                      hasSensorEquipment);
-
-                modifiers.forEach(targetNumber::addModifier);
-                modifiers.forEach(m ->
-                                        LOGGER.error("Modifier: " + m.value()));
+                      SkillType.getType(scoutSkillName), 0, campaignOptions.isUseAgeEffects(), isClanCampaign, date);
+                getAllScoutRollModifiers(unitWeight, unitSpeed, hasEagleEyes, hasSensorEquipment)
+                      .forEach(targetNumber::addModifier);
 
                 if (bestScout == null || targetNumber.getValue() < bestScoutTargetNumber) {
                     bestScout = new ScoutRecord(crewMember, targetNumber, scoutSkillName,

--- a/MekHQ/unittests/mekhq/campaign/stratCon/StratConRulesManagerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/stratCon/StratConRulesManagerTest.java
@@ -42,6 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -724,8 +725,8 @@ class StratConRulesManagerTest {
 
         @Test
         void testBuildScoutMap_NullFormation() {
-            List<ScoutRecord> scouts = StratConRulesManager.buildScoutMap(
-                  null, mock(Hangar.class), mock(CampaignOptions.class));
+            List<ScoutRecord> scouts = StratConRulesManager.buildScoutMap(null, mock(Hangar.class),
+                  mock(CampaignOptions.class), false, LocalDate.now());
             assertNotNull(scouts);
             assertTrue(scouts.isEmpty());
         }
@@ -742,6 +743,22 @@ class StratConRulesManagerTest {
             assertEquals(5, bestScout.unitSpeed());
             assertTrue(bestScout.scoutHasEagleEyes());
             assertTrue(bestScout.unitHasSensorEquipment());
+        }
+
+        @ParameterizedTest
+        @CsvSource({ "true", "false" })
+        void testBuildScoutMap_UseAgingModifiers(boolean useAgingEffects) {
+            Person person = mockPerson(4, true);
+            getBestScoutForUnit(List.of(person), 45, 5, true, false, useAgingEffects, false);
+            verify(person).getSkillModifierData(eq(useAgingEffects), eq(false), any(LocalDate.class));
+        }
+
+        @ParameterizedTest
+        @CsvSource({ "true", "false" })
+        void testBuildScoutMap_IsClanCampaign(boolean isClanCampaign) {
+            Person person = mockPerson(4, true);
+            getBestScoutForUnit(List.of(person), 45, 5, true, false, false, isClanCampaign);
+            verify(person).getSkillModifierData(eq(false), eq(isClanCampaign), any(LocalDate.class));
         }
 
         @Test
@@ -812,6 +829,12 @@ class StratConRulesManagerTest {
         }
 
         @Test
+        void testBuildScoutMap_TN_UnitWeight() {
+            ScoutRecord bestScout = getBestScoutForUnit(List.of(mockPerson(4, false)), 95, 5, false, false);
+            assertEquals(8, bestScout.targetNumber().getValue());
+        }
+
+        @Test
         void testBuildScoutMap_EmptyCrewSkipsUnit() {
             Formation formation = mock(Formation.class);
             Hangar hangar = mock(Hangar.class);
@@ -820,8 +843,8 @@ class StratConRulesManagerTest {
             when(formation.getAllUnitsAsUnits(hangar, false)).thenReturn(Collections.singletonList(unit));
             when(unit.getCrew()).thenReturn(new ArrayList<>());
 
-            List<ScoutRecord> scouts = StratConRulesManager.buildScoutMap(
-                  formation, hangar, mock(CampaignOptions.class));
+            List<ScoutRecord> scouts = StratConRulesManager.buildScoutMap(formation, hangar,
+                  mock(CampaignOptions.class), false, LocalDate.now());
             assertTrue(scouts.isEmpty());
         }
 
@@ -846,11 +869,16 @@ class StratConRulesManagerTest {
             return person;
         }
 
+        private ScoutRecord getBestScoutForUnit(List<Person> crew, double unitWeight, int unitSpeed,
+              boolean hasImprovedSensors, boolean hasActiveProbe) {
+            return getBestScoutForUnit(crew, unitWeight, unitSpeed, hasImprovedSensors, hasActiveProbe, false, false);
+        }
+
         /**
          * Mocks a single unit with multiple crew members and gets the best scout
          */
-        private ScoutRecord getBestScoutForUnit(List<Person> crew,
-              double unitWeight, int unitSpeed, boolean hasImprovedSensors, boolean hasActiveProbe) {
+        private ScoutRecord getBestScoutForUnit(List<Person> crew, double unitWeight, int unitSpeed,
+              boolean hasImprovedSensors, boolean hasActiveProbe, boolean useAgingEffects, boolean isClanCampaign) {
             Formation formation = mock(Formation.class);
             Hangar hangar = mock(Hangar.class);
             Unit unit = mock(Unit.class);
@@ -872,8 +900,12 @@ class StratConRulesManagerTest {
                                                                      ScoutingSkills.getBestScoutingSkill(crewMember))
                                                  .thenReturn(S_SENSOR_OPERATIONS));
 
-                List<ScoutRecord> scouts =
-                      StratConRulesManager.buildScoutMap(formation, hangar, mock(CampaignOptions.class));
+                CampaignOptions campaignOptions = mock(CampaignOptions.class);
+                if (useAgingEffects) {
+                    when(campaignOptions.isUseAgeEffects()).thenReturn(true);
+                }
+                List<ScoutRecord> scouts = StratConRulesManager.buildScoutMap(formation, hangar,
+                      campaignOptions, isClanCampaign, LocalDate.now());
                 assertEquals(1, scouts.size());
 
                 return scouts.getFirst();
@@ -906,8 +938,8 @@ class StratConRulesManagerTest {
                 }).toList();
                 when(formation.getAllUnitsAsUnits(hangar, false)).thenReturn(units);
 
-                List<ScoutRecord> scouts =
-                      StratConRulesManager.buildScoutMap(formation, hangar, mock(CampaignOptions.class));
+                List<ScoutRecord> scouts = StratConRulesManager.buildScoutMap(formation, hangar,
+                      mock(CampaignOptions.class), false, LocalDate.now());
 
                 return scouts;
             }


### PR DESCRIPTION
Existing implementation ignored both settings and always passed them as false/false in skill checks. This change makes target number calculations respect them.

Additionally remove leftover logging statements in scouting checks.