### PR TITLE
Simplify PersonnelTableModelColumn cell value extraction

### DIFF
--- a/MekHQ/src/mekhq/gui/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/PersonnelTab.java
@@ -463,7 +463,8 @@ public final class PersonnelTab extends CampaignGuiTab {
             final TableColumn tableColumn = columnModel.getColumnByModelIndex(column.ordinal());
             tableColumn.setCellRenderer(getPersonModel().getRenderer(choicePersonView.getSelectedItem()));
             tableColumn.setPreferredWidth(column.getWidth());
-            columnModel.setColumnVisible(tableColumn, column.isVisible(getCampaign(), view, getPersonnelTable()));
+            columnModel.setColumnVisible(tableColumn, column.isVisible(getCampaign(), view, getPersonnelTable(),
+                  personModel.isLoadAssignmentFromMarket(), personModel.isGroupByUnit()));
         }
     }
 

--- a/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
@@ -119,7 +119,7 @@ public class PersonnelMarketDialog extends JDialog {
           PersonnelTableModelColumn.GENDER,
           PersonnelTableModelColumn.SKILL_LEVEL,
           PersonnelTableModelColumn.PERSONNEL_ROLE,
-          PersonnelTableModelColumn.UNIT_ASSIGNMENT);
+          PersonnelTableModelColumn.MARKET_UNIT_ASSIGNMENT);
 
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle(
           "mekhq.resources.PersonnelMarketDialog",

--- a/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
@@ -103,6 +103,7 @@ public enum PersonnelTableModelColumn {
     PRE_NOMINAL("Column.PRE_NOMINAL.title", NaturalOrderComparator.INSTANCE),
     GIVEN_NAME("Column.GIVEN_NAME.title", NaturalOrderComparator.INSTANCE),
     SURNAME("Column.SURNAME.title", NaturalOrderComparator.INSTANCE),
+    SURNAME_GROUPED_BY_UNIT("Column.SURNAME.title", NaturalOrderComparator.INSTANCE),
     BLOODNAME("Column.BLOODNAME.title", NaturalOrderComparator.INSTANCE),
     POST_NOMINAL("Column.POST_NOMINAL.title", NaturalOrderComparator.INSTANCE),
     CALLSIGN("Column.CALLSIGN.title", NaturalOrderComparator.INSTANCE),
@@ -112,6 +113,7 @@ public enum PersonnelTableModelColumn {
     SKILL_LEVEL("Column.SKILL_LEVEL.title", LevelSorter.INSTANCE),
     PERSONNEL_ROLE("Column.PERSONNEL_ROLE.title", NaturalOrderComparator.INSTANCE),
     UNIT_ASSIGNMENT("Column.UNIT_ASSIGNMENT.title", NaturalOrderComparator.INSTANCE),
+    MARKET_UNIT_ASSIGNMENT("Column.UNIT_ASSIGNMENT.title", NaturalOrderComparator.INSTANCE),
     FORCE("Column.FORCE.title", NaturalOrderComparator.INSTANCE),
     DEPLOYED("Column.DEPLOYED.title", NaturalOrderComparator.INSTANCE),
     MEK("Column.MEK.title", BonusSorter.INSTANCE),
@@ -240,14 +242,7 @@ public enum PersonnelTableModelColumn {
         return MHQInternationalization.getText("NA.text");
     }
 
-    public Object getCellValue(final Campaign campaign, final PersonnelMarket personnelMarket, final Person person,
-          final boolean loadAssignmentFromMarket, final boolean groupByUnit) {
-        return getDisplayObject(campaign, personnelMarket, person, loadAssignmentFromMarket, groupByUnit);
-    }
-
-    private Object getDisplayObject(Campaign campaign, PersonnelMarket personnelMarket, Person person,
-          boolean loadAssignmentFromMarket, boolean groupByUnit) {
-
+    public Object getCellValue(Campaign campaign, Person person) {
         final boolean isClanCampaign = campaign.isClanCampaign();
         final LocalDate today = campaign.getLocalDate();
         final CampaignOptions campaignOptions = campaign.getCampaignOptions();
@@ -458,8 +453,14 @@ public enum PersonnelTableModelColumn {
                 final String surname = person.getSurname();
                 if (StringUtility.isNullOrBlank(surname)) {
                     yield "";
-                } else if (!groupByUnit) {
+                } else {
                     yield surname;
+                }
+            }
+            case SURNAME_GROUPED_BY_UNIT -> {
+                final String surname = person.getSurname();
+                if (StringUtility.isNullOrBlank(surname)) {
+                    yield "";
                 } else {
                     final Unit unit = person.getUnit();
                     if (unit == null) {
@@ -492,79 +493,78 @@ public enum PersonnelTableModelColumn {
             case UNDER_PROTECTION -> convertBooleanToYesNo(person.isUnderProtection());
             case COVER_MEDICAL_EXPENSES -> convertBooleanToYesNo(person.isCoverIllicitMedicalExpenses());
             case BLOCK_MATERNITY_LEAVE -> convertBooleanToYesNo(person.isBlockMaternityLeave());
+            case MARKET_UNIT_ASSIGNMENT -> {
+                PersonnelMarket market = campaign.getPersonnelMarket();
+                Entity entity = (market == null) ? null : market.getAttachedEntity(person);
+                yield (entity == null) ? "-" : entity.getDisplayName();
+            }
             case UNIT_ASSIGNMENT -> {
-                if (loadAssignmentFromMarket) {
-                    final Entity entity = personnelMarket.getAttachedEntity(person);
-                    yield (entity == null) ? "-" : entity.getDisplayName();
-                } else {
-                    Unit unit = person.getUnit();
-                    if (unit != null) {
-                        String name = unit.getName();
-                        Entity entity = unit.getEntity();
-                        String role = null;
+                Unit unit = person.getUnit();
+                if (unit != null) {
+                    String name = unit.getName();
+                    Entity entity = unit.getEntity();
+                    String role = null;
 
-                        if (entity instanceof SmallCraft || entity instanceof Jumpship || entity instanceof Tank) {
-                            if (unit.isNavigator(person)) {
-                                role = "Navigator";
-                            } else if (unit.isDriver(person)) {
-                                role = (entity instanceof Tank) ? "Driver" : "Pilot";
-                            } else if (unit.isGunner(person)) {
-                                role = "Gunner";
-                            } else if (unit.isCommander(person)
-                                             || ((entity instanceof Tank) && unit.isTechOfficer(person))) {
-                                role = "Commander";
-                            } else {
-                                role = "Crew";
-                            }
-                        } else if (entity instanceof Mek && unit.getFullCrewSize() > 1) {
-                            if (unit.isDriver(person)) {
-                                role = "Pilot";
-                            } else if (unit.isGunner(person)) {
-                                role = "Gunner";
-                            } else if (unit.isTechOfficer(person)) {
-                                role = "Tech Officer";
-                            } else if (unit.isCommander(person)) {
-                                role = "Commander";
-                            }
+                    if (entity instanceof SmallCraft || entity instanceof Jumpship || entity instanceof Tank) {
+                        if (unit.isNavigator(person)) {
+                            role = "Navigator";
+                        } else if (unit.isDriver(person)) {
+                            role = (entity instanceof Tank) ? "Driver" : "Pilot";
+                        } else if (unit.isGunner(person)) {
+                            role = "Gunner";
+                        } else if (unit.isCommander(person)
+                                         || ((entity instanceof Tank) && unit.isTechOfficer(person))) {
+                            role = "Commander";
+                        } else {
+                            role = "Crew";
                         }
-
-                        if (role != null) {
-                            name += " [" + role + "]";
+                    } else if (entity instanceof Mek && unit.getFullCrewSize() > 1) {
+                        if (unit.isDriver(person)) {
+                            role = "Pilot";
+                        } else if (unit.isGunner(person)) {
+                            role = "Gunner";
+                        } else if (unit.isTechOfficer(person)) {
+                            role = "Tech Officer";
+                        } else if (unit.isCommander(person)) {
+                            role = "Commander";
                         }
-
-                        yield name;
                     }
 
-                    // Check for tech units
-                    if (!person.getTechUnits().isEmpty()) {
-                        Unit refitUnit = person.getTechUnits()
-                                               .stream()
-                                               .filter(u -> u.isRefitting() && u.getRefit().getTech() == person)
-                                               .findFirst()
-                                               .orElse(null);
-                        String refitString = null != refitUnit ? "<b>Refitting</b> " + refitUnit.getName() : "";
-                        if (person.getTechUnits().size() == 1) {
-                            unit = person.getTechUnits().getFirst();
-                            if (unit != null) {
-                                yield "<html>" +
-                                            ReportingUtilities.separateIf(refitString,
-                                                  ", ",
-                                                  unit.getName() + " (" + person.getMaintenanceTimeUsing() + "m)") +
-                                            "</html>";
-                            }
-                        } else {
+                    if (role != null) {
+                        name += " [" + role + "]";
+                    }
+
+                    yield name;
+                }
+
+                // Check for tech units
+                if (!person.getTechUnits().isEmpty()) {
+                    Unit refitUnit = person.getTechUnits()
+                                           .stream()
+                                           .filter(u -> u.isRefitting() && u.getRefit().getTech() == person)
+                                           .findFirst()
+                                           .orElse(null);
+                    String refitString = null != refitUnit ? "<b>Refitting</b> " + refitUnit.getName() : "";
+                    if (person.getTechUnits().size() == 1) {
+                        unit = person.getTechUnits().getFirst();
+                        if (unit != null) {
                             yield "<html>" +
                                         ReportingUtilities.separateIf(refitString,
                                               ", ",
-                                              person.getTechUnits().size() +
-                                                    " units (" +
-                                                    person.getMaintenanceTimeUsing() +
-                                                    "m)") +
+                                              unit.getName() + " (" + person.getMaintenanceTimeUsing() + "m)") +
                                         "</html>";
                         }
+                    } else {
+                        yield "<html>" +
+                                    ReportingUtilities.separateIf(refitString,
+                                          ", ",
+                                          person.getTechUnits().size() +
+                                                " units (" +
+                                                person.getMaintenanceTimeUsing() +
+                                                "m)") +
+                                    "</html>";
                     }
                 }
-
                 // Final fallback return of nothing
                 yield "-";
             }
@@ -665,22 +665,16 @@ public enum PersonnelTableModelColumn {
         return null;
     }
 
-    public @Nullable String getToolTipText(final Person person, final boolean loadAssignmentFromMarket) {
-        return getToolTipText(person, loadAssignmentFromMarket, null);
-    }
-
     /**
      * Returns the tooltip text for this column, optionally including color reason explanations.
      *
      * @param person                   the person for this row
-     * @param loadAssignmentFromMarket whether to load assignment from market
      * @param colorReasonKeys          list of i18n keys for color reasons, or null/empty if no special coloring
      *
      * @return the tooltip text, or null if no tooltip
      */
-    public @Nullable String getToolTipText(final Person person, final boolean loadAssignmentFromMarket,
-          final @Nullable java.util.List<String> colorReasonKeys) {
-        String baseTooltip = getBaseToolTipText(person, loadAssignmentFromMarket);
+    public @Nullable String getToolTipText(Person person, @Nullable java.util.List<String> colorReasonKeys) {
+        String baseTooltip = getBaseToolTipText(person);
 
         // For name, rank, and status columns, append color reasons if present
         if (colorReasonKeys != null && !colorReasonKeys.isEmpty() && isNameRankOrStatusColumn()) {
@@ -707,12 +701,12 @@ public enum PersonnelTableModelColumn {
         return baseTooltip;
     }
 
-    private @Nullable String getBaseToolTipText(final Person person, final boolean loadAssignmentFromMarket) {
+    private @Nullable String getBaseToolTipText(Person person) {
         switch (this) {
             case PERSONNEL_STATUS:
                 return person.getStatus().getToolTipText();
             case UNIT_ASSIGNMENT: {
-                if ((person.getTechUnits().size() > 1) && !loadAssignmentFromMarket) {
+                if (person.getTechUnits().size() > 1) {
                     return person.getTechUnits()
                                  .stream()
                                  .map(u1 -> u1.getName() + "<br>")
@@ -742,16 +736,22 @@ public enum PersonnelTableModelColumn {
      * status column.
      */
     private boolean isNameRankOrStatusColumn() {
-        return this == PERSON || this == FIRST_NAME || this == LAST_NAME ||
-                     this == GIVEN_NAME || this == SURNAME || this == BLOODNAME ||
-                     this == RANK || this == PERSONNEL_STATUS;
+        return (this == PERSON) ||
+                     (this == FIRST_NAME) ||
+                     (this == LAST_NAME) ||
+                     (this == GIVEN_NAME) ||
+                     (this == SURNAME) ||
+                     (this == SURNAME_GROUPED_BY_UNIT) ||
+                     (this == BLOODNAME) ||
+                     (this == RANK) ||
+                     (this == PERSONNEL_STATUS);
     }
 
     public int getWidth() {
         return switch (this) {
-            case PERSON, UNIT_ASSIGNMENT -> 125;
+            case PERSON, UNIT_ASSIGNMENT, MARKET_UNIT_ASSIGNMENT -> 125;
             case RANK, FIRST_NAME, GIVEN_NAME, DEPLOYED -> 70;
-            case LAST_NAME, SURNAME, BLOODNAME, CALLSIGN, SKILL_LEVEL, SALARY -> 50;
+            case LAST_NAME, SURNAME, SURNAME_GROUPED_BY_UNIT, BLOODNAME, CALLSIGN, SKILL_LEVEL, SALARY -> 50;
             case PERSONNEL_ROLE -> 150;
             case FORCE -> 100;
             case LOCATION_SYSTEM, LOCATION_PLANET, DESTINATION_SYSTEM, DESTINATION_PLANET -> 100;
@@ -769,6 +769,7 @@ public enum PersonnelTableModelColumn {
                  PRE_NOMINAL,
                  GIVEN_NAME,
                  SURNAME,
+                 SURNAME_GROUPED_BY_UNIT,
                  BLOODNAME,
                  POST_NOMINAL,
                  CALLSIGN,
@@ -776,6 +777,7 @@ public enum PersonnelTableModelColumn {
                  SKILL_LEVEL,
                  PERSONNEL_ROLE,
                  UNIT_ASSIGNMENT,
+                 MARKET_UNIT_ASSIGNMENT,
                  FORCE,
                  DEPLOYED,
                  LOCATION_SYSTEM,
@@ -789,12 +791,15 @@ public enum PersonnelTableModelColumn {
         };
     }
 
-    public boolean isVisible(final Campaign campaign, final PersonnelTabView view, final JTable table) {
+    public boolean isVisible(Campaign campaign, PersonnelTabView view, JTable table,
+          boolean loadAssignmentFromMarket, boolean groupByUnit) {
         return switch (view) {
             case GRAPHIC -> {
                 table.setRowHeight(UIUtil.scaleForGUI(60));
                 yield switch (this) {
-                    case PERSON, UNIT_ASSIGNMENT, FORCE -> true;
+                    case PERSON, FORCE -> true;
+                    case UNIT_ASSIGNMENT -> !loadAssignmentFromMarket;
+                    case MARKET_UNIT_ASSIGNMENT -> loadAssignmentFromMarket;
                     default -> false;
                 };
             }
@@ -804,11 +809,12 @@ public enum PersonnelTableModelColumn {
                      LAST_NAME,
                      SKILL_LEVEL,
                      PERSONNEL_ROLE,
-                     UNIT_ASSIGNMENT,
                      FORCE,
                      DEPLOYED,
                      INJURIES,
                      XP -> true;
+                case UNIT_ASSIGNMENT -> !loadAssignmentFromMarket;
+                case MARKET_UNIT_ASSIGNMENT -> loadAssignmentFromMarket;
                 default -> false;
             };
             case COMBAT -> switch (this) {
@@ -892,9 +898,10 @@ public enum PersonnelTableModelColumn {
                      LAST_NAME,
                      SKILL_LEVEL,
                      PERSONNEL_ROLE,
-                     UNIT_ASSIGNMENT,
                      SHIP_TRANSPORT,
                      TACTICAL_TRANSPORT -> true;
+                case UNIT_ASSIGNMENT -> !loadAssignmentFromMarket;
+                case MARKET_UNIT_ASSIGNMENT -> loadAssignmentFromMarket;
                 default -> false;
             };
             case BIOGRAPHICAL -> switch (this) {
@@ -907,13 +914,14 @@ public enum PersonnelTableModelColumn {
                 case RANK,
                      PRE_NOMINAL,
                      GIVEN_NAME,
-                     SURNAME,
                      BLOODNAME,
                      POST_NOMINAL,
                      CALLSIGN,
                      GENDER,
                      PERSONNEL_ROLE,
                      KILLS -> true;
+                case SURNAME -> !groupByUnit;
+                case SURNAME_GROUPED_BY_UNIT -> groupByUnit;
                 default -> false;
             };
             case DATES -> switch (this) {

--- a/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
@@ -68,14 +68,12 @@ import mekhq.gui.utilities.MekHqTableCellRenderer;
  * @author Jay lawson
  */
 public class PersonnelTableModel extends DataTableModel<Person> {
-    //region Variable Declarations
+
     public static final PersonnelTableModelColumn[] PERSONNEL_COLUMNS = PersonnelTableModelColumn.values();
 
     private final Campaign campaign;
     private PersonnelMarket personnelMarket;
-    private boolean loadAssignmentFromMarket;
     private boolean groupByUnit;
-    //endregion Variable Declarations
 
     public PersonnelTableModel(Campaign c) {
         data = new ArrayList<>();
@@ -128,28 +126,22 @@ public class PersonnelTableModel extends DataTableModel<Person> {
         return getValueAt(getPerson(row), PERSONNEL_COLUMNS[column]);
     }
 
-    public Object getValueAt(final @Nullable Person person,
-          final PersonnelTableModelColumn column) {
+    public Object getValueAt(@Nullable Person person, PersonnelTableModelColumn column) {
         if (getData().isEmpty()) {
             return "";
         } else if (person == null) {
             return "?";
         } else {
-            return column.getCellValue(getCampaign(), personnelMarket, person,
-                  loadAssignmentFromMarket, isGroupByUnit());
+            return column.getCellValue(campaign, person);
         }
-    }
-
-    private Campaign getCampaign() {
-        return campaign;
     }
 
     public void refreshData() {
         if (!isGroupByUnit()) {
-            setData(new ArrayList<>(getCampaign().getAllPersonnel()));
+            setData(new ArrayList<>(campaign.getAllPersonnel()));
         } else {
             List<Person> commanders = new ArrayList<>();
-            for (Person person : getCampaign().getAllPersonnel()) {
+            for (Person person : campaign.getAllPersonnel()) {
                 if ((person.getUnit() != null) && !person.equals(person.getUnit().getCommander())) {
                     // this person is NOT the commander of their unit,
                     // skip them.
@@ -183,7 +175,7 @@ public class PersonnelTableModel extends DataTableModel<Person> {
             setHorizontalAlignment(personnelColumn.getAlignment());
 
             // Display Text
-            final String displayText = personnelColumn.getDisplayText(getCampaign(), person);
+            final String displayText = personnelColumn.getDisplayText(campaign, person);
             if (displayText != null) {
                 setText(displayText);
             }
@@ -265,7 +257,7 @@ public class PersonnelTableModel extends DataTableModel<Person> {
             }
 
             // Tool Tips - includes all applicable color reasons for name/rank/status columns
-            setToolTipText(personnelColumn.getToolTipText(person, loadAssignmentFromMarket, colorReasonKeys));
+            setToolTipText(personnelColumn.getToolTipText(person, colorReasonKeys));
 
             return this;
         }
@@ -290,40 +282,39 @@ public class PersonnelTableModel extends DataTableModel<Person> {
                     setHtmlText(person.getRankName());
                     break;
                 case PERSON:
-                    setText(person.getFullDesc(getCampaign()));
+                    setText(person.getFullDesc(campaign));
                     setImage(person.getPortraitImageIconWithFallback(true, 54).getImage());
                     break;
+                case MARKET_UNIT_ASSIGNMENT:
+                    Entity entity = campaign.getPersonnelMarket().getAttachedEntity(person);
+                    setText((entity != null) ? entity.getDisplayName() : "-");
+                    break;
                 case UNIT_ASSIGNMENT:
-                    if (loadAssignmentFromMarket) {
-                        final Entity en = personnelMarket.getAttachedEntity(person);
-                        setText((en != null) ? en.getDisplayName() : "-");
-                    } else {
-                        Unit u = person.getUnit();
-                        if ((u == null) && !person.getTechUnits().isEmpty()) {
-                            u = person.getTechUnits().getFirst();
-                        }
+                    Unit unit = person.getUnit();
+                    if ((unit == null) && !person.getTechUnits().isEmpty()) {
+                        unit = person.getTechUnits().getFirst();
+                    }
 
-                        if (u != null) {
-                            String desc = "<b>" + u.getName() + "</b><br>";
-                            desc += u.getEntity().getWeightClassName();
-                            if ((!(u.getEntity() instanceof SmallCraft) || !(u.getEntity() instanceof Jumpship))) {
-                                desc += " " + UnitType.getTypeDisplayableName(u.getEntity().getUnitType());
-                            }
-                            desc += "<br>" + u.getStatus();
-                            setText(desc);
-                            Image mekImage = u.getImage(this);
-                            if (mekImage != null) {
-                                setImage(mekImage);
-                            } else {
-                                clearImage();
-                            }
+                    if (unit != null) {
+                        String description = "<b>" + unit.getName() + "</b><br>";
+                        description += unit.getEntity().getWeightClassName();
+                        if ((!(unit.getEntity() instanceof SmallCraft) || !(unit.getEntity() instanceof Jumpship))) {
+                            description += " " + UnitType.getTypeDisplayableName(unit.getEntity().getUnitType());
+                        }
+                        description += "<br>" + unit.getStatus();
+                        setText(description);
+                        Image mekImage = unit.getImage(this);
+                        if (mekImage != null) {
+                            setImage(mekImage);
                         } else {
                             clearImage();
                         }
+                    } else {
+                        clearImage();
                     }
                     break;
                 case FORCE:
-                    Formation formation = getCampaign().getFormationFor(person);
+                    Formation formation = campaign.getFormationFor(person);
                     if (formation != null) {
                         StringBuilder desc = new StringBuilder("<html><b>").append(formation.getName())
                                                    .append("</b>");
@@ -379,6 +370,9 @@ public class PersonnelTableModel extends DataTableModel<Person> {
 
     public void loadAssignmentFromMarket(PersonnelMarket personnelMarket) {
         this.personnelMarket = personnelMarket;
-        this.loadAssignmentFromMarket = (null != personnelMarket);
+    }
+
+    public boolean isLoadAssignmentFromMarket() {
+        return personnelMarket != null;
     }
 }

--- a/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
+++ b/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
@@ -84,6 +84,7 @@ public class PersonnelTableModelColumnTest {
         for (final PersonnelTableModelColumn personnelTableModelColumn : columns) {
             switch (personnelTableModelColumn) {
                 case PERSON:
+                case MARKET_UNIT_ASSIGNMENT:
                 case UNIT_ASSIGNMENT:
                     assertEquals(125, personnelTableModelColumn.getWidth());
                     break;
@@ -95,6 +96,7 @@ public class PersonnelTableModelColumnTest {
                     break;
                 case LAST_NAME:
                 case SURNAME:
+                case SURNAME_GROUPED_BY_UNIT:
                 case BLOODNAME:
                 case CALLSIGN:
                 case SKILL_LEVEL:
@@ -133,6 +135,7 @@ public class PersonnelTableModelColumnTest {
                 case PRE_NOMINAL:
                 case GIVEN_NAME:
                 case SURNAME:
+                case SURNAME_GROUPED_BY_UNIT:
                 case BLOODNAME:
                 case POST_NOMINAL:
                 case CALLSIGN:
@@ -140,6 +143,7 @@ public class PersonnelTableModelColumnTest {
                 case SKILL_LEVEL:
                 case PERSONNEL_ROLE:
                 case UNIT_ASSIGNMENT:
+                case MARKET_UNIT_ASSIGNMENT:
                 case FORCE:
                 case DEPLOYED:
                 case LOCATION_SYSTEM:
@@ -312,15 +316,15 @@ public class PersonnelTableModelColumnTest {
         void noParent_allColumnsReturnDash() {
             Person person = mockPerson();
             Campaign campaign = mockCampaign();
-            assertEquals("-", PersonnelTableModelColumn.LOCATION_SYSTEM.getCellValue(campaign, market, person, false, false));
-            assertEquals("-", PersonnelTableModelColumn.LOCATION_PLANET.getCellValue(campaign, market, person, false, false));
-            assertEquals(CAMPAIGN_NAME, PersonnelTableModelColumn.LOCATION_NAME.getCellValue(campaign, market, person, false, false));
+            assertEquals("-", PersonnelTableModelColumn.LOCATION_SYSTEM.getCellValue(campaign, person));
+            assertEquals("-", PersonnelTableModelColumn.LOCATION_PLANET.getCellValue(campaign, person));
+            assertEquals(CAMPAIGN_NAME, PersonnelTableModelColumn.LOCATION_NAME.getCellValue(campaign, person));
             assertEquals("-",
-                  PersonnelTableModelColumn.DESTINATION_SYSTEM.getCellValue(campaign, market, person, false, false));
+                  PersonnelTableModelColumn.DESTINATION_SYSTEM.getCellValue(campaign, person));
             assertEquals("-",
-                  PersonnelTableModelColumn.DESTINATION_PLANET.getCellValue(campaign, market, person, false, false));
+                  PersonnelTableModelColumn.DESTINATION_PLANET.getCellValue(campaign, person));
             assertEquals("-",
-                  PersonnelTableModelColumn.DESTINATION_NAME.getCellValue(campaign, market, person, false, false));
+                  PersonnelTableModelColumn.DESTINATION_NAME.getCellValue(campaign, person));
         }
 
         @Nested
@@ -344,19 +348,19 @@ public class PersonnelTableModelColumnTest {
             @Test
             void locationSystem_returnsCampaignSystem() {
                 assertEquals("Galatea",
-                      PersonnelTableModelColumn.LOCATION_SYSTEM.getCellValue(campaign, market, person, false, false));
+                      PersonnelTableModelColumn.LOCATION_SYSTEM.getCellValue(campaign, person));
             }
 
             @Test
             void locationPlanet_returnsCampaignPlanet() {
                 assertEquals("Galatea",
-                      PersonnelTableModelColumn.LOCATION_PLANET.getCellValue(campaign, market, person, false, false));
+                      PersonnelTableModelColumn.LOCATION_PLANET.getCellValue(campaign, person));
             }
 
             @Test
             void locationName_returnsCampaignName() {
                 assertEquals(CAMPAIGN_NAME,
-                      PersonnelTableModelColumn.LOCATION_NAME.getCellValue(campaign, market, person, false, false));
+                      PersonnelTableModelColumn.LOCATION_NAME.getCellValue(campaign, person));
             }
 
             @Test
@@ -366,17 +370,14 @@ public class PersonnelTableModelColumnTest {
                 mainLoc.setJumpPath(new JumpPath(new ArrayList<>(List.of(mainSys, destSys))));
 
                 assertEquals(CAMPAIGN_NAME,
-                      PersonnelTableModelColumn.LOCATION_NAME.getCellValue(campaign, market, person, false, false));
+                      PersonnelTableModelColumn.LOCATION_NAME.getCellValue(campaign, person));
             }
 
             @Test
             void destination_allDashWhenNotTraveling() {
-                assertEquals("-", PersonnelTableModelColumn.DESTINATION_SYSTEM.getCellValue(campaign, market, person,
-                      false, false));
-                assertEquals("-", PersonnelTableModelColumn.DESTINATION_PLANET.getCellValue(campaign, market, person,
-                      false, false));
-                assertEquals("-", PersonnelTableModelColumn.DESTINATION_NAME.getCellValue(campaign, market, person,
-                      false, false));
+                assertEquals("-", PersonnelTableModelColumn.DESTINATION_SYSTEM.getCellValue(campaign, person));
+                assertEquals("-", PersonnelTableModelColumn.DESTINATION_PLANET.getCellValue(campaign, person));
+                assertEquals("-", PersonnelTableModelColumn.DESTINATION_NAME.getCellValue(campaign, person));
             }
         }
 
@@ -403,29 +404,26 @@ public class PersonnelTableModelColumnTest {
             @Test
             void locationSystem_returnsAcademySystem() {
                 assertEquals("New Avalon",
-                      PersonnelTableModelColumn.LOCATION_SYSTEM.getCellValue(campaign, market, person, false, false));
+                      PersonnelTableModelColumn.LOCATION_SYSTEM.getCellValue(campaign, person));
             }
 
             @Test
             void locationPlanet_returnsAcademyPlanet() {
                 assertEquals("New Avalon",
-                      PersonnelTableModelColumn.LOCATION_PLANET.getCellValue(campaign, market, person, false, false));
+                      PersonnelTableModelColumn.LOCATION_PLANET.getCellValue(campaign, person));
             }
 
             @Test
             void locationName_returnsAcademyName() {
                 assertEquals("SLDF Naval Academy",
-                      PersonnelTableModelColumn.LOCATION_NAME.getCellValue(campaign, market, person, false, false));
+                      PersonnelTableModelColumn.LOCATION_NAME.getCellValue(campaign, person));
             }
 
             @Test
             void destination_allDashWhenNotTraveling() {
-                assertEquals("-", PersonnelTableModelColumn.DESTINATION_SYSTEM.getCellValue(campaign, market, person,
-                      false, false));
-                assertEquals("-", PersonnelTableModelColumn.DESTINATION_PLANET.getCellValue(campaign, market, person,
-                      false, false));
-                assertEquals("-", PersonnelTableModelColumn.DESTINATION_NAME.getCellValue(campaign, market, person,
-                      false, false));
+                assertEquals("-", PersonnelTableModelColumn.DESTINATION_SYSTEM.getCellValue(campaign, person));
+                assertEquals("-", PersonnelTableModelColumn.DESTINATION_PLANET.getCellValue(campaign, person));
+                assertEquals("-", PersonnelTableModelColumn.DESTINATION_NAME.getCellValue(campaign, person));
             }
         }
 
@@ -462,8 +460,7 @@ public class PersonnelTableModelColumnTest {
                 cl.setJumpPath(new JumpPath(new ArrayList<>(List.of(originSys, academySys))));
                 Person person = buildTravelingPerson(cl);
 
-                assertEquals("New Avalon", PersonnelTableModelColumn.DESTINATION_SYSTEM.getCellValue(campaign, market,
-                      person, false, false));
+                assertEquals("New Avalon", PersonnelTableModelColumn.DESTINATION_SYSTEM.getCellValue(campaign, person));
             }
 
             @Test
@@ -473,8 +470,7 @@ public class PersonnelTableModelColumnTest {
                 cl.setJumpPath(new JumpPath(new ArrayList<>(List.of(originSys, academySys))));
                 Person person = buildTravelingPerson(cl);
 
-                assertEquals("New Avalon", PersonnelTableModelColumn.DESTINATION_PLANET.getCellValue(campaign, market,
-                      person, false, false));
+                assertEquals("New Avalon", PersonnelTableModelColumn.DESTINATION_PLANET.getCellValue(campaign, person));
             }
 
             @Test
@@ -485,7 +481,7 @@ public class PersonnelTableModelColumnTest {
                 Person person = buildTravelingPerson(cl);
 
                 assertEquals("SLDF Naval Academy",
-                      PersonnelTableModelColumn.DESTINATION_NAME.getCellValue(campaign, market, person, false, false));
+                      PersonnelTableModelColumn.DESTINATION_NAME.getCellValue(campaign, person));
             }
 
             @Test
@@ -498,7 +494,7 @@ public class PersonnelTableModelColumnTest {
                 Person person = buildTravelingPerson(cl);
 
                 assertEquals(CAMPAIGN_NAME,
-                      PersonnelTableModelColumn.DESTINATION_NAME.getCellValue(campaign, market, person, false, false));
+                      PersonnelTableModelColumn.DESTINATION_NAME.getCellValue(campaign, person));
             }
         }
 
@@ -523,29 +519,26 @@ public class PersonnelTableModelColumnTest {
             @Test
             void locationName_returnsBaseName() {
                 assertEquals("Wolf's Dragoons HQ",
-                      PersonnelTableModelColumn.LOCATION_NAME.getCellValue(campaign, market, person, false, false));
+                      PersonnelTableModelColumn.LOCATION_NAME.getCellValue(campaign, person));
             }
 
             @Test
             void locationSystem_returnsBaseSystem() {
                 assertEquals("Outreach",
-                      PersonnelTableModelColumn.LOCATION_SYSTEM.getCellValue(campaign, market, person, false, false));
+                      PersonnelTableModelColumn.LOCATION_SYSTEM.getCellValue(campaign, person));
             }
 
             @Test
             void locationPlanet_returnsBasePlanet() {
                 assertEquals("Outreach",
-                      PersonnelTableModelColumn.LOCATION_PLANET.getCellValue(campaign, market, person, false, false));
+                      PersonnelTableModelColumn.LOCATION_PLANET.getCellValue(campaign, person));
             }
 
             @Test
             void destination_allDashWhenNotTraveling() {
-                assertEquals("-", PersonnelTableModelColumn.DESTINATION_SYSTEM.getCellValue(campaign, market, person,
-                      false, false));
-                assertEquals("-", PersonnelTableModelColumn.DESTINATION_PLANET.getCellValue(campaign, market, person,
-                      false, false));
-                assertEquals("-", PersonnelTableModelColumn.DESTINATION_NAME.getCellValue(campaign, market, person,
-                      false, false));
+                assertEquals("-", PersonnelTableModelColumn.DESTINATION_SYSTEM.getCellValue(campaign, person));
+                assertEquals("-", PersonnelTableModelColumn.DESTINATION_PLANET.getCellValue(campaign, person));
+                assertEquals("-", PersonnelTableModelColumn.DESTINATION_NAME.getCellValue(campaign, person));
             }
         }
     }


### PR DESCRIPTION
Refactor the personnel table column structure to simplify the `getCellValue` method. This change delegates conditional column display logic to the view layer and cleans up data extraction by removing the view-related state flags from the cell evaluation.

Details:
- Add `MARKET_UNIT_ASSIGNMENT` and `SURNAME_GROUPED_BY_UNIT` columns
- Simplify `PersonnelTableModelColum.getCellValue`
- Update `isVisible` in `PersonnelTableModelColumn` to accept view flags and show new columns based on the view layer settings
- Use `MARKET_UNIT_ASSIGNEMNT` column in `PersonnelTableModel`
- Calculate `isLoadAssignmentFromMarket` instead of storing it as a field