### PR TITLE
Added 'Sensible Tactics Initiative' Campaign Option to Reduce Game-Breaking Nature of Tactics Initiative without Invalidating Player Progression

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -405,15 +405,18 @@ lblPersonnelGeneralTab.text=General Options
 lblUseTactics.text=Use Commander Initiative Bonus
 lblUseTactics.tooltip=All initiative rolls are modified by the commander's Tactics skill.\
   <br>\
-  <br><b>Warning:</b> Should not be combined with 'Use Individual Initiative Bonus.'\
-  <br>\
   <br><b>Requirement:</b> The commander initiative option must be enabled in MegaMek.
 lblUseInitiativeBonus.text=Use Individual Initiative Bonus
 lblUseInitiativeBonus.tooltip=Each unit has their initiative rolls modified by their Tactics skill.\
   <br>\
-  <br><b>Warning:</b> Should not be combined with 'Use Commander Initiative Bonus.\
-  <br>\
   <br><b>Requirement:</b> The individual initiative option must be enabled in MegaMek.
+lblUseSensibleTactics.text=Use Sensible Tactics Modifiers
+lblUseSensibleTactics.tooltip=When using Commander or Individual Initiative Bonus, a character has their Tactics skill\
+  \ halved (rounded down) when calculating their initiative modifier. This was implemented to help rebalance Tactics \
+  skill modifiers in an effort to make the game more balanced, without invalidating player progression\
+  <br>\
+  <br><b>Requirement:</b> The commander initiative, or individual initiative bonus, option must be enabled in MekHQ \
+  and the matching option must be enabled in MegaMek.
 lblUseToughness.text=Use Toughness
 lblUseToughness.tooltip=A character's Toughness score acts as a modifier to all consciousness checks.
 lblUseRandomToughness.text=Randomize Toughness

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
@@ -228,6 +228,7 @@ public class CampaignOptions {
     // General Personnel
     private boolean useTactics;
     private boolean useInitiativeBonus;
+    private boolean useSensibleTactics;
     private boolean useToughness;
     private boolean useRandomToughness;
     private boolean useArtillery;
@@ -848,6 +849,7 @@ public class CampaignOptions {
         // General Personnel
         setUseTactics(false);
         setUseInitiativeBonus(false);
+        useSensibleTactics = false;
         setUseToughness(false);
         setUseRandomToughness(false);
         setUseArtillery(false);
@@ -1652,6 +1654,14 @@ public class CampaignOptions {
 
     public void setUseInitiativeBonus(final boolean useInitiativeBonus) {
         this.useInitiativeBonus = useInitiativeBonus;
+    }
+
+    public boolean isUseSensibleTactics() {
+        return useSensibleTactics;
+    }
+
+    public void setUseSensibleTactics(final boolean useSensibleTactics) {
+        this.useSensibleTactics = useSensibleTactics;
     }
 
     public boolean isUseToughness() {

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
@@ -267,6 +267,7 @@ public class CampaignOptionsMarshaller {
         // region General Personnel
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useTactics", campaignOptions.isUseTactics());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useInitiativeBonus", campaignOptions.isUseInitiativeBonus());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useSensibleTactics", campaignOptions.isUseSensibleTactics());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useToughness", campaignOptions.isUseToughness());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useRandomToughness", campaignOptions.isUseRandomToughness());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useArtillery", campaignOptions.isUseArtillery());

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
@@ -327,6 +327,7 @@ public class CampaignOptionsUnmarshaller {
             case "autoLogisticsOther" -> campaignOptions.setAutoLogisticsOther(parseInt(nodeContents));
             case "useTactics" -> campaignOptions.setUseTactics(parseBoolean(nodeContents));
             case "useInitiativeBonus" -> campaignOptions.setUseInitiativeBonus(parseBoolean(nodeContents));
+            case "useSensibleTactics" -> campaignOptions.setUseSensibleTactics(parseBoolean(nodeContents));
             case "useToughness" -> campaignOptions.setUseToughness(parseBoolean(nodeContents));
             case "useRandomToughness" -> campaignOptions.setUseRandomToughness(parseBoolean(nodeContents));
             case "useArtillery" -> campaignOptions.setUseArtillery(parseBoolean(nodeContents));

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -3001,7 +3001,9 @@ public class AtBDynamicScenarioFactory {
         // Assign the crew to the unit
         entity.setCrew(entityCrew);
 
-        int tacticsInitiativeBonus = getTacticsModifier(skill, campaign.getRandomSkillPreferences(), faction);
+        int tacticsInitiativeBonus = getTacticsModifier(skill,
+              campaign.getRandomSkillPreferences(),
+              campaignOptions.isUseSensibleTactics());
         if (campaignOptions.isUseTactics()) {
             entity.getCrew().setCommandBonus(tacticsInitiativeBonus);
         } else if (campaignOptions.isUseInitiativeBonus()) {
@@ -3057,14 +3059,13 @@ public class AtBDynamicScenarioFactory {
      *
      * @param skill                  the skill level used to derive the base modifier.
      * @param randomSkillPreferences preferences that govern how command skills are adjusted and randomized.
-     * @param faction                the faction data used to determine leadership-related bonuses, such as formation
-     *                               size.
+     * @param isUseSensibleTactics   if {@code true} Tactics modifiers are reduced
      *
      * @return the calculated tactics modifier, factoring in skill level, preferences, randomization, and
      *       faction-specific adjustments.
      */
     private static int getTacticsModifier(SkillLevel skill, RandomSkillPreferences randomSkillPreferences,
-          Faction faction) {
+          boolean isUseSensibleTactics) {
         int skillLevel = 0;
         if (skill.isGreenOrGreater()) {
             int adjustedValue = min(skill.getAdjustedValue(), EXP_LEGENDARY);
@@ -3072,10 +3073,10 @@ public class AtBDynamicScenarioFactory {
 
             int skillRoll = Math.clamp(d6(2) + commandSkillsModifier, 2, 12);
             skillLevel = switch (skillRoll) {
-                case 3, 4, 5 -> 1;
-                case 6, 7, 8, 9 -> 2;
-                case 10, 11 -> 3;
-                case 12 -> 4;
+                case 3, 4, 5 -> isUseSensibleTactics ? 0 : 1;
+                case 6, 7, 8, 9 -> isUseSensibleTactics ? 1 : 2;
+                case 10, 11 -> isUseSensibleTactics ? 2 : 3; // We're not rounding down here on purpose
+                case 12 -> isUseSensibleTactics ? 2 : 4;
                 default -> 0; // 2
             };
         }

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -34,6 +34,7 @@
 package mekhq.campaign.unit;
 
 import static java.lang.Math.ceil;
+import static java.lang.Math.floor;
 import static java.lang.Math.max;
 import static megamek.common.board.Board.START_NONE;
 import static megamek.common.equipment.MiscType.F_CARGO;
@@ -2142,7 +2143,7 @@ public class Unit implements ITechnology, ILocation {
      */
     @Deprecated(since = "0.50.04")
     public int getCurrentDocks() {
-        return (int) Math.floor(getShipTransportedUnitsSummary().getCurrentTransportCapacity(DOCKING_COLLAR));
+        return (int) floor(getShipTransportedUnitsSummary().getCurrentTransportCapacity(DOCKING_COLLAR));
     }
 
     /**
@@ -4986,9 +4987,14 @@ public class Unit implements ITechnology, ILocation {
             int commanderTacticsBonus = commander.getSkill(SkillType.S_TACTICS)
                                               .getTotalSkillLevel(skillModifierData);
 
-            if (getCampaign().getCampaignOptions().isUseTactics()) {
+            CampaignOptions campaignOptions = getCampaign().getCampaignOptions();
+            if (campaignOptions.isUseSensibleTactics()) {
+                commanderTacticsBonus = (int) floor(commanderTacticsBonus / 2.0);
+            }
+
+            if (campaignOptions.isUseTactics()) {
                 entity.getCrew().setCommandBonus(commanderTacticsBonus);
-            } else if (getCampaign().getCampaignOptions().isUseInitiativeBonus()) {
+            } else if (campaignOptions.isUseInitiativeBonus()) {
                 entity.getCrew().setInitBonus(commanderTacticsBonus);
             }
         }
@@ -6978,7 +6984,7 @@ public class Unit implements ITechnology, ILocation {
      */
     @Deprecated(since = "0.50.06", forRemoval = true)
     public int getAsTechsMaintained() {
-        return (int) Math.floor(asTechDaysMaintained / daysSinceMaintenance);
+        return (int) floor(asTechDaysMaintained / daysSinceMaintenance);
     }
 
     public int getMaintenanceMultiplier() {

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/PersonnelTab.java
@@ -104,6 +104,7 @@ public class PersonnelTab {
     private JPanel pnlPersonnelGeneralOptions;
     private JCheckBox chkUseTactics;
     private JCheckBox chkUseInitiativeBonus;
+    private JCheckBox chkUseSensibleTactics;
     private JCheckBox chkUseToughness;
     private JCheckBox chkUseRandomToughness;
     private JCheckBox chkUseArtillery;
@@ -390,6 +391,7 @@ public class PersonnelTab {
         pnlPersonnelGeneralOptions = new JPanel();
         chkUseTactics = new JCheckBox();
         chkUseInitiativeBonus = new JCheckBox();
+        chkUseSensibleTactics = new JCheckBox();
         chkUseToughness = new JCheckBox();
         chkUseRandomToughness = new JCheckBox();
         chkUseArtillery = new JCheckBox();
@@ -436,7 +438,7 @@ public class PersonnelTab {
         // Header
         generalHeader = new CampaignOptionsHeaderPanel("PersonnelGeneralTab",
               getImageDirectory() + "logo_clan_wolverine.png",
-              5);
+              6);
 
         // Contents
         pnlPersonnelGeneralOptions = createGeneralOptionsPanel();
@@ -491,6 +493,9 @@ public class PersonnelTab {
         chkUseInitiativeBonus = new CampaignOptionsCheckBox("UseInitiativeBonus",
               getMetadata(LEGACY_RULE_BEFORE_METADATA, CampaignOptionFlag.IMPORTANT));
         chkUseInitiativeBonus.addMouseListener(createTipPanelUpdater(generalHeader, "UseInitiativeBonus"));
+        chkUseSensibleTactics = new CampaignOptionsCheckBox("UseSensibleTactics",
+              getMetadata(new Version(0, 51, 1), CampaignOptionFlag.IMPORTANT, CampaignOptionFlag.CUSTOM_SYSTEM));
+        chkUseSensibleTactics.addMouseListener(createTipPanelUpdater(generalHeader, "UseSensibleTactics"));
         chkUseToughness = new CampaignOptionsCheckBox("UseToughness",
               getMetadata(LEGACY_RULE_BEFORE_METADATA, CampaignOptionFlag.CUSTOM_SYSTEM));
         chkUseToughness.addMouseListener(createTipPanelUpdater(generalHeader, "UseToughness"));
@@ -554,6 +559,9 @@ public class PersonnelTab {
 
         layout.gridy++;
         panel.add(chkUseInitiativeBonus, layout);
+
+        layout.gridy++;
+        panel.add(chkUseSensibleTactics, layout);
 
         layout.gridy++;
         panel.add(chkUseToughness, layout);
@@ -1505,6 +1513,7 @@ public class PersonnelTab {
         // General
         chkUseTactics.setSelected(options.isUseTactics());
         chkUseInitiativeBonus.setSelected(options.isUseInitiativeBonus());
+        chkUseSensibleTactics.setSelected(options.isUseSensibleTactics());
         chkUseToughness.setSelected(options.isUseToughness());
         chkUseRandomToughness.setSelected(options.isUseRandomToughness());
         chkUseArtillery.setSelected(options.isUseArtillery());
@@ -1617,6 +1626,7 @@ public class PersonnelTab {
         // General
         options.setUseTactics(chkUseTactics.isSelected());
         options.setUseInitiativeBonus(chkUseInitiativeBonus.isSelected());
+        options.setUseSensibleTactics(chkUseSensibleTactics.isSelected());
         options.setUseToughness(chkUseToughness.isSelected());
         options.setUseRandomToughness(chkUseRandomToughness.isSelected());
         options.setUseArtillery(chkUseArtillery.isSelected());


### PR DESCRIPTION
Getting up to a +10 on initiative rolls from Tactics is broken beyond belief, but players adore it. This PR adds a campaign option that halves the initiative modifier from Tactics (rounding down). This allows the benefit to still exist, but reduces its impact. As a side bonus it also removes the issue of Tactics invalidating all other initiative giving equipment. 