### PR TITLE
Refactor skill checks into Person.checkSkill.modify.perform chains

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -168,10 +168,10 @@ import mekhq.campaign.personnel.medical.MedicalController;
 import mekhq.campaign.personnel.medical.advancedMedicalAlternate.AdvancedMedicalAlternateImplants;
 import mekhq.campaign.personnel.medical.advancedMedicalAlternate.InjurySubType;
 import mekhq.campaign.personnel.medical.advancedMedicalAlternate.Inoculations;
+import mekhq.campaign.personnel.skills.ActionCheckResult;
 import mekhq.campaign.personnel.skills.AttributeCheckUtility;
 import mekhq.campaign.personnel.skills.EscapeSkills;
 import mekhq.campaign.personnel.skills.QuickTrain;
-import mekhq.campaign.personnel.skills.SkillCheckUtility;
 import mekhq.campaign.personnel.skills.enums.AgingMilestone;
 import mekhq.campaign.personnel.skills.enums.SkillAttribute;
 import mekhq.campaign.personnel.turnoverAndRetention.Fatigue;
@@ -1020,12 +1020,11 @@ public class CampaignNewDayManager {
      * @since 0.51.0
      */
     private void embezzleFunds(Person person) {
-        String reason = getTextAt(RESOURCE_BUNDLE, "embezzle.roll");
-        SkillCheckUtility skillCheck = new SkillCheckUtility(reason, person, S_ADMIN, List.of(), 0, false, true);
-        String report = skillCheck.getResultsText();
-        campaign.addReport(SKILL_CHECKS, report);
+        ActionCheckResult actionCheckResult =
+              person.checkSkill(S_ADMIN).resolve(false, getTextAt(RESOURCE_BUNDLE, "embezzle.roll"), true);
+        campaign.addReport(SKILL_CHECKS, actionCheckResult.resultsText());
 
-        if (skillCheck.isSuccess()) {
+        if (actionCheckResult.isSuccess()) {
             Money currentCampaignFunds = finances.getBalance();
             double embezzlePercentile = 0.001;
 

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
@@ -77,8 +77,8 @@ import mekhq.campaign.mission.enums.ContractCommandRights;
 import mekhq.campaign.mission.utilities.ContractUtilities;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
+import mekhq.campaign.personnel.skills.ActionCheckResult;
 import mekhq.campaign.personnel.skills.Skill;
-import mekhq.campaign.personnel.skills.SkillCheckUtility;
 import mekhq.campaign.personnel.skills.SkillModifierData;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.universe.Faction;
@@ -662,34 +662,21 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
 
 
     private static int getCommanderModifier(Campaign campaign) {
-        Person campaignCommander = campaign.getFlaggedCommander();
-        int connections = 0;
-        int negotiationsMarginOfSuccess = 0;
-        if (campaignCommander != null) {
-            connections = campaignCommander.getAdjustedConnections(false);
-
-            CampaignOptions campaignOptions = campaign.getCampaignOptions();
-            boolean isUseAgingEffects = campaignOptions.isUseAgeEffects();
-            boolean isClanCampaign = campaign.isClanCampaign();
-            boolean isUseEdge = campaignOptions.isUseEdge() || campaignOptions.isUseSupportEdge();
-            isUseEdge = isUseEdge && campaignCommander.getOptions().booleanOption(EDGE_COMMANDER_NEGOTIATION);
-            SkillCheckUtility checkUtility = new SkillCheckUtility(
-                  getTextAt(RESOURCE_BUNDLE, "AtbMonthlyContractMarket.contractSkillCheck"),
-                  campaignCommander,
-                  S_NEGOTIATION,
-                  null,
-                  0,
-                  isUseEdge,
-                  true,
-                  isUseAgingEffects,
-                  isClanCampaign,
-                  campaign.getLocalDate());
-            negotiationsMarginOfSuccess = max(0, checkUtility.getMarginOfSuccess());
-
-            campaign.addReport(SKILL_CHECKS, checkUtility.getResultsText());
+        Person commander = campaign.getFlaggedCommander();
+        if (commander == null) {
+            return 0;
         }
+        CampaignOptions campaignOptions = campaign.getCampaignOptions();
+        int connections = commander.getAdjustedConnections(false);
+        boolean isUseEdge = campaignOptions.isUseEdge() || campaignOptions.isUseSupportEdge();
+        isUseEdge = isUseEdge && commander.getOptions().booleanOption(EDGE_COMMANDER_NEGOTIATION);
 
-        return connections + negotiationsMarginOfSuccess;
+        ActionCheckResult actionCheckResult =
+              commander.checkSkill(S_NEGOTIATION, campaign)
+                    .resolve(isUseEdge, getTextAt(RESOURCE_BUNDLE, "AtbMonthlyContractMarket.contractSkillCheck"), true);
+        campaign.addReport(SKILL_CHECKS, actionCheckResult.resultsText());
+
+        return connections + Math.max(0, actionCheckResult.marginOfSuccess());
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -146,6 +146,7 @@ import mekhq.campaign.personnel.ranks.RankValidator;
 import mekhq.campaign.personnel.ranks.Ranks;
 import mekhq.campaign.personnel.skills.Attributes;
 import mekhq.campaign.personnel.skills.Skill;
+import mekhq.campaign.personnel.skills.SkillCheck;
 import mekhq.campaign.personnel.skills.SkillModifierData;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.personnel.skills.Skills;
@@ -5805,6 +5806,60 @@ public class Person implements ILocation {
             addSkill(skillName, 0, 0);
         }
         MekHQ.triggerEvent(new PersonChangedEvent(this));
+    }
+
+    /**
+     * Use {@link #checkSkill(String, boolean, boolean, LocalDate)} or {@link #checkSkill(String, Campaign)} instead.
+     *
+     * <p>Prepares a skill check.</p>
+     *
+     * <p>This constructor creates a {@code SkillCheck} instance which calculates the target number for the
+     * skill check based the person's skill level.</p>
+     *
+     * <p><b>Usage:</b> This is a convenience method that excludes reputation and aging effect checks.</p>
+     *
+     * @param skillName the name of the skill being used, corresponding to a {@link SkillType}
+     *
+     * @return prepared skill check
+     */
+    @Deprecated(since = "0.50.07", forRemoval = true)
+    public SkillCheck checkSkill(String skillName) {
+        return new SkillCheck(this, skillName);
+    }
+
+
+    /**
+     * Prepares a skill check based on individually passed options.
+     *
+     * <p>This method creates a {@code SkillCheck} instance which calculates the target number
+     * for the skill check, based on the person's skill, aging effects, clan campaign rules,
+     * and the current date.</p>
+     *
+     * @param skillName         the name of the skill being checked, corresponding to a {@link SkillType}
+     * @param isUseAgingEffects if {@code true}, considers aging effects during the check
+     * @param isClanCampaign    if {@code true}, applies rules specific to clan campaigns
+     * @param date              the current date, used for time-dependent logic
+     *
+     * @return prepared skill check
+     */
+    public SkillCheck checkSkill(String skillName, boolean isUseAgingEffects, boolean isClanCampaign, LocalDate date) {
+        return new SkillCheck(this, skillName, isUseAgingEffects, isClanCampaign, date);
+    }
+
+    /**
+     * Prepares a skill check based on the campaign's options.
+     *
+     * <p>Automatically extracts aging effect setting, clan campaign status, and the current date from
+     * the provided {@link Campaign} context to calculate the target number.</p>
+     *
+     * @param skillName the name of the skill being checked, corresponding to a {@link SkillType}
+     * @param campaign  the current {@link Campaign} context
+     *
+     * @return prepared skill check
+     */
+    public SkillCheck checkSkill(String skillName, Campaign campaign) {
+        return new SkillCheck(this, skillName, campaign.getCampaignOptions().isUseAgeEffects(),
+              campaign.isClanCampaign(), campaign.getLocalDate());
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
@@ -72,10 +72,10 @@ import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.enums.PersonnelRole;
+import mekhq.campaign.personnel.skills.ActionCheckResult;
 import mekhq.campaign.personnel.skills.InfantryGunnerySkills;
 import mekhq.campaign.personnel.skills.ScoutingSkills;
 import mekhq.campaign.personnel.skills.Skill;
-import mekhq.campaign.personnel.skills.SkillCheckUtility;
 import mekhq.campaign.personnel.skills.SkillModifierData;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.personnel.skills.enums.MarginOfSuccess;
@@ -556,36 +556,22 @@ public class TrainingCombatTeams {
     }
 
     private static int performTrainingSkillCheck(Campaign campaign, Person educator) {
-        final LocalDate today = campaign.getLocalDate();
-        final boolean isClanCampaign = campaign.isClanCampaign();
         final CampaignOptions campaignOptions = campaign.getCampaignOptions();
-        final boolean useAgingEffects = campaignOptions.isUseAgeEffects();
         boolean isUseEdge = campaignOptions.isUseEdge();
         isUseEdge = isUseEdge && educator.getOptions().booleanOption(EDGE_TRAINING);
 
-        SkillCheckUtility skillCheck = new SkillCheckUtility(
-              getTextAt(RESOURCE_BUNDLE, "trainingCombatTeam.skillCheck"),
-              educator,
-              S_TRAINING,
-              new ArrayList<>(),
-              0,
-              isUseEdge,
-              true,
-              useAgingEffects,
-              isClanCampaign,
-              today);
-        int raw = skillCheck.getMarginOfSuccess();
-        MarginOfSuccess marginOfSuccess = getMarginOfSuccessObject(raw);
+        ActionCheckResult actionCheckResult =
+              educator.checkSkill(S_TRAINING, campaign)
+                    .resolve(isUseEdge, getTextAt(RESOURCE_BUNDLE, "trainingCombatTeam.skillCheck"), true);
+        campaign.addReport(SKILL_CHECKS, actionCheckResult.resultsText());
 
+        MarginOfSuccess marginOfSuccess = getMarginOfSuccessObject(actionCheckResult.marginOfSuccess());
         String personnelReport = getFormattedTextAt(RESOURCE_BUNDLE, "learnedProgress.text",
               educator.getHyperlinkedFullTitle(), spanOpeningWithCustomColor(marginOfSuccess.getColor()),
               marginOfSuccess.getLabel(), CLOSING_SPAN_TAG);
         campaign.addReport(PERSONNEL, personnelReport);
 
-        String skillRollReport = skillCheck.getResultsText();
-        campaign.addReport(SKILL_CHECKS, skillRollReport);
-
-        return raw;
+        return actionCheckResult.marginOfSuccess();
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/medical/MedicalController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/MedicalController.java
@@ -55,7 +55,8 @@ import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
 import mekhq.campaign.personnel.medical.advancedMedical.InjuryUtil;
 import mekhq.campaign.personnel.medical.advancedMedicalAlternate.AdvancedMedicalAlternateHealing;
-import mekhq.campaign.personnel.skills.SkillCheckUtility;
+import mekhq.campaign.personnel.skills.ActionCheck;
+import mekhq.campaign.personnel.skills.ActionCheckResult;
 import mekhq.campaign.unit.Unit;
 
 /**
@@ -222,21 +223,14 @@ public class MedicalController {
         LOGGER.debug(getFormattedTextAt(RESOURCE_BUNDLE, "MedicalController.report.intro",
               doctor.getHyperlinkedFullTitle(), patient.getHyperlinkedFullTitle()));
 
-        SkillCheckUtility skillCheckUtility = new SkillCheckUtility(
-              getTextAt(RESOURCE_BUNDLE, "MedicalController.report.skillCheck"),
-              doctor,
-              S_SURGERY,
-              getAdditionalHealingModifiers(patient),
-              0,
-              isUseSupportEdge,
-              false,
-              isUseAgingEffects,
-              isClanCampaign,
-              today);
+        ActionCheckResult actionCheckResult =
+              doctor.checkSkill(S_SURGERY, isUseAgingEffects, isClanCampaign, today)
+                    .withExternalModifiers(getAdditionalHealingModifiers(patient))
+                    .resolve(isUseSupportEdge, getTextAt(RESOURCE_BUNDLE, "MedicalController.report.skillCheck"), false);
 
-        LOGGER.debug(skillCheckUtility.getResultsText());
+        LOGGER.debug(actionCheckResult.resultsText());
 
-        if (skillCheckUtility.isSuccess()) {
+        if (actionCheckResult.isSuccess()) {
             boolean inInfirmary = !(null == patient.getDoctorId());
             patient.heal();
             if (inInfirmary && !patient.needsFixing() && patient.getPrisonerStatus().isFreeOrBondsman()) {

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateHealing.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateHealing.java
@@ -63,8 +63,9 @@ import mekhq.campaign.personnel.Injury;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.medical.BodyLocation;
+import mekhq.campaign.personnel.skills.ActionCheckResult;
 import mekhq.campaign.personnel.skills.AttributeCheckUtility;
-import mekhq.campaign.personnel.skills.SkillCheckUtility;
+import mekhq.campaign.personnel.skills.SkillCheck;
 import mekhq.campaign.personnel.skills.enums.SkillAttribute;
 
 
@@ -423,31 +424,20 @@ public class AdvancedMedicalAlternateHealing {
      */
     private static int getMarginOfSuccessForAssistedHealing(Person doctor, List<TargetRollModifier> modifiers,
           int miscPenalty, boolean useEdge) {
-        SkillCheckUtility surgery = new SkillCheckUtility(
-              getTextAt(RESOURCE_BUNDLE, "AdvancedMedicalAlternateHealing.assistedHealing.normal"),
-              doctor,
-              S_SURGERY,
-              modifiers,
-              miscPenalty,
-              false,
-              true);
-        int marginOfSuccess = surgery.getMarginOfSuccess();
+        SkillCheck skillCheck = doctor.checkSkill(S_SURGERY)
+                                      .withMiscModifier(miscPenalty)
+                                      .withExternalModifiers(modifiers);
+        ActionCheckResult actionCheckResult = skillCheck.resolve(false, getTextAt(RESOURCE_BUNDLE,
+              "AdvancedMedicalAlternateHealing.assistedHealing.normal"), true);
 
         // Edge
-        if (marginOfSuccess <= -6 && useEdge && doctor.getCurrentEdge() > 0) { // Permanent injury
+        if (actionCheckResult.marginOfSuccess() <= -6 && useEdge && doctor.getCurrentEdge() > 0) { // Permanent injury
             // manually update edge because if we pass useEdge == true, the doctor will get one free roll
             doctor.changeCurrentEdge(-1);
-            SkillCheckUtility edgeReroll = new SkillCheckUtility(
-                  getTextAt(RESOURCE_BUNDLE, "AdvancedMedicalAlternateHealing.assistedHealing.edge"),
-                  doctor,
-                  S_SURGERY,
-                  modifiers,
-                  miscPenalty,
-                  false,
-                  true);
-            marginOfSuccess = edgeReroll.getMarginOfSuccess(); // Edge always replaces the original
+            actionCheckResult = skillCheck.resolve(false, getTextAt(RESOURCE_BUNDLE,
+                  "AdvancedMedicalAlternateHealing.assistedHealing.edge"), true);
         }
-        return marginOfSuccess;
+        return actionCheckResult.marginOfSuccess();
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/skills/ActionCheck.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/ActionCheck.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package mekhq.campaign.personnel.skills;
+
+import static mekhq.campaign.personnel.enums.GenderDescriptors.HIS_HER_THEIR;
+import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.BARELY_MADE_IT;
+import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.getMarginOfSuccessObjectFromMarginValue;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
+import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
+import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
+
+import java.util.List;
+
+import megamek.common.TargetRollModifier;
+import megamek.common.annotations.Nullable;
+import megamek.common.rolls.TargetRoll;
+import megamek.logging.MMLogger;
+import mekhq.MekHQ;
+import mekhq.campaign.events.persons.PersonChangedEvent;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.skills.enums.MarginOfSuccess;
+import mekhq.utilities.ReportingUtilities;
+
+/**
+ * Base abstract class for configuring character skill, attribute, and other action checks.
+ *
+ * <p>This class utilizes a builder pattern to allow the caller to attach external modifiers
+ * and miscellaneous adjustments before resolving the check via {@link #resolve(boolean, String, boolean)}.
+ * Subclasses must implement the abstract methods to define the specific mechanics of the action being checked.</p>
+ *
+ * @param <T> the concrete subclass type, used to enable method chaining
+ *
+ * @author Hokk
+ * @since 0.51.01
+ */
+public abstract class ActionCheck<T extends ActionCheck<T>> {
+
+    private static final MMLogger LOGGER = MMLogger.create(ActionCheck.class);
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.SkillCheckUtility";
+
+    protected final Person person;
+    protected final TargetRoll targetNumber;
+
+    /**
+     * Initializes a new action check for the specified person and target number.
+     *
+     * @param person       the {@link Person} performing the action
+     * @param targetNumber the base {@link TargetRoll} required to succeed
+     */
+    protected ActionCheck(Person person, TargetRoll targetNumber) {
+        this.person = person;
+        this.targetNumber = targetNumber;
+    }
+
+    /**
+     * Gets the target number for the skill check.
+     *
+     * <p>The target number represents the value that the rolled number must meet or exceed for the skill check to
+     * succeed.</p>
+     *
+     * @return the target number for the skill check
+     *
+     * @author Illiani
+     * @since 0.50.05
+     */
+    public TargetRoll getTargetNumber() {
+        return targetNumber;
+    }
+
+    /**
+     * Returns the concrete instance of this class for method chaining.
+     *
+     * @return the current instance of {@code T}
+     */
+    abstract protected T getThis();
+
+    /**
+     * Determines if the action uses a "count up" resolution mechanic.
+     *
+     * <p>In count up mechanics, miscellaneous bonuses are subtracted from the target number, while
+     * penalties are added.</p>
+     *
+     * @return {@code true} if the action counts up, {@code false} otherwise
+     */
+    abstract protected boolean isCountUp();
+
+    /**
+     * Determines if the character has a natural aptitude for this action.
+     *
+     * <p>Natural aptitude generally allows the character to roll an extra die and keep the highest two results.</p>
+     *
+     * @return {@code true} if the character has a natural aptitude, {@code false} otherwise
+     */
+    abstract protected boolean hasNaturalAptitude();
+
+    /**
+     * Retrieves the localized name of the action or skill being checked.
+     *
+     * @return the name of the action
+     */
+    abstract protected String getActionName();
+
+    /**
+     * Applies external modifiers to the action check's target number.
+     *
+     * <p>External modifiers can optionally influence the target number. Using edge allows the person to attempt a
+     * re-roll if the initial roll fails. Additionally, the constructor can include margins of success text as
+     * part of the results, if desired.</p>
+     *
+     * @param modifiers a list of {@link TargetRollModifier}s that affect the target number
+     * @return updated action check
+     */
+    public T withExternalModifiers(List<TargetRollModifier> modifiers) {
+        for (TargetRollModifier modifier : modifiers) {
+            targetNumber.addModifier(modifier);
+        }
+        return getThis();
+    }
+
+    /**
+     * Applies a miscellaneous numerical modifier to the action check's target number.
+     *
+     * @param miscModifier any special modifiers, as an {@link Integer}. These values are subtracted from the
+     *                     target number, if the associated skill is classified as 'count up', otherwise they are
+     *                     added to the target number. This means negative values are bonuses, positive values are
+     *                     penalties.
+     * @return updated action check
+     */
+    public T withMiscModifier(int miscModifier) {
+        int finalModifier = isCountUp() ? -miscModifier : miscModifier;
+        targetNumber.addModifier(finalModifier, getFormattedTextAt(RESOURCE_BUNDLE, "skillCheck.miscModifier"));
+        return getThis();
+    }
+
+
+    /**
+     * Executes action check for the specified person.
+     *
+     * <p>External modifiers can optionally influence the target number, while miscellaneous modifiers
+     * alter the target based on whether the skill is classified as 'count up' or not. Using edge allows the person to
+     * attempt a re-roll if the initial roll fails. Additionally, the constructor can include margins of success text as
+     * part of the results, if desired.</p>
+     *
+     * <p><b>Usage:</b> This constructor offers detailed control over the skill check process.
+     * </p>
+     *
+     * @param useEdge                     whether the person should use edge to re-roll if the initial attempt fails
+     * @param reason                      the reason for the check; can be {@code null}
+     * @param includeMarginsOfSuccessText whether to include detailed margins of success information in the results
+     */
+    public ActionCheckResult resolve(boolean useEdge, @Nullable String reason,
+          boolean includeMarginsOfSuccessText) {
+
+        int roll = SkillCheckUtility.getRoll(hasNaturalAptitude());
+        boolean usedEdge = false;
+
+        boolean failed = roll < targetNumber.getValue();
+        boolean canSucceed = !targetNumber.cannotSucceed() && targetNumber.getValue() <= 12;
+        boolean canSpendEdge = useEdge && person.getCurrentEdge() > 0;
+
+        if (failed && canSucceed && canSpendEdge) {
+            // reroll using edge
+            roll = SkillCheckUtility.getRoll(hasNaturalAptitude());
+            usedEdge = true;
+
+            person.changeCurrentEdge(-1);
+            MekHQ.triggerEvent(new PersonChangedEvent(person));
+        }
+
+        int difference = targetNumber.getValue() - roll;
+        int marginOfSuccess = MarginOfSuccess.getMarginOfSuccess(isCountUp() ? difference : -difference);
+        String resultsText = generateResultsText(roll, marginOfSuccess, usedEdge, person,
+              includeMarginsOfSuccessText, hasNaturalAptitude(), reason);
+
+        LOGGER.info(resultsText);
+
+        return new ActionCheckResult(roll, marginOfSuccess, usedEdge, resultsText);
+    }
+
+    /**
+     * Generates a formatted and localized results text describing the outcome of a skill check.
+     *
+     * <p>This method produces a detailed summary of the skill check results, including:</p>
+     * <ul>
+     *   <li>The person's title, name, and gender-based pronoun</li>
+     *   <li>The name of the skill being checked</li>
+     *   <li>The dice roll, target number, and margin of success or failure</li>
+     *   <li>A status message indicating success or failure</li>
+     *   <li>Use of edge (if applicable)</li>
+     * </ul>
+     *
+     * <p>The results text is color-coded using custom span tags based on the margin of success:
+     * <ul>
+     *   <li><b>Neutral Margin:</b> Displayed using a warning color (e.g., yellow).</li>
+     *   <li><b>Failure:</b> Displayed using a negative color (e.g., red).</li>
+     *   <li><b>Success:</b> Displayed using a positive color (e.g., green).</li>
+     * </ul>
+     * </p>
+     *
+     * <p>If edge was used to reroll the skill check, the results will include an additional note with
+     * information about the reroll. If the caller requests it, margin of success details can also be
+     * appended to the results text.</p>
+     *
+     * <p>If the skill name is {@code null}, the method returns a localized error message indicating that the
+     * skill name could not be resolved and that an error occurred during the results generation process.</p>
+     *
+     * @param includeMarginsOfSuccessText whether to include detailed margin of success information in the results text
+     *
+     * @return a localized and formatted {@link String} representing the outcomes of the skill check:
+     *       <ul>
+     *         <li>If successful, the string provides details of the roll, skill, and margin of success.</li>
+     *         <li>If edge was used, additional information about the reroll is included.</li>
+     *         <li>If the skill name is {@code null}, an error message is returned instead.</li>
+     *       </ul>
+     *
+     * @author Illiani
+     * @since 0.50.05
+     */
+    private String generateResultsText(int roll, int marginOfSuccess, boolean usedEdge,
+          Person person, boolean includeMarginsOfSuccessText, boolean hasNaturalAptitude, @Nullable String reason) {
+        String fullTitle = person.getHyperlinkedFullTitle();
+        String genderedReferenced = HIS_HER_THEIR.getDescriptor(person.getGender());
+
+        String colorOpen;
+        int neutralMarginValue = BARELY_MADE_IT.getValue();
+        if (marginOfSuccess == neutralMarginValue) {
+            colorOpen = spanOpeningWithCustomColor(ReportingUtilities.getWarningColor());
+        } else if (marginOfSuccess < neutralMarginValue) {
+            colorOpen = spanOpeningWithCustomColor(ReportingUtilities.getNegativeColor());
+        } else {
+            colorOpen = spanOpeningWithCustomColor(ReportingUtilities.getPositiveColor());
+        }
+
+        String status = getTextAt(RESOURCE_BUNDLE,
+              ActionCheckResult.isSuccess(marginOfSuccess) ? "skillCheck.results.success" : "skillCheck.results.failure");
+
+        StringBuilder resultsText = new StringBuilder(getFormattedTextAt(RESOURCE_BUNDLE,
+              "skillCheck.results",
+              reason == null ? "" : "<b>" + reason + ":</b> ",
+              fullTitle,
+              colorOpen,
+              status,
+              CLOSING_SPAN_TAG,
+              genderedReferenced,
+              getActionName(),
+              roll,
+              targetNumber.getValue()));
+
+        if (hasNaturalAptitude) {
+            resultsText.append(" ").append(getTextAt(RESOURCE_BUNDLE, "skillCheck.naturalAptitude"));
+        }
+
+        if (usedEdge) {
+            resultsText.append(" ").append(getTextAt(RESOURCE_BUNDLE, "skillCheck.rerolled"));
+        }
+
+        if (includeMarginsOfSuccessText) {
+            MarginOfSuccess marginOfSuccessObject = getMarginOfSuccessObjectFromMarginValue(marginOfSuccess);
+            String marginOfSuccessText = colorOpen + marginOfSuccessObject.getLabel() + CLOSING_SPAN_TAG;
+            resultsText.append(" ").append(marginOfSuccessText);
+        }
+
+        return resultsText.toString();
+    }
+
+}

--- a/MekHQ/src/mekhq/campaign/personnel/skills/ActionCheckResult.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/ActionCheckResult.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package mekhq.campaign.personnel.skills;
+
+import mekhq.campaign.personnel.skills.enums.MarginOfSuccess;
+
+import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.BARELY_MADE_IT;
+
+/**
+ * An immutable record representing the outcome of an action check.
+ *
+ * @param roll            Roll result for the action check
+ * @param marginOfSuccess Calculated margin of success for this action check. Represents how much better (or worse)
+ *                        the roll was compared to the target number
+ * @param usedEdge        Indicates whether edge was used during the action check
+ * @param resultsText     A string representing the outcome of the action check
+ *
+ * @author Hokk
+ * @since 0.51.01
+ */
+public record ActionCheckResult(
+      int roll,
+      int marginOfSuccess,
+      boolean usedEdge,
+      String resultsText
+) {
+
+    /**
+     * Determines whether the action check was successful.
+     *
+     * <p>An action check is considered successful if the calculated margin of success is equal or exceeds
+     * {@link MarginOfSuccess#BARELY_MADE_IT}.</p>
+     *
+     * @return {@code true} if the action check succeeded, {@code false} otherwise
+     */
+    public boolean isSuccess() {
+        return isSuccess(marginOfSuccess);
+    }
+
+    /**
+     * Determines whether a given margin of success represents a successful action check.
+     *
+     * <p>A margin is considered successful if it is equal or exceeds {@link MarginOfSuccess#BARELY_MADE_IT}.</p>
+     *
+     * @param marginOfSuccess the margin of success to evaluate
+     * @return {@code true} if the margin qualifies as a success, {@code false} otherwise
+     */
+    public static boolean isSuccess(int marginOfSuccess) {
+        return marginOfSuccess >= BARELY_MADE_IT.getValue();
+    }
+}

--- a/MekHQ/src/mekhq/campaign/personnel/skills/Appraisal.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Appraisal.java
@@ -32,13 +32,13 @@
  */
 package mekhq.campaign.personnel.skills;
 
+import static mekhq.campaign.personnel.skills.SkillType.S_APPRAISAL;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
 import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
 
 import java.time.LocalDate;
-import java.util.List;
 
 import megamek.common.annotations.Nullable;
 import megamek.logging.MMLogger;
@@ -78,21 +78,10 @@ public class Appraisal {
         if (person == null) {
             return 1.0;
         }
-
-        SkillCheckUtility skillCheckUtility = new SkillCheckUtility(
-              getTextAt(RESOURCE_BUNDLE, "Appraisal.skillCheck"),
-              person,
-              SkillType.S_APPRAISAL,
-              List.of(),
-              0,
-              isUseEdge,
-              false,
-              false,
-              false,
-              currentDay);
-        int marginOfSuccessValue = skillCheckUtility.getMarginOfSuccess();
-
-        return getAppraisalCostMultiplier(marginOfSuccessValue);
+        ActionCheckResult actionCheckResult =
+              person.checkSkill(S_APPRAISAL, false, false, currentDay)
+                    .resolve(isUseEdge, getTextAt(RESOURCE_BUNDLE, "Appraisal.skillCheck"), false);
+        return getAppraisalCostMultiplier(actionCheckResult.marginOfSuccess());
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/skills/EscapeSkills.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/EscapeSkills.java
@@ -100,19 +100,12 @@ public class EscapeSkills {
         CampaignOptions campaignOptions = campaign.getCampaignOptions();
         boolean useEdge = campaignOptions.isUseEdge() || campaignOptions.isUseSupportEdge();
         useEdge = useEdge && person.getOptions().booleanOption(EDGE_ESCAPE_ATTEMPTS);
-        SkillCheckUtility skillCheckUtility = new SkillCheckUtility(
-              getTextAt(RESOURCE_BUNDLE, "EscapeArtist.skillCheck"),
-              person,
-              skillToUse,
-              List.of(),
-              0,
-              useEdge,
-              false,
-              false,
-              false,
-              today);
-        int marginOfSuccessValue = skillCheckUtility.getMarginOfSuccess();
-        MarginOfSuccess marginOfSuccess = MarginOfSuccess.getMarginOfSuccessObjectFromMarginValue(marginOfSuccessValue);
+        ActionCheckResult actionCheckResult =
+              person.checkSkill(skillToUse, false, false, today)
+                    .resolve(useEdge, getTextAt(RESOURCE_BUNDLE, "EscapeArtist.skillCheck"), false);
+
+        MarginOfSuccess marginOfSuccess =
+              MarginOfSuccess.getMarginOfSuccessObjectFromMarginValue(actionCheckResult.marginOfSuccess());
 
         // Nothing happens for these cases, so we can just early exit
         List<MarginOfSuccess> noFurtherActionCases = List.of(MarginOfSuccess.IT_WILL_DO, MarginOfSuccess.BARELY_MADE_IT,

--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillCheck.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillCheck.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package mekhq.campaign.personnel.skills;
+
+import megamek.common.rolls.TargetRoll;
+import mekhq.campaign.personnel.Person;
+
+import java.time.LocalDate;
+
+/**
+ * An implementation of {@link ActionCheck} for skill checks.
+ *
+ * <p>This class encapsulates the logic needed to resolve a skill check for a character's
+ * specific {@link SkillType}, accounting for linked attributes, untrained penalties, and natural aptitudes.</p>
+ *
+ * @author Hokk
+ * @since 0.51.01
+ */
+public class SkillCheck extends ActionCheck<SkillCheck> {
+
+    private SkillType skillType;
+
+    /**
+     * Instantiates a skill check from raw values. Prefer the other constructor variants.
+     *
+     * @param person       the {@link Person} performing the skill check
+     * @param skillType    {@link SkillType} skill to be checked
+     * @param targetNumber target number for the skill check
+     */
+    public SkillCheck(Person person, SkillType skillType, TargetRoll targetNumber) {
+        super(person, targetNumber);
+        this.skillType = skillType;
+    }
+
+    /**
+     * Please see {@link Person#checkSkill(String)} and use it instead.
+     */
+    @Deprecated(since = "0.50.07", forRemoval = true)
+    public SkillCheck(Person person, String skillName) {
+        super(person, SkillCheckUtility.determineTargetNumber(person, SkillType.getType(skillName)));
+        this.skillType = SkillType.getType(skillName);
+    }
+
+    /**
+     * Please see {@link Person#checkSkill(String, boolean, boolean, LocalDate)} and use it instead.
+     */
+    public SkillCheck(Person person, String skillName,
+          boolean isUseAgingEffects, boolean isClanCampaign, LocalDate date) {
+        super(person, SkillCheckUtility.determineTargetNumber(
+              person, SkillType.getType(skillName), isUseAgingEffects, isClanCampaign, date));
+        this.skillType = SkillType.getType(skillName);
+    }
+
+    @Override
+    protected SkillCheck getThis() {
+        return this;
+    }
+
+    @Override
+    protected boolean isCountUp() {
+        return skillType.isCountUp();
+    }
+
+    @Override
+    protected boolean hasNaturalAptitude() {
+        Skill skill = person.getSkill(skillType.getName());
+        return skill != null &&  skill.getHasNaturalAptitude();
+    }
+
+    @Override
+    protected String getActionName() {
+        return skillType.getName();
+    }
+}

--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillCheckUtility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillCheckUtility.java
@@ -33,29 +33,16 @@
 package mekhq.campaign.personnel.skills;
 
 import static megamek.common.compute.Compute.d6;
-import static mekhq.campaign.personnel.enums.GenderDescriptors.HIS_HER_THEIR;
-import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.BARELY_MADE_IT;
-import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.DISASTROUS;
-import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.getMarginOfSuccessObjectFromMarginValue;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
-import static mekhq.utilities.MHQInternationalization.getTextAt;
-import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
-import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
 
 import java.time.LocalDate;
 import java.util.List;
 
-import megamek.common.TargetRollModifier;
-import megamek.common.annotations.Nullable;
 import megamek.common.compute.Compute;
 import megamek.common.rolls.TargetRoll;
 import megamek.logging.MMLogger;
-import mekhq.MekHQ;
-import mekhq.campaign.events.persons.PersonChangedEvent;
 import mekhq.campaign.personnel.Person;
-import mekhq.campaign.personnel.skills.enums.MarginOfSuccess;
 import mekhq.campaign.personnel.skills.enums.SkillAttribute;
-import mekhq.utilities.ReportingUtilities;
 
 /**
  * This class calculates the target number for a skill check based on the person's attributes, skills, and the
@@ -66,6 +53,11 @@ import mekhq.utilities.ReportingUtilities;
  * @since 0.50.05
  */
 public class SkillCheckUtility {
+
+    // only static methods
+    private SkillCheckUtility() {
+    }
+
     private static final MMLogger LOGGER = MMLogger.create(SkillCheckUtility.class);
     private static final String RESOURCE_BUNDLE = "mekhq.resources.SkillCheckUtility";
 
@@ -84,399 +76,18 @@ public class SkillCheckUtility {
      */
     protected static final int UNTRAINED_SKILL_MODIFIER = 4; // ATOW pg 43
 
-    private final String reason;
-    private final Person person;
-    private final String skillName;
-    private int marginOfSuccess;
-    private String resultsText;
-    private TargetRoll targetNumber;
-    boolean isCountUp;
-    private int roll;
-    private boolean usedEdge;
-
     /**
-     * Executes a skill check for the specified person and skill type.
+     * Use {@link #determineTargetNumber(Person, SkillType, boolean, boolean, LocalDate)} instead.
      *
-     * <p>This constructor creates a {@code SkillCheckUtility} instance which calculates the target number for the
-     * skill check and performs the roll, determining the outcome based on factors such as the person's skill level,
-     * external modifiers, miscellaneous modifiers, and whether edge is used.</p>
+     * <p>Determines the target number for a skill check ignoring aging effects and clan campaign status.</p>
      *
-     * <p>External modifiers can optionally influence the target number, while miscellaneous modifiers alter the
-     * target based on whether the skill is classified as 'count up' or not. Using edge allows the person to attempt a
-     * re-roll if the initial roll fails. Additionally, the constructor can include margins of success text as part of
-     * the results, if desired.</p>
-     *
-     * <p><b>Usage:</b> This is a convenience constructor that excludes Reputation modifiers. Reputation modifiers
-     * are only applied to Negotiation, Protocols/Any, and Streetwise/Any checks.</p>
-     *
-     * @param reason                      the reason for the check; can be {@code null}
-     * @param person                      the {@link Person} performing the skill check
-     * @param skillName                   the name of the skill being used, corresponding to a {@link SkillType}
-     * @param externalModifiers           an optional list of {@link TargetRollModifier}s that affect the target number
-     * @param miscModifier                a miscellaneous modifier that affects the target number:
-     *                                    <ul>
-     *                                        <li>For 'count up' skills, this value is subtracted from
-     *                                            the target number (i.e., negative values are bonuses,
-     *                                            positive values are penalties).</li>
-     *                                        <li>For non-'count up' skills, this value is added to the
-     *                                            target number (i.e., positive values are penalties).</li>
-     *                                    </ul>
-     * @param useEdge                     whether the person should use edge to re-roll if the initial attempt fails
-     * @param includeMarginsOfSuccessText whether to include detailed margins of success information in the results
-     *
-     * @author Illiani
-     * @since 0.50.05
-     */
-    public SkillCheckUtility(final @Nullable String reason, final Person person, final String skillName,
-          @Nullable List<TargetRollModifier> externalModifiers, final int miscModifier, final boolean useEdge,
-          final boolean includeMarginsOfSuccessText) {
-        this(reason,
-              person,
-              skillName,
-              externalModifiers,
-              miscModifier,
-              useEdge,
-              includeMarginsOfSuccessText,
-              false,
-              false,
-              LocalDate.of(3151, 1, 1));
-    }
-
-    /**
-     * Executes a skill check for the specified person and skill type.
-     *
-     * <p>This constructor creates a {@code SkillCheckUtility} instance which calculates the target number
-     * for the skill check and performs the roll, determining the outcome based on factors such as the person's skill
-     * level, external modifiers, miscellaneous modifiers, and whether edge is used.</p>
-     *
-     * <p>External modifiers can optionally influence the target number, while miscellaneous modifiers
-     * alter the target based on whether the skill is classified as 'count up' or not. Using edge allows the person to
-     * attempt a re-roll if the initial roll fails. Additionally, the constructor can include margins of success text as
-     * part of the results, if desired.</p>
-     *
-     * <p><b>Usage:</b> This constructor offers detailed control over the skill check process.
-     * For simpler use-cases, the
-     * {@link #performQuickSkillCheck(Person, String, List, int, boolean, boolean, LocalDate)} method provides a more
-     * streamlined approach.</p>
-     *
-     * @param reason                      the reason for the check; can be {@code null}
-     * @param person                      the {@link Person} performing the skill check
-     * @param skillName                   the name of the skill being used, corresponding to a {@link SkillType}
-     * @param externalModifiers           an optional list of {@link TargetRollModifier}s that affect the target number
-     * @param miscModifier                a miscellaneous modifier that affects the target number:
-     *                                    <ul>
-     *                                        <li>For 'count up' skills, this value is subtracted from
-     *                                            the target number (i.e., negative values are bonuses,
-     *                                            positive values are penalties).</li>
-     *                                        <li>For non-'count up' skills, this value is added to the
-     *                                            target number (i.e., positive values are penalties).</li>
-     *                                    </ul>
-     * @param useEdge                     whether the person should use edge to re-roll if the initial attempt fails
-     * @param includeMarginsOfSuccessText whether to include detailed margins of success information in the results
-     * @param isUseAgingEffects           if {@code true}, considers aging effects during the check
-     * @param isClanCampaign              if {@code true}, applies rules specific to clan campaigns
-     * @param today                       the current date, used for time-dependent logic
-     *
-     * @author Illiani
-     * @since 0.50.05
-     */
-    public SkillCheckUtility(final @Nullable String reason, final Person person, final String skillName,
-          @Nullable List<TargetRollModifier> externalModifiers, final int miscModifier, final boolean useEdge,
-          final boolean includeMarginsOfSuccessText, boolean isUseAgingEffects, boolean isClanCampaign,
-          LocalDate today) {
-        this.reason = reason;
-        this.person = person;
-        this.skillName = skillName;
-
-        if (isPersonNull()) {
-            return;
-        }
-
-        final SkillType skillType = SkillType.getType(skillName);
-        boolean hasNaturalAptitude = person.hasSkill(skillName) && person.getSkill(skillName).getHasNaturalAptitude();
-        isCountUp = skillType.isCountUp();
-        targetNumber = determineTargetNumber(person, skillType, miscModifier, isUseAgingEffects, isClanCampaign, today);
-
-        if (externalModifiers != null) {
-            for (TargetRollModifier modifier : externalModifiers) {
-                targetNumber.addModifier(modifier);
-            }
-        }
-
-        performCheck(useEdge, hasNaturalAptitude, includeMarginsOfSuccessText);
-    }
-
-    /**
-     * Use {@link #performQuickSkillCheck(Person, String, List, int, boolean, boolean, LocalDate)} instead
+     * @param person    the {@link Person} performing the skill check
+     * @param skillType the associated {@link SkillType} being checked
+     * @return the {@link TargetRoll} for the skill check
      */
     @Deprecated(since = "0.50.07", forRemoval = true)
-    public static boolean performQuickSkillCheck(final Person person, final String skillName,
-          final @Nullable List<TargetRollModifier> externalModifiers, final int miscModifier) {
-        return performQuickSkillCheck(person, skillName, externalModifiers, miscModifier, false, false,
-              LocalDate.of(3151, 1, 1));
-    }
-
-    /**
-     * Performs a quick and simple skill check for a person based on the specified skill name.
-     *
-     * <p>This method evaluates whether the given {@link Person} successfully performs a specified skill
-     * by creating a {@link SkillCheckUtility} instance to handle the calculations. The skill check's success or failure
-     * is determined based on the person's skill level, the provided modifiers (if any), and any campaign-specific
-     * rules.</p>
-     *
-     * <p><b>Usage:</b> This method is designed for common use cases and provides a streamlined approach
-     * to skill checks. For cases that require greater customization, such as support for edge re-rolls or detailed
-     * success metrics, use the {@link SkillCheckUtility} constructor instead.</p>
-     *
-     * @param person            the {@link Person} performing the skill check
-     * @param skillName         the name of the skill to be checked, corresponding to a {@link SkillType}
-     * @param externalModifiers an optional list of {@link TargetRollModifier}s to apply additional adjustments to the
-     *                          target number
-     * @param miscModifier      a miscellaneous modifier that affects the target number:
-     *                          <ul>
-     *                              <li>For 'count up' skills, this value is subtracted from the target number
-     *                                  (i.e., negative values are bonuses, positive values are penalties).</li>
-     *                              <li>For non-'count up' skills, this value is added to the target number
-     *                                  (i.e., positive values are penalties).</li>
-     *                          </ul>
-     * @param isUseAgingEffects if {@code true}, considers aging effects during the check
-     * @param isClanCampaign    if {@code true}, applies rules specific to clan campaigns
-     * @param today             the current date, used for time-dependent logic
-     *
-     * @return {@code true} if the skill check succeeds, {@code false} otherwise
-     *
-     *       <p>This method is often the preferred choice for skill checks in MekHQ due to its simplicity and
-     *       effectiveness.</p>
-     *
-     * @author Illiani
-     * @since 0.50.05
-     */
-    public static boolean performQuickSkillCheck(final Person person, final String skillName,
-          final @Nullable List<TargetRollModifier> externalModifiers, final int miscModifier,
-          boolean isUseAgingEffects, boolean isClanCampaign, LocalDate today) {
-        SkillCheckUtility skillCheck = new SkillCheckUtility(null, person, skillName, externalModifiers, miscModifier,
-              false, false, isUseAgingEffects, isClanCampaign, today);
-        return skillCheck.isSuccess();
-    }
-
-    /**
-     * Checks if the {@code person} object is {@code null} and handles the null case by auto-failing the check with
-     * obviously wrong results.
-     *
-     * <p>If the {@code person} is {@code null}, the method logs a debug message, sets a {@code DISASTROUS} failure
-     * margin, and assigns out-of-range values to the {@code targetNumber} and {@code roll} to make the issue easily
-     * identifiable.</p>
-     *
-     * @return {@code true} if the {@code person} is {@code null}, {@code false} otherwise.
-     *
-     * @author Illiani
-     * @since 0.50.05
-     */
-    private boolean isPersonNull() {
-        if (person == null) {
-            LOGGER.debug("Null person passed into SkillCheckUtility." +
-                               " Auto-failing check with bogus results so the bug stands out.");
-
-            marginOfSuccess = DISASTROUS.getValue();
-            resultsText = getFormattedTextAt(RESOURCE_BUNDLE, "skillCheck.nullPerson");
-            targetNumber = new TargetRoll(Integer.MAX_VALUE, "ERROR");
-            roll = Integer.MIN_VALUE;
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * Generates a formatted and localized results text describing the outcome of a skill check.
-     *
-     * <p>This method produces a detailed summary of the skill check results, including:</p>
-     * <ul>
-     *   <li>The person's title, name, and gender-based pronoun</li>
-     *   <li>The name of the skill being checked</li>
-     *   <li>The dice roll, target number, and margin of success or failure</li>
-     *   <li>A status message indicating success or failure</li>
-     *   <li>Use of edge (if applicable)</li>
-     * </ul>
-     *
-     * <p>The results text is color-coded using custom span tags based on the margin of success:
-     * <ul>
-     *   <li><b>Neutral Margin:</b> Displayed using a warning color (e.g., yellow).</li>
-     *   <li><b>Failure:</b> Displayed using a negative color (e.g., red).</li>
-     *   <li><b>Success:</b> Displayed using a positive color (e.g., green).</li>
-     * </ul>
-     * </p>
-     *
-     * <p>If edge was used to reroll the skill check, the results will include an additional note with
-     * information about the reroll. If the caller requests it, margin of success details can also be
-     * appended to the results text.</p>
-     *
-     * <p>If the skill name is {@code null}, the method returns a localized error message indicating that the
-     * skill name could not be resolved and that an error occurred during the results generation process.</p>
-     *
-     * @param includeMarginsOfSuccessText whether to include detailed margin of success information in the results text
-     *
-     * @return a localized and formatted {@link String} representing the outcomes of the skill check:
-     *       <ul>
-     *         <li>If successful, the string provides details of the roll, skill, and margin of success.</li>
-     *         <li>If edge was used, additional information about the reroll is included.</li>
-     *         <li>If the skill name is {@code null}, an error message is returned instead.</li>
-     *       </ul>
-     *
-     * @author Illiani
-     * @since 0.50.05
-     */
-    private String generateResultsText(boolean includeMarginsOfSuccessText, boolean hasNaturalAptitude) {
-        if (skillName == null) {
-            return getFormattedTextAt(RESOURCE_BUNDLE, "skillCheck.nullSkillName");
-        }
-
-        String fullTitle = person.getHyperlinkedFullTitle();
-        String genderedReferenced = HIS_HER_THEIR.getDescriptor(person.getGender());
-
-        String colorOpen;
-        int neutralMarginValue = BARELY_MADE_IT.getValue();
-        if (marginOfSuccess == neutralMarginValue) {
-            colorOpen = spanOpeningWithCustomColor(ReportingUtilities.getWarningColor());
-        } else if (marginOfSuccess < neutralMarginValue) {
-            colorOpen = spanOpeningWithCustomColor(ReportingUtilities.getNegativeColor());
-        } else {
-            colorOpen = spanOpeningWithCustomColor(ReportingUtilities.getPositiveColor());
-        }
-
-        String status = getTextAt(RESOURCE_BUNDLE, "skillCheck.results." + (isSuccess() ? "success" : "failure"));
-
-        StringBuilder resultsText = new StringBuilder(getFormattedTextAt(RESOURCE_BUNDLE,
-              "skillCheck.results",
-              reason == null ? "" : "<b>" + reason + ":</b> ",
-              fullTitle,
-              colorOpen,
-              status,
-              CLOSING_SPAN_TAG,
-              genderedReferenced,
-              skillName,
-              roll,
-              targetNumber.getValue()));
-
-        if (hasNaturalAptitude) {
-            resultsText.append(" ").append(getTextAt(RESOURCE_BUNDLE, "skillCheck.naturalAptitude"));
-        }
-
-        if (usedEdge) {
-            resultsText.append(" ").append(getTextAt(RESOURCE_BUNDLE, "skillCheck.rerolled"));
-        }
-
-        if (includeMarginsOfSuccessText) {
-            MarginOfSuccess marginOfSuccessObject = getMarginOfSuccessObjectFromMarginValue(marginOfSuccess);
-            String marginOfSuccessText = colorOpen + marginOfSuccessObject.getLabel() + CLOSING_SPAN_TAG;
-            resultsText.append(" ").append(marginOfSuccessText);
-        }
-
-        return resultsText.toString();
-    }
-
-    /**
-     * Gets the calculated margin of success for this skill check.
-     *
-     * <p>The margin of success represents how much better (or worse) the roll was compared to the target number.</p>
-     *
-     * <p><b>Usage:</b> You want to call this method whenever you care about how well a check was passed. Or how
-     * badly it was failed. If you only care whether the check was passed or failed use {@link #isSuccess()}
-     * instead.</p>
-     *
-     * @return the margin of success
-     *
-     * @author Illiani
-     * @since 0.50.05
-     */
-    public int getMarginOfSuccess() {
-        return marginOfSuccess;
-    }
-
-    /**
-     * Determines whether the skill check was successful.
-     *
-     * <p>A skill check is considered successful if the calculated margin of success is greater than or equal to the
-     * margin value of {@link MarginOfSuccess#BARELY_MADE_IT}.</p>
-     *
-     * <p><b>Usage:</b> You want to call this method whenever you only care whether the check was passed or failed.
-     * If you want to know how well the character did use {@link #getMarginOfSuccess()} instead.</p>
-     *
-     * @return {@code true} if the skill check succeeded, {@code false} otherwise
-     *
-     * @author Illiani
-     * @since 0.50.05
-     */
-    public boolean isSuccess() {
-        return marginOfSuccess >= BARELY_MADE_IT.getValue();
-    }
-
-    /**
-     * Gets the results text for the margin of success.
-     *
-     * <p>This is a descriptive string representing the outcome of the skill check, based on the calculated margin of
-     * success.</p>
-     *
-     * @return the results text for the skill check
-     *
-     * @author Illiani
-     * @since 0.50.05
-     */
-    public String getResultsText() {
-        return resultsText;
-    }
-
-    /**
-     * Gets the target number for the skill check.
-     *
-     * <p>The target number represents the value that the rolled number must meet or exceed for the skill check to
-     * succeed.</p>
-     *
-     * @return the target number for the skill check
-     *
-     * @author Illiani
-     * @since 0.50.05
-     */
-    public TargetRoll getTargetNumber() {
-        return targetNumber;
-    }
-
-    /**
-     * Gets the roll result for the skill check.
-     *
-     * <p>The roll is the result of the dice roll used to determine whether the skill check succeeded or failed.</p>
-     *
-     * @return the roll result for the skill check
-     *
-     * @author Illiani
-     * @since 0.50.05
-     */
-    public int getRoll() {
-        return roll;
-    }
-
-    /**
-     * Checks whether edge was used during the skill check.
-     *
-     * <p>Edge provides the opportunity to re-roll if the initial skill check fails, allowing a chance to improve the
-     * outcome.</p>
-     *
-     * @return {@code true} if edge was used during the skill check, {@code false} otherwise
-     *
-     * @author Illiani
-     * @since 0.50.05
-     */
-    @Deprecated(since = "0.51.0", forRemoval = true)
-    public boolean isUsedEdge() {
-        return usedEdge;
-    }
-
-    /**
-     * Use {@link #determineTargetNumber(Person, SkillType, int, boolean, boolean, LocalDate)} instead
-     */
-    @Deprecated(since = "0.50.07", forRemoval = true)
-    public static TargetRoll determineTargetNumber(Person person, SkillType skillType, int miscModifier) {
-        return determineTargetNumber(person, skillType, miscModifier, false, false, LocalDate.of(3151, 1, 1));
+    static TargetRoll determineTargetNumber(Person person, SkillType skillType) {
+        return determineTargetNumber(person, skillType, false, false, LocalDate.of(3151, 1, 1));
     }
 
     /**
@@ -488,30 +99,28 @@ public class SkillCheckUtility {
      *
      * @param person            the {@link Person} performing the skill check
      * @param skillType         the associated {@link SkillType} for the {@link Skill} being used.
-     * @param miscModifier      any special modifiers, as an {@link Integer}. These values are subtracted from the
-     *                          target number, if the associated skill is classified as 'count up', otherwise they are
-     *                          added to the target number. This means negative values are bonuses, positive values are
-     *                          penalties.
      * @param isUseAgingEffects if {@code true}, considers aging effects during the check
      * @param isClanCampaign    if {@code true}, applies rules specific to clan campaigns
      * @param today             the current date, used for time-dependent logic
      *
-     * @return the target number for the skill check
+     * @return the {@link TargetRoll} for the skill check
      *
      * @author Illiani
      * @since 0.50.05
      */
-    public static TargetRoll determineTargetNumber(Person person, SkillType skillType, int miscModifier,
+    public static TargetRoll determineTargetNumber(Person person, SkillType skillType,
           boolean isUseAgingEffects, boolean isClanCampaign, LocalDate today) {
+        if (person == null) {
+            throw new IllegalArgumentException("person == null in determineTargetNumber");
+        }
+
         final String skillName = skillType.getName();
-        final Attributes characterAttributes = person.getATOWAttributes();
-
         boolean isUntrained = !person.hasSkill(skillName);
-        int linkedAttributeCount = skillType.getLinkedAttributeCount();
-
         TargetRoll targetNumber = new TargetRoll();
 
         if (isUntrained) {
+            int linkedAttributeCount = skillType.getLinkedAttributeCount();
+
             if (linkedAttributeCount > 1) {
                 targetNumber.addModifier(UNTRAINED_TARGET_NUMBER_TWO_LINKED_ATTRIBUTES,
                       getFormattedTextAt(RESOURCE_BUNDLE, "skillCheck.untrained.twoLinkedAttributes"));
@@ -520,7 +129,7 @@ public class SkillCheckUtility {
                       getFormattedTextAt(RESOURCE_BUNDLE, "skillCheck.untrained.oneLinkedAttribute"));
             }
 
-            getTotalAttributeScoreForSkill(targetNumber, characterAttributes, skillType);
+            getTotalAttributeScoreForSkill(targetNumber, person.getATOWAttributes(), skillType);
 
             targetNumber.addModifier(UNTRAINED_SKILL_MODIFIER,
                   getFormattedTextAt(RESOURCE_BUNDLE, "skillCheck.untrained.skill"));
@@ -531,145 +140,21 @@ public class SkillCheckUtility {
             targetNumber.addModifier(skillValue, skillName);
         }
 
-        if (skillType.isCountUp()) {
-            targetNumber.addModifier(-miscModifier, getFormattedTextAt(RESOURCE_BUNDLE, "skillCheck.miscModifier"));
-        } else {
-            targetNumber.addModifier(miscModifier, getFormattedTextAt(RESOURCE_BUNDLE, "skillCheck.miscModifier"));
-        }
-
         return targetNumber;
     }
 
     /**
-     * Performs a skill check for a specified person, determining the outcome based on dice rolls and optionally
-     * allowing the use of edge points for a re-roll upon failure.
+     * Generates the roll value for a check, applying the natural aptitude if applicable.
      *
-     * <p>This method begins by rolling two six-sided dice (2d6) and comparing the result against
-     * a pre-calculated target number. If the initial roll meets or exceeds the target number, the skill check succeeds,
-     * and the results are calculated and stored. If the initial roll fails, and edge use is enabled and available, one
-     * edge point is consumed, and a re-roll is performed. The method concludes by storing the final skill check
-     * results, including the margin of success and optional descriptive text, for later use.</p>
-     *
-     * <p>When edge is used, the method records this information and updates the results accordingly
-     * to reflect the additional roll.</p>
-     *
-     * @param useEdge                     whether to allow the person to use an edge point to re-roll if the initial
-     *                                    roll fails. Edge use is conditional on the person's current edge
-     *                                    availability.
-     * @param includeMarginsOfSuccessText whether to include detailed information about the margin of success in the
-     *                                    final results text
-     * @param hasNaturalAptitude          {@code true} if the character rolls 3d6 for this check, using the highest 2
-     *
-     * @author Illiani
-     * @since 0.50.05
+     * @param hasNaturalAptitude {@code true} to roll 3d6 and keep the highest 2; {@code false} to roll 2d6
+     * @return the result of the dice roll
      */
-    void performCheck(boolean useEdge, boolean hasNaturalAptitude, boolean includeMarginsOfSuccessText) {
-        getRoll(hasNaturalAptitude);
-
-        if (performInitialRoll(useEdge, hasNaturalAptitude, includeMarginsOfSuccessText)) {
-            return;
-        }
-
-        // Prevent us from burning Edge on impossible checks
-        if (!targetNumber.cannotSucceed() || targetNumber.getValue() <= 12) {
-            getRoll(hasNaturalAptitude);
-            rollWithEdge(includeMarginsOfSuccessText, hasNaturalAptitude);
-        }
-    }
-
-    /**
-     * Generates the roll value for this check, applying the natural aptitude rule if applicable.
-     *
-     * <p>This method rolls two six-sided dice by default. If the character has the {@code Natural Aptitude} trait
-     * for this skill, a third die is rolled. The final roll value is the sum of the highest two dice, determined using
-     * {@link Compute#getHighestTwoIntegers(int...)}.</p>
-     *
-     * @param hasNaturalAptitude {@code true} if the character rolls 3d6 for this check, using the highest 2
-     *
-     * @author Illiani
-     * @since 0.50.10
-     */
-    private void getRoll(boolean hasNaturalAptitude) {
+    static int getRoll(boolean hasNaturalAptitude) {
         int roll1 = d6(1);
         int roll2 = d6(1);
         int roll3 = hasNaturalAptitude ? d6(1) : 0;
 
-        roll = Compute.getHighestTwoIntegers(roll1, roll2, roll3);
-    }
-
-    /**
-     * Handles the initial dice roll in the skill check and determines whether the check is resolved or if further
-     * action (re-roll with edge) is required.
-     *
-     * <p>This method evaluates the outcome of the initial roll by comparing it against the target number.
-     * If the roll meets or exceeds the target number, the skill check is deemed successful, and the results are
-     * finalized. If the roll fails, the method decides whether edge can or should be used to perform a re-roll. Edge
-     * use is allowed only if the {@code useEdge} parameter is {@code true} and there are available edge points for the
-     * person.</p>
-     *
-     * <p>The method stores key results from the initial roll, including:</p>
-     * <ul>
-     *   <li>The margin of success or failure, calculated based on the target number and roll</li>
-     *   <li>A descriptive results text, optionally including margin details if requested</li>
-     * </ul>
-     *
-     * <p>If the roll does not succeed and edge use is feasible, the method signals the need for a re-roll,
-     * otherwise finalizes the results based on the initial roll.</p>
-     *
-     * @param useEdge                     whether to allow using edge points for a re-roll if the initial roll fails
-     * @param hasNaturalAptitude          {@code true} if the character rolls 3d6 for this check, using the highest 2
-     * @param includeMarginsOfSuccessText whether to include detailed margin of success information in the results text
-     *
-     * @return {@code true} if the skill check is resolved using the initial roll (success or no edge re-roll possible);
-     *       {@code false} if a re-roll using edge is required
-     *
-     * @author Illiani
-     * @since 0.50.05
-     */
-    boolean performInitialRoll(boolean useEdge, boolean hasNaturalAptitude, boolean includeMarginsOfSuccessText) {
-        int availableEdge = person.getCurrentEdge();
-        int targetNumberValue = targetNumber.getValue();
-
-        if (roll >= targetNumberValue || !useEdge || availableEdge < 1) {
-            int difference = isCountUp ? targetNumberValue - roll : roll - targetNumberValue;
-
-            marginOfSuccess = MarginOfSuccess.getMarginOfSuccess(difference);
-            resultsText = generateResultsText(includeMarginsOfSuccessText, hasNaturalAptitude);
-            LOGGER.info(resultsText);
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Executes the re-roll logic for a skill check when edge is used, updating the person's edge points and
-     * recalculating the outcome based on the new roll.
-     *
-     * <p>This method is invoked only after the failure of the initial roll, provided edge usage is
-     * allowed and the person has at least one edge point available. When called, it decrements the person's edge points
-     * by one, triggers an event to update the game state reflecting this change, and marks that edge was used for this
-     * skill check. The results of the skill check are then recalculated based on the new roll, including the margin of
-     * success and the corresponding results text.</p>
-     *
-     * <p>The results text can optionally include detailed information about the margin of success,
-     * depending on the value of the {@code includeMarginsOfSuccessText} parameter.</p>
-     *
-     * @param includeMarginsOfSuccessText whether to include detailed margin of success information in the results text
-     * @param hasNaturalAptitude          {@code true} if the character rolls 3d6 for this check, using the highest 2
-     *
-     * @author Illiani
-     * @since 0.50.05
-     */
-    private void rollWithEdge(boolean includeMarginsOfSuccessText, boolean hasNaturalAptitude) {
-        person.changeCurrentEdge(-1);
-        MekHQ.triggerEvent(new PersonChangedEvent(person));
-        usedEdge = true;
-
-        int targetNumberValue = targetNumber.getValue();
-
-        int difference = isCountUp ? targetNumberValue - roll : roll - targetNumberValue;
-        marginOfSuccess = MarginOfSuccess.getMarginOfSuccess(difference);
-        resultsText = generateResultsText(includeMarginsOfSuccessText, hasNaturalAptitude);
+        return Compute.getHighestTwoIntegers(roll1, roll2, roll3);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -117,6 +117,7 @@ import mekhq.campaign.mission.enums.ScenarioStatus;
 import mekhq.campaign.mission.enums.ScenarioType;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
+import mekhq.campaign.personnel.skills.ActionCheckResult;
 import mekhq.campaign.personnel.skills.ScoutingSkills;
 import mekhq.campaign.personnel.skills.Skill;
 import mekhq.campaign.personnel.skills.SkillCheckUtility;
@@ -1642,7 +1643,7 @@ public class StratConRulesManager {
                     continue;
                 }
 
-boolean isUseEdge = campaignOptions.isUseEdge() && scout.getOptions().booleanOption(EDGE_RECON_FAIL);
+                boolean isUseEdge = campaignOptions.isUseEdge() && scout.getOptions().booleanOption(EDGE_RECON_FAIL);
                 for (int direction = 0; direction < 6; direction++) {
                     StratConCoords checkCoords = currentCoords.translate(direction);
 
@@ -1673,21 +1674,14 @@ boolean isUseEdge = campaignOptions.isUseEdge() && scout.getOptions().booleanOpt
                         continue;
                     }
 
-                    SkillCheckUtility skillCheck = null;
+                    ActionCheckResult actionCheckResult = null;
                     if (useAdvancedScouting) {
-                        skillCheck = new SkillCheckUtility(
-                              getTextAt(RESOURCE_BUNDLE, "StratConRulesManager.scoutingSkillCheck"),
-                              scout,
-                              scoutData.bestScoutSkillName(),
-                              scoutData.getAllScoutRollModifiers(),
-                              0,
-                              isUseEdge,
-                              false,
-                              campaignOptions.isUseAgeEffects(),
-                              campaign.isClanCampaign(),
-                              campaign.getLocalDate()
-                        );
-                        campaign.addReport(SKILL_CHECKS, skillCheck.getResultsText());
+                        actionCheckResult =
+                              scout.checkSkill(scoutData.bestScoutSkillName(), false, false, campaign.getLocalDate())
+                                    .withExternalModifiers(scoutData.getAllScoutRollModifiers())
+                                    .resolve(isUseEdge, getTextAt(RESOURCE_BUNDLE,
+                                          "StratConRulesManager.scoutingSkillCheck"), false);
+                        campaign.addReport(SKILL_CHECKS, actionCheckResult.resultsText());
                     }
 
                     remainingScans--;
@@ -1697,7 +1691,7 @@ boolean isUseEdge = campaignOptions.isUseEdge() && scout.getOptions().booleanOpt
                         hasFatigueIncreased = true;
                     }
 
-                    boolean wasScoutingSuccessful = !useAdvancedScouting || skillCheck.isSuccess();
+                    boolean wasScoutingSuccessful = actionCheckResult == null || actionCheckResult.isSuccess();
                     if (!wasScoutingSuccessful) {
                         // Failed check: hex remains unrevealed, but future scouts may still try it
                         continue;
@@ -1911,7 +1905,7 @@ boolean isUseEdge = campaignOptions.isUseEdge() && scout.getOptions().booleanOpt
                 }
 
                 TargetRoll targetNumber = SkillCheckUtility.determineTargetNumber(crewMember,
-                      SkillType.getType(scoutSkillName), 0, campaignOptions.isUseAgeEffects(), isClanCampaign, date);
+                      SkillType.getType(scoutSkillName), campaignOptions.isUseAgeEffects(), isClanCampaign, date);
                 getAllScoutRollModifiers(unitWeight, unitSpeed, hasEagleEyes, hasSensorEquipment)
                       .forEach(targetNumber::addModifier);
 
@@ -2127,23 +2121,12 @@ boolean isUseEdge = campaignOptions.isUseEdge() && scout.getOptions().booleanOpt
 
         campaign.addReport(BATTLE, reportStatus.toString());
 
+        ActionCheckResult actionCheckResult =
+              commander.checkSkill(S_TACTICS)
+                    .resolve(true, getTextAt(RESOURCE_BUNDLE, "StratConRulesManager.tacticsSkillCheck"), false);
 
-        roll = d6(2);
-        int targetNumber = 9;
-        Skill tactics = commander.getSkill(S_TACTICS);
-
-        SkillCheckUtility skillCheckUtility = new SkillCheckUtility(
-              getTextAt(RESOURCE_BUNDLE, "StratConRulesManager.tacticsSkillCheck"),
-              commander,
-              S_TACTICS,
-              null,
-              0,
-              true,
-              false);
-        campaign.addReport(SKILL_CHECKS, skillCheckUtility.getResultsText());
-
-        if (skillCheckUtility.isSuccess()) {
-            String reportString = tactics != null ?
+        if (actionCheckResult.isSuccess()) {
+            String reportString = commander.getSkill(S_TACTICS) != null ?
                                         resources.getString("reinforcementEvasionSuccessful.text") :
                                         resources.getString("reinforcementEvasionSuccessful.noSkill");
             campaign.addReport(BATTLE, String.format(reportString,
@@ -2157,11 +2140,12 @@ boolean isUseEdge = campaignOptions.isUseEdge() && scout.getOptions().booleanOpt
             return DELAYED;
         }
 
+        // FIXME: roll and target number are not present in the template
         campaign.addReport(BATTLE, String.format(resources.getString("reinforcementEvasionUnsuccessful.text"),
               spanOpeningWithCustomColor(ReportingUtilities.getNegativeColor()),
               CLOSING_SPAN_TAG,
-              roll,
-              targetNumber));
+              actionCheckResult.roll(),
+              9));
 
         ScenarioTemplate scenarioTemplate = getInterceptionScenarioTemplate(formation, campaign.getAllHangar());
 

--- a/MekHQ/src/mekhq/gui/dialog/AdvancedReplacementLimbDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AdvancedReplacementLimbDialog.java
@@ -101,8 +101,8 @@ import mekhq.campaign.personnel.enums.PersonnelStatus;
 import mekhq.campaign.personnel.medical.BodyLocation;
 import mekhq.campaign.personnel.medical.advancedMedicalAlternate.InjurySubType;
 import mekhq.campaign.personnel.medical.advancedMedicalAlternate.ProstheticType;
+import mekhq.campaign.personnel.skills.ActionCheckResult;
 import mekhq.campaign.personnel.skills.Skill;
-import mekhq.campaign.personnel.skills.SkillCheckUtility;
 import mekhq.campaign.personnel.skills.SkillModifierData;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.utilities.glossary.GlossaryEntry;
@@ -1027,16 +1027,13 @@ public class AdvancedReplacementLimbDialog extends JDialog {
 
         for (PlannedSurgery surgery : new ArrayList<>(prioritizedSurgeries)) {
             int spaModifier = surgery.type != COSMETIC_SURGERY && hasMachinistSPA ? -2 : 0;
-            SkillCheckUtility skillCheckUtility = new SkillCheckUtility(
-                  getTextAt(RESOURCE_BUNDLE, "AdvancedReplacementLimbDialog.skillCheck"),
-                  surgeon,
-                  S_SURGERY,
-                  List.of(),
-                  spaModifier,
-                  isUseEdge,
-                  false);
-            campaign.addReport(SKILL_CHECKS, skillCheckUtility.getResultsText());
-            if (skillCheckUtility.isSuccess()) {
+            ActionCheckResult actionCheckResult =
+                  surgeon.checkSkill(S_SURGERY)
+                        .withMiscModifier(spaModifier)
+                        .resolve(isUseEdge, getTextAt(RESOURCE_BUNDLE,
+                              "AdvancedReplacementLimbDialog.skillCheck"), false);
+            campaign.addReport(SKILL_CHECKS, actionCheckResult.resultsText());
+            if (actionCheckResult.isSuccess()) {
                 successfulSurgeries.add(surgery);
                 MedicalLogger.successfulSurgery(patient, campaign.getLocalDate(), surgery.type.toString());
             } else {

--- a/MekHQ/src/mekhq/gui/dialog/SkillCheckDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/SkillCheckDialog.java
@@ -34,7 +34,6 @@ package mekhq.gui.dialog;
 
 import static megamek.common.compute.Compute.randomInt;
 import static mekhq.campaign.enums.DailyReportType.SKILL_CHECKS;
-import static mekhq.campaign.personnel.skills.SkillCheckUtility.determineTargetNumber;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 import java.awt.GridBagConstraints;
@@ -51,10 +50,9 @@ import javax.swing.JSpinner;
 import javax.swing.SpinnerNumberModel;
 
 import megamek.client.ui.comboBoxes.MMComboBox;
-import megamek.common.rolls.TargetRoll;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
-import mekhq.campaign.personnel.skills.SkillCheckUtility;
+import mekhq.campaign.personnel.skills.ActionCheckResult;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.ButtonLabelTooltipPair;
@@ -162,21 +160,15 @@ public class SkillCheckDialog {
      */
     private String performSkillCheck(int selectedSkill, int selectedModifier, int choiceIndex,
           boolean isUseAgingEffects, boolean isClanCampaign, LocalDate today) {
-        String skillName = skillNames.get(selectedSkill);
         boolean useEdge = choiceIndex == DIALOG_USE_EDGE_INDEX;
-        SkillCheckUtility utility = new SkillCheckUtility(null,
-              character,
-              skillName,
-              null,
-              selectedModifier,
-              useEdge,
-              true,
-              isUseAgingEffects,
-              isClanCampaign,
-              today);
-        isSuccess = utility.isSuccess();
+        String skillName = skillNames.get(selectedSkill);
+        ActionCheckResult actionCheckResult =
+              character.checkSkill(skillName, isUseAgingEffects, isClanCampaign, today)
+                    .withMiscModifier(selectedModifier)
+                    .resolve(useEdge, null, true);
 
-        return utility.getResultsText();
+        isSuccess = actionCheckResult.isSuccess();
+        return actionCheckResult.resultsText();
     }
 
 
@@ -327,14 +319,8 @@ public class SkillCheckDialog {
         List<String> skills = new ArrayList<>();
 
         for (String skillName : SkillType.getSkillList()) {
-            SkillType skillType = SkillType.getType(skillName);
-            TargetRoll targetRoll = determineTargetNumber(character,
-                  skillType,
-                  0,
-                  isUseAgingEffects,
-                  isClanCampaign,
-                  today);
-            int targetNumber = targetRoll.getValue();
+            int targetNumber = character.checkSkill(skillName, isUseAgingEffects, isClanCampaign, today)
+                                     .getTargetNumber().getValue();
             boolean isCountsUp = SkillType.getType(skillName).isCountUp();
 
             // Build the label with the target number

--- a/MekHQ/unittests/mekhq/campaign/personnel/PersonTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/PersonTest.java
@@ -80,6 +80,8 @@ import mekhq.campaign.personnel.enums.AwardBonus;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
 import mekhq.campaign.personnel.enums.education.EducationLevel;
 import mekhq.campaign.personnel.enums.education.EducationStage;
+import mekhq.campaign.personnel.skills.SkillCheck;
+import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.randomEvents.personalities.enums.Aggression;
 import mekhq.campaign.randomEvents.personalities.enums.Ambition;
 import mekhq.campaign.randomEvents.personalities.enums.Greed;
@@ -90,6 +92,7 @@ import mekhq.campaign.randomEvents.prisoners.enums.PrisonerStatus;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.PlanetarySystem;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -1909,6 +1912,56 @@ public class PersonTest {
 
                 person.setEduAcademySystem("OtherSystem");
                 assertEquals("Outreach", person.getEduAcademySystem());
+            }
+        }
+
+        /** smoke tests, actual test coverage is in {@link mekhq.campaign.personnel.skills.SkillCheckTest} */
+        @Nested
+        class CheckSkill {
+
+            @BeforeAll
+            static void beforeAll() {
+                SkillType.initializeTypes();
+            }
+
+            @Test
+            @SuppressWarnings("deprecation")
+            void testCheckSkill_Deprecated() {
+                Person person = new Person("GivenName", "Surname", null, "Faction");
+                person.addSkill(SkillType.S_GUN_MEK, 4, 0);
+                SkillCheck check = person.checkSkill(SkillType.S_GUN_MEK);
+                assertEquals(3, check.getTargetNumber().getValue());
+            }
+
+            @Test
+            void testCheckSkill_WithExplicitModifiers() {
+                Person person = new Person("GivenName", "Surname", null, "Faction");
+                person.addSkill(SkillType.S_GUN_MEK, 4, 0);
+                SkillCheck check = person.checkSkill(SkillType.S_GUN_MEK, true, true, LocalDate.of(3151, 1, 1));
+                assertEquals(3, check.getTargetNumber().getValue());
+            }
+
+            @Test
+            void testCheckSkill_WithCampaignContext() {
+                Person person = new Person("GivenName", "Surname", null, "Faction");
+                person.addSkill(SkillType.S_GUN_MEK, 4, 0);
+                Campaign campaign = mock(Campaign.class);
+                CampaignOptions options = mock(CampaignOptions.class);
+                LocalDate date = LocalDate.of(3151, 1, 1);
+
+                when(campaign.getCampaignOptions()).thenReturn(options);
+                when(options.isUseAgeEffects()).thenReturn(true);
+                when(campaign.isClanCampaign()).thenReturn(false);
+                when(campaign.getLocalDate()).thenReturn(date);
+
+                SkillCheck check = person.checkSkill(SkillType.S_GUN_MEK, campaign);
+
+                assertNotNull(check);
+                assertEquals(3, check.getTargetNumber().getValue());
+                verify(campaign).getCampaignOptions();
+                verify(options).isUseAgeEffects();
+                verify(campaign).isClanCampaign();
+                verify(campaign).getLocalDate();
             }
         }
     }

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/ActionCheckResultTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/ActionCheckResultTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package mekhq.campaign.personnel.skills;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class ActionCheckResultTest {
+
+    @Test
+    void testRecord() {
+        ActionCheckResult result = new ActionCheckResult(8, 2, true, "Success");
+        assertEquals(8, result.roll());
+        assertEquals(2, result.marginOfSuccess());
+        assertTrue(result.usedEdge());
+        assertEquals("Success", result.resultsText());
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "-2, false", "-1, false", "0, true", "1, true", "12, true" })
+    void testIsSuccess(int marginOfSuccess, boolean expectedResult) {
+        ActionCheckResult result = new ActionCheckResult(10, marginOfSuccess, false, "");
+        assertEquals(expectedResult, result.isSuccess());
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "-2, false", "-1, false", "0, true", "1, true", "12, true" })
+    void testIsSuccessStatic(int marginOfSuccess, boolean expectedResult) {
+        assertEquals(expectedResult, ActionCheckResult.isSuccess(marginOfSuccess));
+    }
+
+}

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/ActionCheckTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/ActionCheckTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package mekhq.campaign.personnel.skills;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import megamek.common.TargetRollModifier;
+import megamek.common.enums.Gender;
+import megamek.common.rolls.TargetRoll;
+import mekhq.campaign.personnel.Person;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.MockedStatic;
+
+class ActionCheckTest {
+
+    private static class ConcreteActionCheck extends ActionCheck<ConcreteActionCheck> {
+        private final boolean countUp;
+        private final boolean naturalAptitude;
+        private final String actionName;
+
+        ConcreteActionCheck(Person person, TargetRoll targetNumber, boolean countUp,
+              boolean naturalAptitude, String actionName) {
+            super(person, targetNumber);
+            this.countUp = countUp;
+            this.naturalAptitude = naturalAptitude;
+            this.actionName = actionName;
+        }
+
+        @Override
+        protected ConcreteActionCheck getThis() {
+            return this;
+        }
+
+        @Override
+        protected boolean isCountUp() {
+            return countUp;
+        }
+
+        @Override
+        protected boolean hasNaturalAptitude() {
+            return naturalAptitude;
+        }
+
+        @Override
+        protected String getActionName() {
+            return actionName;
+        }
+    }
+
+    private ActionCheckResult resolveWithFixedRoll(ActionCheck<?> check, boolean useEdge,
+          int firstRoll, int secondRoll) {
+        try (MockedStatic<SkillCheckUtility> utils = mockStatic(SkillCheckUtility.class)) {
+            utils.when(() -> SkillCheckUtility.getRoll(anyBoolean())).thenReturn(firstRoll, secondRoll);
+            return check.resolve(useEdge, null, false);
+        }
+    }
+
+    @Test
+    void testGetTargetNumber() {
+        TargetRoll target = new TargetRoll(6, "");
+        ConcreteActionCheck check = new ConcreteActionCheck(mock(Person.class), target, false, false, "Action");
+
+        assertEquals(target, check.getTargetNumber());
+    }
+
+    @Test
+    void testWithExternalModifiers_AppliesModifiers() {
+        TargetRoll target = new TargetRoll(5, "");
+        ConcreteActionCheck check = new ConcreteActionCheck(mock(Person.class), target, false, false, "Action");
+        check.withExternalModifiers(List.of(new TargetRollModifier(2, "Penalty"), new TargetRollModifier(-1, "Bonus")));
+
+        assertEquals(6, check.getTargetNumber().getValue());
+    }
+
+    @Test
+    void testWithMiscModifier_NotCountUp() {
+        Person person = new Person("F", "L", null, "Faction");
+        TargetRoll target = new TargetRoll(5, "");
+        ConcreteActionCheck check = new ConcreteActionCheck(person, target, false, false, "Action");
+        check.withMiscModifier(2);
+
+        assertEquals(7, check.getTargetNumber().getValue());
+    }
+
+    @Test
+    void testWithMiscModifier_CountUp() {
+        TargetRoll target = new TargetRoll(5, "");
+        ConcreteActionCheck check = new ConcreteActionCheck(mock(Person.class), target, true, false, "Action");
+        check.withMiscModifier(2);
+
+        assertEquals(3, check.getTargetNumber().getValue());
+    }
+
+    @Test
+    void testResolve_SuccessFirstRoll() {
+        Person person = new Person("F", "L", null, "Faction");
+        TargetRoll target = new TargetRoll(7, "");
+        ConcreteActionCheck check = new ConcreteActionCheck(person, target, false, false, "Action");
+        ActionCheckResult result = resolveWithFixedRoll(check, true, 8, 0);
+
+        assertTrue(result.isSuccess());
+        assertFalse(result.usedEdge());
+        assertEquals(8, result.roll());
+    }
+
+    @Test
+    void testResolve_FailureNoEdgeEnabled() {
+        Person person = new Person("F", "L", null, "Faction");
+        TargetRoll target = new TargetRoll(7, "");
+        ConcreteActionCheck check = new ConcreteActionCheck(person, target, false, false, "Action");
+        ActionCheckResult result = resolveWithFixedRoll(check, false, 5, 0);
+
+        assertFalse(result.isSuccess());
+        assertFalse(result.usedEdge());
+        assertEquals(5, result.roll());
+    }
+
+    @Test
+    void testResolve_FailureNoAvailableEdge() {
+        Person person = new Person("F", "L", null, "Faction");
+        person.setCurrentEdge(0);
+        TargetRoll target = new TargetRoll(7, "");
+        ConcreteActionCheck check = new ConcreteActionCheck(person, target, false, false, "Action");
+        ActionCheckResult result = resolveWithFixedRoll(check, true, 5, 12);
+
+        assertFalse(result.isSuccess());
+        assertFalse(result.usedEdge());
+    }
+
+    @Test
+    void testResolve_FailureTargetGreaterThanTwelve() {
+        Person person = new Person("F", "L", null, "Faction");
+        TargetRoll target = new TargetRoll(13, "");
+        ConcreteActionCheck check = new ConcreteActionCheck(person, target, false, false, "Action");
+        ActionCheckResult result = resolveWithFixedRoll(check, true, 12, 0);
+
+        assertFalse(result.isSuccess());
+        assertFalse(result.usedEdge());
+    }
+
+    @Test
+    void testResolve_UsesEdgeAndSucceeds() {
+        Person person = mock(Person.class);
+        when(person.getHyperlinkedFullTitle()).thenReturn("Title");
+        when(person.getGender()).thenReturn(Gender.FEMALE);
+        when(person.getCurrentEdge()).thenReturn(1);
+        TargetRoll target = new TargetRoll(7, "");
+        ConcreteActionCheck check = new ConcreteActionCheck(person, target, false, false, "Action");
+        ActionCheckResult result = resolveWithFixedRoll(check, true, 5, 9);
+
+        assertTrue(result.isSuccess());
+        assertTrue(result.usedEdge());
+        assertEquals(9, result.roll());
+        verify(person).changeCurrentEdge(-1);
+    }
+
+    @Test
+    void testResolve_UsesEdgeAndFails() {
+        Person person = mock(Person.class);
+        when(person.getHyperlinkedFullTitle()).thenReturn("Title");
+        when(person.getGender()).thenReturn(Gender.MALE);
+        when(person.getCurrentEdge()).thenReturn(1);
+
+        TargetRoll target = new TargetRoll(7, "");
+        ConcreteActionCheck check = new ConcreteActionCheck(person, target, false, false, "Action");
+        ActionCheckResult result = resolveWithFixedRoll(check, true, 5, 6);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.usedEdge());
+        assertEquals(6, result.roll());
+        verify(person).changeCurrentEdge(-1);
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "true", "false" })
+    void testResolve_PassesNaturalAptitudeToRoll(boolean naturalAptitude) {
+        Person person = new Person("F", "L", null, "Faction");
+        TargetRoll target = new TargetRoll(7, "Base");
+        ConcreteActionCheck check = new ConcreteActionCheck(person, target, false, naturalAptitude, "Action");
+
+        try (MockedStatic<SkillCheckUtility> utils = mockStatic(SkillCheckUtility.class)) {
+            utils.when(() -> SkillCheckUtility.getRoll(anyBoolean())).thenReturn(8);
+            check.resolve(false, null, false);
+            utils.verify(() -> SkillCheckUtility.getRoll(naturalAptitude));
+        }
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/SkillCheckTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/SkillCheckTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package mekhq.campaign.personnel.skills;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import megamek.common.TargetRollModifier;
+import megamek.common.rolls.TargetRoll;
+import mekhq.campaign.personnel.Person;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class SkillCheckTest {
+
+    @BeforeAll
+    static void beforeAll() {
+        SkillType.initializeTypes();
+    }
+
+    @Test
+    void testRawConstructor() {
+        Person person = mock(Person.class);
+        SkillType skillType = SkillType.getType(SkillType.S_GUN_MEK);
+        TargetRoll expectedTargetRoll = new TargetRoll(5, "");
+        SkillCheck check = new SkillCheck(person, skillType, expectedTargetRoll);
+
+        assertEquals(expectedTargetRoll, check.getTargetNumber());
+        assertEquals(SkillType.S_GUN_MEK, check.getActionName());
+        assertEquals(check, check.getThis());
+    }
+
+    @Test
+    void testConstructor_CalculatesTargetNumber() {
+        Person person = mock(Person.class);
+        when(person.hasSkill(eq(SkillType.S_PILOT_MEK))).thenReturn(true);
+        when(person.getSkill(eq(SkillType.S_PILOT_MEK)))
+              .thenReturn(new Skill(SkillType.getType(SkillType.S_PILOT_MEK), 2, 0));
+        when(person.getSkillModifierData(anyBoolean(), anyBoolean(), any())).thenReturn(mock(SkillModifierData.class));
+        SkillCheck check = new SkillCheck(person, SkillType.S_PILOT_MEK, false, false, LocalDate.of(3151, 1, 1));
+
+        assertEquals(6, check.getTargetNumber().getValue()); // == 8 - 2
+        assertEquals(SkillType.S_PILOT_MEK, check.getActionName());
+        assertFalse(check.isCountUp());
+    }
+
+    @Test
+    void testConstructor_CalculatesTargetNumber_Aging() {
+        Person person = new Person("GivenName", "Surname", null, "Faction");
+        LocalDate dateOfBirth = LocalDate.of(3151, 1, 1);
+        int age = 55;
+        LocalDate today = dateOfBirth.plusYears(age);
+        person.addSkill(SkillType.S_NEGOTIATION, 4, 0);
+        person.setDateOfBirth(dateOfBirth);
+        person.setAgeForAttributeModifiers(age);
+        person.setRank(40);
+        SkillCheck check = person.checkSkill(SkillType.S_NEGOTIATION, true, true, today);
+
+        assertNotNull(check);
+        assertEquals(2, Aging.getReputationAgeModifier(age, true, false, 40)); // 2
+        assertEquals(4, check.getTargetNumber().getValue()); // == 10 - 4 - 2 (aging effect)
+    }
+
+    @Test
+    void testDeprecatedConstructor_CalculatesTargetNumber() {
+        Person person = mock(Person.class);
+        when(person.hasSkill(eq(SkillType.S_TACTICS))).thenReturn(true);
+        when(person.getSkill(eq(SkillType.S_TACTICS)))
+              .thenReturn(new Skill(SkillType.getType(SkillType.S_TACTICS), 4, 0));
+        when(person.getSkillModifierData(anyBoolean(), anyBoolean(), any())).thenReturn(mock(SkillModifierData.class));
+        @SuppressWarnings("deprecation")
+        SkillCheck check = new SkillCheck(person, SkillType.S_TACTICS);
+
+        assertEquals(5, check.getTargetNumber().getValue()); // == 9 - 4
+        assertEquals(SkillType.S_TACTICS, check.getActionName());
+        assertFalse(check.isCountUp());
+        assertFalse(check.hasNaturalAptitude());
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "true", "false" })
+    void testHasNaturalAptitude(boolean hasNaturalAptitude) {
+        Person person = mock(Person.class);
+        Skill skill = mock(Skill.class);
+        when(person.getSkill(SkillType.S_GUN_MEK)).thenReturn(skill);
+        when(skill.getHasNaturalAptitude()).thenReturn(hasNaturalAptitude);
+        SkillType skillType = SkillType.getType(SkillType.S_GUN_MEK);
+        SkillCheck check = new SkillCheck(person, skillType, new TargetRoll(4, ""));
+
+        assertEquals(hasNaturalAptitude, check.hasNaturalAptitude());
+    }
+
+    @Test
+    void testHasNaturalAptitude_Untrained() {
+        Person person = mock(Person.class);
+        when(person.getSkill(SkillType.S_GUN_MEK)).thenReturn(null);
+        SkillType skillType = SkillType.getType(SkillType.S_GUN_MEK);
+        SkillCheck check = new SkillCheck(person, skillType, new TargetRoll(4, ""));
+
+        assertFalse(check.hasNaturalAptitude());
+    }
+
+    @Test
+    void testIsCountUpTrue() {
+        Person person = mock(Person.class);
+        SkillType skillType = mock(SkillType.class);
+        when(skillType.isCountUp()).thenReturn(true);
+        when(skillType.getName()).thenReturn("TestCountUpSkill");
+        SkillCheck check = new SkillCheck(person, skillType, new TargetRoll(2, ""));
+
+        assertTrue(check.isCountUp());
+    }
+
+    @Test
+    void testWithExternalModifiers_AppliesToTargetNumber() {
+        Person person = mock(Person.class);
+        SkillType skillType = SkillType.getType(SkillType.S_GUN_MEK);
+        TargetRoll baseRoll = new TargetRoll(5, "");
+        SkillCheck check = new SkillCheck(person, skillType, baseRoll);
+        check.withExternalModifiers(List.of(new TargetRollModifier(2, "One"), new TargetRollModifier(-1, "Two")));
+
+        assertEquals(6, check.getTargetNumber().getValue());
+    }
+
+    @Test
+    void testWithMiscModifier_IsCountUpFalse() {
+        Person person = mock(Person.class);
+        SkillType skillType = SkillType.getType(SkillType.S_GUN_MEK);
+        SkillCheck check = new SkillCheck(person, skillType, new TargetRoll(5, "")).withMiscModifier(2);
+
+        assertEquals(7, check.getTargetNumber().getValue());
+    }
+
+    @Test
+    void testWithMiscModifier_IsCountUpTrue() {
+        Person person = mock(Person.class);
+        SkillType skillType = mock(SkillType.class);
+        when(skillType.isCountUp()).thenReturn(true);
+        when(skillType.getName()).thenReturn("TestCountUpSkill");
+        SkillCheck check = new SkillCheck(person, skillType, new TargetRoll(5, "")).withMiscModifier(2);
+
+        assertEquals(3, check.getTargetNumber().getValue());
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/SkillCheckUtilityTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/SkillCheckUtilityTest.java
@@ -40,7 +40,6 @@ import static mekhq.campaign.personnel.skills.SkillCheckUtility.UNTRAINED_TARGET
 import static mekhq.campaign.personnel.skills.SkillCheckUtility.UNTRAINED_TARGET_NUMBER_TWO_LINKED_ATTRIBUTES;
 import static mekhq.campaign.personnel.skills.SkillCheckUtility.determineTargetNumber;
 import static mekhq.campaign.personnel.skills.SkillCheckUtility.getTotalAttributeScoreForSkill;
-import static mekhq.campaign.personnel.skills.SkillCheckUtility.performQuickSkillCheck;
 import static mekhq.campaign.personnel.skills.SkillType.S_GUN_MEK;
 import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.DISASTROUS;
 import static mekhq.campaign.personnel.skills.enums.SkillAttribute.DEXTERITY;
@@ -61,6 +60,7 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.universe.Faction;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -86,64 +86,15 @@ import org.mockito.Mockito;
 class SkillCheckUtilityTest {
     private static final LocalDate CURRENT_DATE = LocalDate.of(3151, 1, 1);
 
-    @Test
-    void testIsPersonNull_EdgeDisallowed() {
-        SkillCheckUtility checkUtility = new SkillCheckUtility(null,
-              null,
-              S_GUN_MEK,
-              null,
-              0,
-              false,
-              false,
-              false,
-              false,
-              CURRENT_DATE);
-
-        int expectedMarginOfSuccess = DISASTROUS.getValue();
-        assertEquals(expectedMarginOfSuccess, checkUtility.getMarginOfSuccess());
-
-        String RESOURCE_BUNDLE = "mekhq.resources.SkillCheckUtility";
-        String expectedResultsText = getFormattedTextAt(RESOURCE_BUNDLE, "skillCheck.nullPerson");
-        assertEquals(expectedResultsText, checkUtility.getResultsText());
-
-        int expectedTargetNumber = Integer.MAX_VALUE;
-        assertEquals(expectedTargetNumber, checkUtility.getTargetNumber().getValue());
-
-        int expectedRoll = Integer.MIN_VALUE;
-        assertEquals(expectedRoll, checkUtility.getRoll());
+    @BeforeAll
+    static void beforeAll() {
+        SkillType.initializeTypes();
     }
 
-    @Test
-    void testIsPersonNull_EdgeAllowed() {
-        SkillCheckUtility checkUtility = new SkillCheckUtility(null,
-              null,
-              S_GUN_MEK,
-              null,
-              0,
-              true,
-              false,
-              false,
-              false,
-              CURRENT_DATE);
-
-        int expectedMarginOfSuccess = DISASTROUS.getValue();
-        assertEquals(expectedMarginOfSuccess, checkUtility.getMarginOfSuccess());
-
-        String RESOURCE_BUNDLE = "mekhq.resources.SkillCheckUtility";
-        String expectedResultsText = getFormattedTextAt(RESOURCE_BUNDLE, "skillCheck.nullPerson");
-        assertEquals(expectedResultsText, checkUtility.getResultsText());
-
-        int expectedTargetNumber = Integer.MAX_VALUE;
-        assertEquals(expectedTargetNumber, checkUtility.getTargetNumber().getValue());
-
-        int expectedRoll = Integer.MIN_VALUE;
-        assertEquals(expectedRoll, checkUtility.getRoll());
-    }
-
-    @Test
-    void testIsPersonNull_PerformQuickSkillCheck() {
-        boolean results = performQuickSkillCheck(null, S_GUN_MEK, null, 0, false, false, CURRENT_DATE);
-        assertFalse(results);
+    private static Person personWithSkill(String skillName) {
+        Person person = new Person("GivenName", "Surname", null, "Faction");
+        person.addSkill(skillName, 3, 0);
+        return person;
     }
 
     @Test
@@ -266,7 +217,7 @@ class SkillCheckUtilityTest {
             mockSkillType.when(() -> SkillType.getType("MISSING_NAME")).thenReturn(testSkillType);
 
             // Act
-            TargetRoll targetNumber = determineTargetNumber(person, testSkillType, 0, false, false, CURRENT_DATE);
+            TargetRoll targetNumber = determineTargetNumber(person, testSkillType, false, false, CURRENT_DATE);
 
             // Assert
             int expectedTargetNumber = UNTRAINED_TARGET_NUMBER_ONE_LINKED_ATTRIBUTE + UNTRAINED_SKILL_MODIFIER -
@@ -291,7 +242,7 @@ class SkillCheckUtilityTest {
             mockSkillType.when(() -> SkillType.getType("MISSING_NAME")).thenReturn(testSkillType);
 
             // Act
-            TargetRoll targetNumber = determineTargetNumber(person, testSkillType, 0, false, false, CURRENT_DATE);
+            TargetRoll targetNumber = determineTargetNumber(person, testSkillType, false, false, CURRENT_DATE);
 
             // Assert
             int expectedTargetNumber = UNTRAINED_TARGET_NUMBER_TWO_LINKED_ATTRIBUTES -
@@ -338,7 +289,6 @@ class SkillCheckUtilityTest {
                 // Act
                 TargetRoll targetNumber = determineTargetNumber(mockPerson,
                       testSkillType,
-                      0,
                       false,
                       false,
                       CURRENT_DATE);
@@ -384,7 +334,7 @@ class SkillCheckUtilityTest {
             mockSkillType.when(() -> SkillType.getType("MISSING_NAME")).thenReturn(testSkillType);
 
             // Act
-            TargetRoll targetNumber = determineTargetNumber(mockPerson, testSkillType, 0, false, false, CURRENT_DATE);
+            TargetRoll targetNumber = determineTargetNumber(mockPerson, testSkillType, false, false, CURRENT_DATE);
 
             // Assert
             int skillTargetNumber = skill.getFinalSkillValue(skillModifierData);
@@ -427,7 +377,6 @@ class SkillCheckUtilityTest {
                 // Act
                 TargetRoll targetNumber = determineTargetNumber(mockPerson,
                       testSkillType,
-                      0,
                       false,
                       false,
                       CURRENT_DATE);
@@ -461,7 +410,7 @@ class SkillCheckUtilityTest {
             mockSkillType.when(() -> SkillType.getType("MISSING_NAME")).thenReturn(testSkillType);
 
             // Act
-            TargetRoll targetNumber = determineTargetNumber(person, testSkillType, 0, false, false, CURRENT_DATE);
+            TargetRoll targetNumber = determineTargetNumber(person, testSkillType, false, false, CURRENT_DATE);
 
             // Assert
             int expectedTargetNumber = UNTRAINED_TARGET_NUMBER_TWO_LINKED_ATTRIBUTES + UNTRAINED_SKILL_MODIFIER -
@@ -491,7 +440,7 @@ class SkillCheckUtilityTest {
             mockSkillType.when(() -> SkillType.getType("MISSING_NAME")).thenReturn(edgeCaseSkillType);
 
             // Act
-            TargetRoll targetNumber = determineTargetNumber(person, edgeCaseSkillType, 0, false, false, CURRENT_DATE);
+            TargetRoll targetNumber = determineTargetNumber(person, edgeCaseSkillType, false, false, CURRENT_DATE);
 
             // Assert
             int expectedTargetNumber = UNTRAINED_TARGET_NUMBER_ONE_LINKED_ATTRIBUTE + UNTRAINED_SKILL_MODIFIER;
@@ -528,7 +477,7 @@ class SkillCheckUtilityTest {
             mockSkillType.when(() -> SkillType.getType("MISSING_NAME")).thenReturn(testSkillType);
 
             // Act
-            TargetRoll targetNumber = determineTargetNumber(person, testSkillType, 0, false, false, CURRENT_DATE);
+            TargetRoll targetNumber = determineTargetNumber(person, testSkillType, false, false, CURRENT_DATE);
 
             // Assert
             int expectedTargetNumber = UNTRAINED_TARGET_NUMBER_TWO_LINKED_ATTRIBUTES + UNTRAINED_SKILL_MODIFIER -


### PR DESCRIPTION
This commit completely overhauls the skill check resolution architecture to simplify `SkillCheckUtility` and separate concerns. Previously, `SkillCheckUtility` acted as a monolithic, stateful class responsible for calculating target numbers, holding modifiers, executing dice rolls, and formatting output strings.

By introducing the `ActionCheck`, `SkillCheck`, and `ActionCheckResult` classes, we decouple the inputs from the final roll results. This improves composability and testability. Each of these new classes is strictly scoped and much simpler than the original utility. Consequently, `SkillCheckUtility` has been stripped of its state and repurposed into a strictly static utility class focused purely on core rules and dice generation.

Additionally, the rigid constructors of `SkillCheckUtility` have been replaced. Optional modifiers are now applied via builder-like methods (`withMiscModifier`, `withExternalModifiers`). This eliminates the need to pass massive parameter lists filled with `null`s and booleans, improving the readability of the code.

Since skill resolutin always requires a person, convenience methods for instantiating `SkillCheck` were added to the `Person` class. `SkillCheckUtility` does not support null `person` inputs and surfaces an exception instead of auto failing a skill check.

Changes:
- Add `ActionCheck`, an abstract base class utilizing a builder pattern to configure and resolve character actions
- Add `SkillCheck`, an implementation of `ActionCheck` for character skill resolution
- Add `ActionCheckResult`, an immutable record that holds the final result of a check, including the roll, margin of success, edge usage, and localized results text.
- Refactor `SkillCheckUtility` by removing all stateful fields and converting it into a static utility
- Throw an exception if `SkillCheckUtility` gets null person instead of failing the skill check (all cases are verified to never pass nulls, except one that will be guarded in a separate PR)
- Add overloaded `checkSkill` convenience methods to `Person` to initialize `SkillCheck` context
- Update all existing skill checks to use the new API
- Add very extensive unit test coverage for `ActionCheck`, `SkillCheck`, and `ActionCheckResult` to guarantee logic and state integrity