### PR TITLE
Optimize SkillType.getType

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
@@ -1078,8 +1078,14 @@ public class SkillType {
     }
 
     public static @Nullable SkillType getType(String skillName) {
-        skillName = updateSkillName(skillName);
-        return lookupHash.get(skillName);
+        SkillType result = lookupHash.get(skillName);
+        if (result == null) {
+            result = lookupHash.get(updateSkillName(skillName));
+        }
+        if (result == null) {
+            LOGGER.error(String.format("Failed to resolve a skill type '%s'", skillName));
+        }
+        return result;
     }
 
     /**


### PR DESCRIPTION
Since most of these calls use internal constants for skill names, we can try resolving the name from the passed parameters first, falling back to a lookup via `updateSkillName` only if necessary.

Additionally, log resolution errors.