### PR TITLE
Fix #9346: Fix units in transit not being maintained

### DIFF
--- a/MekHQ/src/mekhq/campaign/location/LocationUtils.java
+++ b/MekHQ/src/mekhq/campaign/location/LocationUtils.java
@@ -57,8 +57,12 @@ public final class LocationUtils {
     /**
      * Returns {@code true} if {@code a} and {@code b} are at the same effective location.
      *
-     * <p>Both items must be non-null, neither may currently be in transit, and they must share
-     * the same nearest {@link AbstractBase} ancestor (or both have none, meaning main force).</p>
+     * <ol>
+     *     <li>If either input is null, it is not the same effective location.</ul>
+     *     <li>If either input is in transit, they're only the same effective location if they share an {@code
+     *     AbstractLocation}</ul>
+     *     <li>If both inputs have the same {@code Base} they're in the same location.</li>
+     * </ol>
      *
      * @param firstLocation  first location item
      * @param secondLocation second location item
@@ -66,11 +70,18 @@ public final class LocationUtils {
      * @return {@code true} if the two items are co-located
      */
     public static boolean areSameEffectiveLocation(@Nullable ILocation firstLocation, @Nullable ILocation secondLocation) {
+        // A null location isn't in the same location as anything
         if (firstLocation == null || secondLocation == null) {
             return false;
         }
+
+        // When in transit, only consider two things to have the same location if it's the exact same location. Space
+        // is big and transit time is abstracted, so even if two things have two locations with identical values, the
+        // transit time is ambigous and we can't consider them in the same place. Unless it's the exact same location.
         if (isInTransit(firstLocation) || isInTransit(secondLocation)) {
-            return false;
+            // Intentionally using "==" over .equals - When stuff is in transit, let's explicitly check if these have
+            // the same AbstractLocation object
+            return firstLocation.getCurrentLocation() == secondLocation.getCurrentLocation();
         }
         return Objects.equals(findEffectiveBase(firstLocation), findEffectiveBase(secondLocation));
     }

--- a/MekHQ/src/mekhq/campaign/location/LocationUtils.java
+++ b/MekHQ/src/mekhq/campaign/location/LocationUtils.java
@@ -58,9 +58,9 @@ public final class LocationUtils {
      * Returns {@code true} if {@code a} and {@code b} are at the same effective location.
      *
      * <ol>
-     *     <li>If either input is null, it is not the same effective location.</ul>
+     *     <li>If either input is null, it is not the same effective location.</li>
      *     <li>If either input is in transit, they're only the same effective location if they share an {@code
-     *     AbstractLocation}</ul>
+     *     AbstractLocation}</li>
      *     <li>If both inputs have the same {@code Base} they're in the same location.</li>
      * </ol>
      *
