### PR TITLE
Make improved sensors quirk usable with Advanced Scouting

### DIFF
--- a/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
+++ b/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
@@ -63,8 +63,8 @@ ADVANCED_SCOUTING.definition=If 'Advanced Scouting' is enabled in Campaign Optio
   <p>If the unit has any jump capacity, the unit's speed is increased by 1, unless the unit is Jump Infantry. In \
   which case the unit's jump speed is used instead of its walk speed. If the unit is Aerospace, or an aerodyne \
   DropShip, their walk speed is doubled.</p>\
-  <p>The target number is further reduced by 1 if the unit is equipped with either Improved Sensors, an Active \
-  Probe, or the scout has the Eagle Eyes SPA. This is factored into determining who performs the scout check.</p>\
+  <p>If the scouting mek has the Improved Sensors quirk (and quirks are enabled), is equipped with Improved Sensors \
+  or an active probe, or the pilot has the Eagle Eyes SPA, the target number is further reduced by 1.</p>\
   <h2>Scan Range</h2>\
   <p>Normally only formations assigned to the Patrol <a href='GLOSSARY:COMBAT_ROLES'>Combat Role</a> can effectively \
   scout hexes. This is because they automatically increase their scan range by 1 (from 0). However, some \

--- a/MekHQ/src/mekhq/utilities/EntityUtilities.java
+++ b/MekHQ/src/mekhq/utilities/EntityUtilities.java
@@ -39,7 +39,6 @@ import megamek.common.equipment.MiscType;
 import megamek.common.equipment.Mounted;
 import megamek.common.equipment.Sensor;
 import megamek.common.options.OptionsConstants;
-import megamek.common.options.Quirks;
 import megamek.common.units.Entity;
 import megamek.common.units.UnitType;
 import mekhq.campaign.Campaign;
@@ -97,7 +96,7 @@ public class EntityUtilities {
      * that matches either {@link Sensor#IS_IMPROVED} or {@link Sensor#CL_IMPROVED}.</p>
      *
      * @param entity the {@link Entity} to check for improved sensors. They are also checked for
-     * {@link Quirks} Improved Sensors.
+     * the Improved Sensors quirk.
      *
      * @return {@code true} if the entity has Improved Sensors
      */

--- a/MekHQ/src/mekhq/utilities/EntityUtilities.java
+++ b/MekHQ/src/mekhq/utilities/EntityUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2024-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -38,6 +38,8 @@ import megamek.common.annotations.Nullable;
 import megamek.common.equipment.MiscType;
 import megamek.common.equipment.Mounted;
 import megamek.common.equipment.Sensor;
+import megamek.common.options.OptionsConstants;
+import megamek.common.options.Quirks;
 import megamek.common.units.Entity;
 import megamek.common.units.UnitType;
 import mekhq.campaign.Campaign;
@@ -94,7 +96,8 @@ public class EntityUtilities {
      * <p>Improved Sensors are represented by the presence of a BAP (Beagle Active Probe) flag and an internal name
      * that matches either {@link Sensor#IS_IMPROVED} or {@link Sensor#CL_IMPROVED}.</p>
      *
-     * @param entity the {@link Entity} to check for improved sensors
+     * @param entity the {@link Entity} to check for improved sensors. They are also checked for
+     * {@link Quirks} Improved Sensors.
      *
      * @return {@code true} if the entity has Improved Sensors
      */
@@ -108,7 +111,7 @@ public class EntityUtilities {
                 }
             }
         }
-        return false;
+        return entity.hasQuirk(OptionsConstants.QUIRK_POS_IMPROVED_SENSORS);
     }
 
     /**


### PR DESCRIPTION
Previously, we were only checking equipment and skills for scouting bonuses with advanced scouting, however some meks rudely also have Improved sensors as a quirk. This PR adds a check for the quirk to the entity check associated with advanced scouting check.  