### PR TITLE
Fix filter for deserted and defected personnel (Fixes #7455)

### DIFF
--- a/MekHQ/src/mekhq/gui/enums/PersonnelFilter.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelFilter.java
@@ -508,9 +508,9 @@ public enum PersonnelFilter {
             case ON_LEAVE -> status.isOnLeave() || status.isOnMaternityLeave();
             case MIA -> status.isMIA() || status.isPoW();
             case RETIRED -> status.isRetired();
-            case RESIGNED -> ((status.isResigned()) || (status.isLeft()));
+            case RESIGNED -> status.isResigned() || status.isLeft();
             case AWOL -> status.isAwol();
-            case DESERTED -> status.isDeserted();
+            case DESERTED -> status.isDeserted() || status.isDefected();
             case STUDENT -> status.isStudent();
             case MISSING -> status.isMissing();
             case KIA -> status.isKIA();


### PR DESCRIPTION
The personnel filter has an option to select deserted and defected personnel, but defected personnel are not shown when this is selected.

This is because the filter is only checking for the isDeserted status.

This PR fixes this by also checking the isDefected status.

Closes #7455 