### PR TITLE
Fix message when a part is damaged beyond repair

### DIFF
--- a/MekHQ/resources/mekhq/resources/Parts.properties
+++ b/MekHQ/resources/mekhq/resources/Parts.properties
@@ -51,4 +51,4 @@ PartRepairType.POD_SPACE.text=Pod
 PartRepairType.UNKNOWN_LOCATION.text=Error: Unknown Repair Type
 # Modifier descriptions
 Part.modifier.obsolete=obsolete
-Part.damaged.beyond.repair=Damaged beyond repair
+Part.damaged.beyond.repair=This part is damaged beyond repair

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -34,7 +34,7 @@
 package mekhq.campaign.parts;
 
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
-import static mekhq.utilities.MHQInternationalization.getText;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import java.io.PrintWriter;
 import java.text.DecimalFormat;
@@ -507,7 +507,7 @@ public abstract class Part implements IPartWork, ITechnology, ILocation {
         } else {
             toReturn.append(ReportingUtilities.messageSurroundedBySpanWithColor(
                   MekHQ.getMHQOptions().getFontColorNegativeHexColor(),
-                  getText("Part.damaged.beyond.repair")));
+                  getTextAt(RESOURCE_BUNDLE, "Part.damaged.beyond.repair")));
         }
         toReturn.append("</html>");
         return toReturn.toString();


### PR DESCRIPTION
The message for a part that is damaged beyond repair was not showing as it should. This PR fixes that.