### PR TITLE
PR: Keep LocationNode logic within location package

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1764,7 +1764,7 @@ public class Campaign implements ITechManager, IPlace {
         }
         setParent(location);
         // After reparenting, old has one fewer child. Remove it only if nothing else remains under it.
-        if (old != null && old != location && old.getLocationNode().getChildren().isEmpty()) {
+        if (old != null && old != location && old.getChildLocations().isEmpty()) {
             locations.remove(old);
         }
     }
@@ -1803,8 +1803,8 @@ public class Campaign implements ITechManager, IPlace {
             if (location instanceof CurrentLocation) {
                 location.setParent(null);
             } else if (location instanceof FixedLocation) {
-                for (LocationNode child : new ArrayList<>(location.getLocationNode().getChildren())) {
-                    if (child.getLocatable() instanceof AcademyCampusLocation campus) {
+                for (ILocation child : new ArrayList<>(location.getChildLocations())) {
+                    if (child instanceof AcademyCampusLocation campus) {
                         campus.setParent(null);
                     }
                 }
@@ -1875,8 +1875,8 @@ public class Campaign implements ITechManager, IPlace {
             if (!fixedLocation.getCurrentSystem().getId().equals(systemId)) {
                 continue;
             }
-            for (LocationNode child : fixedLocation.getLocationNode().getChildren()) {
-                if (child.getLocatable() instanceof AcademyCampusLocation campus
+            for (ILocation child : fixedLocation.getChildLocations()) {
+                if (child instanceof AcademyCampusLocation campus
                           && academySet.equals(campus.getAcademySet())
                           && academyName.equals(campus.getAcademyName())) {
                     return campus;
@@ -1895,8 +1895,8 @@ public class Campaign implements ITechManager, IPlace {
      * Use {@link #getOrCreateCampusLocation} for academies at a fixed planetary system.</p>
      */
     public AcademyCampusLocation getOrCreateLocalCampusLocation(String academySet, String academyName) {
-        for (LocationNode child : locationNode.getChildren()) {
-            if (child.getLocatable() instanceof AcademyCampusLocation campus
+        for (ILocation child : getChildLocations()) {
+            if (child instanceof AcademyCampusLocation campus
                       && academySet.equals(campus.getAcademySet())
                       && academyName.equals(campus.getAcademyName())) {
                 return campus;
@@ -1946,8 +1946,8 @@ public class Campaign implements ITechManager, IPlace {
         if (locationNode == null) {
             return;
         }
-        for (LocationNode child : new ArrayList<>(locationNode.getChildren())) {
-            if (!(child.getLocatable() instanceof CurrentLocation travelLocation)) {
+        for (ILocation child : new ArrayList<>(getChildLocations())) {
+            if (!(child instanceof CurrentLocation travelLocation)) {
                 continue;
             }
             if (!travelLocation.isOnPlanet()) {
@@ -5815,7 +5815,7 @@ public class Campaign implements ITechManager, IPlace {
                 continue;
             }
             // Skip locations parented to another node — they are serialized inside their parent's XML.
-            if (location.getLocationNode().getParent() != null) {
+            if (location.isParented()) {
                 continue;
             }
             location.writeToXML(writer, indent);

--- a/MekHQ/src/mekhq/campaign/CurrentLocation.java
+++ b/MekHQ/src/mekhq/campaign/CurrentLocation.java
@@ -50,7 +50,7 @@ import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.events.LocationChangedEvent;
 import mekhq.campaign.events.TransitCompleteEvent;
 import mekhq.campaign.events.TransitStatusChangedEvent;
-import mekhq.campaign.location.LocationNode;
+import mekhq.campaign.location.ILocation;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.personnel.medical.advancedMedicalAlternate.Inoculations;
 import mekhq.campaign.unit.Unit;
@@ -362,12 +362,12 @@ public class CurrentLocation extends AbstractLocation {
         if (jumpPath != null) {
             jumpPath.writeToXML(pw, indent);
         }
-        for (LocationNode child : locationNode.getChildren()) {
-            if (child.getLocatable() instanceof mekhq.campaign.personnel.Person person) {
+        for (ILocation child : getChildLocations()) {
+            if (child instanceof mekhq.campaign.personnel.Person person) {
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent, "personId", person.getId().toString());
-            } else if (child.getLocatable() instanceof Unit unit) {
+            } else if (child instanceof Unit unit) {
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent, "unitId", unit.getId().toString());
-            } else if (child.getLocatable() instanceof Part part) {
+            } else if (child instanceof Part part) {
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent, "partId", String.valueOf(part.getId()));
             }
         }

--- a/MekHQ/src/mekhq/campaign/FixedLocation.java
+++ b/MekHQ/src/mekhq/campaign/FixedLocation.java
@@ -36,6 +36,7 @@ import java.io.PrintWriter;
 
 import megamek.logging.MMLogger;
 import mekhq.campaign.location.AcademyCampusLocation;
+import mekhq.campaign.location.ILocation;
 import mekhq.campaign.location.LocationNode;
 import mekhq.campaign.universe.PlanetarySystem;
 import mekhq.campaign.universe.Systems;
@@ -59,8 +60,8 @@ public class FixedLocation extends AbstractLocation {
 
     @Override
     public void processArrivals(Campaign campaign) {
-        for (LocationNode child : getLocationNode().getChildren()) {
-            if (child.getLocatable() instanceof AcademyCampusLocation campus) {
+        for (ILocation child : getChildLocations()) {
+            if (child instanceof AcademyCampusLocation campus) {
                 campus.processArrivals(campaign);
             }
         }

--- a/MekHQ/src/mekhq/campaign/base/AbstractBase.java
+++ b/MekHQ/src/mekhq/campaign/base/AbstractBase.java
@@ -162,8 +162,7 @@ public abstract class AbstractBase implements IPlace {
      * Returns the immediate parent of this base in the location tree, or {@code null} if unparented.
      */
     public @Nullable ILocation getParent() {
-        LocationNode parent = locationNode.getParent();
-        return parent != null ? parent.getLocatable() : null;
+        return getParentLocation();
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/base/PlayerBase.java
+++ b/MekHQ/src/mekhq/campaign/base/PlayerBase.java
@@ -44,7 +44,6 @@ import mekhq.campaign.CurrentLocation;
 import mekhq.campaign.FixedLocation;
 import mekhq.campaign.location.AcademyCampusLocation;
 import mekhq.campaign.location.ILocation;
-import mekhq.campaign.location.LocationNode;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
@@ -118,16 +117,16 @@ public class PlayerBase extends AbstractBase {
                   getCurrentLocation().getCurrentSystem().getId());
         }
         // Persons who have arrived live under basePersonnel.
-        for (LocationNode child : getBasePersonnel().getLocationNode().getChildren()) {
-            if (child.getLocatable() instanceof Person person) {
+        for (ILocation child : getBasePersonnel().getChildLocations()) {
+            if (child instanceof Person person) {
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent, "personId", person.getId().toString());
             }
         }
         // Travel nodes (CurrentLocation) and homeSchool campuses sit directly under the base.
-        for (LocationNode child : getLocationNode().getChildren()) {
-            if (child.getLocatable() instanceof CurrentLocation currentLocation) {
+        for (ILocation child : getChildLocations()) {
+            if (child instanceof CurrentLocation currentLocation) {
                 currentLocation.writeToXML(pw, indent);
-            } else if (child.getLocatable() instanceof AcademyCampusLocation campus) {
+            } else if (child instanceof AcademyCampusLocation campus) {
                 campus.writeToXML(pw, indent);
             }
         }
@@ -193,7 +192,7 @@ public class PlayerBase extends AbstractBase {
                 } else if (nodeName.equalsIgnoreCase("academyCampus")) {
                     AcademyCampusLocation campus = AcademyCampusLocation.generateInstanceFromXML(wn2);
                     if (campus != null) {
-                        LocationNode.LocationManager.setLocation(campus, base);
+                        campus.setParent(base);
                         NodeList campusChildren = wn2.getChildNodes();
                         for (int ci = 0; ci < campusChildren.getLength(); ci++) {
                             Node campusChild = campusChildren.item(ci);
@@ -203,7 +202,7 @@ public class PlayerBase extends AbstractBase {
                             if (campusChild.getNodeName().equalsIgnoreCase("location")) {
                                 CurrentLocation travelNode = CurrentLocation.generateInstanceFromXML(campusChild, campaign);
                                 if (travelNode != null) {
-                                    LocationNode.LocationManager.setLocation(travelNode, campus);
+                                    travelNode.setParent(campus);
                                     campaign.addLocation(travelNode);
                                 }
                             }

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -110,6 +110,7 @@ import mekhq.campaign.force.CombatTeam;
 import mekhq.campaign.force.Formation;
 import mekhq.campaign.icons.UnitIcon;
 import mekhq.campaign.location.AcademyCampusLocation;
+import mekhq.campaign.location.ILocation;
 import mekhq.campaign.location.LocationNode;
 import mekhq.campaign.market.PersonnelMarket;
 import mekhq.campaign.market.ShoppingList;
@@ -783,7 +784,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
         // Reconnect persons to the main-force personnel node. Skip persons already placed by
         // processPlayerBaseNodes or reconnectChildren (base / travel / campus persons).
         for (Person person : campaign.getAllPersonnel()) {
-            if (person.getLocationNode().getParent() == null) {
+            if (!person.isParented()) {
                 person.setParent(campaign.getMainForcePersonnel());
             }
         }
@@ -1506,8 +1507,8 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                             person.setParent(base.getBasePersonnel());
                         }
                     }
-                    for (LocationNode child : base.getLocationNode().getChildren()) {
-                        if (child.getLocatable() instanceof AcademyCampusLocation campus) {
+                    for (ILocation child : base.getChildLocations()) {
+                        if (child instanceof AcademyCampusLocation campus) {
                             drainCampusPersons(campaign, campus);
                         }
                     }
@@ -1735,7 +1736,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                 // be re-parented here, as that would detach them from their base. Items whose
                 // save pre-dates the arrival-tracking fix fall back to main force so they
                 // remain visible rather than becoming invisible.
-                boolean isOrphaned = currentLocation.getLocationNode().getParent() == null;
+                boolean isOrphaned = !currentLocation.isParented();
                 boolean isActivelyInTransit = currentLocation.getJumpPath() != null
                                                     && !currentLocation.getJumpPath().isEmpty();
                 if (isOrphaned && !isActivelyInTransit) {
@@ -1743,7 +1744,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                     // re-homed by processPlayerBaseNodes falls back to main force.
                     for (UUID personId : currentLocation.drainPendingPersonIds()) {
                         Person person = campaign.getPerson(personId);
-                        if (person != null && person.getLocationNode().getParent() == null) {
+                        if (person != null && !person.isParented()) {
                             person.setParent(campaign.getMainForcePersonnel());
                             LOGGER.warn("reconnectPersonsToTravelLocations: person {} had no parent "
                                   + "(orphaned arrived node); re-homed to main force", personId);
@@ -1751,7 +1752,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                     }
                     for (UUID unitId : currentLocation.drainPendingUnitIds()) {
                         Unit unit = findUnitAnywhere(campaign, unitId);
-                        if (unit != null && unit.getLocationNode().getParent() == null) {
+                        if (unit != null && !unit.isParented()) {
                             LocationNode.LocationManager.setLocation(unit, campaign.getHangar());
                             LOGGER.warn("reconnectPersonsToTravelLocations: unit {} had no parent "
                                   + "(orphaned arrived node); re-homed to main hangar", unitId);
@@ -1759,7 +1760,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                     }
                     for (int partId : currentLocation.drainPendingPartIds()) {
                         Part part = findPartAnywhere(campaign, partId);
-                        if (part != null && part.getLocationNode().getParent() == null) {
+                        if (part != null && !part.isParented()) {
                             LocationNode.LocationManager.setLocation(part, campaign.getWarehouse());
                             LOGGER.warn("reconnectPersonsToTravelLocations: part {} had no parent "
                                   + "(orphaned arrived node); re-homed to main warehouse", partId);
@@ -1798,8 +1799,8 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
 
             // Persons at campus — parented under the campus's Personnel sub-node
             if (location instanceof FixedLocation fixedLocation) {
-                for (LocationNode campusNode : fixedLocation.getLocationNode().getChildren()) {
-                    if (campusNode.getLocatable() instanceof AcademyCampusLocation campusLocation) {
+                for (ILocation campusNode : fixedLocation.getChildLocations()) {
+                    if (campusNode instanceof AcademyCampusLocation campusLocation) {
                         drainCampusPersons(campaign, campusLocation);
                     }
                 }
@@ -1809,8 +1810,8 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
         // Persons at campaign-root campuses (homeSchool) — same pattern as FixedLocation campuses above.
         // Campaign itself is not in campaign.getLocations(), so its direct campus children are never
         // visited by the loop above.
-        for (LocationNode campusNode : campaign.getLocationNode().getChildren()) {
-            if (campusNode.getLocatable() instanceof AcademyCampusLocation campusLocation) {
+        for (ILocation location : campaign.getChildLocations()) {
+            if (location instanceof AcademyCampusLocation campusLocation) {
                 drainCampusPersons(campaign, campusLocation);
             }
         }
@@ -1893,11 +1894,10 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                 // during XML parsing (e.g., reconnected by an earlier load step). Without this
                 // guard, resolveAcademySystemId may return the wrong system for multi-location
                 // academies, creating a duplicate campus and displacing the person.
-                LocationNode parentNode = person.getLocationNode().getParent();
-                if (parentNode != null
-                          && !(parentNode.getLocatable() instanceof Personnel personnel
-                                && personnel.getLocationNode().getParent() instanceof LocationNode node
-                                && node.getLocatable() instanceof Campaign)) {
+                ILocation parentLocation = person.getParentLocation();
+                if (parentLocation != null
+                          && !(parentLocation instanceof Personnel personnel
+                                && personnel.getParentLocation() instanceof Campaign)) {
                     LOGGER.debug("migrateLegacyEducationTravel: skipping {} — already reconnected (stage={})",
                           person.getFullTitle(), stage);
                     continue;
@@ -2005,8 +2005,8 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
             if (!(location instanceof FixedLocation fixedLocation)) {
                 continue;
             }
-            for (LocationNode child : fixedLocation.getLocationNode().getChildren()) {
-                if (child.getLocatable() instanceof AcademyCampusLocation campus
+            for (ILocation child : fixedLocation.getChildLocations()) {
+                if (child instanceof AcademyCampusLocation campus
                           && campus.containsPendingPersonId(person.getId())) {
                     return true;
                 }

--- a/MekHQ/src/mekhq/campaign/location/ILocation.java
+++ b/MekHQ/src/mekhq/campaign/location/ILocation.java
@@ -320,7 +320,44 @@ public interface ILocation {
         return child.setParent(this);
     }
 
-    /** Walks up via {@link LocationNode#getParent()} until reaching the root node. */
+    /**
+     * Returns {@code true} if this location has a parent in the location tree.
+     *
+     * @return {@code true} if this location's node has a parent node
+     */
+    default boolean isParented() {
+        return hasLocationNode() && getLocationNode().getParent() != null;
+    }
+
+    /**
+     * Returns the parent {@link ILocation} in the location tree, or {@code null} if this location has no parent (it is
+     * a root node).
+     *
+     * @return the parent locatable, or {@code null}
+     */
+    @Nullable
+    default ILocation getParentLocation() {
+        if (!isParented()) {
+            return null;
+        }
+        return getLocationNode().getParent().getLocatable();
+    }
+
+    /**
+     * Returns an immutable snapshot of this location's direct children as {@link ILocation} instances.
+     *
+     * @return the set of child locatables; empty if this location has no node or no children
+     */
+    default Set<ILocation> getChildLocations() {
+        if (!hasLocationNode()) {
+            return Set.of();
+        }
+        return getLocationNode().getChildren().stream()
+                     .map(LocationNode::getLocatable)
+                     .collect(Collectors.toUnmodifiableSet());
+    }
+
+    /** Walks up via parent until reaching the root node. */
     private static LocationNode findRoot(LocationNode node) {
         while (node.getParent() != null) {
             node = node.getParent();

--- a/MekHQ/src/mekhq/campaign/location/LocationNode.java
+++ b/MekHQ/src/mekhq/campaign/location/LocationNode.java
@@ -48,6 +48,10 @@ import org.w3c.dom.NodeList;
 
 /**
  * A simple node for forming a tree of {@link ILocation} implementations.
+ * <p>
+ *     Please do not expose the inner workings of {@code LocationNode}. Node logic should only be direcly utilized
+ *     within the {@code location} package.
+ * </p>
  */
 public class LocationNode {
     private static final MMLogger logger = MMLogger.create(LocationNode.class);
@@ -79,7 +83,7 @@ public class LocationNode {
     }
 
     @Nullable
-    public LocationNode getParent() {
+    LocationNode getParent() {
         return parent;
     }
 
@@ -92,7 +96,7 @@ public class LocationNode {
      *
      * @return immutable copy of the node's children in a {@code Set}
      */
-    public Set<LocationNode> getChildren() {
+    Set<LocationNode> getChildren() {
         return Set.copyOf(children);
     }
 
@@ -206,7 +210,7 @@ public class LocationNode {
             }
         }
 
-        public static void setLocation(LocationNode childLocationNode, @Nullable LocationNode parentLocationNode) {
+        private static void setLocation(LocationNode childLocationNode, @Nullable LocationNode parentLocationNode) {
             if ((parentLocationNode != null) && wouldCreateCycle(childLocationNode, parentLocationNode)) {
                 logger.error("Refusing to parent {} under {}: would create a location-tree cycle",
                       childLocationNode.getLocatable(),

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -2770,11 +2770,10 @@ public class Person implements ILocation {
      * @return the campus system ID, or {@code null} if not derivable from either source
      */
     public @Nullable String getEduAcademySystem() {
-        LocationNode node = getLocationNode().getParent();
-        while (node != null) {
-            if (node.getLocatable() instanceof AcademyCampusLocation) {
-                LocationNode campusParent = node.getParent();
-                if (campusParent != null && campusParent.getLocatable() instanceof AbstractLocation location) {
+        for (ILocation cursor = getParentLocation(); cursor != null; cursor = cursor.getParentLocation()) {
+            if (cursor instanceof AcademyCampusLocation) {
+                ILocation campusParent = cursor.getParentLocation();
+                if (campusParent instanceof AbstractLocation location) {
                     PlanetarySystem system = location.getCurrentSystem();
                     if (system != null) {
                         return system.getId();
@@ -2782,7 +2781,6 @@ public class Person implements ILocation {
                 }
                 return legacyEduAcademySystem;
             }
-            node = node.getParent();
         }
         return legacyEduAcademySystem;
     }
@@ -9399,8 +9397,7 @@ public class Person implements ILocation {
 
     @Override
     public boolean setParent(ILocation parent) {
-        LocationNode parentNode = getLocationNode().getParent();
-        ILocation oldParent = parentNode != null ? parentNode.getLocatable() : null;
+        ILocation oldParent = getParentLocation();
         if (ILocation.super.setParent(parent)) {
             if (oldParent instanceof Personnel personnel) {
                 personnel.remove(getId());

--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -77,9 +77,9 @@ import mekhq.campaign.events.persons.PersonChangedEvent;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.enums.TransactionType;
 import mekhq.campaign.location.AcademyCampusLocation;
+import mekhq.campaign.location.ILocation;
 import mekhq.campaign.location.IPlace;
 import mekhq.campaign.location.LocationDispatch;
-import mekhq.campaign.location.LocationNode;
 import mekhq.campaign.log.PerformanceLogger;
 import mekhq.campaign.log.ServiceLogger;
 import mekhq.campaign.personnel.Person;
@@ -806,13 +806,12 @@ public class EducationController {
     }
 
     private static IPlace findHomeLocation(Person person, Campaign campaign) {
-        LocationNode node = person.getLocationNode().getParent();
-        while (node != null) {
-            if (node.getLocatable() instanceof IPlace place
-                      && !(place instanceof AcademyCampusLocation)) {
+        ILocation current = person.getParentLocation();
+        while (current != null) {
+            if (current instanceof IPlace place && !(place instanceof AcademyCampusLocation)) {
                 return place;
             }
-            node = node.getParent();
+            current = current.getParentLocation();
         }
         return campaign;
     }

--- a/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelStatus.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelStatus.java
@@ -44,7 +44,6 @@ import megamek.logging.MMLogger;
 import mekhq.campaign.AbstractLocation;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.location.ILocation;
-import mekhq.campaign.location.LocationNode;
 import mekhq.campaign.personnel.Person;
 import mekhq.utilities.ReportingUtilities;
 
@@ -583,20 +582,16 @@ public enum PersonnelStatus {
         if (person.getStatus().isAbsent()) {
             return false;
         }
-        LocationNode node = person.getLocationNode();
-        if (node == null) {
+        if (!person.hasLocationNode()) {
             return false;
         }
-        LocationNode parent = node.getParent();
-        while (parent != null) {
-            ILocation locatable = parent.getLocatable();
-            if (locatable == campaign) {
+        for (ILocation cursor = person.getParentLocation(); cursor != null; cursor = cursor.getParentLocation()) {
+            if (cursor == campaign) {
                 return false;
             }
-            if (locatable instanceof AbstractLocation) {
+            if (cursor instanceof AbstractLocation) {
                 return true;
             }
-            parent = parent.getParent();
         }
         return false;
     }

--- a/MekHQ/src/mekhq/gui/LocationsTab.java
+++ b/MekHQ/src/mekhq/gui/LocationsTab.java
@@ -55,8 +55,8 @@ import mekhq.campaign.CurrentLocation;
 import mekhq.campaign.base.AbstractBase;
 import mekhq.campaign.base.PlayerBase;
 import mekhq.campaign.events.LocationEvent;
+import mekhq.campaign.location.ILocation;
 import mekhq.campaign.location.IPlace;
-import mekhq.campaign.location.LocationNode;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
@@ -317,8 +317,8 @@ public class LocationsTab extends CampaignGuiTab {
                 return 0;
             }
             int total = 0;
-            for (LocationNode child : place.getLocationNode().getChildren()) {
-                if (child.getLocatable() instanceof CurrentLocation travel && !travel.isOnPlanet()) {
+            for (ILocation child : place.getChildLocations()) {
+                if (child instanceof CurrentLocation travel && !travel.isOnPlanet()) {
                     total += counter.count(travel);
                 }
             }

--- a/MekHQ/src/mekhq/gui/menus/SendToLocationMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/SendToLocationMenu.java
@@ -48,7 +48,6 @@ import javax.swing.JMenuItem;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.base.PlayerBase;
 import mekhq.campaign.location.ILocation;
-import mekhq.campaign.location.LocationNode;
 import mekhq.campaign.universe.Planet;
 import mekhq.campaign.universe.PlanetarySystem;
 import mekhq.gui.baseComponents.JScrollableMenu;
@@ -101,10 +100,7 @@ public class SendToLocationMenu extends JScrollableMenu {
         // match, hiding every base from the menu. Use an identity-keyed set instead.
         Set<ILocation> currentLocations = Collections.newSetFromMap(new IdentityHashMap<>());
         for (ILocation item : items) {
-            LocationNode node = item.getLocationNode();
-            currentLocations.add((node == null || node.getParent() == null)
-                                       ? null
-                                       : node.getParent().getLocatable());
+            currentLocations.add(item.isParented() ? item.getParentLocation() : null);
         }
 
         ILocation sharedCurrent = currentLocations.size() == 1

--- a/MekHQ/src/mekhq/gui/model/LocationDisplay.java
+++ b/MekHQ/src/mekhq/gui/model/LocationDisplay.java
@@ -47,7 +47,6 @@ import mekhq.campaign.base.AbstractBase;
 import mekhq.campaign.base.PlayerBase;
 import mekhq.campaign.location.AcademyCampusLocation;
 import mekhq.campaign.location.ILocation;
-import mekhq.campaign.location.LocationNode;
 import mekhq.campaign.location.LocationUtils;
 import mekhq.campaign.universe.Planet;
 import mekhq.campaign.universe.PlanetarySystem;
@@ -55,7 +54,7 @@ import mekhq.campaign.universe.PlanetarySystem;
 /**
  * Generic display helpers for any {@link ILocation} item (unit, part, person, etc.).
  *
- * <p>All methods walk the item's {@link LocationNode} tree — the same mechanism used by
+ * <p>All methods walk the item's location tree — the same mechanism used by
  * {@code PersonnelTableModelColumn} for persons — so they work correctly for every
  * {@code ILocation} subtype without any per-type special-casing.</p>
  *
@@ -96,14 +95,13 @@ public final class LocationDisplay {
      * </ul>
      */
     public static String getLocationName(ILocation item, Campaign campaign, LocalDate today) {
-        LocationNode node = item.getLocationNode();
-        if (node == null) {
+        if (!item.hasLocationNode()) {
             return campaign.getName();
         }
-        if (isUnderMainForce(node, campaign)) {
+        if (isUnderMainForce(item, campaign)) {
             return campaign.getName();
         }
-        if (node.getNearestAbstractLocation() instanceof CurrentLocation currentLocation
+        if (item.getCurrentLocation() instanceof CurrentLocation currentLocation
                   && currentLocation.getJumpPath() != null && !currentLocation.getJumpPath().isEmpty()) {
             return getTravelStatus(currentLocation, campaign, today);
         }
@@ -112,7 +110,7 @@ public final class LocationDisplay {
         if (base != null) {
             return formatBaseName(base);
         }
-        AcademyCampusLocation campus = findAncestorCampus(node);
+        AcademyCampusLocation campus = findAncestorCampus(item);
         if (campus != null) {
             return campus.getAcademyName();
         }
@@ -153,21 +151,21 @@ public final class LocationDisplay {
               days);
     }
 
-    /** Returns {@code true} when {@code node} or any ancestor is the campaign's main-force roster. */
-    private static boolean isUnderMainForce(LocationNode node, Campaign campaign) {
+    /** Returns {@code true} when {@code item} or any ancestor is the campaign's main-force roster. */
+    private static boolean isUnderMainForce(ILocation item, Campaign campaign) {
         ILocation mainForcePersonnel = campaign.getMainForcePersonnel();
-        for (LocationNode cursor = node; cursor != null; cursor = cursor.getParent()) {
-            if (cursor.getLocatable() == mainForcePersonnel) {
+        for (ILocation cursor = item; cursor != null; cursor = cursor.getParentLocation()) {
+            if (cursor == mainForcePersonnel) {
                 return true;
             }
         }
         return false;
     }
 
-    /** Returns the academy campus that {@code node} sits under, or {@code null} if there is none. */
-    private static @Nullable AcademyCampusLocation findAncestorCampus(LocationNode node) {
-        for (LocationNode cursor = node; cursor != null; cursor = cursor.getParent()) {
-            if (cursor.getLocatable() instanceof AcademyCampusLocation campus) {
+    /** Returns the academy campus that {@code item} sits under, or {@code null} if there is none. */
+    private static @Nullable AcademyCampusLocation findAncestorCampus(ILocation item) {
+        for (ILocation cursor = item; cursor != null; cursor = cursor.getParentLocation()) {
+            if (cursor instanceof AcademyCampusLocation campus) {
                 return campus;
             }
         }
@@ -241,26 +239,22 @@ public final class LocationDisplay {
      */
     private static @Nullable String getDestinationNameFromAncestors(CurrentLocation currentLocation,
           @Nullable PlanetarySystem destination, Campaign campaign) {
-        LocationNode node = currentLocation.getLocationNode();
-        LocationNode parent = node != null ? node.getParent() : null;
-        while (parent != null) {
-            if (parent.getLocatable() instanceof AbstractBase base) {
+        for (ILocation cursor = currentLocation.getParentLocation(); cursor != null; cursor = cursor.getParentLocation()) {
+            if (cursor instanceof AbstractBase base) {
                 return formatBaseName(base);
             }
-            if (parent.getLocatable() instanceof AcademyCampusLocation campus) {
-                return isCampusAtSystem(parent, destination) ? campus.getAcademyName() : campaign.getName();
+            if (cursor instanceof AcademyCampusLocation campus) {
+                return isCampusAtSystem(campus, destination) ? campus.getAcademyName() : campaign.getName();
             }
-            parent = parent.getParent();
         }
         return null;
     }
 
-    /** Returns {@code true} when the campus node's parent is anchored at {@code destination}. */
-    private static boolean isCampusAtSystem(LocationNode campusNode, @Nullable PlanetarySystem destination) {
-        LocationNode fixedNode = campusNode.getParent();
-        return fixedNode != null
-                     && fixedNode.getLocatable() instanceof AbstractLocation campusLocation
-                     && Objects.equals(campusLocation.getCurrentSystem(), destination);
+    /** Returns {@code true} when the campus's parent is anchored at {@code destination}. */
+    private static boolean isCampusAtSystem(AcademyCampusLocation campus, @Nullable PlanetarySystem destination) {
+        ILocation parent = campus.getParentLocation();
+        return parent instanceof AbstractLocation parentLocation
+                     && Objects.equals(parentLocation.getCurrentSystem(), destination);
     }
 
     /** Returns the player base anchored at {@code system}, or {@code null} if there is none. */
@@ -311,7 +305,6 @@ public final class LocationDisplay {
     }
 
     private static AbstractLocation getNearestAbstractLocation(ILocation item) {
-        LocationNode node = item.getLocationNode();
-        return node != null ? node.getNearestAbstractLocation() : null;
+        return item.getCurrentLocation();
     }
 }


### PR DESCRIPTION
This is a refactor with no changes to functionality. 

I made a mistake by directly accessing the `LocationNode` trees from wherever. This makes the methods for getting a `LocationNode`'s `LocationNode` children or parents package-private instead of public. There should be helper methods available to do whatever a contributor needs regarding locations without working directly with the `LocationNode`s tree.