### PR TITLE
Refactor campaign loading and lifecycle management

### DIFF
--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -263,7 +263,7 @@ public class MekHQ implements GameListener {
      * restart back to the splash screen
      */
     public void restart() {
-        disposeGUI();
+        deactivateCampaign();
         new StartupScreenPanel(this).getFrame().setVisible(true);
     }
 
@@ -346,8 +346,37 @@ public class MekHQ implements GameListener {
         System.exit(0);
     }
 
-    public void showNewView() {
+    /**
+     * Activates a campaign. Ensures that previously active campaign is disposed, then creates new
+     * {@link CampaignController} and {@link CampaignGUI} and initializes wiring between all of them.
+     *
+     * @param campaign the {@link Campaign} to be activated
+     */
+    public void activateCampaign(Campaign campaign) {
+        deactivateCampaign();
+        campaign.setApp(this);
+        campaignController = new CampaignController(campaign);
+        campaignController.setHost(campaign.getId());
         campaignGUI = new CampaignGUI(this);
+    }
+
+    /**
+     * Disposes all CampaignGUI components and deactivates the current campaign. Since event bus registration is
+     * linked to UI lifecycle, it also unregisters them from the event bus. Manually unsubscribes non-UI components.
+     * Logs remaining event bus listeners for debug purposes.
+     */
+    private void deactivateCampaign() {
+        if (campaignGUI != null) {
+            campaignGUI.getFrame().dispose();
+            campaignGUI = null;
+        }
+        if (campaignController != null) {
+            if (getCampaign() != null && getCampaign().getStoryArc() != null) {
+                MekHQ.unregisterHandler(getCampaign().getStoryArc());
+            }
+            campaignController = null;
+        }
+        EVENT_BUS.logActiveSubscribers();
     }
 
     /**
@@ -417,10 +446,6 @@ public class MekHQ implements GameListener {
 
     public Campaign getCampaign() {
         return campaignController.getLocalCampaign();
-    }
-
-    public void setCampaign(Campaign c) {
-        campaignController = new CampaignController(c);
     }
 
     public CampaignController getCampaignController() {
@@ -920,18 +945,6 @@ public class MekHQ implements GameListener {
 
     public static void unregisterHandler(Object handler) {
         EVENT_BUS.unregister(handler);
-    }
-
-    /**
-     * Disposes all CampaignGUI components. Since event bus registration is linked to UI lifecycle,
-     * it also unregisters them from the event bus. Logs remaining event bus listeners.
-     */
-    public void disposeGUI() {
-        if (campaignGUI != null) {
-            campaignGUI.getFrame().dispose();
-            campaignGUI = null;
-            EVENT_BUS.logActiveSubscribers();
-        }
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
@@ -90,8 +91,6 @@ import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.medical.advancedMedical.InjuryTypes;
 import mekhq.campaign.personnel.ranks.Ranks;
 import mekhq.campaign.personnel.skills.SkillType;
-import mekhq.campaign.storyArc.StoryArc;
-import mekhq.campaign.storyArc.StoryArcStub;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.Planet;
@@ -114,25 +113,26 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
     private final Task task;
     private RawImagePanel splash;
     private JProgressBar progressBar;
-    private final StoryArcStub storyArcStub;
     private final boolean isInAppNewCampaign;
+    private final Consumer<Campaign> completionHandler;
 
     private final LocalDate DEFAULT_START_DATE = LocalDate.of(3051, 1, 1);
 
     // endregion Variable Declarations
 
     // region Constructors
-    public DataLoadingDialog(final JFrame frame, final MekHQ application, final @Nullable File campaignFile) {
-        this(frame, application, campaignFile, null, false);
+    public DataLoadingDialog(final JFrame frame, final MekHQ application, final @Nullable File campaignFile,
+          Consumer<Campaign> completionHandler) {
+        this(frame, application, campaignFile, false, completionHandler);
     }
 
     public DataLoadingDialog(final JFrame frame, final MekHQ application, final @Nullable File campaignFile,
-          StoryArcStub stub, final boolean isInAppNewCampaign) {
+          final boolean isInAppNewCampaign, Consumer<Campaign> completionHandler) {
         super(frame, "DataLoadingDialog", "DataLoadingDialog.title");
         this.application = application;
         this.campaignFile = campaignFile;
-        this.storyArcStub = stub;
         this.isInAppNewCampaign = isInAppNewCampaign;
+        this.completionHandler = completionHandler;
         this.task = new Task(this);
         getTask().addPropertyChangeListener(this);
         initialize();
@@ -485,7 +485,6 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
             // Generic event processor
             campaign.setCampaignEventProcessor(new CampaignEventProcessor(campaign));
 
-            campaign.setApp(getApplication());
             return campaign;
         }
 
@@ -574,11 +573,12 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
          */
         @Override
         public void done() {
-            Campaign campaign;
+            setVisible(false);
             try {
-                campaign = get();
+                Campaign campaign = get();
+                completionHandler.accept(campaign);
             } catch (InterruptedException | CancellationException ignored) {
-                campaign = null;
+                completionHandler.accept(null);
             } catch (ExecutionException ex) {
                 LOGGER.error("", ex);
                 if (ex.getCause() instanceof NullEntityException) {
@@ -604,30 +604,7 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
                           resources.getString("DataLoadingDialog.ExecutionException.title"),
                           JOptionPane.ERROR_MESSAGE);
                 }
-                campaign = null;
-            }
-
-            // should be moved to callbacks to let callers handle the result
-            if (campaign != null) {
-                if (getApplication().getCampaignController() == null) {
-                    getFrame().dispose();
-                } else {
-                    getApplication().disposeGUI();
-                }
-                getApplication().setCampaign(campaign);
-                getApplication().getCampaignController().setHost(campaign.getId());
-                getApplication().showNewView();
-                if (null != storyArcStub) {
-                    StoryArc storyArc = storyArcStub.loadStoryArc(campaign);
-                    if (null != storyArc) {
-                        campaign.useStoryArc(storyArc, true);
-                    }
-                }
-            } else {
-                setVisible(false);
-                cancel(true);
-                // return back to CampaignGUI or StartupScreen
-                getFrame().setVisible(true);
+                completionHandler.accept(null);
             }
         }
     }

--- a/MekHQ/src/mekhq/gui/menus/MekHQMenuBar.java
+++ b/MekHQ/src/mekhq/gui/menus/MekHQMenuBar.java
@@ -214,11 +214,14 @@ public class MekHQMenuBar extends JMenuBar {
                 return;
             }
             getFrame().setVisible(false); // hide CampaignGUI
-            if (null != getCampaign().getStoryArc()) {
-                MekHQ.unregisterHandler(getCampaign().getStoryArc());
-            }
             // load the campaign
-            new DataLoadingDialog(getFrame(), getApplication(), file).setVisible(true);
+            new DataLoadingDialog(getFrame(), getApplication(), file, campaign -> {
+                if (campaign != null) {
+                    getApplication().activateCampaign(campaign);
+                } else {
+                    getFrame().setVisible(true); // return back to CampaignGUI if loading fails
+                }
+            }).setVisible(true);
         });
         menuLoad.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_L, InputEvent.CTRL_DOWN_MASK));
         menuFile.add(menuLoad);
