### PR TITLE
Add MHQCollapsiblePanel reusable collapsible section component

### DIFF
--- a/MekHQ/src/mekhq/gui/baseComponents/MHQCollapsiblePanel.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/MHQCollapsiblePanel.java
@@ -1,0 +1,414 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.baseComponents;
+
+import java.awt.BasicStroke;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.RenderingHints;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.BorderFactory;
+import javax.swing.Icon;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
+import javax.swing.ToolTipManager;
+import javax.swing.UIManager;
+
+import megamek.common.annotations.Nullable;
+
+/**
+ * A lightweight, theme-friendly collapsible section panel for reusable MekHQ
+ * screens.
+ */
+public class MHQCollapsiblePanel extends JPanel {
+    public static final String EXPANDED_PROPERTY = "expanded";
+    public static final String TOGGLE_ACTION = "toggle";
+
+    private static final int HEADER_VERTICAL_PADDING = 6;
+    private static final int HEADER_HORIZONTAL_PADDING = 8;
+    private static final int CONTENT_LEFT_PADDING = 24;
+    private static final int CONTENT_VERTICAL_PADDING = 6;
+    private static final int CHEVRON_ICON_SIZE = 12;
+
+    private final JPanel headerPanel;
+    private final JLabel iconLabel = new JLabel();
+    private final JLabel titleLabel = new JLabel();
+    private final JLabel summaryLabel = new JLabel() {
+        @Override
+        public String getToolTipText(MouseEvent event) {
+            // The summary is the header's flexible column, so when it is too long it is truncated with an ellipsis
+            // rather than widening the section. Surface the full text as a tooltip only while it is actually
+            // truncated, so sections whose summary already fits do not show a redundant tooltip.
+            return getPreferredSize().width > getWidth() ? getText() : null;
+        }
+    };
+    private final JPanel trailingPanel = new JPanel(new BorderLayout());
+    private final JPanel contentPanel = new JPanel(new BorderLayout());
+    private final Action toggleAction = new AbstractAction(TOGGLE_ACTION) {
+        @Override
+        public void actionPerformed(java.awt.event.ActionEvent event) {
+            toggleExpanded();
+        }
+    };
+
+    private String title;
+    private boolean expanded;
+    private boolean headerHovered;
+    private boolean titleMuted;
+
+    public MHQCollapsiblePanel(String title) {
+        this(title, null);
+    }
+
+    public MHQCollapsiblePanel(String title, @Nullable JComponent content) {
+        this.title = title;
+
+        setLayout(new BorderLayout());
+        setOpaque(false);
+        getActionMap().put(TOGGLE_ACTION, toggleAction);
+
+        headerPanel = createHeaderPanel();
+        add(headerPanel, BorderLayout.NORTH);
+        contentPanel.setOpaque(false);
+        contentPanel.setBorder(BorderFactory.createEmptyBorder(CONTENT_VERTICAL_PADDING,
+                CONTENT_LEFT_PADDING,
+                CONTENT_VERTICAL_PADDING,
+                0));
+        add(contentPanel, BorderLayout.CENTER);
+
+        setSummary("");
+        setContent(content);
+        setExpanded(true);
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+        updateHeader();
+    }
+
+    public void setSummary(String summary) {
+        summaryLabel.setText(summary == null ? "" : summary);
+        summaryLabel.setVisible(summary != null && !summary.isBlank());
+    }
+
+    /**
+     * Mutes or restores the section title color. A muted title is drawn in the theme's disabled foreground, letting a
+     * disabled section be spotted at a glance while the list is collapsed.
+     *
+     * @param muted {@code true} to draw the title in the disabled foreground color, {@code false} for the default
+     */
+    public void setTitleMuted(boolean muted) {
+        this.titleMuted = muted;
+        updateTitleForeground();
+    }
+
+    private void updateTitleForeground() {
+        titleLabel.setForeground(titleMuted ? UIManager.getColor("Label.disabledForeground") : null);
+    }
+
+    public void setTrailingComponent(@Nullable JComponent component) {
+        trailingPanel.removeAll();
+        if (component != null) {
+            trailingPanel.add(component, BorderLayout.CENTER);
+        }
+        trailingPanel.setVisible(component != null);
+        revalidate();
+        repaint();
+    }
+
+    public void setContent(@Nullable JComponent content) {
+        contentPanel.removeAll();
+        if (content != null) {
+            contentPanel.add(content, BorderLayout.CENTER);
+        }
+        revalidate();
+        repaint();
+    }
+
+    public boolean isExpanded() {
+        return expanded;
+    }
+
+    public int getContentPreferredWidth() {
+        return contentPanel.getPreferredSize().width;
+    }
+
+    public void setExpanded(boolean expanded) {
+        if (this.expanded == expanded) {
+            return;
+        }
+
+        boolean previousValue = this.expanded;
+        this.expanded = expanded;
+        contentPanel.setVisible(expanded);
+        updateHeader();
+        firePropertyChange(EXPANDED_PROPERTY, previousValue, expanded);
+        revalidate();
+        repaint();
+    }
+
+    private JPanel createHeaderPanel() {
+        JPanel headerPanel = new JPanel(new GridBagLayout());
+        headerPanel.setOpaque(false);
+        headerPanel.setBorder(BorderFactory.createEmptyBorder(HEADER_VERTICAL_PADDING,
+                HEADER_HORIZONTAL_PADDING,
+                HEADER_VERTICAL_PADDING,
+                HEADER_HORIZONTAL_PADDING));
+        Cursor handCursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR);
+        headerPanel.setCursor(handCursor);
+        headerPanel.setFocusable(true);
+
+        titleLabel.putClientProperty("FlatLaf.styleClass", "h4");
+
+        // Render the summary at the default body font size. It previously used FlatLaf's smaller "small" type class,
+        // which reviewers found too small; the muted foreground still keeps it secondary to the bold section title.
+        summaryLabel.setForeground(UIManager.getColor("Label.disabledForeground"));
+        // Register so the truncation-only tooltip from getToolTipText is shown even though no static tooltip is set.
+        ToolTipManager.sharedInstance().registerComponent(summaryLabel);
+
+        trailingPanel.setOpaque(false);
+        trailingPanel.setVisible(false);
+
+        GridBagConstraints layout = new GridBagConstraints();
+        layout.gridx = 0;
+        layout.gridy = 0;
+        layout.weightx = 0.0;
+        layout.fill = GridBagConstraints.NONE;
+        layout.anchor = GridBagConstraints.WEST;
+        headerPanel.add(iconLabel, layout);
+
+        layout.gridx++;
+        layout.insets = new Insets(0, HEADER_HORIZONTAL_PADDING, 0, 0);
+        headerPanel.add(titleLabel, layout);
+
+        layout.gridx++;
+        layout.weightx = 1.0;
+        layout.insets = new Insets(0, HEADER_HORIZONTAL_PADDING, 0, 0);
+        layout.fill = GridBagConstraints.HORIZONTAL;
+        headerPanel.add(summaryLabel, layout);
+
+        layout.gridx++;
+        layout.weightx = 0.0;
+        layout.fill = GridBagConstraints.NONE;
+        headerPanel.add(trailingPanel, layout);
+
+        // Toggle the section from anywhere in the header. The listener is shared by the header panel and its
+        // non-interactive labels because Swing delivers a mouse event only to the deepest component under the pointer;
+        // without this, clicking directly on the title or the (full-width) summary label would not reach the header.
+        // The trailing panel is intentionally excluded so it can host its own interactive control.
+        MouseAdapter headerInteractionListener = new MouseAdapter() {
+            @Override
+            public void mouseReleased(MouseEvent event) {
+                if (!SwingUtilities.isLeftMouseButton(event)) {
+                    return;
+                }
+                // Toggle on release rather than click: mouseClicked only fires when the press and release land on the
+                // same component with negligible movement, so dragging the pointer horizontally across the header - or
+                // crossing between the icon/title/summary child labels between press and release - would swallow the
+                // click. mouseReleased is delivered to whichever component received the press regardless of movement;
+                // we just confirm the pointer is still within the header bounds so a press-then-drag-away gesture can
+                // still cancel the toggle.
+                Point pointInHeader = SwingUtilities.convertPoint((java.awt.Component) event.getSource(),
+                        event.getPoint(), headerPanel);
+                if (headerPanel.contains(pointInHeader)) {
+                    toggleExpanded();
+                }
+            }
+
+            @Override
+            public void mouseEntered(MouseEvent event) {
+                headerHovered = true;
+                updateHeaderBackground();
+            }
+
+            @Override
+            public void mouseExited(MouseEvent event) {
+                // A child label reports an exit when the pointer merely crosses onto it, so only clear the hover
+                // state once the pointer has actually left the header's bounds.
+                Point pointInHeader = SwingUtilities.convertPoint((java.awt.Component) event.getSource(),
+                        event.getPoint(), headerPanel);
+                headerHovered = headerPanel.contains(pointInHeader);
+                updateHeaderBackground();
+            }
+        };
+        headerPanel.addMouseListener(headerInteractionListener);
+        iconLabel.addMouseListener(headerInteractionListener);
+        titleLabel.addMouseListener(headerInteractionListener);
+        summaryLabel.addMouseListener(headerInteractionListener);
+        headerPanel.addFocusListener(new FocusAdapter() {
+            @Override
+            public void focusGained(FocusEvent event) {
+                updateHeaderBackground();
+            }
+
+            @Override
+            public void focusLost(FocusEvent event) {
+                updateHeaderBackground();
+            }
+        });
+        headerPanel.getInputMap(JComponent.WHEN_FOCUSED).put(KeyStroke.getKeyStroke(KeyEvent.VK_SPACE, 0),
+                TOGGLE_ACTION);
+        headerPanel.getInputMap(JComponent.WHEN_FOCUSED).put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0),
+                TOGGLE_ACTION);
+        headerPanel.getActionMap().put(TOGGLE_ACTION, toggleAction);
+
+        return headerPanel;
+    }
+
+    private void toggleExpanded() {
+        setExpanded(!isExpanded());
+    }
+
+    private void updateHeader() {
+        titleLabel.setText(title);
+        updateTitleForeground();
+        iconLabel.setIcon(getDisclosureIcon());
+        headerPanel.getAccessibleContext().setAccessibleName(title);
+        headerPanel.getAccessibleContext()
+                .setAccessibleDescription(isExpanded() ? "Collapse section" : "Expand section");
+        updateHeaderBackground();
+    }
+
+    private void updateHeaderBackground() {
+        boolean active = headerHovered || headerPanel.isFocusOwner();
+        headerPanel.setOpaque(active);
+        headerPanel.setBackground(active ? getHeaderBackgroundColor() : null);
+        headerPanel.repaint();
+    }
+
+    private Icon getDisclosureIcon() {
+        Icon disclosureIcon = UIManager.getIcon(isExpanded() ? "Tree.expandedIcon" : "Tree.collapsedIcon");
+        if (disclosureIcon != null) {
+            return disclosureIcon;
+        }
+        return new ChevronIcon(isExpanded(), getForeground());
+    }
+
+    private Color getHeaderBackgroundColor() {
+        Color backgroundColor = UIManager.getColor("List.hoverBackground");
+        if (backgroundColor == null) {
+            backgroundColor = UIManager.getColor("Button.hoverBackground");
+        }
+        return backgroundColor == null ? UIManager.getColor("Panel.background") : backgroundColor;
+    }
+
+    @Override
+    public Dimension getPreferredSize() {
+        return getStableSize(getHeaderBaselineSize(), contentPanel.getPreferredSize());
+    }
+
+    @Override
+    public Dimension getMinimumSize() {
+        return getStableSize(getHeaderBaselineSize(), contentPanel.getMinimumSize());
+    }
+
+    private Dimension getHeaderBaselineSize() {
+        Insets insets = headerPanel.getInsets();
+        int width = insets.left + insets.right
+                + iconLabel.getPreferredSize().width
+                + HEADER_HORIZONTAL_PADDING
+                + titleLabel.getPreferredSize().width;
+        if (trailingPanel.isVisible()) {
+            width += HEADER_HORIZONTAL_PADDING + trailingPanel.getPreferredSize().width;
+        }
+
+        return new Dimension(width, headerPanel.getPreferredSize().height);
+    }
+
+    private Dimension getStableSize(Dimension headerSize, Dimension contentSize) {
+        int width = Math.max(headerSize.width, contentSize.width);
+        int height = headerSize.height + (isExpanded() ? contentSize.height : 0);
+        return new Dimension(width, height);
+    }
+
+    private static final class ChevronIcon implements Icon {
+        private final boolean expanded;
+        private final Color color;
+
+        private ChevronIcon(boolean expanded, Color color) {
+            this.expanded = expanded;
+            this.color = color;
+        }
+
+        @Override
+        public void paintIcon(java.awt.Component component, Graphics graphics, int x, int y) {
+            Graphics2D graphics2D = (Graphics2D) graphics.create();
+            graphics2D.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            graphics2D.setColor(color == null ? component.getForeground() : color);
+            graphics2D.setStroke(new BasicStroke(2, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+
+            int left = x + 3;
+            int right = x + getIconWidth() - 3;
+            int top = y + 4;
+            int middle = y + getIconHeight() / 2;
+            int bottom = y + getIconHeight() - 4;
+
+            if (expanded) {
+                graphics2D.drawLine(left, top, middle, bottom);
+                graphics2D.drawLine(middle, bottom, right, top);
+            } else {
+                graphics2D.drawLine(left, top, right, middle);
+                graphics2D.drawLine(right, middle, left, bottom);
+            }
+
+            graphics2D.dispose();
+        }
+
+        @Override
+        public int getIconWidth() {
+            return CHEVRON_ICON_SIZE;
+        }
+
+        @Override
+        public int getIconHeight() {
+            return CHEVRON_ICON_SIZE;
+        }
+    }
+}

--- a/MekHQ/unittests/mekhq/gui/baseComponents/MHQCollapsiblePanelTest.java
+++ b/MekHQ/unittests/mekhq/gui/baseComponents/MHQCollapsiblePanelTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.baseComponents;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Dimension;
+import java.awt.event.ActionEvent;
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.swing.Action;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioural tests for {@link MHQCollapsiblePanel}, covering its expand/collapse state machine, the
+ * {@value MHQCollapsiblePanel#EXPANDED_PROPERTY} property change contract, the shared toggle {@link Action}, and that
+ * supplied content is hosted and measured. Component work runs on the Event Dispatch Thread to mirror real Swing usage.
+ */
+class MHQCollapsiblePanelTest {
+
+    @Test
+    void newPanelIsExpandedByDefault() throws Exception {
+        runOnEdt(() -> {
+            MHQCollapsiblePanel panel = new MHQCollapsiblePanel("Section");
+            assertTrue(panel.isExpanded());
+        });
+    }
+
+    @Test
+    void collapsingHidesContentAndFiresExpandedEvent() throws Exception {
+        runOnEdt(() -> {
+            JLabel content = new JLabel("Body");
+            MHQCollapsiblePanel panel = new MHQCollapsiblePanel("Section", content);
+
+            AtomicInteger eventCount = new AtomicInteger();
+            AtomicReference<Object> lastNewValue = new AtomicReference<>();
+            panel.addPropertyChangeListener(MHQCollapsiblePanel.EXPANDED_PROPERTY, event -> {
+                eventCount.incrementAndGet();
+                lastNewValue.set(event.getNewValue());
+            });
+
+            panel.setExpanded(false);
+
+            assertFalse(panel.isExpanded());
+            // The content lives inside the collapsible content panel (its parent), which is hidden when collapsed.
+            assertFalse(content.getParent().isVisible());
+            assertEquals(1, eventCount.get());
+            assertEquals(Boolean.FALSE, lastNewValue.get());
+        });
+    }
+
+    @Test
+    void expandingAgainShowsContentAndFiresExpandedEvent() throws Exception {
+        runOnEdt(() -> {
+            JLabel content = new JLabel("Body");
+            MHQCollapsiblePanel panel = new MHQCollapsiblePanel("Section", content);
+            panel.setExpanded(false);
+
+            AtomicInteger eventCount = new AtomicInteger();
+            panel.addPropertyChangeListener(MHQCollapsiblePanel.EXPANDED_PROPERTY, event -> eventCount.incrementAndGet());
+
+            panel.setExpanded(true);
+
+            assertTrue(panel.isExpanded());
+            assertTrue(content.getParent().isVisible());
+            assertEquals(1, eventCount.get());
+        });
+    }
+
+    @Test
+    void redundantSetExpandedDoesNotFireEvent() throws Exception {
+        runOnEdt(() -> {
+            MHQCollapsiblePanel panel = new MHQCollapsiblePanel("Section");
+            AtomicInteger eventCount = new AtomicInteger();
+            panel.addPropertyChangeListener(MHQCollapsiblePanel.EXPANDED_PROPERTY, event -> eventCount.incrementAndGet());
+
+            // The panel starts expanded, so expanding it again must be a no-op that fires no event.
+            panel.setExpanded(true);
+
+            assertTrue(panel.isExpanded());
+            assertEquals(0, eventCount.get());
+        });
+    }
+
+    @Test
+    void toggleActionFlipsExpandedState() throws Exception {
+        runOnEdt(() -> {
+            MHQCollapsiblePanel panel = new MHQCollapsiblePanel("Section");
+            Action toggleAction = panel.getActionMap().get(MHQCollapsiblePanel.TOGGLE_ACTION);
+
+            toggleAction.actionPerformed(new ActionEvent(panel, ActionEvent.ACTION_PERFORMED,
+                    MHQCollapsiblePanel.TOGGLE_ACTION));
+            assertFalse(panel.isExpanded());
+
+            toggleAction.actionPerformed(new ActionEvent(panel, ActionEvent.ACTION_PERFORMED,
+                    MHQCollapsiblePanel.TOGGLE_ACTION));
+            assertTrue(panel.isExpanded());
+        });
+    }
+
+    @Test
+    void contentPassedToConstructorIsMeasured() throws Exception {
+        runOnEdt(() -> {
+            JPanel content = new JPanel();
+            content.setPreferredSize(new Dimension(321, 50));
+            MHQCollapsiblePanel panel = new MHQCollapsiblePanel("Section", content);
+
+            // The content's preferred width must be reflected (the panel adds left padding, so allow >=).
+            assertTrue(panel.getContentPreferredWidth() >= 321);
+        });
+    }
+
+    /**
+     * Runs the supplied work synchronously on the Event Dispatch Thread, unwrapping any assertion failure or exception
+     * so JUnit reports it directly rather than as an {@link InvocationTargetException}.
+     */
+    private static void runOnEdt(CheckedRunnable runnable) throws Exception {
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                try {
+                    runnable.run();
+                } catch (Exception ex) {
+                    throw new RuntimeException(ex);
+                }
+            });
+        } catch (InvocationTargetException ex) {
+            Throwable cause = ex.getCause();
+            if (cause instanceof RuntimeException runtimeException
+                      && runtimeException.getCause() instanceof Exception exception) {
+                throw exception;
+            }
+            if (cause instanceof Error error) {
+                throw error;
+            }
+            throw ex;
+        }
+    }
+
+    @FunctionalInterface
+    private interface CheckedRunnable {
+        void run() throws Exception;
+    }
+}


