### PR TITLE
Show bodylocation colour based on parent bodylocation (fixes #8542)

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -8041,8 +8041,8 @@ public class Person implements ILocation {
     }
 
     @Override
-    public Set<Person> fetchPersonnelAtLocation() {
-        return Set.of(this);
+    public java.util.Set<Person> fetchPersonnelAtLocation() {
+        return java.util.Set.of(this);
     }
 
     public List<Skill> getInProgressSkills() {
@@ -9278,7 +9278,7 @@ public class Person implements ILocation {
      * @since 0.50.10
      */
     public SkillModifierData getSkillModifierData(boolean excludeInjuryEffects) {
-        boolean isAmbidextrous = options.booleanOption(ATOW_AMBIDEXTROUS);
+        boolean isAmbidextrous = options.booleanOption(PersonnelOptions.ATOW_AMBIDEXTROUS);
         List<InjuryEffect> injuryEffects = excludeInjuryEffects ? new ArrayList<>() :
                                                  getAllActiveInjuryEffects(isAmbidextrous,
                                                        injuries);
@@ -9331,7 +9331,7 @@ public class Person implements ILocation {
           boolean excludeInjuryEffects) {
         int adjustedReputation = getAdjustedReputation(isUseAgingEffects, isClanCampaign, today, rank);
 
-        boolean isAmbidextrous = options.booleanOption(ATOW_AMBIDEXTROUS);
+        boolean isAmbidextrous = options.booleanOption(PersonnelOptions.ATOW_AMBIDEXTROUS);
         List<InjuryEffect> injuryEffects = excludeInjuryEffects ?
                                                  new ArrayList<>() :
                                                  getAllActiveInjuryEffects(isAmbidextrous,

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -107,6 +107,8 @@ import mekhq.Utilities;
 import mekhq.campaign.AbstractLocation;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.ExtraData;
+import mekhq.campaign.FixedLocation;
+import mekhq.campaign.JumpPath;
 import mekhq.campaign.Personnel;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.events.persons.PersonChangedEvent;
@@ -2719,8 +2721,7 @@ public class Person implements ILocation {
      *
      * <p>This value is a snapshot recorded at enrollment or journey-start and may not reflect the
      * actual remaining travel time. The person's {@link AbstractLocation} (accessible via
-     * {@link #getCurrentLocation()}) holds the authoritative travel state including the live
-     * {@link mekhq.campaign.JumpPath}.</p>
+     * {@link #getCurrentLocation()}) holds the authoritative travel state including the live {@link JumpPath}.</p>
      */
     public int getEduJourneyTime() {
         return eduJourneyTime;
@@ -2735,8 +2736,7 @@ public class Person implements ILocation {
      *
      * <p>This counter is incremented each day during JOURNEY_TO_CAMPUS and JOURNEY_FROM_CAMPUS
      * stages as a rough progress indicator. The person's {@link AbstractLocation} (accessible via
-     * {@link #getCurrentLocation()}) holds the authoritative travel state including the live
-     * {@link mekhq.campaign.JumpPath}.</p>
+     * {@link #getCurrentLocation()}) holds the authoritative travel state including the live {@link JumpPath}.</p>
      */
     public int getEduDaysOfTravel() {
         return eduDaysOfTravel;
@@ -2759,13 +2759,12 @@ public class Person implements ILocation {
      * Returns the ID of the planetary system where the person's academy campus is located.
      *
      * <p>The primary source is the location tree: this walks the person's parent chain to find
-     * the nearest {@link AcademyCampusLocation}, then returns the system ID from its parent
-     * {@link AbstractLocation} (typically a {@link mekhq.campaign.FixedLocation}).</p>
+     * the nearest {@link AcademyCampusLocation}, then returns the system ID from its parent {@link AbstractLocation}
+     * (typically a {@link FixedLocation}).</p>
      *
      * <p>If no campus node is reachable in the tree — for example, during JOURNEY_FROM_CAMPUS,
-     * a local-academy transit before campus arrival, or when loading a pre-location-tree save
-     * file — this falls back to a transient value populated from the legacy {@code eduAcademySystem}
-     * XML tag.</p>
+     * a local-academy transit before campus arrival, or when loading a pre-location-tree save file — this falls back to
+     * a transient value populated from the legacy {@code eduAcademySystem} XML tag.</p>
      *
      * @return the campus system ID, or {@code null} if not derivable from either source
      */
@@ -5812,8 +5811,7 @@ public class Person implements ILocation {
      * Prepares a skill check based on individually passed options.
      *
      * <p>This method creates a {@code SkillCheck} instance which calculates the target number
-     * for the skill check, based on the person's skill, aging effects, clan campaign rules,
-     * and the current date.</p>
+     * for the skill check, based on the person's skill, aging effects, clan campaign rules, and the current date.</p>
      *
      * @param skillName         the name of the skill being checked, corresponding to a {@link SkillType}
      * @param isUseAgingEffects if {@code true}, considers aging effects during the check
@@ -6551,8 +6549,8 @@ public class Person implements ILocation {
         // Techs get support time adjusted by skill and administration multipliers
         if (isTechExpanded() && isTechsUseAdministration) {
             double multiplier = calculateTechTimeMultiplier(isTechsUseAdministration);
-            this.minutesLeft = (int) Math.round(minutesLeft * multiplier);
-            this.overtimeLeft = (int) Math.round(overtimeLeft * multiplier);
+            this.minutesLeft = (int) round(minutesLeft * multiplier);
+            this.overtimeLeft = (int) round(overtimeLeft * multiplier);
         }
     }
 
@@ -6794,7 +6792,7 @@ public class Person implements ILocation {
         // Infantry don't need techs to reload or swap out their ammo
         boolean isForConventionalInfantry = unit != null && unit.isConventionalInfantry();
         if (isForConventionalInfantry) {
-            SkillType mechanicSkillType = SkillType.getType(S_TECH_MECHANIC);
+            SkillType mechanicSkillType = getType(S_TECH_MECHANIC);
             return new Skill(S_TECH_MECHANIC, mechanicSkillType.getRegularLevel(), 0);
         }
 
@@ -7570,7 +7568,7 @@ public class Person implements ILocation {
 
     public List<InjuryEffect> getActiveInjuryEffects() {
         boolean isAmbidextrous = options.booleanOption(ATOW_AMBIDEXTROUS);
-        return AdvancedMedicalAlternate.getAllActiveInjuryEffects(isAmbidextrous, injuries);
+        return getAllActiveInjuryEffects(isAmbidextrous, injuries);
     }
 
     public int getTotalInjurySeverity() {
@@ -7614,6 +7612,15 @@ public class Person implements ILocation {
         return injuries.stream()
                      .filter(i -> i.getSubType().isPermanentModification())
                      .collect(Collectors.toList());
+    }
+
+    public boolean hasProstheticInjuryNoImplant(BodyLocation location) {
+        for (Injury injury : getInjuriesByLocation(location)) {
+            if (injury.getSubType().isProsthetic()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public List<Injury> getNonProstheticInjuries() {
@@ -8036,8 +8043,8 @@ public class Person implements ILocation {
     }
 
     @Override
-    public java.util.Set<Person> fetchPersonnelAtLocation() {
-        return java.util.Set.of(this);
+    public Set<Person> fetchPersonnelAtLocation() {
+        return Set.of(this);
     }
 
     public List<Skill> getInProgressSkills() {
@@ -9273,7 +9280,7 @@ public class Person implements ILocation {
      * @since 0.50.10
      */
     public SkillModifierData getSkillModifierData(boolean excludeInjuryEffects) {
-        boolean isAmbidextrous = options.booleanOption(PersonnelOptions.ATOW_AMBIDEXTROUS);
+        boolean isAmbidextrous = options.booleanOption(ATOW_AMBIDEXTROUS);
         List<InjuryEffect> injuryEffects = excludeInjuryEffects ? new ArrayList<>() :
                                                  getAllActiveInjuryEffects(isAmbidextrous,
                                                        injuries);
@@ -9326,7 +9333,7 @@ public class Person implements ILocation {
           boolean excludeInjuryEffects) {
         int adjustedReputation = getAdjustedReputation(isUseAgingEffects, isClanCampaign, today, rank);
 
-        boolean isAmbidextrous = options.booleanOption(PersonnelOptions.ATOW_AMBIDEXTROUS);
+        boolean isAmbidextrous = options.booleanOption(ATOW_AMBIDEXTROUS);
         List<InjuryEffect> injuryEffects = excludeInjuryEffects ?
                                                  new ArrayList<>() :
                                                  getAllActiveInjuryEffects(isAmbidextrous,

--- a/MekHQ/src/mekhq/gui/dialog/AdvancedReplacementLimbDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AdvancedReplacementLimbDialog.java
@@ -1324,9 +1324,10 @@ public class AdvancedReplacementLimbDialog extends JDialog {
                       && !patient.isLocationMissing(bodyLocation.getParent())) {
                 doll.setLocTag(bodyLocation, "lost");
             } else if (!patient.isLocationMissing(bodyLocation)) {
+                BodyLocation parentLocation = bodyLocation.getParent();
+                boolean parentHasProsthetic = patient.hasProstheticInjuryNoImplant(parentLocation);
                 InjuryLevel level =
-                      MedicalViewDialog.getMaxInjuryLevel(patient.hasProstheticInjuryNoImplant(bodyLocation.getParent()) ?
-                                                                bodyLocation.getParent() : bodyLocation,
+                      MedicalViewDialog.getMaxInjuryLevel(parentHasProsthetic ? parentLocation : bodyLocation,
                             injuriesMappedToPrimaryLocations);
                 Color color = switch (level) {
                     case CHRONIC -> new Color(255, 204, 255, 128); // 50% alpha

--- a/MekHQ/src/mekhq/gui/dialog/AdvancedReplacementLimbDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AdvancedReplacementLimbDialog.java
@@ -1324,7 +1324,10 @@ public class AdvancedReplacementLimbDialog extends JDialog {
                       && !patient.isLocationMissing(bodyLocation.getParent())) {
                 doll.setLocTag(bodyLocation, "lost");
             } else if (!patient.isLocationMissing(bodyLocation)) {
-                InjuryLevel level = MedicalViewDialog.getMaxInjuryLevel(bodyLocation, injuriesMappedToPrimaryLocations);
+                InjuryLevel level =
+                      MedicalViewDialog.getMaxInjuryLevel(patient.hasProstheticInjuryNoImplant(bodyLocation.getParent()) ?
+                                                                bodyLocation.getParent() : bodyLocation,
+                            injuriesMappedToPrimaryLocations);
                 Color color = switch (level) {
                     case CHRONIC -> new Color(255, 204, 255, 128); // 50% alpha
                     case DEADLY -> new Color(Color.RED.getRed(),

--- a/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
@@ -344,7 +344,10 @@ public class MedicalViewDialog extends JDialog {
                       && !person.isLocationMissing(bodyLocation.getParent())) {
                 doll.setLocTag(bodyLocation, "lost");
             } else if (!person.isLocationMissing(bodyLocation)) {
-                InjuryLevel level = getMaxInjuryLevel(bodyLocation, injuriesMappedToPrimaryLocations);
+                InjuryLevel level =
+                      getMaxInjuryLevel(person.hasProstheticInjuryNoImplant(bodyLocation.getParent()) ?
+                                              bodyLocation.getParent() : bodyLocation,
+                            injuriesMappedToPrimaryLocations);
                 Color col = switch (level) {
                     case CHRONIC -> new Color(255, 204, 255);
                     case DEADLY -> Color.RED;

--- a/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
@@ -344,9 +344,10 @@ public class MedicalViewDialog extends JDialog {
                       && !person.isLocationMissing(bodyLocation.getParent())) {
                 doll.setLocTag(bodyLocation, "lost");
             } else if (!person.isLocationMissing(bodyLocation)) {
+                BodyLocation parentLocation = bodyLocation.getParent();
+                boolean parentHasProsthetic = person.hasProstheticInjuryNoImplant(parentLocation);
                 InjuryLevel level =
-                      getMaxInjuryLevel(person.hasProstheticInjuryNoImplant(bodyLocation.getParent()) ?
-                                              bodyLocation.getParent() : bodyLocation,
+                      getMaxInjuryLevel(parentHasProsthetic ? parentLocation : bodyLocation,
                             injuriesMappedToPrimaryLocations);
                 Color col = switch (level) {
                     case CHRONIC -> new Color(255, 204, 255);


### PR DESCRIPTION
As mentioned in #8542 when looking at someone who has lost a limb and had it replaced, the limb itself shows as prosthetic, but the hand/foot seems to be natural.

This PR fixes this by using the color of the parent body location (so leg for a foot or arm for a hand) if that parent body location has a prosthetic. This is only a cosmetic change as the underlying data (injuries) is not changed.

A new helper function was added to Person.java to determine is there is a prosthetic at a given body location.

Closes #8542.

Note: not sure why there are some other changes in Person.java.