@@ -815,11 +818,14 @@ public class MekHQMenuBar extends JMenuBar {
             return;
         }
         getFrame().setVisible(false); // hide CampaignGUI
-        if (null != getCampaign().getStoryArc()) {
-            MekHQ.unregisterHandler(getCampaign().getStoryArc());
-        }
         // start a new campaign
-        new DataLoadingDialog(getFrame(), getApplication(), null, null, true).setVisible(true);
+        new DataLoadingDialog(getFrame(), getApplication(), null, true, campaign -> {
+            if (campaign != null) {
+                getApplication().activateCampaign(campaign);
+            } else {
+                getFrame().setVisible(true); // return back to CampaignGUI if creation fails
+            }
+        }).setVisible(true);
     }
 
 

--- a/MekHQ/src/mekhq/gui/panels/StartupScreenPanel.java
+++ b/MekHQ/src/mekhq/gui/panels/StartupScreenPanel.java
@@ -67,6 +67,7 @@ import megamek.logging.MMLogger;
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.Utilities;
+import mekhq.campaign.storyArc.StoryArc;
 import mekhq.campaign.storyArc.StoryArcStub;
 import mekhq.gui.FileDialogs;
 import mekhq.gui.baseComponents.AbstractMHQPanel;
@@ -323,7 +324,20 @@ public class StartupScreenPanel extends AbstractMHQPanel {
 
     private void startCampaign(final @Nullable File file, @Nullable StoryArcStub storyArcStub) {
         getFrame().setVisible(false); // hide StartupScreen
-        new DataLoadingDialog(getFrame(), app, file, storyArcStub, false).setVisible(true);
+        new DataLoadingDialog(getFrame(), app, file, false, campaign -> {
+            if (campaign != null) {
+                app.activateCampaign(campaign);
+                if (storyArcStub != null) {
+                    StoryArc storyArc = storyArcStub.loadStoryArc(campaign);
+                    if (storyArc != null) {
+                        campaign.useStoryArc(storyArc, true);
+                    }
+                }
+                getFrame().dispose();
+            } else {
+                getFrame().setVisible(true); // return back to StartupScreen
+            }
+        }).setVisible(true);
     }
 
     private @Nullable File selectCampaignFile() {


### PR DESCRIPTION
Refactors campaign loading to use a callback in `DataLoadingDialog`, decoupling it from campaign lifecycle.

- Use `MekHQ.activateCampaign` and `MekHQ.deactivateCampaign` for lifecycle handling
- Introduce `Consumer<Campaign> completionHandler` in `DataLoadingDialog` to return state control to callers
- Move `Campaign.setApp` from `DataLoadingDialog` to `activateCampaign`
- Move event bus unregistration of `StoryArc` to `deactivateCampaign` and prevent accidential unregistration if loading fails
- Refactor `MekHQMenuBar` and `StartupScreen` to use the new callback and lifecycle management methods
- Remove `StoryArc` parameter from `DataLoadingDialog` and handle it more locally in `StartupScreen`