### PR TITLE
  Fix origin-system picker crediting renamed factions to their successor (Outworlds Alliance shows as Raven Alliance)

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -60,6 +60,7 @@ import megamek.client.ui.preferences.PreferencesNode;
 import megamek.client.ui.util.UIUtil;
 import megamek.codeUtilities.MathUtility;
 import megamek.common.TechConstants;
+import megamek.common.annotations.Nullable;
 import megamek.common.enums.Gender;
 import megamek.common.equipment.EquipmentType;
 import megamek.common.options.IOption;
@@ -1583,26 +1584,32 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
      *
      * <ul>
      *   <li>The snapshot is a {@code DIS} (Disputed) marker — to the victor goes the spoils.</li>
-     *   <li>The snapshot owner is a faction with a defined dissolution year that falls within
-     *   100 years of {@code when}. This catches FedCom-era births (FC ends 3067, well within a
-     *   3047 character's lifespan) without retroactively rewriting deep-history births where the
-     *   dissolution is centuries off (a 2470 Star League birth keeps SL — the player chose that
-     *   era deliberately).</li>
+     *   <li>The snapshot owner is a faction with a defined dissolution year within 100 years of {@code when}
+     *   <b>and</b> the eventual owner already held this world at or before {@code when}. The second condition
+     *   restricts substitution to a transient umbrella/overlay state the world reverts out of, and excludes a
+     *   continuous polity that merely renames into a brand-new successor (see below). This catches FedCom-era
+     *   births (FC ends 3067, well within a 3047 character's lifespan) without retroactively rewriting
+     *   deep-history births where the dissolution is centuries off (a 2470 Star League birth keeps SL — the
+     *   player chose that era deliberately).</li>
      * </ul>
      *
      * <p>"Eventual stable owner" is the most-recent non-{@code DIS} faction event in the planet's
      * own future timeline. If the world has no future faction events (data ends at the snapshot),
      * or if the eventual owner is the same as the snapshot, the snapshot is used as-is. The
-     * {@code ABN} (Abandoned) marker is dropped only when other real owners are present.</p>
+     * {@code ABN} (Abandoned) marker is dropped only when other real owners are present. The owner decision
+     * itself lives in {@link #chooseDisplayedOwner}.</p>
      *
      * <p>Concrete cases:</p>
      *
      * <ul>
-     *   <li>New Avalon at 3047, snapshot {@code FC} (ends 3067, within 100y), eventual {@code FS}:
-     *   substitutes — a 3047-born NA citizen is FedSuns-stock regardless of the FedCom overlay.</li>
-     *   <li>Tharkad at 3047, snapshot {@code FC}, eventual {@code LA}: substitutes to {@code LA},
-     *   putting the world on the Lyran side as it ends up.</li>
+     *   <li>New Avalon at 3047, snapshot {@code FC} (ends 3067, within 100y), eventual {@code FS} (held it
+     *   before the FedCom overlay): substitutes — a 3047-born NA citizen is FedSuns-stock.</li>
+     *   <li>Tharkad at 3047, snapshot {@code FC}, eventual {@code LA} (held it before): substitutes to
+     *   {@code LA}, putting the world on the Lyran side as it ends up.</li>
      *   <li>New Avalon at 3070, snapshot {@code DIS}, eventual {@code FS}: substitutes.</li>
+     *   <li>Mishkadrill at 3025, snapshot {@code OA} (Outworlds Alliance, ends 3082, within 100y), eventual
+     *   {@code RA} (Raven Alliance — the rename, never owned the world before 3083): kept as {@code OA}. A
+     *   pre-3083 character is Outworlds-stock, and the OA origin filter still finds the world.</li>
      *   <li>Terra at 2470, snapshot {@code SL} (ends ~2786, 316y off), eventual modern owner: kept
      *   as {@code SL} — the era is intentional.</li>
      *   <li>Hesperus II at 3047, snapshot {@code LA} (no end year), eventual {@code LA}: kept.</li>
@@ -1620,37 +1627,94 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
             if (events == null) {
                 continue;
             }
-            java.util.List<String> snapshot = null;
-            java.util.List<String> eventualOwner = null;
+            List<String> snapshot = null;
+            List<String> eventualOwner = null;
+            // Every faction code that owned this world at or before `when`. Lets us tell a transient
+            // overlay the world reverts out of (the eventual owner also held it earlier — e.g. FedCom
+            // over Davion/Lyran worlds) from a continuous polity that simply renames into a brand-new
+            // successor (the eventual owner is new — e.g. Outworlds Alliance -> Raven Alliance). Only
+            // the former is substituted; see chooseDisplayedOwner.
+            Set<String> priorOwnerCodes = new HashSet<>();
             for (Planet.PlanetaryEvent event : events) {
                 if (event.date == null || event.faction == null || event.faction.getValue() == null) {
                     continue;
                 }
-                java.util.List<String> codes = event.faction.getValue();
+                List<String> codes = event.faction.getValue();
                 if (event.date.isAfter(when)) {
                     if (!isDisputedOnly(codes)) {
                         eventualOwner = codes;
                     }
                 } else {
                     snapshot = codes;
+                    priorOwnerCodes.addAll(codes);
                 }
             }
             // No snapshot means the world wasn't owned at `when` — uncolonized. Don't substitute a
             // future colonization event, or we'd incorrectly mark pre-colonial dates as inhabited
             // and pollute the picker (Copilot review on PR #8935).
-            java.util.List<String> displayed;
-            if (snapshot != null && eventualOwner != null && !sameCodes(snapshot, eventualOwner)
-                      && (isDisputedOnly(snapshot) || anyDissolvesNear(snapshot, when))) {
-                displayed = eventualOwner;
-            } else {
-                displayed = snapshot;
-            }
+            List<String> displayed = chooseDisplayedOwner(snapshot, eventualOwner, priorOwnerCodes,
+                  anyDissolvesNear(snapshot, when));
             addCodes(result, displayed);
         }
         if (result.size() > 1) {
             result.remove(Factions.getInstance().getFaction("ABN"));
         }
         return result;
+    }
+
+    /**
+     * Decides which owner code list to credit a world to: the era-correct {@code snapshot} owner, or its
+     * {@code eventualOwner} when the snapshot is merely a transient state the world ends up leaving.
+     *
+     * <p>The snapshot is replaced by the eventual owner only when it is genuinely transient:</p>
+     * <ul>
+     *   <li>The snapshot is a {@code DIS} (Disputed) marker — to the victor goes the spoils; always substitute.</li>
+     *   <li>The snapshot faction dissolves within {@link #DISSOLUTION_PROXIMITY_YEARS} of {@code when}
+     *   ({@code snapshotDissolvesNear}) <b>and</b> the eventual owner already held this world at or before
+     *   {@code when} (its codes intersect {@code priorOwnerCodes}).</li>
+     * </ul>
+     *
+     * <p>The second clause is the key distinction. A temporary umbrella/overlay state that the world reverts out
+     * of has the eventual owner present earlier in the timeline (FedCom over Davion/Lyran worlds reverts to
+     * {@code FS}/{@code LA}), so it substitutes. A continuous polity that merely renames into a brand-new successor
+     * (Outworlds Alliance -> Raven Alliance, Clan Wolf -> Wolf Empire) has a successor that never owned the world
+     * before the rename, so it is <b>not</b> substituted and the era-correct owner is kept. Substituting it would
+     * credit a pre-rename character to a state that does not yet exist and, worse, make the origin-faction world
+     * filter return no worlds for the still-extant pre-rename faction.</p>
+     *
+     * @param snapshot              the owner code(s) at {@code when}, or {@code null} if the world was uncolonized
+     * @param eventualOwner         the world's latest future non-disputed owner code(s), or {@code null} if none
+     * @param priorOwnerCodes       every faction code that owned the world at or before {@code when}
+     * @param snapshotDissolvesNear whether a snapshot faction dissolves within the proximity window of {@code when}
+     *
+     * @return the owner code list to credit: {@code eventualOwner} when substituting, otherwise {@code snapshot}
+     */
+    @Nullable
+    static List<String> chooseDisplayedOwner(@Nullable List<String> snapshot, @Nullable List<String> eventualOwner,
+          Set<String> priorOwnerCodes, boolean snapshotDissolvesNear) {
+        boolean canSubstitute = (snapshot != null) && (eventualOwner != null) && !sameCodes(snapshot, eventualOwner);
+        if (!canSubstitute) {
+            return snapshot;
+        }
+        boolean eventualOwnerHeldWorldBefore = intersects(eventualOwner, priorOwnerCodes);
+        boolean snapshotIsTransient = isDisputedOnly(snapshot)
+                                            || (snapshotDissolvesNear && eventualOwnerHeldWorldBefore);
+        return snapshotIsTransient ? eventualOwner : snapshot;
+    }
+
+    /**
+     * @return {@code true} if any code in {@code codes} is present in {@code priorOwnerCodes}
+     */
+    private static boolean intersects(@Nullable List<String> codes, Set<String> priorOwnerCodes) {
+        if (codes == null) {
+            return false;
+        }
+        for (String code : codes) {
+            if (priorOwnerCodes.contains(code)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static boolean anyDissolvesNear(java.util.List<String> codes, LocalDate when) {

--- a/MekHQ/unittests/mekhq/gui/dialog/CustomizePersonDialogTest.java
+++ b/MekHQ/unittests/mekhq/gui/dialog/CustomizePersonDialogTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package mekhq.gui.dialog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link CustomizePersonDialog#chooseDisplayedOwner(List, List, Set, boolean)}, the rule that decides whether
+ * a world's era-correct owner is replaced by its eventual owner when building the origin-system picker.
+ *
+ * <p>The pivotal regression is the renamed-faction case (Outworlds Alliance -> Raven Alliance): a faction that
+ * dissolves into a brand-new successor must NOT be substituted, or pre-rename characters get credited to a state that
+ * does not yet exist and the origin-faction world filter finds no worlds for the still-extant faction.</p>
+ */
+class CustomizePersonDialogTest {
+
+    /**
+     * The core bug: Outworlds Alliance (ends 3082) renames into the Raven Alliance in 3083. The Raven Alliance never
+     * owned the world before the rename, so a pre-3083 snapshot must stay Outworlds Alliance even though OA dissolves
+     * within the proximity window.
+     */
+    @Test
+    void renamedFactionKeepsEraCorrectOwner() {
+        List<String> displayed = CustomizePersonDialog.chooseDisplayedOwner(List.of("OA"), List.of("RA"),
+              Set.of("OA"), true);
+
+        assertEquals(List.of("OA"), displayed);
+    }
+
+    /**
+     * Same class of bug for a Clan: Clan Wolf (ends 3142) renames into the Wolf Empire. The successor never held the
+     * world before, so the era-correct Clan Wolf ownership is kept.
+     */
+    @Test
+    void renamedClanKeepsEraCorrectOwner() {
+        List<String> displayed = CustomizePersonDialog.chooseDisplayedOwner(List.of("CW"), List.of("CWE"),
+              Set.of("CW"), true);
+
+        assertEquals(List.of("CW"), displayed);
+    }
+
+    /**
+     * FedCom overlay must still be substituted: the Federated Suns held New Avalon before the FedCom era, so the
+     * eventual owner appears in the prior-owner set and the transient FC label is replaced by FS.
+     */
+    @Test
+    void transientOverlaySubstitutesToRevertedOwner() {
+        List<String> displayed = CustomizePersonDialog.chooseDisplayedOwner(List.of("FC"), List.of("FS"),
+              Set.of("FS", "FC"), true);
+
+        assertEquals(List.of("FS"), displayed);
+    }
+
+    /**
+     * Tharkad: FedCom overlay over a world the Lyrans held before and end up holding again -> substitutes to LA.
+     */
+    @Test
+    void transientOverlaySubstitutesToLyranSide() {
+        List<String> displayed = CustomizePersonDialog.chooseDisplayedOwner(List.of("FC"), List.of("LA"),
+              Set.of("LA", "FC"), true);
+
+        assertEquals(List.of("LA"), displayed);
+    }
+
+    /**
+     * A Disputed snapshot is always substituted regardless of dissolution proximity or prior ownership.
+     */
+    @Test
+    void disputedSnapshotAlwaysSubstitutes() {
+        List<String> displayed = CustomizePersonDialog.chooseDisplayedOwner(List.of("DIS"), List.of("FS"),
+              Set.of("DIS"), false);
+
+        assertEquals(List.of("FS"), displayed);
+    }
+
+    /**
+     * When the snapshot faction does not dissolve near {@code when} and is not disputed, the era-correct owner is kept
+     * even if a different future owner exists.
+     */
+    @Test
+    void stableSnapshotIsKept() {
+        List<String> displayed = CustomizePersonDialog.chooseDisplayedOwner(List.of("OA"), List.of("RA"),
+              Set.of("OA"), false);
+
+        assertEquals(List.of("OA"), displayed);
+    }
+
+    /**
+     * Identical snapshot and eventual owner short-circuits to the snapshot (no spurious substitution).
+     */
+    @Test
+    void sameOwnerIsKept() {
+        List<String> displayed = CustomizePersonDialog.chooseDisplayedOwner(List.of("LA"), List.of("LA"),
+              Set.of("LA"), true);
+
+        assertEquals(List.of("LA"), displayed);
+    }
+
+    /**
+     * No future faction event (data ends at the snapshot) -> the snapshot is used as-is.
+     */
+    @Test
+    void noEventualOwnerKeepsSnapshot() {
+        List<String> displayed = CustomizePersonDialog.chooseDisplayedOwner(List.of("OA"), null,
+              Set.of("OA"), true);
+
+        assertEquals(List.of("OA"), displayed);
+    }
+
+    /**
+     * An uncolonized world (no snapshot) is never credited to a future colonization event.
+     */
+    @Test
+    void uncolonizedWorldHasNoOwner() {
+        List<String> displayed = CustomizePersonDialog.chooseDisplayedOwner(null, List.of("FS"),
+              Set.of(), true);
+
+        assertNull(displayed);
+    }
+}


### PR DESCRIPTION

  ## Root Cause
  `CustomizePersonDialog.ownersAt()` replaces a world's era-correct owner with its eventual owner whenever the current owner dissolves within 100 years of the character's date. That heuristic was built for transient *overlay* states (FedCom over Davion/Lyran worlds), but it also fired on *renamed* polities. The Outworlds Alliance (ends 3082) simply renames into the
  Raven Alliance in 3083, so every OA world was rewritten to RA. Because the same method backs both the dropdown label and the origin-faction world filter, this (a) mislabeled worlds as `[RA]` before 3083 and (b) made the Outworlds Alliance find **zero** selectable origin worlds. Clan Snow Raven was unaffected only because its homeworld systems carry no future RA event,
  despite an identical `end 3082 / successor RA` faction profile.

  ## Fix
  Substitution now additionally requires that the eventual owner **already held the world at or before the character's date**. This distinguishes a reverted overlay (FS/LA held the world before the FedCom era -> still substitutes) from a brand-new rename successor (RA / Wolf Empire never owned it before -> keep the era-correct owner). The decision was extracted into a
  pure, package-private `chooseDisplayedOwner(...)` so it can be unit-tested without loading factions or planets.

  ## Changes
  1. `CustomizePersonDialog.ownersAt()` - tracks `priorOwnerCodes` (every owner at/before the date) and delegates the substitution decision to the new helper.
  2. New `chooseDisplayedOwner(...)` / `intersects(...)` helpers - substitute only for Disputed snapshots or a near-dissolution owner whose successor previously held the world.
  3. Javadoc updated with the new rule and the Mishkadrill (OA->RA) worked example.
  4. Added `megamek.common.annotations.Nullable` import for the new `@Nullable` parameters.

  ## Files Changed
  - `MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java` - the fix.
  - `MekHQ/unittests/mekhq/gui/dialog/CustomizePersonDialogTest.java` - new regression tests.

  ## Testing
  New `CustomizePersonDialogTest` (9 cases, all passing):
  - OA->RA and Clan Wolf->Wolf Empire keep the era-correct owner (the bug).
  - FedCom->FS and Tharkad FedCom->LA still substitute (no regression).
  - Disputed always substitutes; same-owner / no-future-event / uncolonized edges hold.

  ## I hate trying to make things work with the endless issues caused by the FedCom. 