### PR TITLE
Fix #9423: Fixes local/homeschool academy transport issues

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1880,6 +1880,27 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     /**
+     * Returns the existing {@link AcademyCampusLocation} parented under {@code parent}, creating it on demand if it
+     * does not yet exist.
+     *
+     * <p>Used for home-school campuses that travel with the campaign or a player base rather than being anchored to a
+     * fixed planetary system.</p>
+     */
+    public AcademyCampusLocation getOrCreateCampusUnderLocation(String academySet, String academyName,
+          ILocation parent) {
+        for (ILocation child : parent.getChildLocations()) {
+            if (child instanceof AcademyCampusLocation campus
+                      && academySet.equals(campus.getAcademySet())
+                      && academyName.equals(campus.getAcademyName())) {
+                return campus;
+            }
+        }
+        AcademyCampusLocation campus = new AcademyCampusLocation(academySet, academyName);
+        LocationNode.LocationManager.setLocation(campus, parent);
+        return campus;
+    }
+
+    /**
      * Returns the existing local {@link AcademyCampusLocation} (home-school or unit-education) for the given campus
      * parented directly under this campaign, creating it on demand if it does not yet exist.
      *

--- a/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
@@ -1159,6 +1159,9 @@ public class Academy implements Comparable<Academy> {
             // we need to do a little extra work to get travel time, to cover academies with
             // multiple campuses
             if (!isHomeSchool) {
+                if (destination == null) {
+                    destination = campaign.getCurrentSystem();
+                }
                 int distance = campaign.getSimplifiedTravelTime(destination);
 
                 tooltip.append("<b>").append(resources.getString("distance.text")).append("</b> ");

--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -897,11 +897,9 @@ public class EducationController {
           @Nullable CurrentLocation returnLocation) {
         Academy returningFromAcademy = getAcademy(person.getEduAcademySet(), person.getEduAcademyNameInSet());
         boolean isLocal = returningFromAcademy != null && returningFromAcademy.isLocal();
-        Personnel arrivingAtPersonnel = isLocal
-                                              ?
+        Personnel arrivingAtPersonnel = isLocal ?
                                               findPersonnelWhenReturningFromLocal(campaign,
-                                                    person.getEduAcademySystem())
-                                              :
+                                                    person.getEduAcademySystem()) :
                                               campaign.getMainForcePersonnel();
         person.setParent(arrivingAtPersonnel);
         person.changeStatus(campaign, campaign.getLocalDate(), PersonnelStatus.ACTIVE);

--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -72,6 +72,8 @@ import mekhq.campaign.AbstractLocation;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CurrentLocation;
 import mekhq.campaign.JumpPath;
+import mekhq.campaign.Personnel;
+import mekhq.campaign.base.PlayerBase;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.events.persons.PersonChangedEvent;
 import mekhq.campaign.finances.Money;
@@ -320,8 +322,9 @@ public class EducationController {
         if (academy.isHomeSchool()) {
             // if the student is being homeschooled, we skip the journey to the 'academy'
             person.setEduEducationStage(EducationStage.EDUCATION);
-            AcademyCampusLocation campusLocation = campaign.getOrCreateLocalCampusLocation(
-                  academy.getSet(), academy.getName());
+            IPlace homeSchoolLocation = findHomeLocation(person, campaign);
+            AcademyCampusLocation campusLocation = campaign.getOrCreateCampusUnderLocation(
+                  academy.getSet(), academy.getName(), homeSchoolLocation);
             person.setParent(campusLocation.getPersonnel());
         } else if (academy.isLocal()) {
             person.setEduEducationStage(EducationStage.JOURNEY_TO_CAMPUS);
@@ -389,7 +392,7 @@ public class EducationController {
         if (academy.isHomeSchool()) {
             person.setEduAcademyName(campaign.getName());
         } else if (academy.isLocal()) {
-            person.setEduAcademyName(generateName(academy, campus));
+            person.setEduAcademyName(generateName(academy, person.getEduAcademySystem()));
         } else {
             person.setEduAcademyName(person.getEduAcademyNameInSet() +
                                            " (" +
@@ -419,8 +422,9 @@ public class EducationController {
 
         if (academy.isHomeSchool()) {
             person.setEduEducationStage(EducationStage.EDUCATION);
-            AcademyCampusLocation campusLocation = campaign.getOrCreateLocalCampusLocation(
-                  academy.getSet(), academy.getName());
+            IPlace homeBase = findHomeLocation(person, campaign);
+            AcademyCampusLocation campusLocation = campaign.getOrCreateCampusUnderLocation(
+                  academy.getSet(), academy.getName(), homeBase);
             person.setParent(campusLocation.getPersonnel());
         } else if (academy.isLocal()) {
             // already at the local campus — restart EDUCATION directly
@@ -654,17 +658,10 @@ public class EducationController {
         campaign.addReport(PERSONNEL,
               getFormattedTextAt(BUNDLE_NAME, "arrived.text", person.getHyperlinkedFullTitle()));
 
-        Academy landingAcademy = getAcademy(person.getEduAcademySet(), person.getEduAcademyNameInSet());
-        AcademyCampusLocation campusLocation;
-        if (landingAcademy != null && landingAcademy.isHomeSchool()) {
-            campusLocation = campaign.getOrCreateLocalCampusLocation(
-                  person.getEduAcademySet(), person.getEduAcademyNameInSet());
-        } else {
-            campusLocation = campaign.getOrCreateCampusLocation(
-                  person.getEduAcademySet(), person.getEduAcademyNameInSet(), person.getEduAcademySystem());
-            if (campusLocation == null) {
-                throw new IllegalStateException("Campus location must exist for system " + person.getEduAcademySystem());
-            }
+        AcademyCampusLocation campusLocation = campaign.getOrCreateCampusLocation(
+              person.getEduAcademySet(), person.getEduAcademyNameInSet(), person.getEduAcademySystem());
+        if (campusLocation == null) {
+            throw new IllegalStateException("Campus location must exist for system " + person.getEduAcademySystem());
         }
         person.setParent(campusLocation.getPersonnel());
         LocationDispatch.removeTravelNode(travelLocation, campaign);
@@ -769,6 +766,18 @@ public class EducationController {
             return;
         }
 
+        if (academy.isLocal()) {
+            // Local academy: the campus is on the person's own system. The return is a 2-day
+            // local transit — no inter-system dispatch needed, and the person stays in their
+            // current base location rather than being moved to main force.
+            person.setEduJourneyTime(2);
+            person.setEduDaysOfTravel(0);
+            campaign.addReport(PERSONNEL, String.format(resources.getString("returningFromSchool.text"),
+                  person.getHyperlinkedFullTitle(), 2));
+            person.setEduEducationStage(EducationStage.JOURNEY_FROM_CAMPUS);
+            return;
+        }
+
         // Capture the academy system before dispatch — dispatchToLocation moves the person out of
         // the campus node, after which getEduAcademySystem() can no longer walk up to the campus
         // and returns null, causing a NPE in getSimplifiedTravelTime.
@@ -845,10 +854,15 @@ public class EducationController {
         AbstractLocation travelLocation = person.getCurrentLocation();
 
         if (!(travelLocation instanceof CurrentLocation currentLocation)) {
-            int travelTime = max(2,
-                  campaign.getSimplifiedTravelTime(campaign.getSystemById(person.getEduAcademySystem())));
-            if (travelTime != person.getEduJourneyTime()) {
-                person.setEduJourneyTime(travelTime);
+            // Local academies are same-system 2-day transits; their travel time must not be
+            // recalculated from the campaign's current position (which may be on a different planet).
+            Academy fallbackAcademy = getAcademy(person.getEduAcademySet(), person.getEduAcademyNameInSet());
+            if (fallbackAcademy == null || !fallbackAcademy.isLocal()) {
+                int travelTime = max(2,
+                      campaign.getSimplifiedTravelTime(campaign.getSystemById(person.getEduAcademySystem())));
+                if (travelTime != person.getEduJourneyTime()) {
+                    person.setEduJourneyTime(travelTime);
+                }
             }
             if (person.getEduDaysOfTravel() >= person.getEduJourneyTime()) {
                 onDayCounterArrival.run();
@@ -881,18 +895,38 @@ public class EducationController {
 
     private static void arriveHome(Campaign campaign, Person person,
           @Nullable CurrentLocation returnLocation) {
-        person.setParent(campaign.getMainForcePersonnel());
+        Academy returningFromAcademy = getAcademy(person.getEduAcademySet(), person.getEduAcademyNameInSet());
+        boolean isLocal = returningFromAcademy != null && returningFromAcademy.isLocal();
+        Personnel arrivingAtPersonnel = isLocal
+                                              ?
+                                              findPersonnelWhenReturningFromLocal(campaign,
+                                                    person.getEduAcademySystem())
+                                              :
+                                              campaign.getMainForcePersonnel();
+        person.setParent(arrivingAtPersonnel);
         person.changeStatus(campaign, campaign.getLocalDate(), PersonnelStatus.ACTIVE);
 
         for (UUID tagAlong : person.getEduTagAlongs()) {
             Person companion = campaign.getPerson(tagAlong);
             if (companion != null) {
-                companion.setParent(campaign.getMainForcePersonnel());
+                companion.setParent(arrivingAtPersonnel);
                 companion.changeStatus(campaign, campaign.getLocalDate(), PersonnelStatus.ACTIVE);
             }
         }
 
         LocationDispatch.removeTravelNode(returnLocation, campaign);
+    }
+
+    private static Personnel findPersonnelWhenReturningFromLocal(Campaign campaign, @Nullable String systemId) {
+        if (systemId != null) {
+            for (PlayerBase base : campaign.getPlayerBases()) {
+                PlanetarySystem system = base.getCurrentSystem();
+                if (system != null && systemId.equals(system.getId())) {
+                    return base.getPersonnel();
+                }
+            }
+        }
+        return campaign.getMainForcePersonnel();
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -5306,10 +5306,14 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             } else if (academy.isLocal()) {
                 // are any of the local academies accepting applicants from person's Faction or
                 // campaign's Faction? Use the campus-aware variant so faction-restricted local academies
-                // resolve against the system's faction history (handles mergers/splits — see #8915).
-                String faction = academy.getFilteredFactionAtCampus(campaign,
-                      person,
-                      campaign.getCurrentSystem().getId());
+                // resolve against the system's faction history (handles mergers/splits — see #8915). Use
+                // the person's location if possible, not the campaign's.
+                mekhq.campaign.universe.PlanetarySystem personSystem = person.getCurrentSystem();
+                String localCampusId = personSystem != null
+                                             ? personSystem.getId()
+                                             : campaign.getCurrentSystem().getId();
+
+                String faction = academy.getFilteredFactionAtCampus(campaign, person, localCampusId);
 
                 if (faction == null) {
                     if (showIneligibleAcademies) {
@@ -5327,7 +5331,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                           academy,
                           List.of(person),
                           academyOption,
-                          campaign.getCurrentSystem().getId(),
+                          localCampusId,
                           faction);
                 }
             } else if (academy.isHomeSchool()) {
@@ -5598,12 +5602,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                         courses.setToolTipText(academy.getTooltip(campaign,
                               personnel,
                               courseIndex,
-                              campaign.getCurrentSystem()));
+                              campaign.getSystemById(campus)));
                         courses.setActionCommand(makeCommand(CMD_BEGIN_EDUCATION_ENROLLMENT,
                               academy.getSet(),
                               academy.getName(),
                               String.valueOf(courseIndex),
-                              campaign.getCurrentSystem().getId(),
+                              campus,
                               faction));
                     } else {
                         courses.setToolTipText(academy.getTooltip(campaign,

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -5309,9 +5309,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 // resolve against the system's faction history (handles mergers/splits — see #8915). Use
                 // the person's location if possible, not the campaign's.
                 mekhq.campaign.universe.PlanetarySystem personSystem = person.getCurrentSystem();
-                String localCampusId = personSystem != null
-                                             ? personSystem.getId()
-                                             : campaign.getCurrentSystem().getId();
+                String localCampusId = personSystem != null ?
+                                             personSystem.getId() :
+                                             campaign.getCurrentSystem().getId();
 
                 String faction = academy.getFilteredFactionAtCampus(campaign, person, localCampusId);
 
@@ -5598,29 +5598,16 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     String course = academy.getQualifications().get(courseIndex);
                     courses = new JMenuItem(course);
 
-                    if ((academy.isLocal()) || (academy.isHomeSchool())) {
-                        courses.setToolTipText(academy.getTooltip(campaign,
-                              personnel,
-                              courseIndex,
-                              campaign.getSystemById(campus)));
-                        courses.setActionCommand(makeCommand(CMD_BEGIN_EDUCATION_ENROLLMENT,
-                              academy.getSet(),
-                              academy.getName(),
-                              String.valueOf(courseIndex),
-                              campus,
-                              faction));
-                    } else {
-                        courses.setToolTipText(academy.getTooltip(campaign,
-                              personnel,
-                              courseIndex,
-                              campaign.getSystemById(campus)));
-                        courses.setActionCommand(makeCommand(CMD_BEGIN_EDUCATION_ENROLLMENT,
-                              academy.getSet(),
-                              academy.getName(),
-                              String.valueOf(courseIndex),
-                              campus,
-                              faction));
-                    }
+                    courses.setToolTipText(academy.getTooltip(campaign,
+                          personnel,
+                          courseIndex,
+                          campaign.getSystemById(campus)));
+                    courses.setActionCommand(makeCommand(CMD_BEGIN_EDUCATION_ENROLLMENT,
+                          academy.getSet(),
+                          academy.getName(),
+                          String.valueOf(courseIndex),
+                          campus,
+                          faction));
                     courses.addActionListener(this);
                     academyOption.add(courses);
                 }

--- a/MekHQ/unittests/mekhq/campaign/personnel/PersonTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/PersonTest.java
@@ -1586,6 +1586,8 @@ public class PersonTest {
                       .thenReturn(new AcademyCampusLocation(ACADEMY_SET, ACADEMY_NAME));
                 when(campaign.getOrCreateLocalCampusLocation(any(), any()))
                       .thenReturn(new AcademyCampusLocation(ACADEMY_SET, ACADEMY_NAME));
+                when(campaign.getOrCreateCampusUnderLocation(any(), any(), any()))
+                      .thenReturn(new AcademyCampusLocation(ACADEMY_SET, ACADEMY_NAME));
             }
 
             @Test

--- a/MekHQ/unittests/mekhq/campaign/personnel/education/EducationControllerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/education/EducationControllerTest.java
@@ -319,6 +319,8 @@ class EducationControllerTest {
                   .thenReturn(new AcademyCampusLocation(ACADEMY_SET, ACADEMY_NAME));
             when(campaign.getOrCreateLocalCampusLocation(any(), any()))
                   .thenReturn(new AcademyCampusLocation(ACADEMY_SET, ACADEMY_NAME));
+            when(campaign.getOrCreateCampusUnderLocation(any(), any(), any()))
+                  .thenReturn(new AcademyCampusLocation(ACADEMY_SET, ACADEMY_NAME));
         }
 
         @Test


### PR DESCRIPTION
Fixes #9423 

Display the correct place for students traveling to local academies, home school students stay at the base, and local academy students will try to return to a base on that system if there is one. (this last one will be refined in the future via #9440)