@@ -77,7 +77,7 @@ public final class LocationUtils {
 
         // When in transit, only consider two things to have the same location if it's the exact same location. Space
         // is big and transit time is abstracted, so even if two things have two locations with identical values, the
-        // transit time is ambigous and we can't consider them in the same place. Unless it's the exact same location.
+        // transit time is ambiguous and we can't consider them in the same place. Unless it's the exact same location.
         if (isInTransit(firstLocation) || isInTransit(secondLocation)) {
             // Intentionally using "==" over .equals - When stuff is in transit, let's explicitly check if these have
             // the same AbstractLocation object

--- a/MekHQ/src/mekhq/gui/menus/AssignPersonToUnitMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignPersonToUnitMenu.java
@@ -69,11 +69,9 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
         // Immediate Return for Illegal Assignment
         // 1) No people to assign
         // 2) Any of the people you are trying to assign are currently deployed
-        // 3) Any person is currently in transit (no fixed location to match units against)
         if ((people.length == 0) ||
                   Stream.of(people).anyMatch(Person::isDeployed) ||
-                  !StaticChecks.areAllEmployed(people) ||
-                  Stream.of(people).anyMatch(LocationUtils::isInTransit)) {
+                  !StaticChecks.areAllEmployed(people)) {
             return;
         }
 

--- a/MekHQ/src/mekhq/gui/menus/AssignTechToUnitMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignTechToUnitMenu.java
@@ -43,6 +43,7 @@ import megamek.common.units.UnitType;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.Hangar;
 import mekhq.campaign.base.AbstractBase;
+import mekhq.campaign.location.IPlace;
 import mekhq.campaign.location.LocationUtils;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.HangarSorter;
@@ -86,13 +87,17 @@ public class AssignTechToUnitMenu extends JScrollableMenu {
 
         // Get all units that are:
         // 1) Available
-        // 2) Potentially maintained by the person
-        // 3) The unit can take a tech and the person can afford the time to maintain the unit
-        // Only show units co-located with the person (base hangar or main-force hangar)
+        // 2) Co-located with the person (same IPlace ancestor — handles in-transit units correctly)
+        // 3) Potentially maintained by the person
+        // 4) The unit can take a tech and the person can afford the time to maintain the unit
+        IPlace personPlace = person.getPlace();
         AbstractBase effectiveBase = LocationUtils.findEffectiveBase(person);
         Hangar sourceHangar = (effectiveBase != null) ? effectiveBase.getBaseHangar() : campaign.getHangar();
         final List<Unit> units = HangarSorter.defaultSorting()
-                                       .sort(sourceHangar.getUnitsStream().filter(Unit::isAvailable)
+                                       .sort(sourceHangar.getUnitsStream()
+                                                   .filter(Unit::isAvailable)
+                                                   .filter(unit -> LocationUtils.areSameEffectiveLocation(unit,
+                                                         personPlace))
                                                    .filter(unit -> person.canTech(unit.getEntity()))
                                                    .filter(unit -> unit.canTakeTech()
                                                                          &&

--- a/MekHQ/unittests/mekhq/campaign/location/LocationUtilsTest.java
+++ b/MekHQ/unittests/mekhq/campaign/location/LocationUtilsTest.java
@@ -179,7 +179,7 @@ public class LocationUtilsTest {
         }
 
         @Test
-        void eitherInTransit_returnsFalse() {
+        void oneInTransitOtherNot_returnsFalse() {
             PlanetarySystem sys = mock(PlanetarySystem.class);
             when(sys.getTimeToJumpPoint(1.0)).thenReturn(1.0);
             CurrentLocation travelNode = new CurrentLocation(sys, 0.0);
@@ -189,6 +189,36 @@ public class LocationUtilsTest {
             travelNode.setParent(base);
 
             assertFalse(LocationUtils.areSameEffectiveLocation(travelNode, base));
+        }
+
+        @Test
+        void bothInTransitDifferentNodes_returnsFalse() {
+            PlanetarySystem sys = mock(PlanetarySystem.class);
+            when(sys.getTimeToJumpPoint(1.0)).thenReturn(1.0);
+            JumpPath mockJumpPath = mock(JumpPath.class);
+            when(mockJumpPath.isEmpty()).thenReturn(false);
+
+            CurrentLocation travelNode1 = new CurrentLocation(sys, 0.0);
+            travelNode1.setJumpPath(mockJumpPath);
+
+            CurrentLocation travelNode2 = new CurrentLocation(sys, 0.0);
+            travelNode2.setJumpPath(mockJumpPath);
+
+            assertFalse(LocationUtils.areSameEffectiveLocation(travelNode1, travelNode2));
+        }
+
+        @Test
+        void bothInTransitSameNode_returnsTrue() {
+            PlanetarySystem sys = mock(PlanetarySystem.class);
+            when(sys.getTimeToJumpPoint(1.0)).thenReturn(1.0);
+            CurrentLocation travelNode = new CurrentLocation(sys, 0.0);
+            JumpPath mockJumpPath = mock(JumpPath.class);
+            when(mockJumpPath.isEmpty()).thenReturn(false);
+            travelNode.setJumpPath(mockJumpPath);
+            base.setParent(travelNode);
+
+            assertTrue(LocationUtils.areSameEffectiveLocation(
+                  base.getBaseHangar(), base.getBaseWarehouse()));
         }
     }
 }


### PR DESCRIPTION
Fixes #9346

Tweaked `LocationUtils.sameEffectiveLocation` - Two things  in transit can be the same location if they have the exact same `AbstractLocation`. Also allows you to assign crew even if in transit. 