### PR TITLE
Calculate StratCon scouting skill checks once

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillCheck.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillCheck.java
@@ -73,6 +73,14 @@ public class SkillCheck extends ActionCheck<SkillCheck> {
         this.skillType = SkillType.getType(skillName);
     }
 
+    public SkillType getSkillType() {
+        return skillType;
+    }
+
+    public boolean isEasierThan(SkillCheck other) {
+        return !targetNumber.cannotSucceed() && (targetNumber.getValue() < other.targetNumber.getValue());
+    }
+
     @Override
     protected SkillCheck getThis() {
         return this;

--- a/MekHQ/src/mekhq/campaign/stratCon/ScoutRecord.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/ScoutRecord.java
@@ -32,30 +32,11 @@
  */
 package mekhq.campaign.stratCon;
 
-import megamek.common.TargetRollModifier;
-import megamek.common.rolls.TargetRoll;
 import mekhq.campaign.personnel.Person;
-
-import java.util.List;
+import mekhq.campaign.personnel.skills.SkillCheck;
 
 public record ScoutRecord(
       Person scout,
-      TargetRoll targetNumber,
-      String bestScoutSkillName,
-      boolean scoutHasEagleEyes,
-      double unitWeight,
-      int unitSpeed,
-      boolean unitHasSensorEquipment
-) {
-
-    /**
-     * Returns the full list of {@link TargetRollModifier}s affecting scouting.
-     *
-     * @return a list of {@link TargetRollModifier} reflecting all bonuses scout has
-     */
-    public List<TargetRollModifier> getAllScoutRollModifiers() {
-        return StratConRulesManager.getAllScoutRollModifiers(unitWeight, unitSpeed,
-              scoutHasEagleEyes, unitHasSensorEquipment);
-    }
-
-}
+      SkillCheck skillCheck,
+      double unitWeight
+) {}

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -120,9 +120,8 @@ import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.skills.ActionCheckResult;
 import mekhq.campaign.personnel.skills.ScoutingSkills;
 import mekhq.campaign.personnel.skills.Skill;
-import mekhq.campaign.personnel.skills.SkillCheckUtility;
+import mekhq.campaign.personnel.skills.SkillCheck;
 import mekhq.campaign.personnel.skills.SkillModifierData;
-import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.personnel.turnoverAndRetention.Fatigue;
 import mekhq.campaign.stratCon.StratConContractDefinition.StrategicObjectiveType;
 import mekhq.campaign.stratCon.StratConScenario.ScenarioState;
@@ -1609,12 +1608,9 @@ public class StratConRulesManager {
         }
 
         // Build a map of scouts and their information
-        CampaignOptions campaignOptions = campaign.getCampaignOptions();
-        Formation formation = campaign.getFormation(forceID);
-        Hangar hangar = campaign.getAllHangar();
-        List<ScoutRecord> scouts = buildScoutMap(formation, hangar, campaignOptions,
-              campaign.isClanCampaign(), campaign.getLocalDate());
+        List<ScoutRecord> scouts = buildScoutMap(campaign.getFormation(forceID), campaign.getAllHangar(), campaign);
 
+        CampaignOptions campaignOptions = campaign.getCampaignOptions();
         boolean useAdvancedScouting = campaignOptions.isUseAdvancedScouting();
         // Each scout may scan up to scanMultiplier hexes
         // Each scout may scan up to a radius of individualScanRange hexes
