### PR TITLE
Link event bus subscriptions to UI lifecycle

### DIFF
--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -99,7 +99,6 @@ import megamek.common.planetaryConditions.PlanetaryConditions;
 import megamek.logging.MMLogger;
 import megamek.server.Server;
 import megamek.server.totalWarfare.TWGameManager;
-import megameklab.MMLConstants;
 import megameklab.MegaMekLab;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignController;
@@ -264,12 +263,7 @@ public class MekHQ implements GameListener {
      * restart back to the splash screen
      */
     public void restart() {
-
-        // Actually close MHQ
-        if (campaignGUI != null) {
-            campaignGUI.getFrame().dispose();
-        }
-
+        disposeGUI();
         new StartupScreenPanel(this).getFrame().setVisible(true);
     }
 
@@ -926,6 +920,18 @@ public class MekHQ implements GameListener {
 
     public static void unregisterHandler(Object handler) {
         EVENT_BUS.unregister(handler);
+    }
+
+    /**
+     * Disposes all CampaignGUI components. Since event bus registration is linked to UI lifecycle,
+     * it also unregisters them from the event bus. Logs remaining event bus listeners.
+     */
+    public void disposeGUI() {
+        if (campaignGUI != null) {
+            campaignGUI.getFrame().dispose();
+            campaignGUI = null;
+            EVENT_BUS.logActiveSubscribers();
+        }
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
@@ -115,7 +115,6 @@ public class RandomFactionGenerator {
         borderTracker.setRegionCenter(location.getX(), location.getY());
         borderTracker.setRegionRadius(c.getCampaignOptions().getContractSearchRadius());
         MekHQ.registerHandler(borderTracker);
-        MekHQ.registerHandler(this);
         for (final Faction faction : Factions.getInstance().getFactions()) {
             if (faction.isDeepPeriphery()) {
                 borderTracker.setBorderSize(faction, MHQConstants.FACTION_GENERATOR_BORDER_RANGE_DEEP_PERIPHERY);
@@ -133,7 +132,6 @@ public class RandomFactionGenerator {
 
     public void dispose() {
         MekHQ.unregisterHandler(borderTracker);
-        MekHQ.unregisterHandler(this);
     }
 
     private LocalDate getCurrentDate() {

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -209,7 +209,6 @@ public class CampaignGUI extends JPanel {
         this.app = app;
         reportHLL = new ReportHyperlinkListener(this);
         initComponents();
-        MekHQ.registerHandler(this);
         setUserPreferences();
 
         commandCenterTab = new CommandCenterTab(this, MHQTabType.COMMAND_CENTER.toString());
@@ -241,6 +240,18 @@ public class CampaignGUI extends JPanel {
         activateTab(financesTab);
     }
     // endregion Constructors
+
+    @Override
+    public void addNotify() {
+        super.addNotify();
+        MekHQ.registerHandler(this);
+    }
+
+    @Override
+    public void removeNotify() {
+        MekHQ.unregisterHandler(this);
+        super.removeNotify();
+    }
 
     // region Getters/Setters
     public JFrame getFrame() {
@@ -663,10 +674,7 @@ public class CampaignGUI extends JPanel {
                     .orElse(tabMain.getTabCount());
         tabMain.insertTab(tab.getTabName(), null, tab, null, index);
         tabMain.setMnemonicAt(index, tab.tabType().getMnemonic());
-        SwingUtilities.invokeLater(() -> {
-            tab.refreshAll();
-            tab.activateTab();
-        });
+        SwingUtilities.invokeLater(tab::refreshAll);
     }
 
     /**
@@ -675,7 +683,6 @@ public class CampaignGUI extends JPanel {
      * @param tab The tab to deactivate
      */
     private void deactivateTab(CampaignGuiTab tab) {
-        tab.deactivateTab();
         tabMain.remove(tab);
     }
 

--- a/MekHQ/src/mekhq/gui/CampaignGuiTab.java
+++ b/MekHQ/src/mekhq/gui/CampaignGuiTab.java
@@ -58,6 +58,18 @@ public abstract class CampaignGuiTab extends JPanel {
         initTab();
     }
 
+    @Override
+    public void addNotify() {
+        super.addNotify();
+        MekHQ.registerHandler(this);
+    }
+
+    @Override
+    public void removeNotify() {
+        MekHQ.unregisterHandler(this);
+        super.removeNotify();
+    }
+
     public CampaignGUI getCampaignGui() {
         return gui;
     }
@@ -88,17 +100,4 @@ public abstract class CampaignGuiTab extends JPanel {
     abstract public void refreshAll();
 
     abstract public MHQTabType tabType();
-
-    /**
-     * Called when tab is activated.
-     */
-    public void activateTab() {
-        MekHQ.registerHandler(this);
-    }
-    /**
-     * Called when tab is deactivated.
-     */
-    public void deactivateTab() {
-        MekHQ.unregisterHandler(this);
-    }
 }

--- a/MekHQ/src/mekhq/gui/HangarTab.java
+++ b/MekHQ/src/mekhq/gui/HangarTab.java
@@ -141,6 +141,18 @@ public final class HangarTab extends CampaignGuiTab {
     // endregion Constructors
 
     @Override
+    public void addNotify() {
+        super.addNotify();
+        GUIPreferences.getInstance().addPreferenceChangeListener(scalingChangeListener);
+    }
+
+    @Override
+    public void removeNotify() {
+        GUIPreferences.getInstance().removePreferenceChangeListener(scalingChangeListener);
+        super.removeNotify();
+    }
+
+    @Override
     public MHQTabType tabType() {
         return MHQTabType.HANGAR;
     }
@@ -678,18 +690,6 @@ public final class HangarTab extends CampaignGuiTab {
             columnModel.setColumnVisible(columnModel.getColumnByModelIndex(UnitTableModel.COL_DESTINATION_PLANET),
                   true);
         }
-    }
-
-    @Override
-    public void activateTab() {
-        super.activateTab();
-        GUIPreferences.getInstance().addPreferenceChangeListener(scalingChangeListener);
-    }
-
-    @Override
-    public void deactivateTab() {
-        super.deactivateTab();
-        GUIPreferences.getInstance().removePreferenceChangeListener(scalingChangeListener);
     }
 
     public void focusOnUnit(UUID id) {

--- a/MekHQ/src/mekhq/gui/NavigationTab.java
+++ b/MekHQ/src/mekhq/gui/NavigationTab.java
@@ -104,17 +104,4 @@ public class NavigationTab extends CampaignGuiTab {
         locationsTab.refreshAll();
     }
 
-    @Override
-    public void activateTab() {
-        super.activateTab();
-        mapTab.activateTab();
-        locationsTab.activateTab();
-    }
-
-    @Override
-    public void deactivateTab() {
-        mapTab.deactivateTab();
-        locationsTab.deactivateTab();
-        super.deactivateTab();
-    }
 }

--- a/MekHQ/src/mekhq/gui/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/PersonnelTab.java
@@ -124,6 +124,18 @@ public final class PersonnelTab extends CampaignGuiTab {
     // endregion Constructors
 
     @Override
+    public void addNotify() {
+        super.addNotify();
+        GUIPreferences.getInstance().addPreferenceChangeListener(scalingChangeListener);
+    }
+
+    @Override
+    public void removeNotify() {
+        GUIPreferences.getInstance().removePreferenceChangeListener(scalingChangeListener);
+        super.removeNotify();
+    }
+
+    @Override
     public MHQTabType tabType() {
         return MHQTabType.PERSONNEL;
     }
@@ -357,18 +369,6 @@ public final class PersonnelTab extends CampaignGuiTab {
         PersonnelTableMouseAdapter.connect(getCampaignGui(), personnelTable, personModel, splitPersonnel);
 
         filterPersonnel();
-    }
-
-    @Override
-    public void activateTab() {
-        super.activateTab();
-        GUIPreferences.getInstance().addPreferenceChangeListener(scalingChangeListener);
-    }
-
-    @Override
-    public void deactivateTab() {
-        super.deactivateTab();
-        GUIPreferences.getInstance().removePreferenceChangeListener(scalingChangeListener);
     }
 
     private DefaultComboBoxModel<PersonnelFilter> createPersonGroupModel() {

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -182,7 +182,7 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
 
     @Override
     protected Container createCenterPane() {
-        setSplash(UIUtil.createSplashComponent(getApplication().getIconPackage().getLoadingScreenImages(), getFrame()));
+        setSplash(UIUtil.createSplashComponent(getApplication().getIconPackage().getLoadingScreenImages(), this));
         return getSplash();
     }
 
@@ -201,7 +201,7 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
         setSize(getSplash().getPreferredSize());
         pack();
         fitAndCenter();
-        getFrame().setVisible(true);
+        setVisible(true);
     }
     // endregion Initialization
 
@@ -607,12 +607,16 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
                 campaign = null;
             }
 
-            setVisible(false);
+            // should be moved to callbacks to let callers handle the result
             if (campaign != null) {
+                if (getApplication().getCampaignController() == null) {
+                    getFrame().dispose();
+                } else {
+                    getApplication().disposeGUI();
+                }
                 getApplication().setCampaign(campaign);
                 getApplication().getCampaignController().setHost(campaign.getId());
                 getApplication().showNewView();
-                getFrame().dispose();
                 if (null != storyArcStub) {
                     StoryArc storyArc = storyArcStub.loadStoryArc(campaign);
                     if (null != storyArc) {
@@ -620,7 +624,9 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
                     }
                 }
             } else {
+                setVisible(false);
                 cancel(true);
+                // return back to CampaignGUI or StartupScreen
                 getFrame().setVisible(true);
             }
         }

--- a/MekHQ/src/mekhq/gui/menus/MekHQMenuBar.java
+++ b/MekHQ/src/mekhq/gui/menus/MekHQMenuBar.java
@@ -34,7 +34,6 @@
 
 package mekhq.gui.menus;
 
-import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
@@ -109,7 +108,6 @@ import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Systems;
 import mekhq.gui.CampaignGUI;
-import mekhq.gui.CampaignGuiTab;
 import mekhq.gui.FileDialogs;
 import mekhq.gui.campaignOptions.CampaignOptionsDialog;
 import mekhq.gui.dialog.*;
@@ -167,8 +165,18 @@ public class MekHQMenuBar extends JMenuBar {
         add(initViewMenu());
         add(initManageCampaignMenu());
         add(initHelpMenu());
+    }
 
+    @Override
+    public void addNotify() {
+        super.addNotify();
         MekHQ.registerHandler(this);
+    }
+
+    @Override
+    public void removeNotify() {
+        MekHQ.unregisterHandler(this);
+        super.removeNotify();
     }
 
     private MekHQ getApplication() {
@@ -205,19 +213,12 @@ public class MekHQMenuBar extends JMenuBar {
             if (file == null) {
                 return;
             }
-            new DataLoadingDialog(getFrame(), getApplication(), file).setVisible(true);
-            // Unregister event handlers for CampaignGUI and tabs
-            for (int i = 0; i < getTabMain().getTabCount(); i++) {
-                if (getTabMain().getComponentAt(i) instanceof CampaignGuiTab) {
-                    ((CampaignGuiTab) getTabMain().getComponentAt(i)).deactivateTab();
-                }
-            }
-            MekHQ.unregisterHandler(this);
-            MekHQ.unregisterHandler(getGui());
-            // check for a loaded story arc and unregister that handler as well
+            getFrame().setVisible(false); // hide CampaignGUI
             if (null != getCampaign().getStoryArc()) {
                 MekHQ.unregisterHandler(getCampaign().getStoryArc());
             }
+            // load the campaign
+            new DataLoadingDialog(getFrame(), getApplication(), file).setVisible(true);
         });
         menuLoad.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_L, InputEvent.CTRL_DOWN_MASK));
         menuFile.add(menuLoad);
@@ -813,24 +814,11 @@ public class MekHQMenuBar extends JMenuBar {
                   (savePrompt == JOptionPane.YES_OPTION && !getGui().saveCampaign(null))) {
             return;
         }
-
-        // Unregister handlers for campaign tabs
-        for (int i = 0; i < getTabMain().getTabCount(); i++) {
-            Component tab = getTabMain().getComponentAt(i);
-            if (tab instanceof CampaignGuiTab) {
-                ((CampaignGuiTab) tab).deactivateTab();
-            }
-        }
-
-        // Unregister other handlers
-        MekHQ.unregisterHandler(this);
-        MekHQ.unregisterHandler(getGui());
-
-        if (getCampaign().getStoryArc() != null) {
+        getFrame().setVisible(false); // hide CampaignGUI
+        if (null != getCampaign().getStoryArc()) {
             MekHQ.unregisterHandler(getCampaign().getStoryArc());
         }
-
-        // Start a new campaign
+        // start a new campaign
         new DataLoadingDialog(getFrame(), getApplication(), null, null, true).setVisible(true);
     }
 

--- a/MekHQ/src/mekhq/gui/menus/TemporaryPersonnelManagementMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/TemporaryPersonnelManagementMenu.java
@@ -203,8 +203,18 @@ public class TemporaryPersonnelManagementMenu extends JMenu {
               "miHireVesselCrew.text", "popupHireVesselCrewNum.text",
               "miFireVesselCrew.text", "popupFireVesselCrewNum.text",
               "miFullStrengthVesselCrew.text", "miFireAllVesselCrew.text");
+    }
 
+    @Override
+    public void addNotify() {
+        super.addNotify();
         MekHQ.registerHandler(this);
+    }
+
+    @Override
+    public void removeNotify() {
+        MekHQ.unregisterHandler(this);
+        super.removeNotify();
     }
 
     public Campaign getCampaign() {

--- a/MekHQ/src/mekhq/gui/panels/StartupScreenPanel.java
+++ b/MekHQ/src/mekhq/gui/panels/StartupScreenPanel.java
@@ -322,6 +322,7 @@ public class StartupScreenPanel extends AbstractMHQPanel {
     }
 
     private void startCampaign(final @Nullable File file, @Nullable StoryArcStub storyArcStub) {
+        getFrame().setVisible(false); // hide StartupScreen
         new DataLoadingDialog(getFrame(), app, file, storyArcStub, false).setVisible(true);
     }
 

--- a/MekHQ/src/mekhq/gui/view/AdvanceTimePanel.java
+++ b/MekHQ/src/mekhq/gui/view/AdvanceTimePanel.java
@@ -136,7 +136,18 @@ public class AdvanceTimePanel extends ScalingWidthConstrainedPanel {
         add(btnAdvanceNDays);
 
         refresh(date);
+    }
+
+    @Override
+    public void addNotify() {
+        super.addNotify();
         MekHQ.registerHandler(this);
+    }
+
+    @Override
+    public void removeNotify() {
+        MekHQ.unregisterHandler(this);
+        super.removeNotify();
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/view/CommandSummaryPanel.java
+++ b/MekHQ/src/mekhq/gui/view/CommandSummaryPanel.java
@@ -119,7 +119,18 @@ public class CommandSummaryPanel extends ScalingWidthConstrainedPanel {
         add(lblCombatStrengthValue, gridBagConstraints);
 
         refreshAll();
+    }
+
+    @Override
+    public void addNotify() {
+        super.addNotify();
         MekHQ.registerHandler(this);
+    }
+
+    @Override
+    public void removeNotify() {
+        MekHQ.unregisterHandler(this);
+        super.removeNotify();
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/view/CurrentLocationPanel.java
+++ b/MekHQ/src/mekhq/gui/view/CurrentLocationPanel.java
@@ -153,7 +153,18 @@ public class CurrentLocationPanel extends ScalingWidthConstrainedPanel {
         add(btnRecruitment, gridBagConstraints);
 
         refresh();
+    }
+
+    @Override
+    public void addNotify() {
+        super.addNotify();
         MekHQ.registerHandler(this);
+    }
+
+    @Override
+    public void removeNotify() {
+        MekHQ.unregisterHandler(this);
+        super.removeNotify();
     }
 
     /**


### PR DESCRIPTION
Existing UI component subscription logic is completely manual. It compilcates the implementation and leads to memory leaks over time.

This change addresses the issue by following:
- Link UI component event bus registration and unregistration to Swing component lifecycle
- Introduce `disposeGUI` in `MekHQ` to centralize UI disposal and log active event bus subscribers
- Remove event bus registration and unregistration from `RandomFactionGenerator` since it has no event handlers
- Remove manual subscription management for UI components during campaign loading and creation
- Hide irrelevant frames during campaign loading and creation

As the result, it fixes all existing memory leaks related to UI component subscriptions.