### PR TITLE
Fix Parts in Use resetting to default (closes #9358)

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
@@ -575,7 +575,7 @@ public class PartsReportDialog extends JDialog {
 
     private Set<PartInUse> getPartsInUseFromTable() {
         Set<PartInUse> partsInUse = new HashSet<>();
-        for (int row = 0; row < overviewPartsInUseTable.getRowCount(); row++) {
+        for (int row = 0; row < overviewPartsModel.getRowCount(); row++) {
             partsInUse.add(overviewPartsModel.getPartInUse(row));
         }
         return partsInUse;
@@ -623,7 +623,7 @@ public class PartsReportDialog extends JDialog {
             stockMap.clear();
         }
 
-        for (int row = 0; row < overviewPartsInUseTable.getRowCount(); row++) {
+        for (int row = 0; row < overviewPartsModel.getRowCount(); row++) {
             PartInUse partInUse = overviewPartsModel.getPartInUse(row);
             stockMap.put(PartsInUseManager.getStockKey(partInUse), partInUse.getRequestedStock());
         }


### PR DESCRIPTION
When the Parts in Use dialog is filtered, some actions (like closing it or ordering parts to minimum stock levels) will reset the requested % values to their default values.

The reason is that the underlying StockMap gets cleared, and is then repopulated. However, this repopulation is based on the rows in the table view (which does not have all rows), and not on the rows in the table model. Consequently, the StockMap lacks rows for some items, and these then get repopulated by the defaults. 

This PR fixes this by using the table model to determine the rows for the underlying StockMap.

closes #9358