### PR DESCRIPTION
# Add `MHQCollapsiblePanel` — a reusable collapsible section component

## Summary
Adds `mekhq.gui.baseComponents.MHQCollapsiblePanel`, a lightweight, theme-friendly collapsible "section" panel intended for reuse across MekHQ screens. It renders a clickable header (disclosure chevron + title, optional summary, optional trailing control) above a content area that expands and collapses.

The component is fully self-contained — its only non-JDK dependency is `megamek.common.annotations.Nullable` — so it can be dropped into any panel without pulling in additional infrastructure.

## Features
- **Click anywhere on the header to toggle**, including the title and summary labels. The toggle is *drag-tolerant*: it fires on `mouseReleased` within the header bounds, so clicking while the pointer moves horizontally (or crosses between the icon/title/summary labels) still registers. Dragging off the header before releasing cancels the toggle.
- **Keyboard accessible** — the header is focusable and toggles on `Space`/`Enter`, with accessible name/description set for screen readers.
- **Hover & focus feedback** on the header using theme colors (`List.hoverBackground` / `Button.hoverBackground` fallbacks).
- **Optional summary** — secondary text shown next to the title; truncated with an ellipsis when space is tight and given a tooltip *only* while truncated.
- **Optional trailing component** — an interactive control (e.g. an `Edit` button) hosted on the right of the header and intentionally excluded from the toggle area.
- **Muted title** option to visually mark disabled/inactive sections.
- **Observable** — fires a `PropertyChangeEvent` (`MHQCollapsiblePanel.EXPANDED_PROPERTY`) on every state change.
- **FlatLaf-friendly** — uses the `h4` type class for the title and theme `UIManager` colors/icons throughout.