@@ -1676,11 +1672,8 @@ public class StratConRulesManager {
 
                     ActionCheckResult actionCheckResult = null;
                     if (useAdvancedScouting) {
-                        actionCheckResult =
-                              scout.checkSkill(scoutData.bestScoutSkillName(), false, false, campaign.getLocalDate())
-                                    .withExternalModifiers(scoutData.getAllScoutRollModifiers())
-                                    .resolve(isUseEdge, getTextAt(RESOURCE_BUNDLE,
-                                          "StratConRulesManager.scoutingSkillCheck"), false);
+                        actionCheckResult = scoutData.skillCheck().resolve(
+                              isUseEdge, getTextAt(RESOURCE_BUNDLE, "StratConRulesManager.scoutingSkillCheck"), false);
                         campaign.addReport(SKILL_CHECKS, actionCheckResult.resultsText());
                     }
 
@@ -1849,9 +1842,7 @@ public class StratConRulesManager {
      *
      * @param formation       the {@link Formation} containing units to evaluate
      * @param hangar          the {@link Hangar} used to help retrieve units from the force
-     * @param campaignOptions {@link CampaignOptions}, used to check useCommanderOnly options
-     * @param isClanCampaign  if {@code true}, applies rules specific to clan campaigns
-     * @param date            the current date, used for time-dependent logic
+     * @param campaign        the {@link Campaign} context
      *
      * @return a list of {@link ScoutRecord} objects, each representing the best scout and their skill details for a
      *       unit, sorted from the highest to lowest scout skill level
@@ -1859,8 +1850,7 @@ public class StratConRulesManager {
      * @author Illiani
      * @since 0.50.07
      */
-    static List<ScoutRecord> buildScoutMap(Formation formation, Hangar hangar, CampaignOptions campaignOptions,
-          boolean isClanCampaign, LocalDate date) {
+    static List<ScoutRecord> buildScoutMap(Formation formation, Hangar hangar, Campaign campaign) {
         if (formation == null) {
             return new ArrayList<>();
         }
@@ -1884,7 +1874,7 @@ public class StratConRulesManager {
                 unitSpeed = AtBDynamicScenarioFactory.calculateAtBSpeed(entity);
                 hasSensorEquipment = hasImprovedSensors(entity) || hasActiveProbe(entity);
 
-                if (unit.isOnlyCommandersMatter(campaignOptions)) {
+                if (unit.isOnlyCommandersMatter(campaign.getCampaignOptions())) {
                     Person commander = unit.getCommander();
                     if (commander == null) {
                         LOGGER.info("No commander for unit: {} {}", unit.getName(), unit.getId());
@@ -1896,7 +1886,6 @@ public class StratConRulesManager {
 
             // Find the best scout in this unit, if any
             ScoutRecord bestScout = null;
-            int bestScoutTargetNumber = Integer.MAX_VALUE;
             for (Person crewMember : unitCrew) {
                 boolean hasEagleEyes = crewMember.getOptions().booleanOption(OptionsConstants.MISC_EAGLE_EYES);
                 String scoutSkillName = ScoutingSkills.getBestScoutingSkill(crewMember);
@@ -1904,15 +1893,12 @@ public class StratConRulesManager {
                     continue;
                 }
 
-                TargetRoll targetNumber = SkillCheckUtility.determineTargetNumber(crewMember,
-                      SkillType.getType(scoutSkillName), campaignOptions.isUseAgeEffects(), isClanCampaign, date);
-                getAllScoutRollModifiers(unitWeight, unitSpeed, hasEagleEyes, hasSensorEquipment)
-                      .forEach(targetNumber::addModifier);
+                List<TargetRollModifier> mods = getAllScoutRollModifiers(
+                      unitWeight, unitSpeed, hasEagleEyes, hasSensorEquipment);
+                SkillCheck skillCheck = crewMember.checkSkill(scoutSkillName, campaign).withExternalModifiers(mods);
 
-                if (bestScout == null || targetNumber.getValue() < bestScoutTargetNumber) {
-                    bestScout = new ScoutRecord(crewMember, targetNumber, scoutSkillName,
-                          hasEagleEyes, unitWeight, unitSpeed, hasSensorEquipment);
-                    bestScoutTargetNumber = targetNumber.getValue();
+                if (bestScout == null || skillCheck.isEasierThan(bestScout.skillCheck())) {
+                    bestScout = new ScoutRecord(crewMember, skillCheck, unitWeight);
                 }
             }
 
@@ -1921,13 +1907,13 @@ public class StratConRulesManager {
             }
 
             LOGGER.info("Unit {} (weight: {}t, speed: {}) has best scout: {} with skill {} at TN {}",
-                  unit.getId(), unitWeight, unitSpeed, bestScout.scout(), bestScout.bestScoutSkillName(),
-                  bestScout.targetNumber().getValue());
+                  unit.getId(), unitWeight, unitSpeed, bestScout.scout(),
+                  bestScout.skillCheck().getSkillType().getName(), bestScout.skillCheck().getTargetNumber().getValue());
             scouts.add(bestScout);
         }
 
         // Sort scouts by the target number of their best scout skill, the lowest first
-        scouts.sort(Comparator.comparingInt(a -> a.targetNumber().getValue()));
+        scouts.sort(Comparator.comparingInt(a -> a.skillCheck().getTargetNumber().getValue()));
         return scouts;
     }
 

--- a/MekHQ/unittests/mekhq/campaign/stratCon/StratConRulesManagerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/stratCon/StratConRulesManagerTest.java
@@ -47,6 +47,7 @@ import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -76,6 +77,7 @@ import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.skills.ScoutingSkills;
 import mekhq.campaign.personnel.skills.Skill;
+import mekhq.campaign.personnel.skills.SkillCheck;
 import mekhq.campaign.personnel.skills.SkillModifierData;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.stratCon.StratConContractDefinition.StrategicObjectiveType;
@@ -725,8 +727,8 @@ class StratConRulesManagerTest {
 
         @Test
         void testBuildScoutMap_NullFormation() {
-            List<ScoutRecord> scouts = StratConRulesManager.buildScoutMap(null, mock(Hangar.class),
-                  mock(CampaignOptions.class), false, LocalDate.now());
+            List<ScoutRecord> scouts =
+                  StratConRulesManager.buildScoutMap(null, mock(Hangar.class), mock(Campaign.class));
             assertNotNull(scouts);
             assertTrue(scouts.isEmpty());
         }
@@ -735,14 +737,12 @@ class StratConRulesManagerTest {
         void testBuildScoutMap_SingleCrewMember() {
             Person person = mockPerson(4, true);
             ScoutRecord bestScout = getBestScoutForUnit(List.of(person), 45, 5, true, false);
+            SkillCheck skillCheck = bestScout.skillCheck();
 
             assertEquals(person, bestScout.scout());
-            assertEquals(S_SENSOR_OPERATIONS, bestScout.bestScoutSkillName());
-            assertEquals(3, bestScout.targetNumber().getValue());
+            assertEquals(S_SENSOR_OPERATIONS, skillCheck.getSkillType().getName());
+            assertEquals(3, skillCheck.getTargetNumber().getValue());
             assertEquals(45.0, bestScout.unitWeight());
-            assertEquals(5, bestScout.unitSpeed());
-            assertTrue(bestScout.scoutHasEagleEyes());
-            assertTrue(bestScout.unitHasSensorEquipment());
         }
 
         @ParameterizedTest
@@ -795,43 +795,43 @@ class StratConRulesManagerTest {
         @Test
         void testBuildScoutMap_TN_NoEagleEyes() {
             ScoutRecord bestScout = getBestScoutForUnit(List.of(mockPerson(4, false)), 45, 5, false, false);
-            assertEquals(4, bestScout.targetNumber().getValue());
+            assertEquals(4, bestScout.skillCheck().getTargetNumber().getValue());
         }
 
         @Test
         void testBuildScoutMap_TN_EagleEyes() {
             ScoutRecord bestScout = getBestScoutForUnit(List.of(mockPerson(4, true)), 45, 5, false, false);
-            assertEquals(3, bestScout.targetNumber().getValue());
+            assertEquals(3, bestScout.skillCheck().getTargetNumber().getValue());
         }
 
         @Test
         void testBuildScoutMap_TN_EagleEyes_AP() {
             ScoutRecord bestScout = getBestScoutForUnit(List.of(mockPerson(4, true)), 45, 5, false, true);
-            assertEquals(3, bestScout.targetNumber().getValue());
+            assertEquals(3, bestScout.skillCheck().getTargetNumber().getValue());
         }
 
         @Test
         void testBuildScoutMap_TN_EagleEyes_IS() {
             ScoutRecord bestScout = getBestScoutForUnit(List.of(mockPerson(4, true)), 45, 5, true, false);
-            assertEquals(3, bestScout.targetNumber().getValue());
+            assertEquals(3, bestScout.skillCheck().getTargetNumber().getValue());
         }
 
         @Test
         void testBuildScoutMap_TN_EagleEyes_IS_AP() {
             ScoutRecord bestScout = getBestScoutForUnit(List.of(mockPerson(4, true)), 45, 5, true, true);
-            assertEquals(3, bestScout.targetNumber().getValue());
+            assertEquals(3, bestScout.skillCheck().getTargetNumber().getValue());
         }
 
         @Test
         void testBuildScoutMap_TN_UnitSpeed() {
             ScoutRecord bestScout = getBestScoutForUnit(List.of(mockPerson(4, false)), 45, 9, false, false);
-            assertEquals(3, bestScout.targetNumber().getValue());
+            assertEquals(3, bestScout.skillCheck().getTargetNumber().getValue());
         }
 
         @Test
         void testBuildScoutMap_TN_UnitWeight() {
             ScoutRecord bestScout = getBestScoutForUnit(List.of(mockPerson(4, false)), 95, 5, false, false);
-            assertEquals(8, bestScout.targetNumber().getValue());
+            assertEquals(8, bestScout.skillCheck().getTargetNumber().getValue());
         }
 
         @Test
@@ -843,30 +843,29 @@ class StratConRulesManagerTest {
             when(formation.getAllUnitsAsUnits(hangar, false)).thenReturn(Collections.singletonList(unit));
             when(unit.getCrew()).thenReturn(new ArrayList<>());
 
-            List<ScoutRecord> scouts = StratConRulesManager.buildScoutMap(formation, hangar,
-                  mock(CampaignOptions.class), false, LocalDate.now());
+            List<ScoutRecord> scouts = StratConRulesManager.buildScoutMap(formation, hangar, mock(Campaign.class));
             assertTrue(scouts.isEmpty());
         }
 
         private Person mockPerson(int sensorOperationsSkill, boolean hasEagleEye) {
-            Person person = mock(Person.class);
-            PersonnelOptions options = mock(PersonnelOptions.class);
+            Person person = new Person("GivenName", "Surname", null, "Faction");
             Skill skill = mock(Skill.class);
-            SkillModifierData skillModData = mock(SkillModifierData.class);
-
-            when(person.hasSkill(S_SENSOR_OPERATIONS)).thenReturn(true);
-            when(person.getSkill(S_SENSOR_OPERATIONS)).thenReturn(skill);
-            when(person.getSkillModifierData()).thenReturn(skillModData);
-            when(person.getSkillModifierData(anyBoolean())).thenReturn(skillModData);
-            when(person.getSkillModifierData(
-                  anyBoolean(), anyBoolean(), any(LocalDate.class))).thenReturn(skillModData);
-            when(person.getSkillModifierData(
-                  anyBoolean(), anyBoolean(), any(LocalDate.class), anyBoolean())).thenReturn(skillModData);
-            when(skill.getFinalSkillValue(skillModData)).thenReturn(sensorOperationsSkill);
-            when(person.getOptions()).thenReturn(options);
+            when(skill.getFinalSkillValue(any(SkillModifierData.class))).thenReturn(sensorOperationsSkill);
+            person.addSkill(S_SENSOR_OPERATIONS, skill);
+            PersonnelOptions options = mock(PersonnelOptions.class);
             when(options.booleanOption(OptionsConstants.MISC_EAGLE_EYES)).thenReturn(hasEagleEye);
+            person.setOptions(options);
+            return spy(person);
+        }
 
-            return person;
+        private static Campaign mockCampaign(boolean useAgingEffects, boolean isClanCampaign) {
+            Campaign campaign = mock(Campaign.class);
+            when(campaign.isClanCampaign()).thenReturn(isClanCampaign);
+            when(campaign.getLocalDate()).thenReturn(LocalDate.now());
+            CampaignOptions campaignOptions = mock(CampaignOptions.class);
+            when(campaignOptions.isUseAgeEffects()).thenReturn(useAgingEffects);
+            when(campaign.getCampaignOptions()).thenReturn(campaignOptions);
+            return campaign;
         }
 
         private ScoutRecord getBestScoutForUnit(List<Person> crew, double unitWeight, int unitSpeed,
@@ -900,12 +899,8 @@ class StratConRulesManagerTest {
                                                                      ScoutingSkills.getBestScoutingSkill(crewMember))
                                                  .thenReturn(S_SENSOR_OPERATIONS));
 
-                CampaignOptions campaignOptions = mock(CampaignOptions.class);
-                if (useAgingEffects) {
-                    when(campaignOptions.isUseAgeEffects()).thenReturn(true);
-                }
-                List<ScoutRecord> scouts = StratConRulesManager.buildScoutMap(formation, hangar,
-                      campaignOptions, isClanCampaign, LocalDate.now());
+                Campaign campaign = mockCampaign(useAgingEffects, isClanCampaign);
+                List<ScoutRecord> scouts = StratConRulesManager.buildScoutMap(formation, hangar, campaign);
                 assertEquals(1, scouts.size());
 
                 return scouts.getFirst();
@@ -938,10 +933,9 @@ class StratConRulesManagerTest {
                 }).toList();
                 when(formation.getAllUnitsAsUnits(hangar, false)).thenReturn(units);
 
-                List<ScoutRecord> scouts = StratConRulesManager.buildScoutMap(formation, hangar,
-                      mock(CampaignOptions.class), false, LocalDate.now());
+                Campaign campaign = mockCampaign(false, false);
 
-                return scouts;
+                return StratConRulesManager.buildScoutMap(formation, hangar, campaign);
             }
         }
     }


### PR DESCRIPTION
Previously, we were calculating scouting check target number twice: once when best scouts were determined and later when such skill checks were resolved. This change removes code duplication, leaving only one source of truth for the calculation.

Additionally, introduce `getSkillType` and `isEasierThan` helper methods for `SkillCheck`.