### PR TITLE
Fix #9362 and #9381: Extract Arrival logic from `CurrentLocation` to `IPlace`

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1932,32 +1932,30 @@ public class Campaign implements ITechManager, IPlace {
 
     @Override
     public void onArrival(Campaign campaign, boolean isSilentProcessing) {
-        CampaignOptions campaignOptions = campaign.getCampaignOptions();
-        LocalDate today = campaign.getLocalDate();
+        // We are intentionally using the passed in Campaign. When Campaign is split into Force and Campaign, Force
+        // will be an IPlace, so this method will move to Force, but we'll still need Campaign for some information.
 
         // This should be before inoculations so that we can correctly read the TO&E
         if (!campaign.getAutomatedMothballUnits().isEmpty()) {
             performAutomatedActivation(campaign);
         }
 
+        CampaignOptions campaignOptions = campaign.getCampaignOptions();
+        if (campaignOptions.isUseRandomDiseases() && campaignOptions.isUseAlternativeAdvancedMedical()) {
+            if (getParentLocation() instanceof AbstractLocation loc) {
+                loc.checkForDiseaseOrBioweaponOutbreaks(campaign, campaign.getLocalDate());
+            }
+        }
+
+        // Inoculations (generic IPlace behavior)
+        IPlace.super.onArrival(campaign, isSilentProcessing);
+
         if (getParentLocation() instanceof AbstractLocation loc) {
-            if (campaignOptions.isUseRandomDiseases() && campaignOptions.isUseAlternativeAdvancedMedical()) {
-                loc.checkForDiseaseOrBioweaponOutbreaks(campaign, today);
-            }
-
-            if (campaignOptions.isUseRandomDiseases() && campaignOptions.isUseAlternativeAdvancedMedical()) {
-                if (!isSilentProcessing) {
-                    Inoculations.triggerInoculationPrompt(campaign, false);
-                } else {
-                    Inoculations.autoInoculateAll(campaign, loc);
-                }
-            }
-
             loc.testForEarlyArrival(campaign);
         }
 
         // We've just stopped traveling, so we should see if there are any local applicants.
-        if (!HumanResources.isUsingLegacyPersonnelMarket(campaignOptions)) {
+        if (!HumanResources.isUsingLegacyPersonnelMarket(campaign.getCampaignOptions())) {
             campaign.refreshApplicants(true);
             CampaignNewDayManager.showRarePersonnelDialog(campaign, false);
         }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1931,6 +1931,39 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     @Override
+    public void onArrival(Campaign campaign, boolean isSilentProcessing) {
+        CampaignOptions campaignOptions = campaign.getCampaignOptions();
+        LocalDate today = campaign.getLocalDate();
+
+        // This should be before inoculations so that we can correctly read the TO&E
+        if (!campaign.getAutomatedMothballUnits().isEmpty()) {
+            performAutomatedActivation(campaign);
+        }
+
+        if (getParentLocation() instanceof AbstractLocation loc) {
+            if (campaignOptions.isUseRandomDiseases() && campaignOptions.isUseAlternativeAdvancedMedical()) {
+                loc.checkForDiseaseOrBioweaponOutbreaks(campaign, today);
+            }
+
+            if (campaignOptions.isUseRandomDiseases() && campaignOptions.isUseAlternativeAdvancedMedical()) {
+                if (!isSilentProcessing) {
+                    Inoculations.triggerInoculationPrompt(campaign, false);
+                } else {
+                    Inoculations.autoInoculateAll(campaign, loc);
+                }
+            }
+
+            loc.testForEarlyArrival(campaign);
+        }
+
+        // We've just stopped traveling, so we should see if there are any local applicants.
+        if (!HumanResources.isUsingLegacyPersonnelMarket(campaignOptions)) {
+            campaign.refreshApplicants(true);
+            CampaignNewDayManager.showRarePersonnelDialog(campaign, false);
+        }
+    }
+
+    @Override
     public void processArrivals(Campaign campaign) {
         if (locationNode == null) {
             return;

--- a/MekHQ/src/mekhq/campaign/CurrentLocation.java
+++ b/MekHQ/src/mekhq/campaign/CurrentLocation.java
@@ -34,9 +34,7 @@
 package mekhq.campaign;
 
 import static megamek.common.compute.Compute.randomInt;
-import static mekhq.campaign.HumanResources.isUsingLegacyPersonnelMarket;
 import static mekhq.campaign.enums.DailyReportType.GENERAL;
-import static mekhq.campaign.market.contractMarket.ContractAutomation.performAutomatedActivation;
 
 import java.io.PrintWriter;
 import java.time.LocalDate;
@@ -51,8 +49,8 @@ import mekhq.campaign.events.LocationChangedEvent;
 import mekhq.campaign.events.TransitCompleteEvent;
 import mekhq.campaign.events.TransitStatusChangedEvent;
 import mekhq.campaign.location.ILocation;
+import mekhq.campaign.location.IPlace;
 import mekhq.campaign.parts.Part;
-import mekhq.campaign.personnel.medical.advancedMedicalAlternate.Inoculations;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.PlanetarySystem;
 import mekhq.utilities.MHQXMLUtility;
@@ -322,33 +320,13 @@ public class CurrentLocation extends AbstractLocation {
             MekHQ.triggerEvent(new TransitStatusChangedEvent(this));
         }
 
-        // If we were previously traveling and now aren't, we should check to see if we have arrived at a contract
-        // system earlier than necessary. And, if appropriate, trigger inoculation prompts and activate mothballed
-        // units
+        // If we were previously traveling and now aren't, notify each IPlace child that it has
+        // arrived. The IPlace implementation handles place-specific arrival logic.
         if (wasTraveling && isOnPlanet()) {
-            // This should be before inoculations so that we can correctly read the TO&E
-            if (!campaign.getAutomatedMothballUnits().isEmpty()) {
-                performAutomatedActivation(campaign);
-            }
-
-            if (campaignOptions.isUseRandomDiseases() && campaignOptions.isUseAlternativeAdvancedMedical()) {
-                checkForDiseaseOrBioweaponOutbreaks(campaign, today);
-            }
-
-            if (campaignOptions.isUseRandomDiseases() && campaignOptions.isUseAlternativeAdvancedMedical()) {
-                if (!isSilentProcessing) {
-                    Inoculations.triggerInoculationPrompt(campaign, false);
-                } else {
-                    Inoculations.autoInoculateAll(campaign, this);
+            for (ILocation child : getChildLocations()) {
+                if (child instanceof IPlace place) {
+                    place.onArrival(campaign, isSilentProcessing);
                 }
-            }
-
-            testForEarlyArrival(campaign);
-
-            // We've just stopped traveling, so we should see if there are any local applicants.
-            if (!isUsingLegacyPersonnelMarket(campaignOptions)) {
-                campaign.refreshApplicants(true);
-                CampaignNewDayManager.showRarePersonnelDialog(campaign, false);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/location/IPlace.java
+++ b/MekHQ/src/mekhq/campaign/location/IPlace.java
@@ -139,6 +139,19 @@ public interface IPlace extends ILocation {
     }
 
     /**
+     * Called when this place has just completed in-system transit and is now on-planet.
+     *
+     * <p>The default is a no-op. Implementors such as {@link mekhq.campaign.Campaign} override this
+     * to perform place-specific arrival behaviors (mothball activation, inoculation prompts,
+     * early-arrival contract checks, personnel market refresh, etc.).</p>
+     *
+     * @param campaign          the root campaign context
+     * @param isSilentProcessing {@code true} when processing happens without user interaction (e.g.
+     *                           fast-forward), which suppresses dialog prompts
+     */
+    default void onArrival(Campaign campaign, boolean isSilentProcessing) {}
+
+    /**
      * Processes arriving travel nodes parented to this place.
      *
      * <p>Landing hangar and warehouse default to this place's own resources; if either is

--- a/MekHQ/src/mekhq/campaign/location/IPlace.java
+++ b/MekHQ/src/mekhq/campaign/location/IPlace.java
@@ -36,15 +36,18 @@ package mekhq.campaign.location;
 import java.util.ArrayList;
 
 import megamek.common.annotations.Nullable;
+import mekhq.campaign.AbstractLocation;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CurrentLocation;
 import mekhq.campaign.Hangar;
 import mekhq.campaign.Personnel;
 import mekhq.campaign.Warehouse;
+import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.parts.AmmoStorage;
 import mekhq.campaign.parts.Armor;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.PartInventory;
+import mekhq.campaign.personnel.medical.advancedMedicalAlternate.Inoculations;
 
 /**
  * A sub-interface of {@link ILocation} that marks a node in the {@link LocationNode} tree as a
@@ -141,15 +144,26 @@ public interface IPlace extends ILocation {
     /**
      * Called when this place has just completed in-system transit and is now on-planet.
      *
-     * <p>The default is a no-op. Implementors such as {@link mekhq.campaign.Campaign} override this
-     * to perform place-specific arrival behaviors (mothball activation, inoculation prompts,
-     * early-arrival contract checks, personnel market refresh, etc.).</p>
+     * <p>The default implementation fires disease and inoculation checks, which apply to every
+     * arriving {@code IPlace}. Implementors such as {@link mekhq.campaign.Campaign} override this
+     * (calling {@code IPlace.super.onArrival} at the appropriate point) to add place-specific
+     * behaviors such as mothball activation, early-arrival contract checks, and personnel market
+     * refresh.</p>
      *
-     * @param campaign          the root campaign context
+     * @param campaign           the root campaign context
      * @param isSilentProcessing {@code true} when processing happens without user interaction (e.g.
      *                           fast-forward), which suppresses dialog prompts
      */
-    default void onArrival(Campaign campaign, boolean isSilentProcessing) {}
+    default void onArrival(Campaign campaign, boolean isSilentProcessing) {
+        CampaignOptions campaignOptions = campaign.getCampaignOptions();
+        if (campaignOptions.isUseRandomDiseases() && campaignOptions.isUseAlternativeAdvancedMedical()) {
+            if (!isSilentProcessing) {
+                Inoculations.triggerInoculationPrompt(campaign, false);
+            } else if (getParentLocation() instanceof AbstractLocation loc) {
+                Inoculations.autoInoculateAll(campaign, loc);
+            }
+        }
+    }
 
     /**
      * Processes arriving travel nodes parented to this place.


### PR DESCRIPTION
Fixes #9362 
Fixes #9381 

Extracted the new day arrival logic from `CurrentLocation` to use a method from `IPlace`. 

`Campaign` has special on arrival logic related to mothballing and market and so only `Campaign` arriving should trigger these, not every `CurrentLocation` on new day. 