### PR TITLE
Fix navigation tab issues in CampaignGUI

### DIFF
--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -581,10 +581,6 @@ public class CampaignGUI extends JPanel {
         return navigationTab;
     }
 
-    public MapTab getMapTab() {
-        return navigationTab.getMapTab();
-    }
-
     public PersonnelTab getPersonnelTab() {
         return personnelTab;
     }
@@ -621,10 +617,10 @@ public class CampaignGUI extends JPanel {
      * Sets the selected tab.
      */
     public void setSelectedTab(CampaignGuiTab tab) {
-        IntStream.range(0, tabMain.getTabCount())
-              .filter(ii -> Objects.equals(tabMain.getComponentAt(ii), tab))
-              .findFirst()
-              .ifPresent(ii -> tabMain.setSelectedIndex(ii));
+        int index = tabMain.indexOfComponent(tab);
+        if (index >= 0) {
+            tabMain.setSelectedIndex(index);
+        }
     }
 
     /**
@@ -635,7 +631,7 @@ public class CampaignGUI extends JPanel {
     public void setSelectedTab(MHQTabType tabType) {
         Optional<? extends CampaignGuiTab> tab = switch (tabType) {
             case COMMAND_CENTER -> Optional.of(getCommandCenterTab());
-            case NAVIGATION, INTERSTELLAR_MAP -> Optional.of(getNavigationTab());
+            case NAVIGATION -> Optional.of(getNavigationTab());
             case TOE -> Optional.of(getTOETab());
             case BRIEFING_ROOM -> Optional.of(getBriefingRoomTab());
             case STRAT_CON -> getStratConTab();

--- a/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
+++ b/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
@@ -375,7 +375,7 @@ public class InterstellarMapPanel extends JPanel {
                         }
                         center(selectedSystem);
                         // bring up a planetary system map
-                        hqView.getMapTab().switchPlanetaryMap(selectedSystem);
+                        hqView.getNavigationTab().getMapTab().switchPlanetaryMap(selectedSystem);
                     } else {
                         PlanetarySystem target = nearestNeighbour(scr2mapX(e.getX()), scr2mapY(e.getY()));
                         if (null == target) {

--- a/MekHQ/src/mekhq/gui/LocationsTab.java
+++ b/MekHQ/src/mekhq/gui/LocationsTab.java
@@ -74,6 +74,7 @@ import mekhq.gui.view.LocationPlacePanel;
  * {@link LocationsTabView} owns the widgets, and {@link LocationsTabController} drives both data refresh and user
  * interaction.</p>
  */
+// FIXME: this class should not inherit from CampaignGuiTab because it is managed by NavigationTab now
 public class LocationsTab extends CampaignGuiTab {
 
     private enum ViewMode {
@@ -112,7 +113,7 @@ public class LocationsTab extends CampaignGuiTab {
 
     @Override
     public MHQTabType tabType() {
-        return MHQTabType.NAVIGATION;
+        return null;
     }
 
     @Override

--- a/MekHQ/src/mekhq/gui/MapTab.java
+++ b/MekHQ/src/mekhq/gui/MapTab.java
@@ -87,6 +87,7 @@ import mekhq.gui.view.PlanetViewPanel;
 /**
  * Displays interstellar map and contains transit controls.
  */
+// FIXME: this class should not inherit from CampaignGuiTab because it is managed by NavigationTab now
 public final class MapTab extends CampaignGuiTab implements ActionListener {
     private static final int PADDING = UIUtil.scaleForGUI(10);
 
@@ -105,7 +106,7 @@ public final class MapTab extends CampaignGuiTab implements ActionListener {
 
     @Override
     public MHQTabType tabType() {
-        return MHQTabType.INTERSTELLAR_MAP;
+        return null;
     }
 
     /*

--- a/MekHQ/src/mekhq/gui/NavigationTab.java
+++ b/MekHQ/src/mekhq/gui/NavigationTab.java
@@ -37,6 +37,8 @@ import static mekhq.utilities.MHQInternationalization.getText;
 import java.awt.BorderLayout;
 
 import megamek.common.ui.EnhancedTabbedPane;
+import mekhq.campaign.universe.Planet;
+import mekhq.campaign.universe.PlanetarySystem;
 import mekhq.gui.enums.MHQTabType;
 
 /**
@@ -67,6 +69,28 @@ public class NavigationTab extends CampaignGuiTab {
 
     public MapTab getMapTab() {
         return mapTab;
+    }
+
+    public void showSystem(PlanetarySystem planetarySystem) {
+        mapTab.switchSystemsMap(planetarySystem);
+        int index = innerTabs.indexOfComponent(mapTab);
+        if (index >= 0) {
+            innerTabs.setSelectedIndex(index);
+        }
+    }
+
+    public void showPlanet(Planet planet) {
+        // Stay on the interstellar map if their origin planet is the primary planet...
+        if (planet.getParentSystem().getPrimaryPlanet().equals(planet)) {
+            showSystem(planet.getParentSystem());
+        } else {
+            // ...otherwise, dive on in to the system view!
+            mapTab.switchPlanetaryMap(planet);
+            int index = innerTabs.indexOfComponent(mapTab);
+            if (index >= 0) {
+                innerTabs.setSelectedIndex(index);
+            }
+        }
     }
 
     @Override

--- a/MekHQ/src/mekhq/gui/PlanetarySystemMapPanel.java
+++ b/MekHQ/src/mekhq/gui/PlanetarySystemMapPanel.java
@@ -761,6 +761,6 @@ public class PlanetarySystemMapPanel extends JPanel {
      * Switch back to the interstellar map
      */
     private void back() {
-        hqView.getMapTab().switchSystemsMap();
+        hqView.getNavigationTab().getMapTab().switchSystemsMap();
     }
 }

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -138,6 +138,7 @@ import mekhq.gui.dialog.SmallSVAmmoSwapDialog;
 import mekhq.gui.dialog.reportDialogs.MaintenanceReportDialog;
 import mekhq.gui.dialog.reportDialogs.MonthlyUnitCostReportDialog;
 import mekhq.gui.dialog.reportDialogs.PartQualityReportDialog;
+import mekhq.gui.enums.MHQTabType;
 import mekhq.gui.menus.AssignUnitToForceMenu;
 import mekhq.gui.menus.AssignUnitToPersonMenu;
 import mekhq.gui.menus.ExportUnitSpriteMenu;

--- a/MekHQ/src/mekhq/gui/enums/MHQTabType.java
+++ b/MekHQ/src/mekhq/gui/enums/MHQTabType.java
@@ -49,7 +49,6 @@ public enum MHQTabType {
     //region Enum Declaration
     COMMAND_CENTER("MHQTabType.COMMAND_CENTER.text", KeyEvent.VK_O),
     NAVIGATION("MHQTabType.NAVIGATION.text", KeyEvent.VK_UNDEFINED),
-    INTERSTELLAR_MAP("MHQTabType.INTERSTELLAR_MAP.text", KeyEvent.VK_S),
     TOE("MHQTabType.TOE.text", KeyEvent.VK_T),
     BRIEFING_ROOM("MHQTabType.BRIEFING_ROOM.text", KeyEvent.VK_B),
     STRAT_CON("MHQTabType.STRAT_CON.text", KeyEvent.VK_C),
@@ -97,10 +96,6 @@ public enum MHQTabType {
 
     public boolean isBriefingRoom() {
         return this == BRIEFING_ROOM;
-    }
-
-    public boolean isInterstellarMap() {
-        return this == INTERSTELLAR_MAP;
     }
 
     public boolean isPersonnel() {

--- a/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
@@ -65,6 +65,7 @@ import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Systems;
 import mekhq.campaign.universe.factionStanding.FactionStandingUtilities;
 import mekhq.gui.CampaignGUI;
+import mekhq.gui.enums.MHQTabType;
 
 /**
  * Contract summary view for ContractMarketDialog
@@ -270,8 +271,8 @@ public class ContractSummaryPanel extends JPanel {
             public void mouseClicked(MouseEvent e) {
                 // Display where it is on the interstellar map
                 CampaignGUI gui = campaign.getApp().getCampaigngui();
-                gui.getMapTab().switchSystemsMap(contract.getSystem());
-                gui.setSelectedTab(gui.getMapTab());
+                gui.getNavigationTab().showSystem(contract.getSystem());
+                gui.setSelectedTab(gui.getNavigationTab());
             }
         });
         gridBagConstraintsText.gridy = y;

--- a/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
@@ -211,8 +211,8 @@ public class MissionViewPanel extends JScrollablePanel {
                 @Override
                 public void mouseClicked(MouseEvent e) {
                     // Display where it is on the interstellar map
-                    gui.getMapTab().switchSystemsMap(mission.getSystem());
-                    gui.setSelectedTab(gui.getMapTab());
+                    gui.getNavigationTab().showSystem(mission.getSystem());
+                    gui.setSelectedTab(gui.getNavigationTab());
                 }
             });
             gridBagConstraints = new GridBagConstraints();
@@ -306,8 +306,8 @@ public class MissionViewPanel extends JScrollablePanel {
                 @Override
                 public void mouseClicked(MouseEvent e) {
                     // Display where it is on the interstellar map
-                    gui.getMapTab().switchSystemsMap(contract.getSystem());
-                    gui.setSelectedTab(gui.getMapTab());
+                    gui.getNavigationTab().showSystem(contract.getSystem());
+                    gui.setSelectedTab(gui.getNavigationTab());
                 }
             });
             gridBagConstraints = new GridBagConstraints();
@@ -635,8 +635,8 @@ public class MissionViewPanel extends JScrollablePanel {
             @Override
             public void mouseClicked(MouseEvent e) {
                 // Display where it is on the interstellar map
-                gui.getMapTab().switchSystemsMap(contract.getSystem());
-                gui.setSelectedTab(gui.getMapTab());
+                gui.getNavigationTab().showSystem(contract.getSystem());
+                gui.setSelectedTab(gui.getNavigationTab());
             }
         });
         gridBagConstraints = new GridBagConstraints();

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -131,6 +131,7 @@ import mekhq.campaign.universe.PlanetarySystem;
 import mekhq.gui.CampaignGUI;
 import mekhq.gui.baseComponents.JScrollablePanel;
 import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
+import mekhq.gui.enums.MHQTabType;
 import mekhq.gui.model.PersonnelEventLogModel;
 import mekhq.gui.model.PersonnelKillLogModel;
 import mekhq.gui.utilities.MarkdownRenderer;
@@ -1203,15 +1204,8 @@ public class PersonViewPanel extends JScrollablePanel {
                 lblOrigin2.addMouseListener(new MouseAdapter() {
                     @Override
                     public void mouseClicked(MouseEvent e) {
-                        PlanetarySystem system = person.getOriginPlanet().getParentSystem();
-                        // Stay on the interstellar map if their origin planet is the primary planet...
-                        if (system.getPrimaryPlanet().equals(person.getOriginPlanet())) {
-                            gui.getMapTab().switchSystemsMap(system);
-                        } else {
-                            // ...otherwise, dive on in to the system view!
-                            gui.getMapTab().switchPlanetaryMap(person.getOriginPlanet());
-                        }
-                        gui.setSelectedTab(gui.getMapTab());
+                        gui.getNavigationTab().showPlanet(person.getOriginPlanet());
+                        gui.setSelectedTab(gui.getNavigationTab());
                     }
                 });
             } else {

--- a/MekHQ/unittests/mekhq/gui/enums/MHQTabTypeTest.java
+++ b/MekHQ/unittests/mekhq/gui/enums/MHQTabTypeTest.java
@@ -55,7 +55,6 @@ public class MHQTabTypeTest {
     public void testGetMnemonic() {
         assertEquals(KeyEvent.VK_O, MHQTabType.COMMAND_CENTER.getMnemonic());
         assertEquals(KeyEvent.VK_UNDEFINED, MHQTabType.NAVIGATION.getMnemonic());
-        assertEquals(KeyEvent.VK_S, MHQTabType.INTERSTELLAR_MAP.getMnemonic());
         assertEquals(KeyEvent.VK_H, MHQTabType.HANGAR.getMnemonic());
         assertEquals(KeyEvent.VK_L, MHQTabType.MEK_LAB.getMnemonic());
     }
@@ -102,17 +101,6 @@ public class MHQTabTypeTest {
                 assertTrue(mhqTabType.isBriefingRoom());
             } else {
                 assertFalse(mhqTabType.isBriefingRoom());
-            }
-        }
-    }
-
-    @Test
-    public void testIsInterstellarMap() {
-        for (final MHQTabType mhqTabType : types) {
-            if (mhqTabType == MHQTabType.INTERSTELLAR_MAP) {
-                assertTrue(mhqTabType.isInterstellarMap());
-            } else {
-                assertFalse(mhqTabType.isInterstellarMap());
             }
         }
     }


### PR DESCRIPTION
`MapTab` was moved into newly created `NavigationTab`, but the change did not update `CampaignGUI` accordingly, instead a helper method was returning nested `MapTab`. And, since `CampaignGUI` was not managing `MapTab` anymore, calls like `setSelectedTab` did not work. This broke hyperlink navigation in many places.

To address the above this PR includes the following changes:
- Remove `CampaignGUI.getMapTab`
- Remove `MHQTabType.INTERSTELLAR_MAP`
- Introduce `showSystem` and `showPlanet` helper methods in `NavigationTab` to help with subtab switching
- Use the above methods in UI navigation logic
- Use `setSelectedTab(getNavigationTab)` instead of `getMapTab`
- Simplify `CampaignGUI.setSelectedTab` logic