### PR TITLE
Fix #9294: Fixed Starting Attribute Scores for New Personnel

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/generator/DefaultPersonnelGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/generator/DefaultPersonnelGenerator.java
@@ -107,7 +107,7 @@ public class DefaultPersonnelGenerator extends AbstractPersonnelGenerator {
 
         generateBirthday(campaign, person, expLvl, person.isClanPersonnel() && !person.getPhenotype().isNone());
 
-        AbstractSkillGenerator skillGenerator = new DefaultSkillGenerator(getSkillPreferences());
+        AbstractSkillGenerator skillGenerator = new DefaultSkillGenerator(campaign.getRandomSkillPreferences());
 
         skillGenerator.generateSkills(campaign, person, expLvl);
         skillGenerator.generateAttributes(person, campaignOptions.isUseEdge());


### PR DESCRIPTION
Fix #9294

We were instantiating a brand new instance of skill generator instead of using the one in campaign, resulting in campaign options being discarded.