### PR TITLE
Fix trainee skill selection in TrainingCombatTeams

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
@@ -272,12 +272,12 @@ public class TrainingCombatTeams {
                         SkillType skillType = traineeSkill.getType();
                         int targetLevel = skillType.getRegularLevel();
 
-                        int traineeSkillLevel = traineeSkill.getLevel();
-                        if (traineeSkillLevel >= targetLevel) {
+                        int traineeExperienceLevel = traineeSkill.getExperienceLevel(null);
+                        if (traineeExperienceLevel >= targetLevel) {
                             continue;
                         }
 
-                        if (traineeSkillLevel < educatorSkills.get(commanderSkill)) {
+                        if (traineeExperienceLevel < educatorSkills.get(commanderSkill)) {
                             skillsBeingTrained.add(traineeSkill);
                         }
                     }


### PR DESCRIPTION
PR #9129 changed how skill evaluation works for educators, but evaluation for the trainees remained the same leading to inconsistency (see #9327). This change aligns trainee and educator skill calculations.