### PR TITLE
Fix edge rerolls in natural healing checks

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateHealing.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateHealing.java
@@ -302,9 +302,11 @@ public class AdvancedMedicalAlternateHealing {
         ActionCheckResult result = naturalHealing.resolve(false, getTextAt(RESOURCE_BUNDLE,
               "AdvancedMedicalAlternateHealing.naturalHealing.normal"), true);
 
-        if (result.marginOfSuccess() <= -6 && useEdge) { // Attempt to reroll a permanent injury with edge
-            // FIXME: we allow one free reroll here
-            result = naturalHealing.resolve(true, getTextAt(RESOURCE_BUNDLE,
+        // Attempt to reroll a permanent injury with edge
+        if ((result.marginOfSuccess() <= -6) && useEdge &&  (patient.getCurrentEdge() > 0)) {
+            // manually update edge because if we pass useEdge == true, the patient will get one free roll
+            patient.changeCurrentEdge(-1);
+            result = naturalHealing.resolve(false, getTextAt(RESOURCE_BUNDLE,
                   "AdvancedMedicalAlternateHealing.naturalHealing.edge"), true);
         }
         return result.marginOfSuccess();


### PR DESCRIPTION
Existing implementation was making edge rerolls for critical failures manually. Since the second (conditional) roll was done as a normal attribute check with `useEdge == true`, it was giving the patient one extra free roll.

This PR makes the check behave as intended.