## Public API
| Member | Description |
| --- | --- |
| `MHQCollapsiblePanel(String title)` | Create an (expanded) section with no content yet. |
| `MHQCollapsiblePanel(String title, JComponent content)` | Create a section hosting `content`. |
| `setTitle(String)` | Update the header title. |
| `setSummary(String)` | Set secondary header text (hidden when blank). |
| `setContent(JComponent)` | Replace the content area. |
| `setTrailingComponent(JComponent)` | Add/replace a trailing header control (hidden when `null`). |
| `setTitleMuted(boolean)` | Draw the title in the theme's disabled foreground. |
| `setExpanded(boolean)` / `isExpanded()` | Programmatic expand/collapse + state query. |
| `getContentPreferredWidth()` | Preferred width of the content area. |
| `EXPANDED_PROPERTY` | Property name fired on expand/collapse. |
| `TOGGLE_ACTION` | Action-map key for the shared toggle `Action`. |

> Sections default to **expanded**.

## Usage examples

**Basic — title + content**
```java
JPanel body = new JPanel(new BorderLayout());
body.add(new JLabel("Settings go here"), BorderLayout.CENTER);

MHQCollapsiblePanel section = new MHQCollapsiblePanel("Advanced Options", body);
parentPanel.add(section);
```

**With a summary line**
```java
MHQCollapsiblePanel section = new MHQCollapsiblePanel("Rank Systems");
section.setSummary("Manage rank systems, rank names, and rank salary multipliers.");
section.setContent(buildRankSystemsTable());
```

