### PR TITLE
Limit Campaign to depend only on CampaignGUI instead of whole MekHQ

### DIFF
--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -354,11 +354,11 @@ public class MekHQ implements GameListener {
      */
     public void activateCampaign(Campaign campaign) {
         deactivateCampaign();
-        campaign.setApp(this);
-        campaignController = new CampaignController(campaign);
+        campaignController = new CampaignController(this, campaign);
         campaignController.setHost(campaign.getId());
-        campaignController.activate();
         campaignGUI = new CampaignGUI(this);
+        campaign.setGUI(campaignGUI);
+        campaignController.activate();
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -261,6 +261,7 @@ import mekhq.campaign.universe.selectors.factionSelectors.AbstractFactionSelecto
 import mekhq.campaign.universe.selectors.planetSelectors.AbstractPlanetSelector;
 import mekhq.campaign.work.IAcquisitionWork;
 import mekhq.campaign.work.IPartWork;
+import mekhq.gui.CampaignGUI;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogWidth;
 import mekhq.gui.campaignOptions.enums.ProcurementPersonnelPick;
@@ -414,7 +415,7 @@ public class Campaign implements ITechManager, IPlace {
 
     private CampaignOptions campaignOptions;
     private RandomSkillPreferences randomSkillPreferences = new RandomSkillPreferences();
-    private MekHQ app;
+    private CampaignGUI gui;
 
     private ShoppingList shoppingList;
 
@@ -704,18 +705,15 @@ public class Campaign implements ITechManager, IPlace {
         this.humanResources = humanResources;
     }
 
-    /**
-     * @return the app
-     */
-    public MekHQ getApp() {
-        return app;
+    public void setGUI(CampaignGUI gui) {
+        this.gui = gui;
     }
 
     /**
-     * @param app the app to set
+     * @return the {@link CampaignGUI}
      */
-    public void setApp(MekHQ app) {
-        this.app = app;
+    public CampaignGUI getGUI() {
+        return gui;
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/CampaignController.java
+++ b/MekHQ/src/mekhq/campaign/CampaignController.java
@@ -34,13 +34,18 @@ package mekhq.campaign;
 
 import java.util.UUID;
 
+import megamek.common.event.Subscribe;
 import mekhq.MekHQ;
+import mekhq.campaign.events.StoryFinishedEvent;
 import mekhq.campaign.market.PersonnelMarket;
+
+import javax.swing.SwingUtilities;
 
 /**
  * Manages the timeline of a {@link Campaign}.
  */
 public class CampaignController {
+    private final MekHQ app;
     private final Campaign localCampaign;
     private boolean isHost;
     private UUID host;
@@ -51,7 +56,8 @@ public class CampaignController {
      *
      * @param campaign The {@link Campaign} being used locally.
      */
-    public CampaignController(Campaign campaign) {
+    public CampaignController(MekHQ app, Campaign campaign) {
+        this.app = app;
         localCampaign = campaign;
         campaignEventProcessor = new CampaignEventProcessor(campaign);
     }
@@ -65,6 +71,7 @@ public class CampaignController {
             MekHQ.registerHandler(personnelMarket);
         }
         MekHQ.registerHandler(campaignEventProcessor);
+        MekHQ.registerHandler(this);
     }
 
     /**
@@ -79,6 +86,7 @@ public class CampaignController {
             MekHQ.unregisterHandler(personnelMarket);
         }
         MekHQ.unregisterHandler(campaignEventProcessor);
+        MekHQ.unregisterHandler(this);
     }
 
     /**
@@ -124,4 +132,12 @@ public class CampaignController {
     public void advanceDay() {
         getLocalCampaign().newDay();
     }
+
+    @Subscribe
+    public void handle(StoryFinishedEvent event) {
+        // do on a different thread, because restart will trigger event bus registrations which can
+        // lead to ConcurrentModificationException if done on the event bus trigger thread
+        SwingUtilities.invokeLater(app::restart);
+    }
+
 }

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -251,7 +251,7 @@ public class CampaignNewDayManager {
     public boolean newDay() {
         // Clear previous daily report nags (we want this up top so that we can make sure no messages have been
         // posted prior to this point).
-        CommandCenterTab commandCenter = campaign.getApp().getCampaigngui().getCommandCenterTab();
+        CommandCenterTab commandCenter = campaign.getGUI().getCommandCenterTab();
         for (DailyReportType type : DailyReportType.values()) {
             commandCenter.clearDailyReportNag(type.getTabIndex());
         }

--- a/MekHQ/src/mekhq/campaign/events/StoryFinishedEvent.java
+++ b/MekHQ/src/mekhq/campaign/events/StoryFinishedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -30,37 +30,16 @@
  * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
  * affiliated with Microsoft.
  */
-package mekhq.campaign.storyArc.storytrigger;
+package mekhq.campaign.events;
 
-import java.io.PrintWriter;
-import java.text.ParseException;
-
-import megamek.Version;
-import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.events.StoryFinishedEvent;
-import mekhq.campaign.storyArc.StoryTrigger;
-import org.w3c.dom.Node;
+import mekhq.campaign.storyArc.storytrigger.GameOverStoryTrigger;
 
 /**
- * A StoryTrigger to end the game by killing the current campaign and putting the player back in the startup screen.
- * This would typically be used for game failure (i.e. main character is killed).
+ * An event triggered when a story arc finishes and the current campaign should end. See {@link GameOverStoryTrigger}.
  */
-public class GameOverStoryTrigger extends StoryTrigger {
-
-    @Override
-    protected void execute() {
-        MekHQ.triggerEvent(new StoryFinishedEvent(getCampaign()));
-    }
-
-    @Override
-    public void writeToXml(PrintWriter pw1, int indent) {
-        writeToXmlBegin(pw1, indent++);
-        writeToXmlEnd(pw1, --indent);
-    }
-
-    @Override
-    protected void loadFieldsFromXmlNode(Node wn, Campaign c, Version v) throws ParseException {
-        // nothing to load
+public final class StoryFinishedEvent extends CampaignEvent {
+    public StoryFinishedEvent(Campaign campaign) {
+        super(campaign);
     }
 }

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -191,7 +191,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
         LOGGER.info("Starting load of campaign file from XML...");
         // Initialize variables.
         Campaign campaign = CampaignFactory.createCampaign();
-        campaign.setApp(app);
+        campaign.setGUI(app.getCampaigngui());
 
         Document xmlDoc;
 
@@ -217,7 +217,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
         // Confirm the campaign version is compatible with the current MekHQ version. This function lives here so that
         // we don't attempt to load incompatible campaigns and risk running into errors that might prevent the player
         // from viewing this dialog
-        new MilestoneUpgradePathDialog(campaign, version);
+        new MilestoneUpgradePathDialog(app, campaign, version);
 
         // Assuming there is no upgrade path, we set version and continue parsing the campaign.
         campaign.setVersion(version);
@@ -1697,7 +1697,6 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
      *
      * <p><b>Note B:</b> This approach has to be used, rather than self-correcting during person-load, as the spouse
      * may not have been substantiated when person is loaded.</p>
-     * </p>
      *
      * @param personnel the collection of {@link Person} objects to process
      *

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/ContractAutomation.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/ContractAutomation.java
@@ -149,7 +149,7 @@ public class ContractAutomation {
 
             campaign.getCurrentLocation().setJumpPath(jumpPath);
             campaign.getUnits().forEach(unit -> unit.setSite(Unit.SITE_FACILITY_BASIC));
-            campaign.getApp().getCampaigngui().refreshAllTabs();
+            campaign.getGUI().refreshAllTabs();
             boolean useTwoWayPay = campaign.getCampaignOptions().isUseTwoWayPay();
 
             // This will return an empty string if the transaction was successful

--- a/MekHQ/src/mekhq/campaign/storyArc/StoryPoint.java
+++ b/MekHQ/src/mekhq/campaign/storyArc/StoryPoint.java
@@ -163,7 +163,7 @@ public abstract class StoryPoint {
         processTriggers();
         proceedToNextStoryPoint();
         // refresh the GUI in case things have changed or been added
-        getCampaign().getApp().getCampaigngui().refreshAllTabs();
+        getCampaign().getGUI().refreshAllTabs();
 
     }
 

--- a/MekHQ/src/mekhq/campaign/storyArc/storypoint/WaitStoryPoint.java
+++ b/MekHQ/src/mekhq/campaign/storyArc/storypoint/WaitStoryPoint.java
@@ -81,7 +81,7 @@ public class WaitStoryPoint extends StoryPoint {
         // convert number of days to an actual date that we can check
         date = getCampaign().getLocalDate().plusDays(days);
         // refresh for objectives
-        getCampaign().getApp().getCampaigngui().refreshAllTabs();
+        getCampaign().getGUI().refreshAllTabs();
     }
 
     public LocalDate getDate() {

--- a/MekHQ/src/mekhq/campaign/storyArc/storytrigger/SwitchTabStoryTrigger.java
+++ b/MekHQ/src/mekhq/campaign/storyArc/storytrigger/SwitchTabStoryTrigger.java
@@ -55,7 +55,7 @@ public class SwitchTabStoryTrigger extends StoryTrigger {
 
     @Override
     protected void execute() {
-        getCampaign().getApp().getCampaigngui().setSelectedTab(tab);
+        getCampaign().getGUI().setSelectedTab(tab);
     }
 
     @Override

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -164,6 +164,8 @@ public final class BriefingTab extends CampaignGuiTab {
     private static final int BRIEFING_SPLIT_DIVIDER_SIZE = 10;
     private static final int SCENARIO_TABLE_ROW_HEIGHT = 24;
 
+    private final MekHQ app;
+
     private LanceAssignmentView panLanceAssignment;
     private JTabbedPane scenarioWorkTabs;
     private JTable scenarioTable;
@@ -219,8 +221,9 @@ public final class BriefingTab extends CampaignGuiTab {
     }
 
     // region Constructors
-    public BriefingTab(CampaignGUI gui, String tabName) {
+    public BriefingTab(MekHQ app, CampaignGUI gui, String tabName) {
         super(gui, tabName);
+        this.app = app;
         selectedScenario = -1;
     }
     // endregion Constructors
@@ -810,7 +813,7 @@ public final class BriefingTab extends CampaignGuiTab {
 
         CampaignOptions campaignOptions = getCampaignOptions();
 
-        getCampaign().getApp().getAutosaveService().requestBeforeMissionEndAutosave(getCampaign());
+        app.getAutosaveService().requestBeforeMissionEndAutosave(getCampaign());
 
         final CompleteMissionDialog cmd = new CompleteMissionDialog(getFrame());
         if (!cmd.showDialog().isConfirmed()) {
@@ -1730,7 +1733,7 @@ public final class BriefingTab extends CampaignGuiTab {
             return;
         }
 
-        getCampaign().getApp().resolveScenario(scenario);
+        app.resolveScenario(scenario);
     }
 
     /**
@@ -1753,7 +1756,7 @@ public final class BriefingTab extends CampaignGuiTab {
         if (chosen.isEmpty()) {
             return;
         }
-        getCampaign().getApp().startAutoResolve(scenario, chosen);
+        app.startAutoResolve(scenario, chosen);
     }
 
     private void runPrincessAutoResolve() {

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -213,7 +213,7 @@ public class CampaignGUI extends JPanel {
 
         commandCenterTab = new CommandCenterTab(this, MHQTabType.COMMAND_CENTER.toString());
         toeTab = new TOETab(this, MHQTabType.TOE.toString());
-        briefingRoomTab = new BriefingTab(this, MHQTabType.BRIEFING_ROOM.toString());
+        briefingRoomTab = new BriefingTab(app, this, MHQTabType.BRIEFING_ROOM.toString());
         stratConTab = new StratConTab(this, MHQTabType.STRAT_CON.toString());
         navigationTab = new NavigationTab(this, MHQTabType.NAVIGATION.toString());
         personnelTab = new PersonnelTab(this, MHQTabType.PERSONNEL.toString());

--- a/MekHQ/src/mekhq/gui/InfirmaryTab.java
+++ b/MekHQ/src/mekhq/gui/InfirmaryTab.java
@@ -169,7 +169,7 @@ public final class InfirmaryTab extends CampaignGuiTab {
                           person.getHyperlinkedFullTitle());
                     getCampaign().addReport(MEDICAL, report);
                 } else {
-                    new AdvancedReplacementLimbDialog(getCampaign(), person, false);
+                    new AdvancedReplacementLimbDialog(getCampaign(), getCampaignGui().getIconPackage(), person, false);
                 }
             }
         });
@@ -207,8 +207,7 @@ public final class InfirmaryTab extends CampaignGuiTab {
                         Person selectedPatient = listAssignedPatient.getSelectedValue();
                         if (selectedPatient != null) {
                             MedicalViewDialog medicalViewDialog = new MedicalViewDialog(null,
-                                  getCampaign(),
-                                  selectedPatient);
+                                  getCampaign(), selectedPatient, getCampaignGui().getIconPackage());
                             medicalViewDialog.setVisible(true);
                         }
                     }
@@ -257,8 +256,7 @@ public final class InfirmaryTab extends CampaignGuiTab {
                         Person selectedPatient = listUnassignedPatient.getSelectedValue();
                         if (selectedPatient != null) {
                             MedicalViewDialog medicalViewDialog = new MedicalViewDialog(null,
-                                  getCampaign(),
-                                  selectedPatient);
+                                  getCampaign(), selectedPatient, getCampaignGui().getIconPackage());
                             medicalViewDialog.setVisible(true);
                         }
                     }

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -399,7 +399,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_MEDICAL_RECORDS: {
-                MedicalViewDialog medDialog = new MedicalViewDialog(null, getCampaign(), selectedPerson);
+                MedicalViewDialog medDialog =
+                      new MedicalViewDialog(null, getCampaign(), selectedPerson, gui.getIconPackage());
                 medDialog.setModalityType(Dialog.ModalityType.APPLICATION_MODAL);
                 medDialog.setVisible(true);
                 break;
@@ -2511,7 +2512,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                               selectedPerson.getHyperlinkedFullTitle());
                         getCampaign().addReport(MEDICAL, report);
                     } else {
-                        new AdvancedReplacementLimbDialog(getCampaign(), selectedPerson, false);
+                        new AdvancedReplacementLimbDialog(getCampaign(), gui.getIconPackage(), selectedPerson, false);
                     }
                 }
             });

--- a/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogCore.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogCore.java
@@ -432,7 +432,7 @@ public class ImmersiveDialogCore extends JDialog {
         String commandKey = splitReference[0];
         String entryKey = splitReference[1];
 
-        CampaignGUI campaignGUI = campaign.getApp().getCampaigngui();
+        CampaignGUI campaignGUI = campaign.getGUI();
 
         if (commandKey.equalsIgnoreCase(GLOSSARY_COMMAND_STRING)) {
             GlossaryEntry glossaryEntry = GlossaryEntry.getGlossaryEntryFromLookUpName(entryKey);

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
@@ -144,9 +144,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         this.campaign = campaign;
         this.campaignOptions = campaign.getCampaignOptions();
         this.mode = mode;
-        if (campaign.getApp() != null) {
-            campaignGui = campaign.getApp().getCampaigngui();
-        }
+        this.campaignGui = campaign.getGUI();
         initialize();
     }
 

--- a/MekHQ/src/mekhq/gui/dialog/AdvancedReplacementLimbDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AdvancedReplacementLimbDialog.java
@@ -85,6 +85,7 @@ import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
 import megamek.common.annotations.Nullable;
 import megamek.logging.MMLogger;
+import mekhq.IconPackage;
 import mekhq.MekHQ;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
@@ -210,14 +211,16 @@ public class AdvancedReplacementLimbDialog extends JDialog {
      *
      * <p>If the patient is {@code null}, the dialog performs no initialization and returns without being shown.</p>
      *
-     * @param campaign the active campaign context
-     * @param patient  the patient undergoing treatment, or {@code null}
-     * @param isGMMode whether the dialog has been launched in GM Mode (bypassing all restrictions)
+     * @param campaign    the active campaign context
+     * @param iconPackage the {@link IconPackage} icon package to be used with the dialog
+     * @param patient     the patient undergoing treatment, or {@code null}
+     * @param isGMMode    whether the dialog has been launched in GM Mode (bypassing all restrictions)
      *
      * @author Illiani
      * @since 0.50.10
      */
-    public AdvancedReplacementLimbDialog(Campaign campaign, @Nullable Person patient, boolean isGMMode) {
+    public AdvancedReplacementLimbDialog(Campaign campaign, IconPackage iconPackage,
+          @Nullable Person patient, boolean isGMMode) {
         this.patient = patient;
         this.campaign = campaign;
         this.campaignOptions = campaign.getCampaignOptions();
@@ -230,10 +233,10 @@ public class AdvancedReplacementLimbDialog extends JDialog {
 
         gatherRelevantInjuries(patient.getInjuries());
         gatherTreatmentOptions();
-        paperDoll();
+        paperDoll(iconPackage);
 
         setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-        initializeUI();
+        initializeUI(iconPackage);
         pack();
         setLocationRelativeTo(null);
         setModal(true);
@@ -248,7 +251,7 @@ public class AdvancedReplacementLimbDialog extends JDialog {
      * @author Illiani
      * @since 0.50.10
      */
-    private void initializeUI() {
+    private void initializeUI(IconPackage iconPackage) {
         setTitle(getText("accessingTerminal.title"));
         setLayout(new BorderLayout());
 
@@ -340,7 +343,7 @@ public class AdvancedReplacementLimbDialog extends JDialog {
                   RESOURCE_BUNDLE, "AdvancedReplacementLimbDialog.button.normalMode"));
             normalModeButton.addActionListener(evt -> {
                 dispose();
-                new AdvancedReplacementLimbDialog(campaign, patient, false);
+                new AdvancedReplacementLimbDialog(campaign, iconPackage, patient, false);
             });
             buttonPanel.add(normalModeButton);
         } else {
@@ -349,7 +352,7 @@ public class AdvancedReplacementLimbDialog extends JDialog {
             gmModeButton.setEnabled(campaign.isGM());
             gmModeButton.addActionListener(evt -> {
                 dispose();
-                new AdvancedReplacementLimbDialog(campaign, patient, true);
+                new AdvancedReplacementLimbDialog(campaign, iconPackage, patient, true);
             });
             buttonPanel.add(gmModeButton);
         }
@@ -1235,19 +1238,15 @@ public class AdvancedReplacementLimbDialog extends JDialog {
      * @author Illiani
      * @since 0.50.10
      */
-    public void paperDoll() {
+    public void paperDoll(IconPackage iconPackage) {
         // Preload default paper dolls
-        try (InputStream fis = new FileInputStream(campaign.getApp()
-                                                         .getIconPackage()
-                                                         .getGuiElement(MALE_PAPER_DOLL))) {
+        try (InputStream fis = new FileInputStream(iconPackage.getGuiElement(MALE_PAPER_DOLL))) {
             defaultMaleDoll = new PaperDoll(fis);
         } catch (IOException e) {
             LOGGER.error("", e);
         }
 
-        try (InputStream fis = new FileInputStream(campaign.getApp()
-                                                         .getIconPackage()
-                                                         .getGuiElement(FEMALE_PAPER_DOLL))) {
+        try (InputStream fis = new FileInputStream(iconPackage.getGuiElement(FEMALE_PAPER_DOLL))) {
             defaultFemaleDoll = new PaperDoll(fis);
         } catch (IOException e) {
             LOGGER.error("", e);

--- a/MekHQ/src/mekhq/gui/dialog/AutoAwardsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AutoAwardsDialog.java
@@ -92,7 +92,7 @@ public class AutoAwardsDialog extends JDialog {
 
     public AutoAwardsDialog(Campaign c, Map<Integer, Map<Integer, List<Object>>> allAwardData, int ceremonyCount) {
         campaign = c;
-        gui = campaign.getApp().getCampaigngui();
+        gui = campaign.getGUI();
         allData = allAwardData;
         logger.info("attempting to extract a single page");
         data = allAwardData.get(ceremonyCount);

--- a/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
@@ -95,6 +95,7 @@ public class CampaignExportWizard extends JDialog {
     private JLabel lblStatus;
 
     private final Campaign sourceCampaign;
+    private final MekHQ app;
 
     private Optional<File> destinationCampaignFile;
     private final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.CampaignExportWizard",
@@ -110,7 +111,8 @@ public class CampaignExportWizard extends JDialog {
         DestinationFileSelection // this should always be last
     }
 
-    public CampaignExportWizard(Campaign c) {
+    public CampaignExportWizard(MekHQ app, Campaign c) {
+        this.app = app;
         chkExportState.setText(resourceMap.getString("chkExportSettings.text"));
         chkExportState.setToolTipText(resourceMap.getString("chkExportSettings.tooltip"));
         chkExportContractOffers.setText(resourceMap.getString("chkExportContractOffers.text"));
@@ -493,12 +495,11 @@ public class CampaignExportWizard extends JDialog {
         Campaign destinationCampaign;
         if (newCampaign) {
             destinationCampaign = CampaignFactory.createCampaign();
-            destinationCampaign.setApp(sourceCampaign.getApp());
             destinationCampaign.setCampaignOptions(sourceCampaign.getCampaignOptions());
             destinationCampaign.setGameOptions(sourceCampaign.getGameOptions());
         } else {
             try (FileInputStream fis = new FileInputStream(file)) {
-                destinationCampaign = CampaignFactory.newInstance(sourceCampaign.getApp()).createCampaign(fis);
+                destinationCampaign = CampaignFactory.newInstance(app).createCampaign(fis);
                 // Restores all transient attributes from serialized objects
                 destinationCampaign.restore();
                 destinationCampaign.cleanUp();

--- a/MekHQ/src/mekhq/gui/dialog/CampaignUpgradeDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignUpgradeDialog.java
@@ -114,18 +114,19 @@ public class CampaignUpgradeDialog {
      * the chosen preset, optionally runs a completion callback, or allows further customization via a campaign options
      * dialog.</p>
      *
+     * @param app      The application context
      * @param campaign The campaign being upgraded; must not be {@code null}.
      *
      * @author Illiani
      * @since 0.50.07
      */
-    public static void campaignUpgradeDialog(Campaign campaign) {
+    public static void campaignUpgradeDialog(MekHQ app, Campaign campaign) {
         JPanel supplementalPanel = createSupplementalPanel();
 
         // This will occur if there are no presets available. This should never occur under normal circumstances as
         // MekHQ always ships with a battery of presets.
         if (supplementalPanel == null) {
-            exitApp(campaign.getApp());
+            exitApp(app);
             return;
         }
 
@@ -145,13 +146,13 @@ public class CampaignUpgradeDialog {
         int comboChoiceIndex = upgradeDialog.getComboBoxChoiceIndex();
 
         switch (dialogChoiceIndex) {
-            case PRESET_SELECTION_CANCELLED -> exitApp(campaign.getApp());
+            case PRESET_SELECTION_CANCELLED -> exitApp(app);
             case PRESET_SELECTION_SELECT -> {
                 if (comboChoiceIndex < 0 || comboChoiceIndex >= presets.size()) {
                     LOGGER.errorDialog("Error",
                           "Invalid campaign preset index {}. Please report to the MekHQ team",
                           comboChoiceIndex);
-                    exitApp(campaign.getApp());
+                    exitApp(app);
                     // This is wholly unnecessary as the app will have already been closed.
                     // We include it because otherwise the IDE complains.
                     return;
@@ -222,7 +223,7 @@ public class CampaignUpgradeDialog {
                 CampaignOptionsDialog optionsDialog = new CampaignOptionsDialog(null, campaign);
                 optionsDialog.setVisible(true);
                 if (optionsDialog.wasCanceled()) {
-                    exitApp(campaign.getApp());
+                    exitApp(app);
                 }
             }
         }

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -472,7 +472,7 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
                 // This needs to be the final stage in Progress 7 as otherwise the display of any confirmation
                 // dialogs will get 'stuck' behind other dialogs
                 if (campaignVersion.isLowerThan(MHQConstants.VERSION)) {
-                    handleCampaignUpgrading(campaign);
+                    handleCampaignUpgrading(application, campaign);
                 }
                 // endregion Progress 7
             }
@@ -498,13 +498,14 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
          * <p><b>Note:</b> This method should not be called from the Event Dispatch Thread (EDT), as it will block
          * the thread until the upgrade is finished.</p>
          *
+         * @param app      the application context
          * @param campaign the {@link Campaign} instance to be upgraded
          *
          * @author Illiani
          * @since 0.50.07
          */
-        private static void handleCampaignUpgrading(Campaign campaign) {
-            CampaignUpgradeDialog.campaignUpgradeDialog(campaign);
+        private static void handleCampaignUpgrading(MekHQ app, Campaign campaign) {
+            CampaignUpgradeDialog.campaignUpgradeDialog(app, campaign);
         }
 
         /**

--- a/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
@@ -61,6 +61,7 @@ import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
 import megamek.common.ui.FastJScrollPane;
 import megamek.logging.MMLogger;
+import mekhq.IconPackage;
 import mekhq.MekHQ;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
@@ -103,26 +104,21 @@ public class MedicalViewDialog extends JDialog {
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.MedicalViewDialog",
           MekHQ.getMHQOptions().getLocale());
 
-    public MedicalViewDialog(Window parent, Campaign campaign, Person person) {
+    public MedicalViewDialog(Window parent, Campaign campaign, Person person, IconPackage iconPackage) {
         super();
         this.campaign = Objects.requireNonNull(campaign);
         this.person = Objects.requireNonNull(person);
         gatherRelevantInjuries(person.getInjuries());
 
         // Preload default paper dolls
-        try (InputStream fis = new FileInputStream(campaign.getApp()
-                                                         .getIconPackage()
-                                                         .getGuiElement("default_male_paperdoll"))) { // TODO : Remove inline file
-            // path
+        // TODO: Remove inline file path
+        try (InputStream fis = new FileInputStream(iconPackage.getGuiElement("default_male_paperdoll"))) {
             defaultMaleDoll = new PaperDoll(fis);
         } catch (IOException e) {
             LOGGER.error("", e);
         }
-
-        try (InputStream fis = new FileInputStream(campaign.getApp()
-                                                         .getIconPackage()
-                                                         .getGuiElement("default_female_paperdoll"))) { // TODO : Remove inline file
-            // path
+        // TODO: Remove inline file path
+        try (InputStream fis = new FileInputStream(iconPackage.getGuiElement("default_female_paperdoll"))) {
             defaultFemaleDoll = new PaperDoll(fis);
         } catch (IOException e) {
             LOGGER.error("", e);

--- a/MekHQ/src/mekhq/gui/dialog/MilestoneUpgradePathDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MilestoneUpgradePathDialog.java
@@ -53,6 +53,7 @@ import megamek.common.util.milestoneReleaseInformation.MilestoneData;
 import megamek.logging.MMLogger;
 import megamek.utilities.ImageUtilities;
 import mekhq.MHQConstants;
+import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogWidth;
@@ -75,13 +76,14 @@ public class MilestoneUpgradePathDialog {
      *
      * <p>If the dialog is shown, once it has been acknowledged, the application will exit.</p>
      *
+     * @param app                    the application context
      * @param campaign               the {@link Campaign} for which to check upgrade requirements
      * @param currentCampaignVersion the current {@link Version} of the campaign
      *
      * @author Illiani
      * @since 0.50.07
      */
-    public MilestoneUpgradePathDialog(Campaign campaign, Version currentCampaignVersion) {
+    public MilestoneUpgradePathDialog(MekHQ app, Campaign campaign, Version currentCampaignVersion) {
         // Are any upgrades necessary?
         final List<MilestoneData> upgradePath = getUpgradePath(currentCampaignVersion);
         if (upgradePath.isEmpty()) {
@@ -103,7 +105,7 @@ public class MilestoneUpgradePathDialog {
               true);
 
         // If upgrades were necessary, exit the app once the dialog has been confirmed
-        campaign.getApp().exit(false);
+        app.exit(false);
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
@@ -1962,7 +1962,7 @@ public class ResolveScenarioWizardDialog extends JDialog {
         }
         PersonViewPanel personViewPanel = new PersonViewPanel(person,
               tracker.getCampaign(),
-              tracker.getCampaign().getApp().getCampaigngui());
+              tracker.getCampaign().getGUI());
         final JDialog dialog = new JDialog(frame, isPrisoner ? "Prisoner View" : "Personnel View", true);
         dialog.getContentPane().setLayout(new GridBagLayout());
 

--- a/MekHQ/src/mekhq/gui/dialog/markets/personnelMarket/PersonnelMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/personnelMarket/PersonnelMarketDialog.java
@@ -153,7 +153,7 @@ public class PersonnelMarketDialog extends JDialog {
         this.market = market;
         this.campaign = market.getCampaign();
         this.campaignOptions = campaign.getCampaignOptions();
-        this.parent = campaign.getApp().getCampaigngui().getFrame();
+        this.parent = campaign.getGUI().getFrame();
         this.currentApplicants = market.getCurrentApplicants();
 
         initializeComponents();
@@ -381,7 +381,7 @@ public class PersonnelMarketDialog extends JDialog {
               "button.personnelMarket.advanceDays"));
         btnAdvanceMultipleDays.addActionListener(e -> {
             closeAction(); // Close old instance
-            AdvanceDaysDialog advanceDaysDialog = new AdvanceDaysDialog(parent, campaign.getApp().getCampaigngui());
+            AdvanceDaysDialog advanceDaysDialog = new AdvanceDaysDialog(parent, campaign.getGUI());
             advanceDaysDialog.setVisible(true);
             advanceDaysDialog.addWindowListener(new WindowAdapter() {
                 @Override
@@ -510,7 +510,7 @@ public class PersonnelMarketDialog extends JDialog {
      * @since 0.50.06
      */
     private JSplitPane initializePersonView(AtomicReference<Person> selectedPerson, JPanel mainPanel) {
-        personViewPanel = new PersonViewPanel(selectedPerson.get(), campaign, campaign.getApp().getCampaigngui());
+        personViewPanel = new PersonViewPanel(selectedPerson.get(), campaign, campaign.getGUI());
         JScrollPane viewScrollPane = new JScrollPane(personViewPanel);
         viewScrollPane.setMinimumSize(PERSON_VIEW_MINIMUM_SIZE);
         viewScrollPane.setBorder(null);

--- a/MekHQ/src/mekhq/gui/dialog/randomEvents/RoninEventDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/randomEvents/RoninEventDialog.java
@@ -79,7 +79,7 @@ public class RoninEventDialog extends ImmersiveDialogCore {
     @Override
     protected JPanel buildRightSpeakerPanel(@Nullable Person speaker, Campaign campaign) {
         JPanel speakerBox = new JPanel();
-        PersonViewPanel personViewPanel = new PersonViewPanel(speaker, campaign, campaign.getApp().getCampaigngui());
+        PersonViewPanel personViewPanel = new PersonViewPanel(speaker, campaign, campaign.getGUI());
         speakerBox.add(personViewPanel);
         speakerBox.setAlignmentX(CENTER_ALIGNMENT);
 

--- a/MekHQ/src/mekhq/gui/menus/MekHQMenuBar.java
+++ b/MekHQ/src/mekhq/gui/menus/MekHQMenuBar.java
@@ -346,7 +346,7 @@ public class MekHQMenuBar extends JMenuBar {
         // endregion XML Export
 
         JMenuItem miExportCampaignSubset = createMenuItem("miExportCampaignSubset.text", KeyEvent.VK_S, evt -> {
-            CampaignExportWizard cew = new CampaignExportWizard(getCampaign());
+            CampaignExportWizard cew = new CampaignExportWizard(getApplication(), getCampaign());
             cew.display(CampaignExportWizard.CampaignExportWizardState.ForceSelection);
         });
         menuExport.add(miExportCampaignSubset);

--- a/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
@@ -273,7 +273,7 @@ public class ContractSummaryPanel extends JPanel {
             @Override
             public void mouseClicked(MouseEvent e) {
                 // Display where it is on the interstellar map
-                CampaignGUI gui = campaign.getApp().getCampaigngui();
+                CampaignGUI gui = campaign.getGUI();
                 gui.getNavigationTab().showSystem(contract.getSystem());
                 gui.setSelectedTab(gui.getNavigationTab());
             }


### PR DESCRIPTION
This refactoring improves encapsulation by decoupling the `Campaign` model from the global application context. Furthermore, it helps with concentrating lifecycle management in `CampaignController`, resulting in a cleaner and more maintainable logic.

Change details:
- Replace `MekHQ` reference in `Campaign` with `CampaignGUI`
- Introduce `StoryFinishedEvent` and handle it in `CampaignController`
- Pass `MekHQ` directly to `CampaignController`, `BriefingTab`, and wizards
- Inject `IconPackage` directly into medical dialogs to decouple from app