### PR TITLE
Stop using PersonRankStringSorter in the Personnel Table

### DIFF
--- a/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
@@ -88,7 +88,7 @@ import mekhq.gui.sorter.EducationLevelSorter;
 import mekhq.gui.sorter.FormattedNumberSorter;
 import mekhq.gui.sorter.IntegerStringSorter;
 import mekhq.gui.sorter.LevelSorter;
-import mekhq.gui.sorter.PersonRankStringSorter;
+import mekhq.gui.sorter.PersonRankSorter;
 import mekhq.gui.sorter.ReasoningSorter;
 import mekhq.utilities.MHQInternationalization;
 import mekhq.utilities.ReportingUtilities;
@@ -234,12 +234,12 @@ public enum PersonnelTableModelColumn {
         return MHQInternationalization.getText("NA.text");
     }
 
-    public String getCellValue(final Campaign campaign, final PersonnelMarket personnelMarket, final Person person,
+    public Object getCellValue(final Campaign campaign, final PersonnelMarket personnelMarket, final Person person,
           final boolean loadAssignmentFromMarket, final boolean groupByUnit) {
-        return getDisplayString(campaign, personnelMarket, person, loadAssignmentFromMarket, groupByUnit);
+        return getDisplayObject(campaign, personnelMarket, person, loadAssignmentFromMarket, groupByUnit);
     }
 
-    private String getDisplayString(Campaign campaign, PersonnelMarket personnelMarket, Person person,
+    private Object getDisplayObject(Campaign campaign, PersonnelMarket personnelMarket, Person person,
           boolean loadAssignmentFromMarket, boolean groupByUnit) {
 
         final boolean isClanCampaign = campaign.isClanCampaign();
@@ -422,7 +422,7 @@ public enum PersonnelTableModelColumn {
                                                             convertBooleanToYesNo(person.isPrefersWomen());
             case PROTOMEK -> skillValue.apply(SkillType.S_GUN_PROTO);
             case QUICK_TRAIN_IGNORE -> convertBooleanToYesNo(person.isQuickTrainIgnore());
-            case RANK -> person.makeHTMLRank();
+            case RANK -> person;
             case REASONING -> person.getReasoning().getLabel();
             case RECRUITMENT_DATE -> MekHQ.getMHQOptions().getDisplayFormattedDate(person.getRecruitment());
             case REFLEXES -> getAttributeScoreDisplay(person, SkillAttribute.REFLEXES);
@@ -653,6 +653,8 @@ public enum PersonnelTableModelColumn {
     public @Nullable String getDisplayText(final Campaign campaign, final Person person) {
         if (this == PersonnelTableModelColumn.AGE) {
             return Integer.toString(person.getAge(campaign.getLocalDate()));
+        } else if (this == PersonnelTableModelColumn.RANK) {
+            return person.getRankName();
         }
         return null;
     }
@@ -1018,7 +1020,7 @@ public enum PersonnelTableModelColumn {
 
     public Comparator<?> getComparator(final Campaign campaign) {
         return switch (this) {
-            case RANK -> new PersonRankStringSorter(campaign);
+            case RANK -> new PersonRankSorter(new NaturalOrderComparator());
             case HIGHEST_EDUCATION, CURRENT_EDUCATION -> new EducationLevelSorter();
             case AGE, BIRTHDAY, RECRUITMENT_DATE, LAST_RANK_CHANGE_DATE, DUE_DATE, RETIREMENT_DATE, DEATH_DATE ->
                   new DateStringComparator();

--- a/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
@@ -111,6 +111,14 @@ public class PersonnelTableModel extends DataTableModel<Person> {
         return PERSONNEL_COLUMNS[column].toString();
     }
 
+    @Override
+    public Class<?> getColumnClass(int column) {
+        if (PERSONNEL_COLUMNS[column] == PersonnelTableModelColumn.RANK) {
+            return Person.class;
+        }
+        return String.class;
+    }
+
     public @Nullable Person getPerson(final int row) {
         return (row < getRowCount()) ? (Person) getData().get(row) : null;
     }
@@ -120,7 +128,7 @@ public class PersonnelTableModel extends DataTableModel<Person> {
         return getValueAt(getPerson(row), PERSONNEL_COLUMNS[column]);
     }
 
-    public String getValueAt(final @Nullable Person person,
+    public Object getValueAt(final @Nullable Person person,
           final PersonnelTableModelColumn column) {
         if (getData().isEmpty()) {
             return "";
@@ -275,9 +283,12 @@ public class PersonnelTableModel extends DataTableModel<Person> {
             final PersonnelTableModelColumn personnelColumn = PERSONNEL_COLUMNS[table.convertColumnIndexToModel(column)];
             final Person person = getPerson(modelRow);
 
-            setText(getValueAt(person, personnelColumn));
+            setText(String.valueOf(getValueAt(person, personnelColumn)));
 
             switch (personnelColumn) {
+                case RANK:
+                    setHtmlText(person.getRankName());
+                    break;
                 case PERSON:
                     setText(person.getFullDesc(getCampaign()));
                     setImage(person.getPortraitImageIconWithFallback(true, 54).getImage());

--- a/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
+++ b/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
@@ -69,7 +69,7 @@ import mekhq.gui.sorter.EducationLevelSorter;
 import mekhq.gui.sorter.FormattedNumberSorter;
 import mekhq.gui.sorter.IntegerStringSorter;
 import mekhq.gui.sorter.LevelSorter;
-import mekhq.gui.sorter.PersonRankStringSorter;
+import mekhq.gui.sorter.PersonRankSorter;
 import mekhq.gui.sorter.ReasoningSorter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -165,7 +165,7 @@ public class PersonnelTableModelColumnTest {
         final Campaign mockCampaign = mock(Campaign.class);
         for (final PersonnelTableModelColumn personnelTableModelColumn : columns) {
             switch (personnelTableModelColumn) {
-                case RANK -> assertInstanceOf(PersonRankStringSorter.class,
+                case RANK -> assertInstanceOf(PersonRankSorter.class,
                       personnelTableModelColumn.getComparator(mockCampaign));
                 case HIGHEST_EDUCATION, CURRENT_EDUCATION -> assertInstanceOf(EducationLevelSorter.class,
                       personnelTableModelColumn.getComparator(mockCampaign));


### PR DESCRIPTION
`PersonRankStringSorter` has poor performance and creates maintainability issues. This change replaces it with `PersonRankSorter` for `RANK` column in the Personnel Table. To make it possible, a `Person` reference is now passed to `JTable`, which results in some signature changes.

Importantly, it is not the way it's going to be, but rather a step in a broader refactoring scope. It enables future improvements, which will ultimately make table model well isolated and performant.