### PR TITLE
Fix memory leak caused by CampaignEventProcessor

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -416,12 +416,6 @@ public class Campaign implements ITechManager, IPlace {
     private RandomSkillPreferences randomSkillPreferences = new RandomSkillPreferences();
     private MekHQ app;
 
-    /**
-     * This is not unused even if IDEA says it is. This event processor subscribes to various events that need to be
-     * applied to Campaign.
-     */
-    private transient CampaignEventProcessor campaignEventProcessor;
-
     private ShoppingList shoppingList;
 
     private AbstractContractMarket contractMarket;
@@ -1128,10 +1122,6 @@ public class Campaign implements ITechManager, IPlace {
             initUnitGenerator();
         }
         return unitGenerator;
-    }
-
-    public void setCampaignEventProcessor(CampaignEventProcessor processor) {
-        campaignEventProcessor = processor;
     }
 
     public void setAtBConfig(AtBConfiguration config) {
@@ -7341,7 +7331,7 @@ public class Campaign implements ITechManager, IPlace {
      * <p>Eligible personnel must have either a primary or secondary role as a medic, must not be currently deployed,
      * and must be employed.</p>
      *
-     * <p></p>For each eligible person, their total skill level in {@link SkillType#S_MEDTECH} (including all
+     * <p>For each eligible person, their total skill level in {@link SkillType#S_MEDTECH} (including all
      * modifiers) is added to the running total.</p>
      *
      * @return The total number of medics available.

--- a/MekHQ/src/mekhq/campaign/CampaignController.java
+++ b/MekHQ/src/mekhq/campaign/CampaignController.java
@@ -32,10 +32,10 @@
  */
 package mekhq.campaign;
 
+import java.util.UUID;
+
 import mekhq.MekHQ;
 import mekhq.campaign.market.PersonnelMarket;
-
-import java.util.UUID;
 
 /**
  * Manages the timeline of a {@link Campaign}.
@@ -44,14 +44,16 @@ public class CampaignController {
     private final Campaign localCampaign;
     private boolean isHost;
     private UUID host;
+    private final CampaignEventProcessor campaignEventProcessor;
 
     /**
      * Creates a new {@code CampaignController} for the given {@link Campaign}
      *
-     * @param c The {@link Campaign} being used locally.
+     * @param campaign The {@link Campaign} being used locally.
      */
-    public CampaignController(Campaign c) {
-        localCampaign = c;
+    public CampaignController(Campaign campaign) {
+        localCampaign = campaign;
+        campaignEventProcessor = new CampaignEventProcessor(campaign);
     }
 
     /**
@@ -62,6 +64,7 @@ public class CampaignController {
         if (personnelMarket != null) {
             MekHQ.registerHandler(personnelMarket);
         }
+        MekHQ.registerHandler(campaignEventProcessor);
     }
 
     /**
@@ -75,6 +78,7 @@ public class CampaignController {
         if (personnelMarket != null) {
             MekHQ.unregisterHandler(personnelMarket);
         }
+        MekHQ.unregisterHandler(campaignEventProcessor);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/CampaignEventProcessor.java
+++ b/MekHQ/src/mekhq/campaign/CampaignEventProcessor.java
@@ -33,7 +33,6 @@
 package mekhq.campaign;
 
 import megamek.common.event.Subscribe;
-import mekhq.MekHQ;
 import mekhq.campaign.events.persons.PersonCrewAssignmentEvent;
 import mekhq.campaign.events.persons.PersonEvent;
 import mekhq.campaign.personnel.Person;
@@ -49,17 +48,6 @@ public record CampaignEventProcessor(Campaign campaign) {
 
     public CampaignEventProcessor(Campaign campaign) {
         this.campaign = campaign;
-        MekHQ.registerHandler(this);
-    }
-
-    /**
-     * Unregisters this processor from MekHQ's event handling system.
-     *
-     * <p>This should be called when the associated campaign is being shut down
-     * or replaced, to avoid memory leaks from lingering event handlers.</p>
-     */
-    public void shutdown() {
-        MekHQ.unregisterHandler(this);
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -75,7 +75,6 @@ import mekhq.MekHQ;
 import mekhq.NullEntityException;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.Campaign.AdministratorSpecialization;
-import mekhq.campaign.CampaignEventProcessor;
 import mekhq.campaign.CampaignFactory;
 import mekhq.campaign.camOpsReputation.ReputationController;
 import mekhq.campaign.campaignOptions.CampaignOptions;
@@ -481,9 +480,6 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
             if (isNewCampaign) {
                 new WarAndPeaceProcessor(campaign, true);
             }
-
-            // Generic event processor
-            campaign.setCampaignEventProcessor(new CampaignEventProcessor(campaign));
 
             return campaign;
         }


### PR DESCRIPTION
Done by moving `CampaignEventProcessor` and its event bus registration logic to `CampaignController`. It has an added benefit of removing event orchestration logic from `DataLoadingDialog`.