### PR TITLE
Add Amputation Recovery Injury

### DIFF
--- a/MekHQ/resources/mekhq/resources/AlternateInjuries.properties
+++ b/MekHQ/resources/mekhq/resources/AlternateInjuries.properties
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+# Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
 #
 # This file is part of MekHQ.
 #
@@ -192,6 +192,7 @@ AlternateInjuries.ELECTIVE_IMPLANT_RECOVERY.simpleName=Elective Implant Recovery
 AlternateInjuries.EI_IMPLANT_RECOVERY.simpleName=EI Implant Recovery
 AlternateInjuries.PAIN_SHUNT_RECOVERY.simpleName=Pain Shunt Recovery
 AlternateInjuries.IMPLANT_REMOVAL_RECOVERY.simpleName=Brain Implant Removal Recovery
+AlternateInjuries.AMPUTATION_RECOVERY.simpleName=Amputation Recovery
 AlternateInjuries.report.implant.fatigue={0}<b>MEDICAL ALERT:</b>{1} {2} has gained a point of permanent Fatigue from \
   their Neural Implant.
 AlternateInjuries.report.implant.degradation={0}<b>MEDICAL ALERT:</b>{1} {2} is suffering mental degradation from \

--- a/MekHQ/src/mekhq/campaign/HumanResources.java
+++ b/MekHQ/src/mekhq/campaign/HumanResources.java
@@ -376,9 +376,12 @@ public class HumanResources {
 
     public int getPatientsFor(Person doctor) {
         int patients = 0;
+        UUID doctorId = doctor.getId();
         for (Person person : getActivePersonnel(true, true)) {
-            if ((null != person.getDoctorId()) && person.getDoctorId().equals(doctor.getId())) {
-                patients++;
+            if ((null != person.getDoctorId()) && person.getDoctorId().equals(doctorId)) {
+                if (person.hasInjuries(true)) {
+                    patients++;
+                }
             }
         }
         return patients;
@@ -1772,58 +1775,58 @@ public class HumanResources {
                 case MEKWARRIOR: {
                     bloodnameTarget += person.hasSkill(SkillType.S_GUN_MEK) ?
                                              person.getSkill(SkillType.S_GUN_MEK)
-                                                   .getFinalSkillValue(skillModifierData) :
+                                             .getFinalSkillValue(skillModifierData) :
                                              TargetRoll.AUTOMATIC_FAIL;
                     bloodnameTarget += person.hasSkill(SkillType.S_PILOT_MEK) ?
                                              person.getSkill(SkillType.S_PILOT_MEK)
-                                                   .getFinalSkillValue(skillModifierData) :
+                                             .getFinalSkillValue(skillModifierData) :
                                              TargetRoll.AUTOMATIC_FAIL;
                     break;
                 }
                 case AEROSPACE: {
                     bloodnameTarget += person.hasSkill(SkillType.S_GUN_AERO) ?
                                              person.getSkill(SkillType.S_GUN_AERO)
-                                                   .getFinalSkillValue(skillModifierData) :
+                                             .getFinalSkillValue(skillModifierData) :
                                              TargetRoll.AUTOMATIC_FAIL;
                     bloodnameTarget += person.hasSkill(SkillType.S_PILOT_AERO) ?
                                              person.getSkill(SkillType.S_PILOT_AERO)
-                                                   .getFinalSkillValue(skillModifierData) :
+                                             .getFinalSkillValue(skillModifierData) :
                                              TargetRoll.AUTOMATIC_FAIL;
                     break;
                 }
                 case ELEMENTAL: {
                     bloodnameTarget += person.hasSkill(SkillType.S_GUN_BA) ?
                                              person.getSkill(SkillType.S_GUN_BA)
-                                                   .getFinalSkillValue(skillModifierData) :
+                                             .getFinalSkillValue(skillModifierData) :
                                              TargetRoll.AUTOMATIC_FAIL;
                     bloodnameTarget += person.hasSkill(SkillType.S_ANTI_MEK) ?
                                              person.getSkill(SkillType.S_ANTI_MEK)
-                                                   .getFinalSkillValue(skillModifierData) :
+                                             .getFinalSkillValue(skillModifierData) :
                                              TargetRoll.AUTOMATIC_FAIL;
                     break;
                 }
                 case VEHICLE: {
                     bloodnameTarget += person.hasSkill(SkillType.S_GUN_VEE) ?
                                              person.getSkill(SkillType.S_GUN_VEE)
-                                                   .getFinalSkillValue(skillModifierData) :
+                                             .getFinalSkillValue(skillModifierData) :
                                              TargetRoll.AUTOMATIC_FAIL;
                     switch (person.getPrimaryRole()) {
                         case VEHICLE_CREW_GROUND:
                             bloodnameTarget += person.hasSkill(SkillType.S_PILOT_GVEE) ?
                                                      person.getSkill(SkillType.S_PILOT_GVEE)
-                                                           .getFinalSkillValue(skillModifierData) :
+                                                     .getFinalSkillValue(skillModifierData) :
                                                      TargetRoll.AUTOMATIC_FAIL;
                             break;
                         case VEHICLE_CREW_NAVAL:
                             bloodnameTarget += person.hasSkill(SkillType.S_PILOT_NVEE) ?
                                                      person.getSkill(SkillType.S_PILOT_NVEE)
-                                                           .getFinalSkillValue(skillModifierData) :
+                                                     .getFinalSkillValue(skillModifierData) :
                                                      TargetRoll.AUTOMATIC_FAIL;
                             break;
                         case VEHICLE_CREW_VTOL:
                             bloodnameTarget += person.hasSkill(SkillType.S_PILOT_VTOL) ?
                                                      person.getSkill(SkillType.S_PILOT_VTOL)
-                                                           .getFinalSkillValue(skillModifierData) :
+                                                     .getFinalSkillValue(skillModifierData) :
                                                      TargetRoll.AUTOMATIC_FAIL;
                             break;
                         default:
@@ -1835,7 +1838,7 @@ public class HumanResources {
                     bloodnameTarget += 2 *
                                              (person.hasSkill(SkillType.S_GUN_PROTO) ?
                                                     person.getSkill(SkillType.S_GUN_PROTO)
-                                                          .getFinalSkillValue(skillModifierData) :
+                                                    .getFinalSkillValue(skillModifierData) :
                                                     TargetRoll.AUTOMATIC_FAIL);
                     break;
                 }
@@ -1845,28 +1848,28 @@ public class HumanResources {
                             bloodnameTarget += 2 *
                                                      (person.hasSkill(SkillType.S_PILOT_SPACE) ?
                                                             person.getSkill(SkillType.S_PILOT_SPACE)
-                                                                  .getFinalSkillValue(skillModifierData) :
+                                                            .getFinalSkillValue(skillModifierData) :
                                                             TargetRoll.AUTOMATIC_FAIL);
                             break;
                         case VESSEL_GUNNER:
                             bloodnameTarget += 2 *
                                                      (person.hasSkill(SkillType.S_GUN_SPACE) ?
                                                             person.getSkill(SkillType.S_GUN_SPACE)
-                                                                  .getFinalSkillValue(skillModifierData) :
+                                                            .getFinalSkillValue(skillModifierData) :
                                                             TargetRoll.AUTOMATIC_FAIL);
                             break;
                         case VESSEL_CREW:
                             bloodnameTarget += 2 *
                                                      (person.hasSkill(SkillType.S_TECH_VESSEL) ?
                                                             person.getSkill(SkillType.S_TECH_VESSEL)
-                                                                  .getFinalSkillValue(skillModifierData) :
+                                                            .getFinalSkillValue(skillModifierData) :
                                                             TargetRoll.AUTOMATIC_FAIL);
                             break;
                         case VESSEL_NAVIGATOR:
                             bloodnameTarget += 2 *
                                                      (person.hasSkill(SkillType.S_NAVIGATION) ?
                                                             person.getSkill(SkillType.S_NAVIGATION)
-                                                                  .getFinalSkillValue(skillModifierData) :
+                                                            .getFinalSkillValue(skillModifierData) :
                                                             TargetRoll.AUTOMATIC_FAIL);
                             break;
                         default:

--- a/MekHQ/src/mekhq/campaign/HumanResources.java
+++ b/MekHQ/src/mekhq/campaign/HumanResources.java
@@ -379,9 +379,7 @@ public class HumanResources {
         UUID doctorId = doctor.getId();
         for (Person person : getActivePersonnel(true, true)) {
             if ((null != person.getDoctorId()) && person.getDoctorId().equals(doctorId)) {
-                if (person.hasInjuries(true)) {
-                    patients++;
-                }
+                patients++;
             }
         }
         return patients;

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedical/InjuryTypes.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedical/InjuryTypes.java
@@ -83,6 +83,8 @@ public final class InjuryTypes {
     public static final InjuryType PUNCTURED_LUNG = new PuncturedLung();
     public static final InjuryType CTE = new Cte();
     public static final InjuryType BROKEN_BACK = new BrokenBack();
+    public static final InjuryType AMPUTATION_RECOVERY = new AmputationRecovery();
+
     // New injury types go here (or extend the class)
     public static final InjuryType SEVERED_SPINE = new SeveredSpine();
     public static final InjuryType TRANSIT_DISORIENTATION_SYNDROME = new TransitDisorientationSyndrome();
@@ -373,6 +375,8 @@ public final class InjuryTypes {
             InjuryType.register(242, "alt:BIRTH_DEFECT", AlternateInjuries.BIRTH_DEFECT);
             InjuryType.register(243, "alt:TERRIBLE_BRUISES", AlternateInjuries.TERRIBLE_BRUISES);
             InjuryType.register(244, "alt:OLD_WOUND", AlternateInjuries.OLD_WOUND);
+            InjuryType.register(245, "alt:AMPUTATION_RECOVERY", AlternateInjuries.AMPUTATION_RECOVERY);
+
 
             InjuryType.register("am:severed_spine", SEVERED_SPINE);
             InjuryType.register("am:replacement_limb_recovery", REPLACEMENT_LIMB_RECOVERY);
@@ -382,6 +386,7 @@ public final class InjuryTypes {
             InjuryType.register("am:Crippling_Flashbacks", CRIPPLING_FLASHBACKS);
             InjuryType.register("am:Childlike_Regression", CHILDLIKE_REGRESSION);
             InjuryType.register("am:Catatonia", CATATONIA);
+            InjuryType.register("am:amputation_recovery", AMPUTATION_RECOVERY);
             registered = true;
         }
     }
@@ -607,6 +612,34 @@ public final class InjuryTypes {
                 default -> Collections.emptyList();
             };
         }
+    }
+
+    public static final class AmputationRecovery extends AMInjuryType {
+        public AmputationRecovery() {
+            recoveryTime = 10;
+            permanent = false;
+            simpleName = "amputation recovery";
+            level = InjuryLevel.MINOR;
+        }
+
+        @Override
+        public boolean isValidInLocation(BodyLocation loc) {
+            return loc.isLimb();
+        }
+
+        @Override
+        public String getName(BodyLocation loc, int severity) {
+            return String.format("%s Amputation Recovery", loc.locationName());
+        }
+
+        @Override
+        public String getFluffText(BodyLocation loc, int severity, Gender gender) {
+            return "Amputation recovery for " +
+                         GenderDescriptors.HIS_HER_THEIR.getDescriptor(gender) +
+                         ' ' +
+                         loc.locationName();
+        }
+
     }
 
     public static final class ReplacementLimbRecovery extends AMInjuryType {

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedical/InjuryUtil.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedical/InjuryUtil.java
@@ -62,6 +62,7 @@ import mekhq.campaign.personnel.enums.GenderDescriptors;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
 import mekhq.campaign.personnel.medical.BodyLocation;
 import mekhq.campaign.personnel.medical.advancedMedicalAlternate.AdvancedMedicalAlternate;
+import mekhq.campaign.personnel.medical.advancedMedicalAlternate.AlternateInjuries;
 import mekhq.campaign.personnel.skills.Skill;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.unit.Unit;
@@ -188,6 +189,7 @@ public final class InjuryUtil {
 
         // We double-check the injury has been added, as it might have been removed by purgeIllogicalInjuries
         boolean hasNewInjuries = false;
+        boolean hasMissingLimbHandled = false;
         List<Injury> currentInjuries = person.getInjuries();
         for (Injury injury : newInjuries) {
             if (!hasNewInjuries && currentInjuries.contains(injury)) {
@@ -196,6 +198,13 @@ public final class InjuryUtil {
 
             if (injury.getType().impliesDead(injury.getLocation())) {
                 person.changeStatus(campaign, campaign.getLocalDate(), PersonnelStatus.MEDICAL_COMPLICATIONS);
+            }
+            // For missing limbs, we add an amputation recovery so they always show up in the infirmary
+            if (!hasMissingLimbHandled && injury.getType().impliesMissingLocation() && injury.getLocation().isLimb()) {
+                hasMissingLimbHandled = true;
+                Injury amputationRecovery = AlternateInjuries.AMPUTATION_RECOVERY.newInjury(campaign, person,
+                      injury.getLocation(), 1);
+                person.addInjury(amputationRecovery);
             }
         }
 
@@ -239,6 +248,18 @@ public final class InjuryUtil {
         List<Injury> newInjuries = new ArrayList<>();
         for (Entry<BodyLocation, Integer> accEntry : hitAccumulator.entrySet()) {
             newInjuries.addAll(genInjuries(campaign, person, accEntry.getKey(), accEntry.getValue()));
+        }
+        // For missing limbs, we add an amputation recovery so they always show up in the infirmary
+        Injury amputation_recovery = null;
+        for (Injury injury : newInjuries) {
+            if (injury.getType().impliesMissingLocation()) {
+                amputation_recovery = InjuryTypes.AMPUTATION_RECOVERY.newInjury(campaign, person,
+                      injury.getLocation(), 1);
+                break;
+            }
+        }
+        if (null != amputation_recovery) {
+            newInjuries.add(amputation_recovery);
         }
         return newInjuries;
     }

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedical/InjuryUtil.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedical/InjuryUtil.java
@@ -190,8 +190,23 @@ public final class InjuryUtil {
         // We double-check the injury has been added, as it might have been removed by purgeIllogicalInjuries
         boolean hasNewInjuries = false;
         boolean hasMissingLimbHandled = false;
+        Injury injuryToRemove = null;
+        // Prepare an amputation recovery injury in case we need it later
+        Injury amputationRecovery = AlternateInjuries.AMPUTATION_RECOVERY.newInjury(campaign, person,
+              BodyLocation.RIGHT_HAND, 1);
+        if (isUseKinderMode) {
+            int originalRecoveryTime = amputationRecovery.getOriginalTime();
+            int newRecoveryTime = (int) ceil(originalRecoveryTime / 2.0);
+            amputationRecovery.setOriginalTime(newRecoveryTime);
+            amputationRecovery.setTime(newRecoveryTime);
+        }
+
         List<Injury> currentInjuries = person.getInjuries();
         for (Injury injury : newInjuries) {
+            if (!injury.getType().impliesMissingLocation() && null == injuryToRemove) {
+                injuryToRemove = injury;
+            }
+
             if (!hasNewInjuries && currentInjuries.contains(injury)) {
                 hasNewInjuries = true;
             }
@@ -202,10 +217,18 @@ public final class InjuryUtil {
             // For missing limbs, we add an amputation recovery so they always show up in the infirmary
             if (!hasMissingLimbHandled && injury.getType().impliesMissingLocation() && injury.getLocation().isLimb()) {
                 hasMissingLimbHandled = true;
-                Injury amputationRecovery = AlternateInjuries.AMPUTATION_RECOVERY.newInjury(campaign, person,
-                      injury.getLocation(), 1);
+                amputationRecovery.setLocation(injury.getLocation());
                 person.addInjury(amputationRecovery);
             }
+        }
+
+        // We do not want to end up with six injuries on a person due to the amputation recovery being added
+        if (hasNewInjuries && hasMissingLimbHandled) {
+            if (newInjuries.size() == 5) {
+                person.removeInjury(injuryToRemove, campaign.getLocalDate());
+                newInjuries.remove(injuryToRemove);
+            }
+            newInjuries.add(amputationRecovery);
         }
 
         if (hasNewInjuries) {
@@ -249,17 +272,26 @@ public final class InjuryUtil {
         for (Entry<BodyLocation, Integer> accEntry : hitAccumulator.entrySet()) {
             newInjuries.addAll(genInjuries(campaign, person, accEntry.getKey(), accEntry.getValue()));
         }
+
+        Injury injuryToRemove = null;
         // For missing limbs, we add an amputation recovery so they always show up in the infirmary
-        Injury amputation_recovery = null;
+        Injury amputationRecovery = null;
         for (Injury injury : newInjuries) {
+            if (!injury.getType().impliesMissingLocation() && null == injuryToRemove) {
+                injuryToRemove = injury;
+            }
             if (injury.getType().impliesMissingLocation()) {
-                amputation_recovery = InjuryTypes.AMPUTATION_RECOVERY.newInjury(campaign, person,
+                amputationRecovery = InjuryTypes.AMPUTATION_RECOVERY.newInjury(campaign, person,
                       injury.getLocation(), 1);
                 break;
             }
         }
-        if (null != amputation_recovery) {
-            newInjuries.add(amputation_recovery);
+        // We do not want to end up with six injuries on a person due to the amputation recovery being added
+        if (null != amputationRecovery) {
+            if (newInjuries.size() == 5) {
+                newInjuries.remove(injuryToRemove);
+            }
+            newInjuries.add(amputationRecovery);
         }
         return newInjuries;
     }

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AlternateInjuries.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AlternateInjuries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -91,6 +91,7 @@ public class AlternateInjuries {
     private static final int TRANSIT_DISORIENTATION_SYNDROME_HEALING_DAYS = 1;
     private static final int CHILDUS_FEVER_RECOVERY_TIME = 365;
     private static final int OLD_WOUND_HEALING_DAYS = 7;
+    private static final int AMPUTATION_RECOVERY_HEALING_DAYS = 10; // 3-4 weeks for initial healing
 
     private static final InjuryLevel SEVER_INJURY_LEVEL = CHRONIC;
     private static final InjuryLevel FRACTURE_INJURY_LEVEL = MAJOR;
@@ -295,6 +296,7 @@ public class AlternateInjuries {
     public static final InjuryType REPLACEMENT_ORGAN_RECOVERY = new ReplacementOrganRecovery();
     public static final InjuryType COSMETIC_SURGERY_RECOVERY = new CosmeticSurgeryRecovery();
     public static final InjuryType FAILED_SURGERY_RECOVERY = new FailedSurgeryRecovery();
+    public static final InjuryType AMPUTATION_RECOVERY = new AmputationRecovery();
     public static final InjuryType ELECTIVE_MYOMER_ARM = new ElectiveMyomerArm();
     public static final InjuryType ELECTIVE_MYOMER_HAND = new ElectiveMyomerHand();
     public static final InjuryType ELECTIVE_MYOMER_LEG = new ElectiveMyomerLeg();
@@ -2814,6 +2816,18 @@ public class AlternateInjuries {
                   NONE,
                   Set.of(GENERIC));
             this.simpleName = getTextAt(RESOURCE_BUNDLE, "AlternateInjuries.PAIN_SHUNT_RECOVERY.simpleName");
+        }
+    }
+
+    public static final class AmputationRecovery extends BaseInjury {
+        AmputationRecovery() {
+            super(AMPUTATION_RECOVERY_HEALING_DAYS,
+                  false,
+                  MINOR,
+                  NONE,
+                  Set.of(LEFT_HAND, RIGHT_HAND, LEFT_ARM, RIGHT_ARM, LEFT_FOOT, RIGHT_FOOT, LEFT_LEG, RIGHT_LEG));
+            this.simpleName = getTextAt(RESOURCE_BUNDLE,
+                  "AlternateInjuries.AMPUTATION_RECOVERY.simpleName");
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AlternateInjuries.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AlternateInjuries.java
@@ -2824,7 +2824,7 @@ public class AlternateInjuries {
             super(AMPUTATION_RECOVERY_HEALING_DAYS,
                   false,
                   MINOR,
-                  NONE,
+                  InjuryEffect.BLOOD_LOSS,
                   Set.of(LEFT_HAND, RIGHT_HAND, LEFT_ARM, RIGHT_ARM, LEFT_FOOT, RIGHT_FOOT, LEFT_LEG, RIGHT_LEG));
             this.simpleName = getTextAt(RESOURCE_BUNDLE,
                   "AlternateInjuries.AMPUTATION_RECOVERY.simpleName");


### PR DESCRIPTION
When a person suffers a 'Lost limb' injury, they no longer automatically appear in the Infirmary. The reason is that a 'Lost limb' is a permanent injury and PR #9054 specifically excludes persons with only permanent injuries from appearing in the Infirmary.

This situation is undesirable, since a person with a 'Lost limb' could not be noticed for some time. Having a person with a 'Lost limb' could mean the player may want to replace the limb with a prosthetic but for that the player must be aware of the situation.

This PR fixes this by adding a single 'Amputation recovery' injury to a person that suffers a 'Lost limb' injury. This is not a permanent injury and so this means the person will appear in the Infirmary for as long as this new injury remains. It is also more realistic that a person suffering from a 'Lost limb' injury would need some time to recover.