### PR TITLE
Do an extra Campaign.cleanUp after scenario removal

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -4879,6 +4879,12 @@ public class Campaign implements ITechManager, IPlace {
             }
         }
         scenarios.remove(scenario.getId());
+
+        // https://github.com/MegaMek/mekhq/pull/7761
+        // there's a bug preventing clearAllFormationsAndPersonnel from removing all scenario links,
+        // hence we have to do an extra clean up here:
+        cleanUp();
+
         MekHQ.triggerEvent(new ScenarioRemovedEvent(scenario));
     }
 
@@ -4891,6 +4897,12 @@ public class Campaign implements ITechManager, IPlace {
         mission.clearScenarios();
 
         missions.remove(mission.getId());
+
+        // https://github.com/MegaMek/mekhq/pull/7761
+        // there's a bug preventing clearAllFormationsAndPersonnel from removing all scenario links,
+        // hence we have to do an extra clean up here:
+        cleanUp();
+
         MekHQ.triggerEvent(new MissionRemovedEvent(mission));
     }
 
@@ -5102,12 +5114,20 @@ public class Campaign implements ITechManager, IPlace {
             for (UUID unitID : orphanFormationUnitIDs) {
                 formation.removeUnit(this, unitID, false);
             }
+
+            int scenarioId = formation.getScenarioId();
+            if ((scenarioId != Scenario.S_DEFAULT_ID) && (getScenario(scenarioId) == null)) {
+                formation.setScenarioId(Scenario.S_DEFAULT_ID, this);
+                LOGGER.error(String.format("Fixing a broken scenario link for formation %s", formation.getName()));
+            }
         }
 
         // clean up units that are assigned to non-existing scenarios
         for (Unit unit : this.getUnits()) {
-            if (this.getScenario(unit.getScenarioId()) == null) {
+            int scenarioId = unit.getScenarioId();
+            if ((scenarioId != Scenario.S_DEFAULT_ID) && (getScenario(scenarioId) == null)) {
                 unit.setScenarioId(Scenario.S_DEFAULT_ID);
+                LOGGER.error(String.format("Fixing a broken scenario link for unit %s", unit.getName()));
             }
         }
     }

--- a/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
@@ -518,11 +518,7 @@ public enum PersonnelTableModelColumn {
             return "-";
         }
         Scenario scenario = campaign.getScenario(unit.getScenarioId());
-        if (scenario == null) {
-            unit.setScenarioId(Scenario.S_DEFAULT_ID);
-            return "-";
-        }
-        return scenario.getName();
+        return scenario == null ? "-" : scenario.getName();
     }
 
     private static BiFunction<Person, Campaign, String> skillModelExtractor(String skillName) {


### PR DESCRIPTION
There's a bug preventing proper unit / formation undeployment when scenarios are deleted (#7761). Likely it happens because `Scenario.clearAllFormationsAndPersonnel` only undeploys entities that it tracks. In such case, issues with the tracking logic will lead to broken `scenarioId` links.

`Campaign.cleanUp` now additionally checks for `DEFAULT_ID` before overriding `scenarioId`.

This change is a workaround. It does an additional campaing clean up every time we delete a scenario. Clean up logic was extended to include formations and now logs when scenario links get fixed.

Additionally, a side effect fixing unit scenario links was removed from personnel table logic.