### PR TITLE
Migrate attribute checks to the new API

### DIFF
--- a/MekHQ/resources/mekhq/resources/AttributeCheckUtility.properties
+++ b/MekHQ/resources/mekhq/resources/AttributeCheckUtility.properties
@@ -28,16 +28,6 @@
 # Microsoft's "Game Content Usage Rules"
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
-# suppress inspection "UnusedProperty" for the whole file
-AttributeCheck.results={0}{1} {2}<b>{3}</b>{4} {5} <b>{6}</b> check with a roll of <b>{7}</b> vs. a target number of \
-  <b>{8}</b>.
-AttributeCheck.results.success=Passed
-AttributeCheck.results.failure=Failed
-AttributeCheck.rerolled=A point of <b>Edge</b> when making this check.
-skillCheck.naturalAptitude=Used a point of <b>Edge</b>.
-AttributeCheck.nullAttributeName=ERROR: first Attribute is null. Please report this bug to the MegaMek team.
-AttributeCheck.nullPerson=ERROR: Person is null. Please report this bug to the MegaMek team.
-# Target Roll Modifiers
+
 AttributeCheck.twoLinkedAttributes=Target Number (Two Linked Attributes)
 AttributeCheck.oneLinkedAttribute=Target Number (One Linked Attribute)
-AttributeCheck.miscModifier=Misc Modifier

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -165,7 +165,6 @@ import mekhq.campaign.personnel.medical.advancedMedicalAlternate.AdvancedMedical
 import mekhq.campaign.personnel.medical.advancedMedicalAlternate.InjurySubType;
 import mekhq.campaign.personnel.medical.advancedMedicalAlternate.Inoculations;
 import mekhq.campaign.personnel.skills.ActionCheckResult;
-import mekhq.campaign.personnel.skills.AttributeCheckUtility;
 import mekhq.campaign.personnel.skills.EscapeSkills;
 import mekhq.campaign.personnel.skills.QuickTrain;
 import mekhq.campaign.personnel.skills.enums.AgingMilestone;
