### PR TITLE
Add temp crews to field kitchen usage

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -708,7 +708,7 @@ public class CampaignNewDayManager {
                   checkFieldKitchenCapacity(campaign.getFormation(FORMATION_ORIGIN).getAllUnitsAsUnits(hangar,
                         false), campaignOptions.getFieldKitchenCapacity());
             int fieldKitchenUsage = checkFieldKitchenUsage(campaign.getActivePersonnel(false, false),
-                  campaignOptions.isUseFieldKitchenIgnoreNonCombatants());
+                  campaignOptions.isUseFieldKitchenIgnoreNonCombatants(), campaign);
             boolean withinCapacity = !campaign.isOnContractAndPlanetside() ||
                                            areFieldKitchensWithinCapacity(fieldKitchenCapacity, fieldKitchenUsage);
             campaign.setFieldKitchenWithinCapacity(withinCapacity);

--- a/MekHQ/src/mekhq/campaign/CampaignSummary.java
+++ b/MekHQ/src/mekhq/campaign/CampaignSummary.java
@@ -450,7 +450,7 @@ public class CampaignSummary {
                   ContractRentalType.KITCHENS);
 
             int fieldKitchenUsage = checkFieldKitchenUsage(campaign.getActivePersonnel(false, true),
-                  campaignOptions.isUseFieldKitchenIgnoreNonCombatants());
+                  campaignOptions.isUseFieldKitchenIgnoreNonCombatants(), campaign);
 
             boolean isWithinCapacity = areFieldKitchensWithinCapacity(fieldKitchenCapacity, fieldKitchenUsage);
             color = isWithinCapacity ?

--- a/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/Fatigue.java
+++ b/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/Fatigue.java
@@ -126,7 +126,7 @@ public class Fatigue {
             if (!personnelRole.isCombat() && isUseFieldKitchenIgnoreNonCombatants) {
                 continue;
             }
-            fieldKitchenUsage+=campaign.getTempCrewPool(personnelRole);
+            fieldKitchenUsage += campaign.getTempCrewPool(personnelRole);
         }
 
         for (Person person : activePersonnel) {

--- a/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/Fatigue.java
+++ b/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/Fatigue.java
@@ -53,6 +53,7 @@ import mekhq.campaign.force.CombatTeam;
 import mekhq.campaign.force.Formation;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
 import mekhq.campaign.stratCon.StratConRulesManager;
 import mekhq.campaign.stratCon.StratConTrackState;
@@ -118,8 +119,15 @@ public class Fatigue {
      * @return the total number of personnel requiring field kitchen support.
      */
     public static int checkFieldKitchenUsage(List<Person> activePersonnel,
-          boolean isUseFieldKitchenIgnoreNonCombatants) {
+          boolean isUseFieldKitchenIgnoreNonCombatants, Campaign campaign) {
         int fieldKitchenUsage = 0;
+
+        for (PersonnelRole personnelRole : campaign.getTempCrewRoleKeys()) {
+            if (!personnelRole.isCombat() && isUseFieldKitchenIgnoreNonCombatants) {
+                continue;
+            }
+            fieldKitchenUsage+=campaign.getTempCrewPool(personnelRole);
+        }
 
         for (Person person : activePersonnel) {
             if (!person.isCombat() && isUseFieldKitchenIgnoreNonCombatants) {


### PR DESCRIPTION
Fixes #9374 

Up until now, temporary crews have been notional in support stress for the unit, and we were not tracking them in terms of field kitchen use. This is no longer the case, we are now going to be tracking temp crews and making sure that they get fed as well. Below is a screen shot of field kitchen use demonstrating 147 combat personnel with 23 temp soldier with a total field kitchen use of 170 personnel. 

Something to note is that even when we disable the option for only track combat personnel is that we are not going to be tracking temporary Astechs for field kitchen use, I didn't want to add it at this time as I think it would deserve a separate option that we can add in a future PR if it is something that is desired. 

<img width="839" height="637" alt="image" src="https://github.com/user-attachments/assets/112fbb6c-7ee2-4873-9e80-fa25416e7104" />
