### PR TITLE
Add sorting to the date column in the transaction table in the finance tab (fixes #8630)

### DIFF
--- a/MekHQ/src/mekhq/gui/FinancesTab.java
+++ b/MekHQ/src/mekhq/gui/FinancesTab.java
@@ -82,6 +82,7 @@ import mekhq.gui.dialog.NewLoanDialog;
 import mekhq.gui.enums.MHQTabType;
 import mekhq.gui.model.FinanceTableModel;
 import mekhq.gui.model.LoanTableModel;
+import mekhq.gui.sorter.DateStringComparator;
 import mekhq.gui.sorter.FormattedNumberSorter;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.ChartPanel;
@@ -148,6 +149,7 @@ public final class FinancesTab extends CampaignGuiTab {
         JTable financeTable = new JTable(financeModel);
         // make column headers in the table clickable and sortable
         TableRowSorter<TableModel> sorter = new TableRowSorter<>(financeTable.getModel());
+        sorter.setComparator(FinanceTableModel.COL_DATE, new DateStringComparator());
         sorter.setComparator(FinanceTableModel.COL_DEBIT, new FormattedNumberSorter());
         sorter.setComparator(FinanceTableModel.COL_CREDIT, new FormattedNumberSorter());
         sorter.setComparator(FinanceTableModel.COL_BALANCE, new FormattedNumberSorter());


### PR DESCRIPTION
As reported in issue #8630 the date column is not sorted correctly when using a date format other than mm-dd-yyyy.

This PR fixes this by adding a dateStringComparator to the DATE column in the transaction table in the Finances tab.

Closes #8630 