### PR TITLE
Fix the alert message colour for BioweaponSpreadMessages

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/Inoculations.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/Inoculations.java
@@ -828,8 +828,8 @@ public class Inoculations {
 
     public static void triggerBioweaponSpreadMessages(Campaign campaign, boolean isInTransit, boolean hasCure,
           Set<String> diseases) {
-        String alertColor = spanOpeningWithCustomColor(isInTransit ? getNegativeColor() : getWarningColor());
-        alertColor = hasCure ? alertColor : getNegativeColor();
+        String alertColor = isInTransit ? getNegativeColor() : getWarningColor();
+        alertColor = spanOpeningWithCustomColor(hasCure ? alertColor : getNegativeColor());
 
         String reportKey;
         if (!hasCure) {


### PR DESCRIPTION
The alert message for a Bioweapon spreading is not applying the right colour. This is the same issue as was fixed in #8896 but for another message.

This PR appllies the same fix to this message type.

<img width="447" height="120" alt="Bioweapon" src="https://github.com/user-attachments/assets/eec6cd28-d832-459b-b883-5da4bf6237eb" />
