### PR TITLE
Fix memory leak caused by PersonnelMarket

### DIFF
--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -357,6 +357,7 @@ public class MekHQ implements GameListener {
         campaign.setApp(this);
         campaignController = new CampaignController(campaign);
         campaignController.setHost(campaign.getId());
+        campaignController.activate();
         campaignGUI = new CampaignGUI(this);
     }
 
@@ -371,9 +372,7 @@ public class MekHQ implements GameListener {
             campaignGUI = null;
         }
         if (campaignController != null) {
-            if (getCampaign() != null && getCampaign().getStoryArc() != null) {
-                MekHQ.unregisterHandler(getCampaign().getStoryArc());
-            }
+            campaignController.deactivate();
             campaignController = null;
         }
         EVENT_BUS.logActiveSubscribers();

--- a/MekHQ/src/mekhq/campaign/CampaignConfiguration.java
+++ b/MekHQ/src/mekhq/campaign/CampaignConfiguration.java
@@ -484,10 +484,6 @@ public class CampaignConfiguration {
         this.campaignOptions = campaignOptions;
     }
 
-    public void setPersonnelMarket(PersonnelMarket personnelMarket) {
-        this.personnelMarket = personnelMarket;
-    }
-
     public void setContractMarket(AbstractContractMarket contractMarket) {
         this.contractMarket = contractMarket;
     }

--- a/MekHQ/src/mekhq/campaign/CampaignController.java
+++ b/MekHQ/src/mekhq/campaign/CampaignController.java
@@ -32,6 +32,9 @@
  */
 package mekhq.campaign;
 
+import mekhq.MekHQ;
+import mekhq.campaign.market.PersonnelMarket;
+
 import java.util.UUID;
 
 /**
@@ -49,6 +52,29 @@ public class CampaignController {
      */
     public CampaignController(Campaign c) {
         localCampaign = c;
+    }
+
+    /**
+     * Manually registers campaign-related event bus listeners.
+     */
+    public void activate() {
+        PersonnelMarket personnelMarket = localCampaign.getHumanResources().getPersonnelMarket();
+        if (personnelMarket != null) {
+            MekHQ.registerHandler(personnelMarket);
+        }
+    }
+
+    /**
+     * Manually unregister campaign-related event bus listeners.
+     */
+    public void deactivate() {
+        if (localCampaign.getStoryArc() != null) {
+            MekHQ.unregisterHandler(localCampaign.getStoryArc());
+        }
+        PersonnelMarket personnelMarket = localCampaign.getHumanResources().getPersonnelMarket();
+        if (personnelMarket != null) {
+            MekHQ.unregisterHandler(personnelMarket);
+        }
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
@@ -99,13 +99,11 @@ public class PersonnelMarket {
 
     public PersonnelMarket() {
         method = new PersonnelMarketDisabled();
-        MekHQ.registerHandler(this);
     }
 
     public PersonnelMarket(Campaign c) {
         generatePersonnelForDay(c);
         setType(c.getCampaignOptions().getPersonnelMarketName());
-        MekHQ.registerHandler(this);
     }
 
     /**


### PR DESCRIPTION
To address the issue, `PersonnelMarket` lifecycle management was moved to `CampaignController`.

Additionally, existing non-UI lifecycle management logic was also moved to `CampaignController`.