**Trailing control (kept clickable, separate from the toggle)**
```java
JButton editButton = new JButton("Edit");
editButton.addActionListener(e -> openEditor());

MHQCollapsiblePanel section = new MHQCollapsiblePanel("Personnel", personnelPanel);
section.setTrailingComponent(editButton);
```

**React to expand/collapse**
```java
section.addPropertyChangeListener(MHQCollapsiblePanel.EXPANDED_PROPERTY, event -> {
    boolean expanded = (boolean) event.getNewValue();
    logger.info("Section is now {}", expanded ? "expanded" : "collapsed");
});
```

**Start collapsed / toggle programmatically**
```java
section.setExpanded(false);  // collapse by default
// ... later, in response to some event:
section.setExpanded(true);   // expand programmatically
```

**Mark a disabled section with a muted title**
```java
MHQCollapsiblePanel section = new MHQCollapsiblePanel("Legacy Settings", legacyPanel);
section.setTitleMuted(true); // drawn in the theme's disabled foreground
```

**Stack several sections in a vertical list**
```java
JPanel stack = new JPanel();
stack.setLayout(new BoxLayout(stack, BoxLayout.Y_AXIS));

stack.add(new MHQCollapsiblePanel("General", generalPanel));
stack.add(new MHQCollapsiblePanel("Finances", financesPanel));
stack.add(new MHQCollapsiblePanel("Personnel", personnelPanel));
```

## Testing
Adds `MHQCollapsiblePanelTest` (JUnit 5, run on the EDT) covering:
- defaults to expanded,
- collapsing hides content and fires the `expanded` event,
- re-expanding restores content and fires the event,
- redundant `setExpanded` is a no-op (no event),
- the shared toggle `Action` flips state,
- constructor-supplied content is hosted and measured.