### PR TITLE
Project Mission Overhaul: Renamed `AbstractMission` to `AbstractMissionTransition`

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -182,7 +182,7 @@ import mekhq.campaign.market.ShoppingList;
 import mekhq.campaign.market.contractMarket.AbstractContractMarket;
 import mekhq.campaign.market.personnelMarket.markets.NewPersonnelMarket;
 import mekhq.campaign.market.unitMarket.AbstractUnitMarket;
-import mekhq.campaign.mission.AbstractMission;
+import mekhq.campaign.mission.AbstractMissionTransition;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.AtBDynamicScenario;
 import mekhq.campaign.mission.AtBScenario;
@@ -856,7 +856,7 @@ public class Campaign implements ITechManager, IPlace {
         this.isOverridingCommandCircuitRequirements = isOverridingCommandCircuitRequirements;
     }
 
-    public boolean isUseCommandCircuitForContract(AbstractMission abstractMission) {
+    public boolean isUseCommandCircuitForContract(AbstractMissionTransition abstractMission) {
         if (abstractMission instanceof AtBContract atBContract) {
             return FactionStandingUtilities.isUseCommandCircuit(
                   isOverridingCommandCircuitRequirements, gmMode,
@@ -2203,7 +2203,7 @@ public class Campaign implements ITechManager, IPlace {
 
     /**
      * @return all hangars across all locations associated with this campaign.
-     *                         TODO: This won't work once we support multiple hangars. Method separated from getHangar() for future refactor
+     *                               TODO: This won't work once we support multiple hangars. Method separated from getHangar() for future refactor
      */
     public Hangar getAllHangar() {
         return units;
@@ -2839,7 +2839,7 @@ public class Campaign implements ITechManager, IPlace {
 
     /**
      * @return all warehouses across all locations associated with this campaign.
-     *                         TODO: This won't work once we support multiple warehouse. Method separated from getWarehouse() for future
+     *                               TODO: This won't work once we support multiple warehouse. Method separated from getWarehouse() for future
      */
     public Warehouse getAllWarehouse() {
         return parts;

--- a/MekHQ/src/mekhq/campaign/mission/AbstractMissionTransition.java
+++ b/MekHQ/src/mekhq/campaign/mission/AbstractMissionTransition.java
@@ -97,8 +97,8 @@ import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-public class AbstractMission {
-    private static final MMLogger LOGGER = MMLogger.create(AbstractMission.class);
+public class AbstractMissionTransition {
+    private static final MMLogger LOGGER = MMLogger.create(AbstractMissionTransition.class);
     private static final String RESOURCE_BUNDLE = "mekhq.resources.AbstractMission";
 
     private String name;
@@ -202,7 +202,7 @@ public class AbstractMission {
     public final static int OH_FULL = 2;
     public final static int OH_NUM = 3;
 
-    public AbstractMission() {}
+    public AbstractMissionTransition() {}
 
     public String getName() {
         return name;
@@ -694,8 +694,8 @@ public class AbstractMission {
      * Retrieves the list of scenarios.
      *
      * <p><b>Note:</b> this returns the actual scenario array. Any changes made to the array will be directly
-     * modifying the version retained inside the {@link AbstractMission} object. If you just want to parse the list
-     * {@link #getScenariosCopy()} is a safer option.</p>
+     * modifying the version retained inside the {@link AbstractMissionTransition} object. If you just want to parse the
+     * list {@link #getScenariosCopy()} is a safer option.</p>
      *
      * @return a list of Scenario objects.
      */
@@ -1411,8 +1411,9 @@ public class AbstractMission {
     }
 
     /**
-     * Writes all {@link AbstractMission} fields to XML. Subclasses that have their own private fields must override
-     * this, call {@code super.writeToXMLBegin(...)}, append only their private tags, and return the resulting indent.
+     * Writes all {@link AbstractMissionTransition} fields to XML. Subclasses that have their own private fields must
+     * override this, call {@code super.writeToXMLBegin(...)}, append only their private tags, and return the resulting
+     * indent.
      */
     protected int writeToXMLBegin(Campaign campaign, final PrintWriter printWriter, int indent) {
         // opening tag and core identity
@@ -1548,8 +1549,9 @@ public class AbstractMission {
     }
 
     /**
-     * Parses all {@link AbstractMission} fields from child nodes of the mission XML element. Subclasses with private
-     * fields must override this, call {@code super.loadFieldsFromXmlNode(...)}, then handle only their own nodes.
+     * Parses all {@link AbstractMissionTransition} fields from child nodes of the mission XML element. Subclasses with
+     * private fields must override this, call {@code super.loadFieldsFromXmlNode(...)}, then handle only their own
+     * nodes.
      */
     public void loadFieldsFromXmlNode(Campaign campaign, Version version, Node node) throws ParseException {
         NodeList nodeList = node.getChildNodes();
@@ -1743,20 +1745,20 @@ public class AbstractMission {
     }
 
     /**
-     * Instantiates the correct {@link AbstractMission} subclass from XML and fully loads its state. The concrete type
-     * is determined by the {@code type} attribute on the node, identical to before.
+     * Instantiates the correct {@link AbstractMissionTransition} subclass from XML and fully loads its state. The
+     * concrete type is determined by the {@code type} attribute on the node, identical to before.
      * <p>
      * Callers that previously used {@code Mission.generateInstanceFromXML} should migrate to this method; the static
      * delegate on {@link Mission} is preserved only for backward compatibility.
      */
-    public static AbstractMission generateInstanceFromXML(Node node, Campaign campaign, Version version) {
-        AbstractMission retVal = null;
+    public static AbstractMissionTransition generateInstanceFromXML(Node node, Campaign campaign, Version version) {
+        AbstractMissionTransition retVal = null;
         NamedNodeMap nodeAttributes = node.getAttributes();
         Node classNameNode = nodeAttributes.getNamedItem("type");
         String className = classNameNode.getTextContent();
 
         try {
-            retVal = (AbstractMission) Class.forName(className).getDeclaredConstructor().newInstance();
+            retVal = (AbstractMissionTransition) Class.forName(className).getDeclaredConstructor().newInstance();
             retVal.loadFieldsFromXmlNode(campaign, version, node);
         } catch (Exception ex) {
             LOGGER.error("", ex);

--- a/MekHQ/src/mekhq/campaign/mission/ContractDifficulty.java
+++ b/MekHQ/src/mekhq/campaign/mission/ContractDifficulty.java
@@ -66,7 +66,7 @@ public class ContractDifficulty {
      *
      * @return a difficulty rating from {@code 1} to {@code 10}, or {@code -99} if enemy strength estimation fails
      */
-    public static int calculateContractDifficulty(AbstractMission mission, int gameYear,
+    public static int calculateContractDifficulty(AbstractMissionTransition mission, int gameYear,
           boolean useGenericBV, List<Entity> playerCombatUnits) {
 
         final int ERROR = -99;

--- a/MekHQ/src/mekhq/campaign/mission/Mission.java
+++ b/MekHQ/src/mekhq/campaign/mission/Mission.java
@@ -49,7 +49,7 @@ import org.w3c.dom.Node;
  *
  * @author Jay Lawson (jaylawson39 at yahoo.com)
  */
-public class Mission extends AbstractMission {
+public class Mission extends AbstractMissionTransition {
     private static final MMLogger LOGGER = MMLogger.create(Mission.class);
 
     // region Constructors
@@ -76,12 +76,12 @@ public class Mission extends AbstractMission {
     }
 
     /**
-     * @deprecated Call {@link AbstractMission#generateInstanceFromXML} directly. This delegate exists only so that
-     *       existing call sites in the campaign loader do not need to be updated immediately.
+     * @deprecated Call {@link AbstractMissionTransition#generateInstanceFromXML} directly. This delegate exists only so
+     *       that existing call sites in the campaign loader do not need to be updated immediately.
      */
     @Deprecated
     public static Mission generateInstanceFromXML(Node node, Campaign campaign, Version version) {
-        return (Mission) AbstractMission.generateInstanceFromXML(node, campaign, version);
+        return (Mission) AbstractMissionTransition.generateInstanceFromXML(node, campaign, version);
     }
 
     @Override

--- a/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
@@ -38,7 +38,7 @@ import static megamek.utilities.ImageUtilities.scaleImageIcon;
 import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
 import static mekhq.campaign.Campaign.AdministratorSpecialization.LOGISTICS;
 import static mekhq.campaign.Campaign.AdministratorSpecialization.TRANSPORT;
-import static mekhq.campaign.mission.AbstractMission.UNKNOWN_DIFFICULTY;
+import static mekhq.campaign.mission.AbstractMissionTransition.UNKNOWN_DIFFICULTY;
 
 import java.awt.Cursor;
 import java.awt.FlowLayout;

--- a/MekHQ/unittests/mekhq/campaign/mission/AbstractMissionTransitionIOTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/AbstractMissionTransitionIOTest.java
@@ -79,9 +79,10 @@ import org.w3c.dom.NodeList;
 import testUtilities.MHQTestUtilities;
 
 /**
- * Save/load (XML serialization) regression tests for the {@link AbstractMission} hierarchy.
+ * Save/load (XML serialization) regression tests for the {@link AbstractMissionTransition} hierarchy.
  *
- * <p>These tests guard the refactor that moved the shared mission/contract state onto {@link AbstractMission}, leaving
+ * <p>These tests guard the refactor that moved the shared mission/contract state onto
+ * {@link AbstractMissionTransition}, leaving
  * {@link Mission}, {@link Contract}, and {@link AtBContract} as thin subclasses. Because loading and saving of
  * contracts is a sensitive code path (a corrupted contract silently breaks a player's campaign), each sample file is
  * checked in two ways:</p>
@@ -96,7 +97,7 @@ import testUtilities.MHQTestUtilities;
  * plain {@link Mission}, a {@link Contract}, and a fully-populated {@link AtBContract} (scenarios, StratCon state and
  * NPCs included).</p>
  */
-public class AbstractMissionXmlIOTest {
+public class AbstractMissionTransitionIOTest {
     private static final Path MISSIONS_DIR = Path.of("testresources", "data", "missions");
 
     /** Any version at or above the current release; keeps the version-gated compatibility branches dormant. */
@@ -128,7 +129,7 @@ public class AbstractMissionXmlIOTest {
 
     @Test
     void plainMissionLoadsAsMissionWithExpectedFields() throws Exception {
-        AbstractMission mission = loadFirstMissionFromFile("Mission.cpnx");
+        AbstractMissionTransition mission = loadFirstMissionFromFile("Mission.cpnx");
 
         // A plain mission must NOT be promoted to a Contract / AtBContract.
         assertEquals(Mission.class, mission.getClass(), "plain mission must load as exactly Mission");
@@ -143,7 +144,7 @@ public class AbstractMissionXmlIOTest {
     }
 
     /**
-     * Previously {@link AbstractMission#writeToXMLBegin} unconditionally wrote
+     * Previously {@link AbstractMissionTransition#writeToXMLBegin} unconditionally wrote
      * {@code <contractType>UNDEFINED</contractType>} for a plain mission. On reload, the {@code contractType} handler
      * called {@code setContractTypeAndName(UNDEFINED)}, whose side effect overwrote the {@code contractTypeName} that
      * was just read from {@code <type>}; the free-text type (here {@code "affdsf"}) became {@code "Undefined"}. A plain
@@ -163,7 +164,7 @@ public class AbstractMissionXmlIOTest {
 
     @Test
     void contractLoadsAsContractWithExpectedFields() throws Exception {
-        AbstractMission mission = loadFirstMissionFromFile("Contract.cpnx");
+        AbstractMissionTransition mission = loadFirstMissionFromFile("Contract.cpnx");
 
         assertEquals(Contract.class, mission.getClass(), "sample must load as exactly Contract");
         Contract contract = (Contract) mission;
@@ -197,7 +198,7 @@ public class AbstractMissionXmlIOTest {
     }
 
     /**
-     * Previously {@link AbstractMission#writeToXMLBegin} unconditionally wrote
+     * Previously {@link AbstractMissionTransition#writeToXMLBegin} unconditionally wrote
      * {@code <contractType>UNDEFINED</contractType>} for a plain mission. On reload, the {@code contractType} handler
      * called {@code setContractTypeAndName(UNDEFINED)}, whose side effect overwrote the {@code contractTypeName} that
      * was just read from {@code <type>}; the free-text type (here {@code "affdsf"}) became {@code "Undefined"}. A plain
@@ -217,7 +218,7 @@ public class AbstractMissionXmlIOTest {
 
     @Test
     void atbContractLoadsAsAtBContractWithExpectedFields() throws Exception {
-        AbstractMission mission = loadFirstMissionFromFile("AtBContract.cpnx");
+        AbstractMissionTransition mission = loadFirstMissionFromFile("AtBContract.cpnx");
 
         assertEquals(AtBContract.class, mission.getClass(), "sample must load as exactly AtBContract");
         AtBContract contract = (AtBContract) mission;
@@ -443,10 +444,10 @@ public class AbstractMissionXmlIOTest {
         AtBContract atbContract = new AtBContract();
         atbContract.setName("New AtB Contract");
 
-        List<AbstractMission> missions = List.of(plainMission, contract, atbContract);
+        List<AbstractMissionTransition> missions = List.of(plainMission, contract, atbContract);
 
-        for (AbstractMission mission : missions) {
-            AbstractMission reloaded = parseMission(writeMission(mission));
+        for (AbstractMissionTransition mission : missions) {
+            AbstractMissionTransition reloaded = parseMission(writeMission(mission));
             assertEquals(mission.getClass(), reloaded.getClass(), "type must survive for " + mission.getClass());
             assertEquals(mission.getName(), reloaded.getName(), "name must survive for " + mission.getClass());
             assertEquals(mission.getStatus(), reloaded.getStatus(), "status must survive for " + mission.getClass());
@@ -559,10 +560,10 @@ public class AbstractMissionXmlIOTest {
      * second write onward must be idempotent; any writer/reader disagreement on a tag shows up here as a mismatch.
      */
     private void assertRoundTripStable(String fileName) throws Exception {
-        AbstractMission original = loadFirstMissionFromFile(fileName);
+        AbstractMissionTransition original = loadFirstMissionFromFile(fileName);
 
         String firstWrite = writeMission(original);
-        AbstractMission reloaded = parseMission(firstWrite);
+        AbstractMissionTransition reloaded = parseMission(firstWrite);
         String secondWrite = writeMission(reloaded);
 
         assertEquals(original.getClass(), reloaded.getClass(), "concrete type must survive a save/load cycle");
@@ -570,7 +571,7 @@ public class AbstractMissionXmlIOTest {
         assertEquals(firstWrite, secondWrite, "serialized form must be stable across a save/load/save cycle");
     }
 
-    private void assertCoreFieldsEqual(AbstractMission expected, AbstractMission actual) {
+    private void assertCoreFieldsEqual(AbstractMissionTransition expected, AbstractMissionTransition actual) {
         assertEquals(expected.getName(), actual.getName(), "name");
         assertEquals(expected.getContractTypeName(), actual.getContractTypeName(), "contractTypeName");
         assertEquals(expected.getStatus(), actual.getStatus(), "status");
@@ -618,37 +619,39 @@ public class AbstractMissionXmlIOTest {
 
     /**
      * Reads a {@code <missions>} sample file and instantiates the first {@code <mission>} element through the real
-     * production entry point, {@link AbstractMission#generateInstanceFromXML}.
+     * production entry point, {@link AbstractMissionTransition#generateInstanceFromXML}.
      */
-    private AbstractMission loadFirstMissionFromFile(String fileName) throws Exception {
+    private AbstractMissionTransition loadFirstMissionFromFile(String fileName) throws Exception {
         byte[] bytes = Files.readAllBytes(MISSIONS_DIR.resolve(fileName));
         Document document = parseDocument(bytes);
         Node missionNode = firstChildElement(document.getDocumentElement());
         assertNotNull(missionNode, "sample " + fileName + " must contain a <mission> element");
 
-        AbstractMission mission = AbstractMission.generateInstanceFromXML(missionNode, campaign, VERSION);
+        AbstractMissionTransition mission = AbstractMissionTransition.generateInstanceFromXML(missionNode,
+              campaign,
+              VERSION);
         assertNotNull(mission, "generateInstanceFromXML returned null for " + fileName);
         return mission;
     }
 
     /** Parses a single {@code <mission>} element (as produced by {@link #writeMission}) back into an object. */
-    private AbstractMission parseMission(String missionXml) throws Exception {
-        AbstractMission mission = generateFromXml(missionXml, VERSION);
+    private AbstractMissionTransition parseMission(String missionXml) throws Exception {
+        AbstractMissionTransition mission = generateFromXml(missionXml, VERSION);
         assertNotNull(mission, "re-parse of a written mission returned null");
         return mission;
     }
 
     /**
      * Instantiates a mission from a single {@code <mission>} XML string at the given save {@link Version}. Unlike
-     * {@link #parseMission}, this returns whatever {@link AbstractMission#generateInstanceFromXML} produces - including
-     * {@code null} for malformed input - so robustness and version-compatibility tests can assert on it.
+     * {@link #parseMission}, this returns whatever {@link AbstractMissionTransition#generateInstanceFromXML} produces -
+     * including {@code null} for malformed input - so robustness and version-compatibility tests can assert on it.
      */
-    private AbstractMission generateFromXml(String missionXml, Version version) throws Exception {
+    private AbstractMissionTransition generateFromXml(String missionXml, Version version) throws Exception {
         Document document = parseDocument(missionXml.getBytes(StandardCharsets.UTF_8));
-        return AbstractMission.generateInstanceFromXML(document.getDocumentElement(), campaign, version);
+        return AbstractMissionTransition.generateInstanceFromXML(document.getDocumentElement(), campaign, version);
     }
 
-    private String writeMission(AbstractMission mission) {
+    private String writeMission(AbstractMissionTransition mission) {
         StringWriter stringWriter = new StringWriter();
         try (PrintWriter printWriter = new PrintWriter(stringWriter)) {
             mission.writeToXML(campaign, printWriter, 0);

--- a/MekHQ/unittests/mekhq/campaign/mission/ContractDifficultyTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/ContractDifficultyTest.java
@@ -73,7 +73,7 @@ class ContractDifficultyTest {
     @MethodSource("provideContractDifficultyParameters")
     public void calculateContractDifficultySameSkillMatchesExpectedRating(double enemyBV, double playerBV,
           boolean useGenericBattleValue, int expectedResult) {
-        AbstractMission mission = new AbstractMission();
+        AbstractMissionTransition mission = new AbstractMissionTransition();
         List<Entity> playerCombatUnits = new ArrayList<>();
 
         try (MockedStatic<ContractDifficulty> mockedDifficulty = mockStatic(ContractDifficulty.class,


### PR DESCRIPTION
Change done to support architectural changes to support multi-contract missions.

No functionality changes