@@ -1753,19 +1752,12 @@ public class CampaignNewDayManager {
      * @since 0.51.0
      */
     private static boolean performPersonalityBreakCheck(Campaign campaign, Person person, int modifier) {
-        String reason = getTextAt(RESOURCE_BUNDLE, "mentalBreak.check");
-        AttributeCheckUtility attributeCheck = new AttributeCheckUtility(reason,
-              person,
-              SkillAttribute.WILLPOWER,
-              null,
-              null,
-              modifier,
-              true,
-              true);
+        ActionCheckResult attributeCheckResult =
+              person.checkAttribute(SkillAttribute.WILLPOWER).withMiscModifier(modifier)
+                    .resolve(true, getTextAt(RESOURCE_BUNDLE, "mentalBreak.check"), true);
+        campaign.addReport(SKILL_CHECKS, attributeCheckResult.resultsText());
 
-        campaign.addReport(SKILL_CHECKS, attributeCheck.getResultsText());
-
-        return !attributeCheck.isSuccess();
+        return !attributeCheckResult.isSuccess();
     }
 
     /**
@@ -1841,19 +1833,12 @@ public class CampaignNewDayManager {
           boolean isUseAltAdvancedMedical, boolean isUseFatigue, int fatigueRate) {
         int modifier = getCompulsionCheckModifier(COMPULSION_ADDICTION);
 
-        String reason = getTextAt(RESOURCE_BUNDLE, "discontinuationSyndrome.check");
-        AttributeCheckUtility attributeCheck = new AttributeCheckUtility(reason,
-              person,
-              SkillAttribute.WILLPOWER,
-              null,
-              null,
-              modifier,
-              true,
-              true);
+        ActionCheckResult attributeCheckResult =
+              person.checkAttribute(SkillAttribute.WILLPOWER).withMiscModifier(modifier)
+                    .resolve(true, getTextAt(RESOURCE_BUNDLE, "discontinuationSyndrome.check"), true);
+        campaign.addReport(SKILL_CHECKS, attributeCheckResult.resultsText());
 
-        campaign.addReport(SKILL_CHECKS, attributeCheck.getResultsText());
-
-        boolean failedWillpowerCheck = attributeCheck.isSuccess();
+        boolean failedWillpowerCheck = attributeCheckResult.isSuccess();
         person.processDiscontinuationSyndrome(campaign,
               isUseAdvancedMedical,
               isUseAltAdvancedMedical,

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -144,6 +144,7 @@ import mekhq.campaign.personnel.ranks.Rank;
 import mekhq.campaign.personnel.ranks.RankSystem;
 import mekhq.campaign.personnel.ranks.RankValidator;
 import mekhq.campaign.personnel.ranks.Ranks;
+import mekhq.campaign.personnel.skills.AttributeCheck;
 import mekhq.campaign.personnel.skills.Attributes;
 import mekhq.campaign.personnel.skills.Skill;
 import mekhq.campaign.personnel.skills.SkillCheck;
@@ -5836,6 +5837,35 @@ public class Person implements ILocation {
     public SkillCheck checkSkill(String skillName, Campaign campaign) {
         return new SkillCheck(this, skillName, campaign.getCampaignOptions().isUseAgeEffects(),
               campaign.isClanCampaign(), campaign.getLocalDate());
+    }
+
+    /**
+     * Prepares an attribute check.
+     *
+     * <p>This method creates an {@link AttributeCheck} instance which calculates the target number
+     * for the attribute check.</p>
+     *
+     * @param attribute the {@link SkillAttribute} to be checked
+     *
+     * @return prepared attribute check
+     */
+    public AttributeCheck checkAttribute(SkillAttribute attribute) {
+        return new AttributeCheck(this, attribute);
+    }
+
+    /**
+     * Prepares a double attribute check.
+     *
+     * <p>This method creates an {@link AttributeCheck} instance which calculates the target number
+     * for the attribute check.</p>
+     *
+     * @param firstAttribute  first {@link SkillAttribute} to be checked
+     * @param secondAttribute second {@link SkillAttribute} to be checked
+     *
+     * @return prepared attribute check
+     */
+    public AttributeCheck checkAttributes(SkillAttribute firstAttribute, SkillAttribute secondAttribute) {
+        return new AttributeCheck(this, firstAttribute, secondAttribute);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateHealing.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateHealing.java
@@ -45,7 +45,6 @@ import static mekhq.campaign.personnel.PersonnelOptions.UNOFFICIAL_TRAUMA_SURGEO
 import static mekhq.campaign.personnel.medical.advancedMedicalAlternate.HealingMarginOfSuccessEffects.getEffectFromHealingAttempt;
 import static mekhq.campaign.personnel.skills.SkillType.S_SURGERY;
 import static mekhq.campaign.personnel.skills.enums.SkillAttribute.BODY;
-import static mekhq.campaign.personnel.skills.enums.SkillAttribute.NONE;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import java.time.LocalDate;
@@ -64,7 +63,7 @@ import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.medical.BodyLocation;
 import mekhq.campaign.personnel.skills.ActionCheckResult;
-import mekhq.campaign.personnel.skills.AttributeCheckUtility;
+import mekhq.campaign.personnel.skills.AttributeCheck;
 import mekhq.campaign.personnel.skills.SkillCheck;
 import mekhq.campaign.personnel.skills.enums.SkillAttribute;
 
@@ -298,31 +297,17 @@ public class AdvancedMedicalAlternateHealing {
      */
     private static int getMarginOfSuccessForUnassistedHealing(Person patient, List<TargetRollModifier> modifiers,
           int miscPenalty, boolean useEdge) {
-        AttributeCheckUtility naturalHealing = new AttributeCheckUtility(
-              getTextAt(RESOURCE_BUNDLE, "AdvancedMedicalAlternateHealing.naturalHealing.normal"),
-              patient,
-              BODY,
-              NONE,
-              modifiers,
-              miscPenalty,
-              false,
-              true);
-        int marginOfSuccess = naturalHealing.getMarginOfSuccess();
+        AttributeCheck naturalHealing =
+              patient.checkAttribute(BODY).withExternalModifiers(modifiers).withMiscModifier(miscPenalty);
+        ActionCheckResult result = naturalHealing.resolve(false, getTextAt(RESOURCE_BUNDLE,
+              "AdvancedMedicalAlternateHealing.naturalHealing.normal"), true);
 
-        // Edge
-        if (marginOfSuccess <= -6 && useEdge) { // Attempt to reroll a permanent injury
-            AttributeCheckUtility edgeReroll = new AttributeCheckUtility(
-                  getTextAt(RESOURCE_BUNDLE, "AdvancedMedicalAlternateHealing.naturalHealing.edge"),
-                  patient,
-                  BODY,
-                  NONE,
-                  modifiers,
-                  miscPenalty,
-                  false,
-                  true);
-            marginOfSuccess = edgeReroll.getMarginOfSuccess(); // Edge always replaces the original
+        if (result.marginOfSuccess() <= -6 && useEdge) { // Attempt to reroll a permanent injury with edge
+            // FIXME: we allow one free reroll here
+            result = naturalHealing.resolve(true, getTextAt(RESOURCE_BUNDLE,
+                  "AdvancedMedicalAlternateHealing.naturalHealing.edge"), true);
         }
-        return marginOfSuccess;
+        return result.marginOfSuccess();
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateImplants.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateImplants.java
@@ -57,7 +57,6 @@ import static mekhq.utilities.ReportingUtilities.getNegativeColor;
 import static mekhq.utilities.ReportingUtilities.getWarningColor;
 import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import megamek.codeUtilities.ObjectUtility;
@@ -68,7 +67,7 @@ import mekhq.campaign.personnel.InjuryType;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.SpecialAbility;
-import mekhq.campaign.personnel.skills.AttributeCheckUtility;
+import mekhq.campaign.personnel.skills.ActionCheckResult;
 import mekhq.campaign.personnel.skills.enums.SkillAttribute;
 
 public class AdvancedMedicalAlternateImplants {
@@ -208,18 +207,13 @@ public class AdvancedMedicalAlternateImplants {
         }
 
         int resistanceModifier = person.getOptions().booleanOption(UNOFFICIAL_IMPLANT_RESISTANCE) ? -2 : 0;
-        AttributeCheckUtility attributeCheckUtility = new AttributeCheckUtility(
-              getTextAt(RESOURCE_BUNDLE, "AlternateInjuries.skillCheck.degradation"),
-              person,
-              SkillAttribute.BODY,
-              SkillAttribute.WILLPOWER,
-              new ArrayList<>(),
-              resistanceModifier,
-              true,
-              false);
-        campaign.addReport(SKILL_CHECKS, attributeCheckUtility.getResultsText());
+        ActionCheckResult attributeCheckResult =
+              person.checkAttributes(SkillAttribute.BODY, SkillAttribute.WILLPOWER)
+                    .withMiscModifier(resistanceModifier)
+                    .resolve(true, getTextAt(RESOURCE_BUNDLE, "AlternateInjuries.skillCheck.degradation"), false);
+        campaign.addReport(SKILL_CHECKS, attributeCheckResult.resultsText());
 
-        if (!attributeCheckUtility.isSuccess() && useAbilities) {
+        if (!attributeCheckResult.isSuccess() && useAbilities) {
             String flaw = getAndApplyEIDegradationFlaw(person);
             if (!flaw.isBlank()) {
                 String key = "AlternateInjuries.report." +

--- a/MekHQ/src/mekhq/campaign/personnel/skills/AttributeCheck.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/AttributeCheck.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package mekhq.campaign.personnel.skills;
+
+import megamek.common.rolls.TargetRoll;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.skills.enums.SkillAttribute;
+
+/**
+ * An implementation of {@link ActionCheck} for attribute checks.
+ *
+ * <p>This class encapsulates the logic needed to resolve an attribute check for a character's
+ * specific {@link SkillAttribute}, accounting for necessary factors.</p>
+ *
+ * @author Hokk
+ * @since 0.51.01
+ */
+public class AttributeCheck extends ActionCheck<AttributeCheck> {
+
+    private final SkillAttribute firstAttribute;
+    private final SkillAttribute secondAttribute;
+
+    /**
+     * Instantiates an attribute check from raw values. Prefer the other constructor variants.
+     *
+     * @param person       the {@link Person} performing the skill check
+     * @param targetNumber target number for the skill check
+     */
+    public AttributeCheck(Person person, TargetRoll targetNumber,
+          SkillAttribute firstAttribute, SkillAttribute secondAttribute) {
+        super(person, targetNumber);
+        if (firstAttribute == null || firstAttribute.isNone()) {
+            throw new IllegalArgumentException("First attribute for an attribute check is not present");
+        }
+        this.firstAttribute = firstAttribute;
+        this.secondAttribute = secondAttribute;
+    }
+
+    /**
+     * Please see {@link Person#checkAttribute(SkillAttribute)} and use it instead.
+     */
+    public AttributeCheck(Person person, SkillAttribute attribute) {
+        this(person, attribute, SkillAttribute.NONE);
+    }
+
+    /**
+     * Please see {@link Person#checkAttributes(SkillAttribute, SkillAttribute)} and use it instead.
+     */
+    public AttributeCheck(Person person, SkillAttribute firstAttribute, SkillAttribute secondAttribute) {
+        super(person, AttributeCheckUtility.determineTargetNumber(person, firstAttribute, secondAttribute, 0));
+        this.firstAttribute = firstAttribute;
+        this.secondAttribute = secondAttribute;
+    }
+
+    public boolean isEasierThan(AttributeCheck other) {
+        return !targetNumber.cannotSucceed() && (targetNumber.getValue() < other.targetNumber.getValue());
+    }
+
+    @Override
+    protected AttributeCheck getThis() {
+        return this;
+    }
+
+    @Override
+    protected boolean isCountUp() {
+        return false;
+    }
+
+    @Override
+    protected boolean hasNaturalAptitude() {
+        return false;
+    }
+
+    @Override
+    protected String getActionName() {
+        String label = firstAttribute.getLabel();
+        if (secondAttribute != null && secondAttribute != SkillAttribute.NONE) {
+            label = label + "-" + secondAttribute.getLabel();
+        }
+        return label;
+    }
+
+}

--- a/MekHQ/src/mekhq/campaign/personnel/skills/AttributeCheckUtility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/AttributeCheckUtility.java
@@ -32,30 +32,16 @@
  */
 package mekhq.campaign.personnel.skills;
 
-import static megamek.common.compute.Compute.d6;
-import static mekhq.campaign.personnel.enums.GenderDescriptors.HIS_HER_THEIR;
-import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.BARELY_MADE_IT;
-import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.DISASTROUS;
-import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.getMarginOfSuccessObjectFromMarginValue;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
-import static mekhq.utilities.MHQInternationalization.getTextAt;
-import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
-import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
 
 import java.util.List;
 
-import megamek.common.TargetRollModifier;
 import megamek.common.annotations.Nullable;
 import megamek.common.rolls.TargetRoll;
-import megamek.logging.MMLogger;
-import mekhq.MekHQ;
-import mekhq.campaign.events.persons.PersonChangedEvent;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.medical.advancedMedicalAlternate.InjuryEffect;
-import mekhq.campaign.personnel.skills.enums.MarginOfSuccess;
 import mekhq.campaign.personnel.skills.enums.SkillAttribute;
-import mekhq.utilities.ReportingUtilities;
 
 /**
  * Utility class for executing attribute checks.
@@ -70,7 +56,11 @@ import mekhq.utilities.ReportingUtilities;
  * @since 0.50.07
  */
 public class AttributeCheckUtility {
-    private static final MMLogger LOGGER = MMLogger.create(AttributeCheckUtility.class);
+
+    // only static methods
+    private AttributeCheckUtility() {
+    }
+
     private static final String RESOURCE_BUNDLE = "mekhq.resources.AttributeCheckUtility";
 
     /**
@@ -82,334 +72,6 @@ public class AttributeCheckUtility {
      * The target number for an attribute check with two attributes.
      */
     protected static final int TARGET_NUMBER_TWO_LINKED_ATTRIBUTES = 18; // ATOW pg 39-41
-
-    private final String reason;
-    private final Person person;
-    private final SkillAttribute firstSkillAttribute;
-    private final SkillAttribute secondSkillAttribute;
-    private int marginOfSuccess;
-    private String resultsText;
-    private TargetRoll targetNumber;
-    boolean isCountUp;
-    private int roll;
-    private boolean usedEdge;
-
-
-    /**
-     * Executes an attribute check for the specified person and attribute type(s).
-     *
-     * <p>This constructor creates a {@link AttributeCheckUtility} instance which calculates the target number for
-     * the attribute check and performs the roll, determining the outcome based on factors such as the person's
-     * attribute levels, external modifiers, miscellaneous modifiers, and whether edge is used.</p>
-     *
-     * <p>External modifiers can optionally influence the target number, while miscellaneous modifiers alter the
-     * target based on whether the attribute is classified as 'count up' or not. Using edge allows the person to attempt
-     * a re-roll if the initial roll fails. Additionally, the constructor can include margins of success text as part of
-     * the results, if desired.</p>
-     *
-     * <p><b>Usage:</b> This constructor offers detailed control over the attribute check process. For simpler
-     * use-cases, the {@link #performQuickAttributeCheck(Person, SkillAttribute, SkillAttribute, List, int)} provides a
-     * more streamlined approach.</p>
-     *
-     * @param reason                      the reason for the check; can be {@code null}
-     * @param person                      the {@link Person} performing the attribute check
-     * @param firstSkillAttribute         the primary attribute to be used in the check.
-     * @param secondSkillAttribute        the secondary optional attribute to be used in the check. Can be null.
-     * @param externalModifiers           an optional list of {@link TargetRollModifier}s that affect the target number
-     * @param miscModifier                a miscellaneous modifier that affects the target number:
-     *                                    <ul>
-     *                                        <li>For 'count up' attributes, this value is subtracted from
-     *                                            the target number (i.e., negative values are bonuses,
-     *                                            positive values are penalties).</li>
-     *                                        <li>For non-'count up' attributes, this value is added to the
-     *                                            target number (i.e., positive values are penalties).</li>
-     *                                    </ul>
-     * @param useEdge                     whether the person should use edge to re-roll if the initial attempt fails
-     * @param includeMarginsOfSuccessText whether to include detailed margins of success information in the results
-     *
-     * @author Illiani
-     * @since 0.50.07
-     */
-    public AttributeCheckUtility(final @Nullable String reason, final Person person,
-          final SkillAttribute firstSkillAttribute, final @Nullable SkillAttribute secondSkillAttribute,
-          @Nullable List<TargetRollModifier> externalModifiers, final int miscModifier, final boolean useEdge,
-          final boolean includeMarginsOfSuccessText) {
-        this.reason = reason;
-        this.person = person;
-        this.firstSkillAttribute = firstSkillAttribute;
-        this.secondSkillAttribute = secondSkillAttribute;
-
-        if (isPersonNull()) {
-            return;
-        }
-
-        targetNumber = determineTargetNumber(person, firstSkillAttribute, secondSkillAttribute, miscModifier);
-
-        if (externalModifiers != null) {
-            for (TargetRollModifier modifier : externalModifiers) {
-                targetNumber.addModifier(modifier);
-            }
-        }
-
-        performCheck(useEdge, includeMarginsOfSuccessText);
-    }
-
-    /**
-     * Performs a quick and simple attribute check for a person based on the specified attributes.
-     *
-     * <p>This method evaluates whether the given {@link Person} successfully performs a specified attribute check by
-     * creating a {@link AttributeCheckUtility} instance to handle the calculations. The attribute check's success or
-     * failure is determined based on the person's attribute levels, the provided modifiers (if any), and any
-     * campaign-specific rules.</p>
-     *
-     * <p><b>Usage:</b> This method is designed for common use cases and provides a streamlined approach to attribute
-     * checks. For cases that require greater customization, such as support for edge re-rolls or detailed success
-     * metrics, use the {@link AttributeCheckUtility} constructor instead.</p>
-     *
-     * <p>This method is often the preferred choice for attribute checks in MekHQ due to its simplicity.</p>
-     *
-     * @param person               the {@link Person} performing the Attribute check
-     * @param firstSkillAttribute  the primary attribute to be used in the check.
-     * @param secondSkillAttribute the secondary optional attribute to be used in the check. Can be null.
-     * @param externalModifiers    an optional list of {@link TargetRollModifier}s to apply additional adjustments to
-     *                             the target number
-     * @param miscModifier         a miscellaneous modifier that affects the target number:
-     *                             <ul>
-     *                                 <li>For 'count up' Attributes, this value is subtracted from the target number
-     *                                     (i.e., negative values are bonuses, positive values are penalties).</li>
-     *                                 <li>For non-'count up' Attributes, this value is added to the target number
-     *                                     (i.e., positive values are penalties).</li>
-     *                             </ul>
-     *
-     * @return {@code true} if the Attribute check succeeds, {@code false} otherwise
-     *
-     * @author Illiani
-     * @since 0.50.07
-     */
-    public static boolean performQuickAttributeCheck(final Person person, final SkillAttribute firstSkillAttribute,
-          final @Nullable SkillAttribute secondSkillAttribute,
-          final @Nullable List<TargetRollModifier> externalModifiers,
-          final int miscModifier) {
-        AttributeCheckUtility attributeCheck = new AttributeCheckUtility(null,
-              person,
-              firstSkillAttribute,
-              secondSkillAttribute,
-              externalModifiers,
-              miscModifier,
-              false,
-              false);
-        return attributeCheck.isSuccess();
-    }
-
-    /**
-     * Checks if the {@code person} object is {@code null} and handles the null case by auto-failing the check with
-     * obviously wrong results.
-     *
-     * <p>If the {@code person} is {@code null}, the method logs a debug message, sets a {@code DISASTROUS} failure
-     * margin, and assigns out-of-range values to the {@code targetNumber} and {@code roll} to make the issue easily
-     * identifiable.</p>
-     *
-     * @return {@code true} if the {@code person} is {@code null}, {@code false} otherwise.
-     *
-     * @author Illiani
-     * @since 0.50.07
-     */
-    private boolean isPersonNull() {
-        if (person == null) {
-            LOGGER.debug("Null person passed into AttributeCheckUtility." +
-                               " Auto-failing check with bogus results so the bug stands out.");
-
-            marginOfSuccess = DISASTROUS.getValue();
-            resultsText = getFormattedTextAt(RESOURCE_BUNDLE, "AttributeCheck.nullPerson");
-            targetNumber = new TargetRoll(Integer.MAX_VALUE, "ERROR");
-            roll = Integer.MIN_VALUE;
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * Generates a formatted and localized results text describing the outcome of an Attribute check.
-     *
-     * <p>This method produces a detailed summary of the Attribute check results, including:</p>
-     * <ul>
-     *   <li>The person's title, name, and gender-based pronoun</li>
-     *   <li>The name of the Attribute being checked</li>
-     *   <li>The dice roll, target number, and margin of success or failure</li>
-     *   <li>A status message indicating success or failure</li>
-     *   <li>Use of edge (if applicable)</li>
-     * </ul>
-     *
-     * <p>The result text is color-coded using custom span tags based on the margin of success:
-     * <ul>
-     *   <li><b>Neutral Margin:</b> Displayed using a warning color (e.g., yellow).</li>
-     *   <li><b>Failure:</b> Displayed using a negative color (e.g., red).</li>
-     *   <li><b>Success:</b> Displayed using a positive color (e.g., green).</li>
-     * </ul>
-     * </p>
-     *
-     * <p>If edge was used to reroll the Attribute check, the results will include an additional note with
-     * information about the reroll. If the caller requests it, margin of success details can also be appended to the
-     * result text.</p>
-     *
-     * <p>If the first Attribute name is {@code null}, the method returns a localized error message indicating that the
-     * Attribute name could not be resolved and that an error occurred during the result generation process.</p>
-     *
-     * @param includeMarginsOfSuccessText whether to include detailed margin of success information in the result text
-     *
-     * @return a localized and formatted {@link String} representing the outcomes of the Attribute check:
-     *       <ul>
-     *         <li>If successful, the string provides details of the roll, Attribute, and margin of success.</li>
-     *         <li>If edge was used, additional information about the reroll is included.</li>
-     *         <li>If the first Attribute name is {@code null}, an error message is returned instead.</li>
-     *       </ul>
-     *
-     * @author Illiani
-     * @since 0.50.07
-     */
-    private String generateResultsText(boolean includeMarginsOfSuccessText) {
-        if (firstSkillAttribute == null) {
-            return getFormattedTextAt(RESOURCE_BUNDLE, "AttributeCheck.nullAttributeName");
-        }
-
-        String fullTitle = person.getHyperlinkedFullTitle();
-        String genderedReferenced = HIS_HER_THEIR.getDescriptor(person.getGender());
-
-        String colorOpen;
-        int neutralMarginValue = BARELY_MADE_IT.getValue();
-        if (marginOfSuccess == neutralMarginValue) {
-            colorOpen = spanOpeningWithCustomColor(ReportingUtilities.getWarningColor());
-        } else if (marginOfSuccess < neutralMarginValue) {
-            colorOpen = spanOpeningWithCustomColor(ReportingUtilities.getNegativeColor());
-        } else {
-            colorOpen = spanOpeningWithCustomColor(ReportingUtilities.getPositiveColor());
-        }
-
-        String status = getTextAt(RESOURCE_BUNDLE, "AttributeCheck.results." + (isSuccess() ? "success" : "failure"));
-
-        String label = getAttributeCheckLabel();
-        StringBuilder resultsText = new StringBuilder(getFormattedTextAt(RESOURCE_BUNDLE,
-              "AttributeCheck.results",
-              reason == null ? "" : "<b>" + reason + ":</b> ",
-              fullTitle,
-              colorOpen,
-              status,
-              CLOSING_SPAN_TAG,
-              genderedReferenced,
-              label,
-              roll,
-              targetNumber.getValue()));
-
-        if (usedEdge) {
-            resultsText.append(" ").append(getTextAt(RESOURCE_BUNDLE, "AttributeCheck.rerolled"));
-        }
-
-        if (includeMarginsOfSuccessText) {
-            MarginOfSuccess marginOfSuccessObject = getMarginOfSuccessObjectFromMarginValue(marginOfSuccess);
-            String marginOfSuccessText = colorOpen + marginOfSuccessObject.getLabel() + CLOSING_SPAN_TAG;
-            resultsText.append(" ").append(marginOfSuccessText);
-        }
-
-        return resultsText.toString();
-    }
-
-    /**
-     * Gets the calculated margin of success for this attribute check.
-     *
-     * <p>The margin of success represents how much better (or worse) the roll was compared to the target number.</p>
-     *
-     * <p><b>Usage:</b> You want to call this method whenever you care about how well a check was passed. Or how
-     * badly it was failed. If you only care whether the check was passed or failed use {@link #isSuccess()}
-     * instead.</p>
-     *
-     * @return the margin of success
-     *
-     * @author Illiani
-     * @since 0.50.07
-     */
-    public int getMarginOfSuccess() {
-        return marginOfSuccess;
-    }
-
-    /**
-     * Determines whether the Attribute check was successful.
-     *
-     * <p>An attribute check is considered successful if the calculated margin of success is greater than or equal to
-     * the margin value of {@link MarginOfSuccess#BARELY_MADE_IT}.</p>
-     *
-     * <p><b>Usage:</b> You want to call this method whenever you only care whether the check was passed or failed.
-     * If you want to know how well the character did use {@link #getMarginOfSuccess()} instead.</p>
-     *
-     * @return {@code true} if the attribute check succeeded, {@code false} otherwise
-     *
-     * @author Illiani
-     * @since 0.50.07
-     */
-    public boolean isSuccess() {
-        return marginOfSuccess >= BARELY_MADE_IT.getValue();
-    }
-
-    /**
-     * Gets the result text for the margin of success.
-     *
-     * <p>This is a descriptive string representing the outcome of the attribute check, based on the calculated
-     * margin of success.</p>
-     *
-     * @return the results text for the attribute check
-     *
-     * @author Illiani
-     * @since 0.50.07
-     */
-    public String getResultsText() {
-        return resultsText;
-    }
-
-    /**
-     * Gets the target number for the attribute check.
-     *
-     * <p>The target number represents the value that the rolled number must meet or exceed for the attribute check to
-     * succeed.</p>
-     *
-     * @return the target number for the attribute check
-     *
-     * @author Illiani
-     * @since 0.50.07
-     */
-    public TargetRoll getTargetNumber() {
-        return targetNumber;
-    }
-
-    /**
-     * Gets the roll result for the attribute check.
-     *
-     * <p>The roll is the result of the dice roll used to determine whether the attribute check succeeded or
-     * failed.</p>
-     *
-     * @return the roll result for the attribute check
-     *
-     * @author Illiani
-     * @since 0.50.07
-     */
-    public int getRoll() {
-        return roll;
-    }
-
-    /**
-     * Checks whether edge was used during the attribute check.
-     *
-     * <p>Edge provides the opportunity to re-roll if the initial attribute check fails, allowing a chance to improve
-     * the outcome.</p>
-     *
-     * @return {@code true} if edge was used during the attribute check, {@code false} otherwise
-     *
-     * @author Illiani
-     * @since 0.50.07
-     */
-    @Deprecated(since = "0.51.0", forRemoval = true)
-    public boolean isUsedEdge() {
-        return usedEdge;
-    }
 
     /**
      * Determines the target number for a roll based on the given person's attributes, the requested attributes, and a
@@ -425,13 +87,18 @@ public class AttributeCheckUtility {
      * @author Illiani
      * @since 0.50.07
      */
-    public static TargetRoll determineTargetNumber(Person person, @Nullable SkillAttribute firstSkillAttribute,
-          SkillAttribute secondSkillAttribute, int miscModifier) {
+    static TargetRoll determineTargetNumber(Person person, SkillAttribute firstSkillAttribute,
+          @Nullable SkillAttribute secondSkillAttribute, int miscModifier) {
+
+        if (firstSkillAttribute == null || firstSkillAttribute.isNone()) {
+            throw new IllegalArgumentException("First attribute for an attribute check is not present");
+        }
+
         final Attributes characterAttributes = person.getATOWAttributes();
 
         TargetRoll targetNumber = new TargetRoll();
 
-        getBaseTargetNumber(targetNumber, secondSkillAttribute != null);
+        getBaseTargetNumber(targetNumber, secondSkillAttribute != null && !secondSkillAttribute.isNone());
         getAttributeModifiers(firstSkillAttribute, secondSkillAttribute, characterAttributes, targetNumber,
               person.getActiveInjuryEffects(), person.getOptions(), person.getAgeForAttributeModifiers());
 
@@ -460,7 +127,7 @@ public class AttributeCheckUtility {
               options, ageForAttributeModifiers);
         targetNumber.addModifier(firstAttributeModifier, firstSkillAttribute.getLabel());
 
-        if (secondSkillAttribute != null) {
+        if (secondSkillAttribute != null && !secondSkillAttribute.isNone()) {
             int secondAttributeModifier = -characterAttributes.getAdjustedAttributeScore(secondSkillAttribute,
                   injuryEffects, options, ageForAttributeModifiers);
             targetNumber.addModifier(secondAttributeModifier, secondSkillAttribute.getLabel());
@@ -487,122 +154,4 @@ public class AttributeCheckUtility {
         }
     }
 
-    /**
-     * Performs an attribute check for a specified person, determining the outcome based on dice rolls and optionally
-     * allowing the use of edge points for a re-roll upon failure.
-     *
-     * <p>This method begins by rolling two six-sided dice (2d6) and comparing the result against a pre-calculated
-     * target number. If the initial roll meets or exceeds the target number, the Attribute check succeeds, and the
-     * results are calculated and stored. If the initial roll fails, and edge use is enabled and available, one edge
-     * point is consumed, and a re-roll is performed.</p>
-     *
-     * <p>The method concludes by storing the final Attribute check results, including the margin of success and
-     * optional descriptive text, for later use.</p>
-     *
-     * <p>When edge is used, the method records this information and updates the results accordingly to reflect the
-     * additional roll.</p>
-     *
-     * @param useEdge                     whether to allow the person to use an edge point to re-roll if the initial
-     *                                    roll fails. Edge use is conditional on the person's current edge
-     *                                    availability.
-     * @param includeMarginsOfSuccessText whether to include detailed information about the margin of success in the
-     *                                    final results text
-     *
-     * @author Illiani
-     * @since 0.50.07
-     */
-    private void performCheck(boolean useEdge, boolean includeMarginsOfSuccessText) {
-        roll = d6(2);
-        if (performInitialRoll(useEdge, includeMarginsOfSuccessText)) {
-            return;
-        }
-        // Prevent us from burning Edge on impossible checks
-        if (!targetNumber.cannotSucceed() || targetNumber.getValue() <= 12) {
-            roll = d6(2);
-            rollWithEdge(includeMarginsOfSuccessText);
-        }
-    }
-
-    /**
-     * Handles the initial dice roll in the Attribute check and determines whether the check is resolved or if further
-     * action (re-roll with edge) is required.
-     *
-     * <p>This method evaluates the outcome of the initial roll by comparing it against the target number. If the
-     * roll meets or exceeds the target number, the Attribute check is deemed successful, and the results are finalized.
-     * If the roll fails, the method decides whether Edge can or should be used to perform a re-roll. Edge use is
-     * allowed only if the {@code useEdge} parameter is {@code true} and there are available edge points for the
-     * person.</p>
-     *
-     * <p>The method stores key results from the initial roll, including:</p>
-     * <ul>
-     *   <li>The margin of success or failure, calculated based on the target number and roll</li>
-     *   <li>A descriptive results text, optionally including margin details if requested</li>
-     * </ul>
-     *
-     * <p>If the roll does not succeed and edge use is feasible, the method signals the need for a re-roll, otherwise
-     * finalizes the results based on the initial roll.</p>
-     *
-     * @param useEdge                     whether to allow using edge points for a re-roll if the initial roll fails
-     * @param includeMarginsOfSuccessText whether to include detailed margin of success information in the result text
-     *
-     * @return {@code true} if the Attribute check is resolved using the initial roll (success or no edge re-roll
-     *       possible); {@code false} if a re-roll using edge is required
-     *
-     * @author Illiani
-     * @since 0.50.07
-     */
-    boolean performInitialRoll(boolean useEdge, boolean includeMarginsOfSuccessText) {
-        int availableEdge = person.getCurrentEdge();
-        int targetNumberValue = targetNumber.getValue();
-
-        if (roll >= targetNumberValue || !useEdge || availableEdge < 1) {
-            int difference = isCountUp ? targetNumberValue - roll : roll - targetNumberValue;
-
-            marginOfSuccess = MarginOfSuccess.getMarginOfSuccess(difference);
-            resultsText = generateResultsText(includeMarginsOfSuccessText);
-
-            LOGGER.info(resultsText);
-            return true;
-        }
-        return false;
-    }
-
-    private String getAttributeCheckLabel() {
-        String label = firstSkillAttribute.getLabel();
-        if (secondSkillAttribute != null) {
-            label = label + "-" + secondSkillAttribute.getLabel();
-        }
-
-        return label;
-    }
-
-    /**
-     * Executes the re-roll logic for an Attribute check when edge is used, updating the person's edge points and
-     * recalculating the outcome based on the new roll.
-     *
-     * <p>This method is invoked only after the failure of the initial roll, provided edge usage is allowed and the
-     * person has at least one edge point available. When called, it decrements the person's edge points by one,
-     * triggers an event to update the game state reflecting this change, and marks that edge was used for this
-     * Attribute check. The results of the Attribute check are then recalculated based on the new roll, including the
-     * margin of success and the corresponding results text.</p>
-     *
-     * <p>The result text can optionally include detailed information about the margin of success, depending on the
-     * value of the {@code includeMarginsOfSuccessText} parameter.</p>
-     *
-     * @param includeMarginsOfSuccessText whether to include detailed margin of success information in the result text
-     *
-     * @author Illiani
-     * @since 0.50.07
-     */
-    private void rollWithEdge(boolean includeMarginsOfSuccessText) {
-        person.changeCurrentEdge(-1);
-        MekHQ.triggerEvent(new PersonChangedEvent(person));
-        usedEdge = true;
-
-        int targetNumberValue = targetNumber.getValue();
-
-        int difference = isCountUp ? targetNumberValue - roll : roll - targetNumberValue;
-        marginOfSuccess = MarginOfSuccess.getMarginOfSuccess(difference);
-        resultsText = generateResultsText(includeMarginsOfSuccessText);
-    }
 }

--- a/MekHQ/src/mekhq/gui/dialog/AttributeCheckDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AttributeCheckDialog.java
@@ -34,7 +34,6 @@ package mekhq.gui.dialog;
 
 import static megamek.common.compute.Compute.randomInt;
 import static mekhq.campaign.enums.DailyReportType.SKILL_CHECKS;
-import static mekhq.campaign.personnel.skills.AttributeCheckUtility.determineTargetNumber;
 import static mekhq.campaign.personnel.skills.enums.SkillAttribute.BODY;
 import static mekhq.campaign.personnel.skills.enums.SkillAttribute.CHARISMA;
 import static mekhq.campaign.personnel.skills.enums.SkillAttribute.DEXTERITY;
@@ -59,7 +58,7 @@ import javax.swing.SpinnerNumberModel;
 import megamek.client.ui.comboBoxes.MMComboBox;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
-import mekhq.campaign.personnel.skills.AttributeCheckUtility;
+import mekhq.campaign.personnel.skills.ActionCheckResult;
 import mekhq.campaign.personnel.skills.enums.SkillAttribute;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.ButtonLabelTooltipPair;
@@ -203,17 +202,12 @@ public class AttributeCheckDialog {
         SkillAttribute firstAttribute = attributes.getFirst();
         SkillAttribute secondAttribute = attributes.size() > 1 ? attributes.get(1) : null;
         boolean useEdge = choiceIndex == DIALOG_USE_EDGE_INDEX;
-        AttributeCheckUtility utility = new AttributeCheckUtility(null,
-              character,
-              firstAttribute,
-              secondAttribute,
-              null,
-              selectedModifier,
-              useEdge,
-              true);
-        isSuccess = utility.isSuccess();
+        ActionCheckResult attributeCheckResult =
+              character.checkAttributes(firstAttribute, secondAttribute).withMiscModifier(selectedModifier)
+                    .resolve(useEdge, null, true);
+        isSuccess = attributeCheckResult.isSuccess();
 
-        return utility.getResultsText();
+        return attributeCheckResult.resultsText();
     }
 
 
@@ -366,7 +360,7 @@ public class AttributeCheckDialog {
             List<SkillAttribute> attributes = deriveAttributesFromOption(attributeOption);
             SkillAttribute firstAttribute = attributes.getFirst();
             SkillAttribute secondAttribute = attributes.size() > 1 ? attributes.get(1) : null;
-            int targetNumber = determineTargetNumber(character, firstAttribute, secondAttribute, 0).getValue();
+            int targetNumber = character.checkAttributes(firstAttribute, secondAttribute).getTargetNumber().getValue();
 
             // Build the label with the target number
             String formattedAttributeName = "<html><b>" + attributeOption + "</b>";

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/AttributeCheckTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/AttributeCheckTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package mekhq.campaign.personnel.skills;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import megamek.common.rolls.TargetRoll;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.skills.enums.SkillAttribute;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class AttributeCheckTest {
+
+    @BeforeAll
+    static void beforeAll() {
+        SkillType.initializeTypes();
+    }
+
+    @Test
+    void testRawConstructor() {
+        Person person = mock(Person.class);
+        TargetRoll expectedTargetRoll = new TargetRoll(5, "");
+        AttributeCheck check = new AttributeCheck(person, expectedTargetRoll, SkillAttribute.BODY, null);
+
+        assertEquals(expectedTargetRoll, check.getTargetNumber());
+        assertEquals(SkillAttribute.BODY.getLabel(), check.getActionName());
+        assertEquals(check, check.getThis());
+    }
+
+    @Test
+    void testConstructor_SingleAttribute_CalculatesTargetNumber() {
+        Person person = mock(Person.class);
+        Attributes attributes = mock(Attributes.class);
+        when(person.getATOWAttributes()).thenReturn(attributes);
+        when(attributes.getAdjustedAttributeScore(eq(SkillAttribute.BODY), anyList(), any(), anyInt())).thenReturn(5);
+
+        AttributeCheck check = new AttributeCheck(person, SkillAttribute.BODY);
+
+        assertNotNull(check);
+        assertEquals(7, check.getTargetNumber().getValue()); // 12 (Base) - 5 (Score) = 7
+        assertEquals(SkillAttribute.BODY.getLabel(), check.getActionName());
+        assertFalse(check.isCountUp());
+    }
+
+    @Test
+    void testConstructor_DoubleAttribute_CalculatesTargetNumber() {
+        Person person = mock(Person.class);
+        Attributes attributes = mock(Attributes.class);
+        when(person.getATOWAttributes()).thenReturn(attributes);
+        when(attributes.getAdjustedAttributeScore(eq(SkillAttribute.DEXTERITY), any(), any(), anyInt())).thenReturn(6);
+        when(attributes.getAdjustedAttributeScore(eq(SkillAttribute.REFLEXES), any(), any(), anyInt())).thenReturn(4);
+
+        AttributeCheck check = new AttributeCheck(person, SkillAttribute.DEXTERITY, SkillAttribute.REFLEXES);
+
+        assertNotNull(check);
+        assertEquals(8, check.getTargetNumber().getValue()); // 18 (Base) - 6 - 4 = 8
+
+        String expectedLabel = SkillAttribute.DEXTERITY.getLabel() + "-" + SkillAttribute.REFLEXES.getLabel();
+        assertEquals(expectedLabel, check.getActionName());
+    }
+
+    @Test
+    void testConstructor_NullFirstAttribute() {
+        Person person = mock(Person.class);
+        assertThrows(IllegalArgumentException.class, () -> new AttributeCheck(person, (SkillAttribute) null));
+    }
+
+    @Test
+    void testConstructor_NoneFirstAttribute() {
+        Person person = mock(Person.class);
+        assertThrows(IllegalArgumentException.class, () -> new AttributeCheck(person, SkillAttribute.NONE));
+    }
+
+    @Test
+    void testIsEasierThan() {
+        Person person = mock(Person.class);
+        AttributeCheck hardCheck = new AttributeCheck(person, new TargetRoll(9, ""), SkillAttribute.BODY, null);
+        AttributeCheck easyCheck = new AttributeCheck(person, new TargetRoll(5, ""), SkillAttribute.BODY, null);
+
+        assertTrue(easyCheck.isEasierThan(hardCheck));
+        assertFalse(hardCheck.isEasierThan(easyCheck));
+    }
+
+    @Test
+    void testIsEasierThanEquals() {
+        Person person = mock(Person.class);
+        AttributeCheck hardCheck = new AttributeCheck(person, new TargetRoll(3, ""), SkillAttribute.BODY, null);
+        AttributeCheck easyCheck = new AttributeCheck(person, new TargetRoll(3, ""), SkillAttribute.BODY, null);
+
+        assertFalse(easyCheck.isEasierThan(hardCheck));
+        assertFalse(hardCheck.isEasierThan(easyCheck));
+    }
+
+    @Test
+    void testHasNaturalAptitude_AlwaysFalse() {
+        Person person = mock(Person.class);
+        AttributeCheck check = new AttributeCheck(person, new TargetRoll(6, ""), SkillAttribute.BODY, null);
+        assertFalse(check.hasNaturalAptitude());
+    }
+
+    @Test
+    void testIsCountUp_AlwaysFalse() {
+        Person person = mock(Person.class);
+        AttributeCheck check = new AttributeCheck(person, new TargetRoll(6, ""), SkillAttribute.BODY, null);
+        assertFalse(check.isCountUp());
+    }
+}


### PR DESCRIPTION
Refactor attribute checks to use a new `AttributeCheck` class extending `ActionCheck`. This replaces the stateful `AttributeCheckUtility` class with an API accessible from the `Person` class, bringing attribute checks in line with action checks.

- Add `AttributeCheck` extending `ActionCheck`
- Add `checkAttribute` and `checkAttributes` to `Person`
- Convert `AttributeCheckUtility` into a stateless utility class
- Migrate all checks based on `AttributeCheckUtilitty` to the new API
- Remove unused translation strings from `AttributeCheckUtility.properties`
- Add comprehensive test coverage for `AttributeCheck`