### PR TITLE
Remove deprecated skill check calls

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -1021,7 +1021,7 @@ public class CampaignNewDayManager {
      */
     private void embezzleFunds(Person person) {
         ActionCheckResult actionCheckResult =
-              person.checkSkill(S_ADMIN).resolve(false, getTextAt(RESOURCE_BUNDLE, "embezzle.roll"), true);
+              person.checkSkill(S_ADMIN, campaign).resolve(false, getTextAt(RESOURCE_BUNDLE, "embezzle.roll"), true);
         campaign.addReport(SKILL_CHECKS, actionCheckResult.resultsText());
 
         if (actionCheckResult.isSuccess()) {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -5809,26 +5809,6 @@ public class Person implements ILocation {
     }
 
     /**
-     * Use {@link #checkSkill(String, boolean, boolean, LocalDate)} or {@link #checkSkill(String, Campaign)} instead.
-     *
-     * <p>Prepares a skill check.</p>
-     *
-     * <p>This constructor creates a {@code SkillCheck} instance which calculates the target number for the
-     * skill check based the person's skill level.</p>
-     *
-     * <p><b>Usage:</b> This is a convenience method that excludes reputation and aging effect checks.</p>
-     *
-     * @param skillName the name of the skill being used, corresponding to a {@link SkillType}
-     *
-     * @return prepared skill check
-     */
-    @Deprecated(since = "0.50.07", forRemoval = true)
-    public SkillCheck checkSkill(String skillName) {
-        return new SkillCheck(this, skillName);
-    }
-
-
-    /**
      * Prepares a skill check based on individually passed options.
      *
      * <p>This method creates a {@code SkillCheck} instance which calculates the target number

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateHealing.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateHealing.java
@@ -189,11 +189,11 @@ public class AdvancedMedicalAlternateHealing {
     private static void performUnassistedHealingCheck(Campaign campaign, Person patient,
           List<TargetRollModifier> modifiers, Set<BodyLocation> prostheticPenalties) {
 
-        PersonnelOptions personnelOptions = patient.getOptions();
-        boolean hasTraumaSurgeon = personnelOptions.booleanOption(UNOFFICIAL_TRAUMA_SURGEON);
-        boolean hasProthesisTechnician = personnelOptions.booleanOption(UNOFFICIAL_PROTHESIS_TECHNICIAN);
-        boolean hasPathologicInsight = personnelOptions.booleanOption(UNOFFICIAL_PATHOLOGIC_INSIGHT);
-        boolean hasHypochondriac = personnelOptions.booleanOption(UNOFFICIAL_HYPOCHONDRIAC);
+        PersonnelOptions patientOptions = patient.getOptions();
+        boolean hasTraumaSurgeon = patientOptions.booleanOption(UNOFFICIAL_TRAUMA_SURGEON);
+        boolean hasProthesisTechnician = patientOptions.booleanOption(UNOFFICIAL_PROTHESIS_TECHNICIAN);
+        boolean hasPathologicInsight = patientOptions.booleanOption(UNOFFICIAL_PATHOLOGIC_INSIGHT);
+        boolean hasHypochondriac = patientOptions.booleanOption(UNOFFICIAL_HYPOCHONDRIAC);
 
         // We need a defensive copy of the list as we're going to be removing injuries from it when successfully healing
         for (Injury injury : new ArrayList<>(patient.getInjuries())) {
@@ -212,7 +212,7 @@ public class AdvancedMedicalAlternateHealing {
                 miscPenalty += hasHypochondriac ? 1 : 0;
 
                 boolean useEdge = campaign.getCampaignOptions().isUseSupportEdge();
-                useEdge = useEdge && patient.getOptions().booleanOption(EDGE_MEDICAL);
+                useEdge = useEdge && patientOptions.booleanOption(EDGE_MEDICAL);
                 int marginOfSuccess = getMarginOfSuccessForUnassistedHealing(patient, modifiers, miscPenalty, useEdge);
 
                 LocalDate today = campaign.getLocalDate();
@@ -348,14 +348,14 @@ public class AdvancedMedicalAlternateHealing {
     private static void performAssistedHealingCheck(Campaign campaign, Person patient, Person doctor,
           List<TargetRollModifier> modifiers, Set<BodyLocation> prostheticPenalties) {
 
-        PersonnelOptions doctorPersonnelOptions = doctor.getOptions();
-        boolean hasHolisticCareSPA = doctorPersonnelOptions.booleanOption(UNOFFICIAL_HOLISTIC_CARE);
-        boolean hasTraumaSurgeon = doctorPersonnelOptions.booleanOption(UNOFFICIAL_TRAUMA_SURGEON);
-        boolean hasProthesisTechnician = doctorPersonnelOptions.booleanOption(UNOFFICIAL_PROTHESIS_TECHNICIAN);
-        boolean hasPathologicInsight = doctorPersonnelOptions.booleanOption(UNOFFICIAL_PATHOLOGIC_INSIGHT);
+        PersonnelOptions doctorOptions = doctor.getOptions();
+        boolean hasHolisticCareSPA = doctorOptions.booleanOption(UNOFFICIAL_HOLISTIC_CARE);
+        boolean hasTraumaSurgeon = doctorOptions.booleanOption(UNOFFICIAL_TRAUMA_SURGEON);
+        boolean hasProthesisTechnician = doctorOptions.booleanOption(UNOFFICIAL_PROTHESIS_TECHNICIAN);
+        boolean hasPathologicInsight = doctorOptions.booleanOption(UNOFFICIAL_PATHOLOGIC_INSIGHT);
 
-        PersonnelOptions patientPersonnelOptions = patient.getOptions();
-        boolean hasHypochondriac = patientPersonnelOptions.booleanOption(UNOFFICIAL_HYPOCHONDRIAC);
+        PersonnelOptions patientOptions = patient.getOptions();
+        boolean hasHypochondriac = patientOptions.booleanOption(UNOFFICIAL_HYPOCHONDRIAC);
 
         // We need a defensive copy of the list as we're going to be removing injuries from it when successfully healing
         for (Injury injury : new ArrayList<>(patient.getInjuries())) {
@@ -374,7 +374,7 @@ public class AdvancedMedicalAlternateHealing {
                     miscPenalty += hasHypochondriac ? 1 : 0;
 
                     boolean useEdge = campaign.getCampaignOptions().isUseSupportEdge();
-                    useEdge = useEdge && doctor.getOptions().booleanOption(EDGE_MEDICAL);
+                    useEdge = useEdge && doctorOptions.booleanOption(EDGE_MEDICAL);
                     int marginOfSuccess = getMarginOfSuccessForAssistedHealing(
                           doctor, campaign, modifiers, miscPenalty, useEdge);
 

--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillCheck.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillCheck.java
@@ -64,15 +64,6 @@ public class SkillCheck extends ActionCheck<SkillCheck> {
     }
 
     /**
-     * Please see {@link Person#checkSkill(String)} and use it instead.
-     */
-    @Deprecated(since = "0.50.07", forRemoval = true)
-    public SkillCheck(Person person, String skillName) {
-        super(person, SkillCheckUtility.determineTargetNumber(person, SkillType.getType(skillName)));
-        this.skillType = SkillType.getType(skillName);
-    }
-
-    /**
      * Please see {@link Person#checkSkill(String, boolean, boolean, LocalDate)} and use it instead.
      */
     public SkillCheck(Person person, String skillName,

--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillCheckUtility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillCheckUtility.java
@@ -77,20 +77,6 @@ public class SkillCheckUtility {
     protected static final int UNTRAINED_SKILL_MODIFIER = 4; // ATOW pg 43
 
     /**
-     * Use {@link #determineTargetNumber(Person, SkillType, boolean, boolean, LocalDate)} instead.
-     *
-     * <p>Determines the target number for a skill check ignoring aging effects and clan campaign status.</p>
-     *
-     * @param person    the {@link Person} performing the skill check
-     * @param skillType the associated {@link SkillType} being checked
-     * @return the {@link TargetRoll} for the skill check
-     */
-    @Deprecated(since = "0.50.07", forRemoval = true)
-    static TargetRoll determineTargetNumber(Person person, SkillType skillType) {
-        return determineTargetNumber(person, skillType, false, false, LocalDate.of(3151, 1, 1));
-    }
-
-    /**
      * Determines the target number for a skill check based on the person's attributes, skill type, and whether they are
      * trained in the skill.
      *

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -2122,7 +2122,7 @@ public class StratConRulesManager {
         campaign.addReport(BATTLE, reportStatus.toString());
 
         ActionCheckResult actionCheckResult =
-              commander.checkSkill(S_TACTICS)
+              commander.checkSkill(S_TACTICS, campaign)
                     .resolve(true, getTextAt(RESOURCE_BUNDLE, "StratConRulesManager.tacticsSkillCheck"), false);
 
         if (actionCheckResult.isSuccess()) {

--- a/MekHQ/src/mekhq/gui/dialog/AdvancedReplacementLimbDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AdvancedReplacementLimbDialog.java
@@ -1028,7 +1028,7 @@ public class AdvancedReplacementLimbDialog extends JDialog {
         for (PlannedSurgery surgery : new ArrayList<>(prioritizedSurgeries)) {
             int spaModifier = surgery.type != COSMETIC_SURGERY && hasMachinistSPA ? -2 : 0;
             ActionCheckResult actionCheckResult =
-                  surgeon.checkSkill(S_SURGERY)
+                  surgeon.checkSkill(S_SURGERY, campaign)
                         .withMiscModifier(spaModifier)
                         .resolve(isUseEdge, getTextAt(RESOURCE_BUNDLE,
                               "AdvancedReplacementLimbDialog.skillCheck"), false);

--- a/MekHQ/unittests/mekhq/campaign/personnel/PersonTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/PersonTest.java
@@ -1925,15 +1925,6 @@ public class PersonTest {
             }
 
             @Test
-            @SuppressWarnings("deprecation")
-            void testCheckSkill_Deprecated() {
-                Person person = new Person("GivenName", "Surname", null, "Faction");
-                person.addSkill(SkillType.S_GUN_MEK, 4, 0);
-                SkillCheck check = person.checkSkill(SkillType.S_GUN_MEK);
-                assertEquals(3, check.getTargetNumber().getValue());
-            }
-
-            @Test
             void testCheckSkill_WithExplicitModifiers() {
                 Person person = new Person("GivenName", "Surname", null, "Faction");
                 person.addSkill(SkillType.S_GUN_MEK, 4, 0);

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/SkillCheckTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/SkillCheckTest.java
@@ -104,22 +104,6 @@ class SkillCheckTest {
         assertEquals(4, check.getTargetNumber().getValue()); // == 10 - 4 - 2 (aging effect)
     }
 
-    @Test
-    void testDeprecatedConstructor_CalculatesTargetNumber() {
-        Person person = mock(Person.class);
-        when(person.hasSkill(eq(SkillType.S_TACTICS))).thenReturn(true);
-        when(person.getSkill(eq(SkillType.S_TACTICS)))
-              .thenReturn(new Skill(SkillType.getType(SkillType.S_TACTICS), 4, 0));
-        when(person.getSkillModifierData(anyBoolean(), anyBoolean(), any())).thenReturn(mock(SkillModifierData.class));
-        @SuppressWarnings("deprecation")
-        SkillCheck check = new SkillCheck(person, SkillType.S_TACTICS);
-
-        assertEquals(5, check.getTargetNumber().getValue()); // == 9 - 4
-        assertEquals(SkillType.S_TACTICS, check.getActionName());
-        assertFalse(check.isCountUp());
-        assertFalse(check.hasNaturalAptitude());
-    }
-
     @ParameterizedTest
     @CsvSource({ "true", "false" })
     void testHasNaturalAptitude(boolean hasNaturalAptitude) {

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/SkillCheckUtilityTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/SkillCheckUtilityTest.java
@@ -40,14 +40,10 @@ import static mekhq.campaign.personnel.skills.SkillCheckUtility.UNTRAINED_TARGET
 import static mekhq.campaign.personnel.skills.SkillCheckUtility.UNTRAINED_TARGET_NUMBER_TWO_LINKED_ATTRIBUTES;
 import static mekhq.campaign.personnel.skills.SkillCheckUtility.determineTargetNumber;
 import static mekhq.campaign.personnel.skills.SkillCheckUtility.getTotalAttributeScoreForSkill;
-import static mekhq.campaign.personnel.skills.SkillType.S_GUN_MEK;
-import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.DISASTROUS;
 import static mekhq.campaign.personnel.skills.enums.SkillAttribute.DEXTERITY;
 import static mekhq.campaign.personnel.skills.enums.SkillAttribute.NONE;
 import static mekhq.campaign.personnel.skills.enums.SkillAttribute.REFLEXES;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;


### PR DESCRIPTION
As a side effect it makes assisted healing, embezzlement, and surgery checks respect aging effects and other campaign settings affecting skill checks.

Additionally, do minor renaming in `AdvancedMedicalAlternateHealing`.