### PR TITLE
Damaged beyond repair message did not show for some parts (fixes #9296)

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -344,6 +344,10 @@ public abstract class Part implements IPartWork, ITechnology, ILocation {
         return brandNew;
     }
 
+    public boolean isDamagedBeyondRepair() {
+        return getSkillMin() > SkillType.EXP_LEGENDARY;
+    }
+
     public void setBrandNew(boolean b) {
         this.brandNew = b;
     }
@@ -494,7 +498,7 @@ public abstract class Part implements IPartWork, ITechnology, ILocation {
             toReturn.append("<br>");
         }
 
-        if (getSkillMin() <= SkillType.EXP_LEGENDARY) {
+        if (!isDamagedBeyondRepair()) {
             toReturn.append(getTimeLeft())
                   .append(" minutes")
                   .append(null != getTech() ? " (scheduled)" : "")

--- a/MekHQ/src/mekhq/campaign/parts/TankLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/TankLocation.java
@@ -337,7 +337,7 @@ public class TankLocation extends Part {
 
     @Override
     public String getDesc() {
-        if (!isBreached() || isSalvaging()) {
+        if (isDamagedBeyondRepair() || isSalvaging() || !isBreached()) {
             return super.getDesc();
         }
         String toReturn = "<html><font";

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -537,7 +537,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
 
     @Override
     public String getDesc() {
-        if (isSalvaging()) {
+        if (isDamagedBeyondRepair() || isSalvaging()) {
             return super.getDesc();
         }
 

--- a/MekHQ/src/mekhq/campaign/parts/meks/MekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/meks/MekLocation.java
@@ -933,7 +933,7 @@ public class MekLocation extends Part {
 
     @Override
     public String getDesc() {
-        if ((!isBreached() && !isBlownOff())) {
+        if (isDamagedBeyondRepair() || (!isBreached() && !isBlownOff())) {
             return super.getDesc();
         }
         StringBuilder toReturn = new StringBuilder();

--- a/MekHQ/src/mekhq/campaign/parts/protomeks/ProtoMekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/protomeks/ProtoMekLocation.java
@@ -608,7 +608,7 @@ public class ProtoMekLocation extends Part {
 
     @Override
     public String getDesc() {
-        if ((!isBreached() && !isBlownOff()) || isSalvaging()) {
+        if (isDamagedBeyondRepair() || isSalvaging() || (!isBreached() && !isBlownOff())) {
             return super.getDesc();
         }
         StringBuilder toReturn = new StringBuilder();


### PR DESCRIPTION
A message to show that a part is damaged beyond repair was recently added. However, for some parts this message did not show because some different handling of those parts led to the default behaviour being skipped.

This PR fixes this by checking if a part is damaged beyond repair, and if so falling back to the default behaviour for parts where in this case a message is shown.

A new isDamagedBeyondRepair() helper method was also added for this.

Closes #9296