### PR TITLE
Introduce Person.spendEdge and switch edge rerolls to use it

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3919,7 +3919,7 @@ public class Campaign implements ITechManager, IPlace {
                   (roll < target.getValue()) &&
                   hasEdgeTrigger &&
                   (person.getCurrentEdge() > 0)) {
-            person.changeCurrentEdge(-1);
+            person.spendEdge();
             roll = d6(2);
             report += " <b>failed!</b> but uses Edge to reroll...getting a " + roll + ": ";
         }
@@ -4220,7 +4220,7 @@ public class Campaign implements ITechManager, IPlace {
                           (roll < target.getValue()) &&
                           tech.getOptions().booleanOption(PersonnelOptions.EDGE_REPAIR_FAILED_REFIT) &&
                           (tech.getCurrentEdge() > 0)) {
-                    tech.changeCurrentEdge(-1);
+                    tech.spendEdge();
                     roll = tech.isRightTechTypeFor(theRefit) ? d6(2) : Utilities.roll3d6();
                     // This is needed to update the edge values of individual crewmen
                     if (tech.isEngineer()) {
@@ -4448,7 +4448,7 @@ public class Campaign implements ITechManager, IPlace {
                              ((tech.getExperienceLevel(this, false, true) == SkillType.EXP_LEGENDARY) ||
                                     tech.getPrimaryRole().isVesselCrew())) // For vessel crews
                             && (roll < target.getValue())) {
-                tech.changeCurrentEdge(-1);
+                tech.spendEdge();
                 roll = tech.isRightTechTypeFor(partWork) ? d6(2) : Utilities.roll3d6();
                 // This is needed to update the edge values of individual crewmen
                 if (tech.isEngineer()) {

--- a/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/CamOpsSalvageUtilities.java
+++ b/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/CamOpsSalvageUtilities.java
@@ -419,7 +419,7 @@ public class CamOpsSalvageUtilities {
             campaign.addReport(PERSONNEL,
                   getFormattedTextAt(RESOURCE_BUNDLE, "CamOpsSalvageUtilities.reroll",
                         victim.getHyperlinkedName()));
-            victim.changeCurrentEdge(-1);
+            victim.spendEdge();
 
             int roll = d6(2);
             return roll != 2;

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -6157,6 +6157,15 @@ public class Person implements ILocation {
         atowAttributes.changeCurrentEdge(amount);
     }
 
+    public void spendEdge() {
+        if (getCurrentEdge() > 0) {
+            atowAttributes.changeCurrentEdge(-1);
+            MekHQ.triggerEvent(new PersonChangedEvent(this));
+        } else {
+            LOGGER.error("Trying to spend edge, but it is at {}", getCurrentEdge(), new IllegalArgumentException());
+        }
+    }
+
     /**
      * @return this person's currently available edge points. Used for weekly refresh.
      */

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedical/InjuryUtil.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedical/InjuryUtil.java
@@ -483,7 +483,7 @@ public final class InjuryUtil {
                           "%s made a mistake in the treatment of %s, but used Edge to reroll.",
                           doctor.getHyperlinkedFullTitle(),
                           person.getHyperlinkedName())));
-                    doctor.changeCurrentEdge(-1);
+                    doctor.spendEdge();
                     roll = Compute.randomInt(100);
                 }
 

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateHealing.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateHealing.java
@@ -305,7 +305,7 @@ public class AdvancedMedicalAlternateHealing {
         // Attempt to reroll a permanent injury with edge
         if ((result.marginOfSuccess() <= -6) && useEdge &&  (patient.getCurrentEdge() > 0)) {
             // manually update edge because if we pass useEdge == true, the patient will get one free roll
-            patient.changeCurrentEdge(-1);
+            patient.spendEdge();
             result = naturalHealing.resolve(false, getTextAt(RESOURCE_BUNDLE,
                   "AdvancedMedicalAlternateHealing.naturalHealing.edge"), true);
         }
@@ -404,7 +404,7 @@ public class AdvancedMedicalAlternateHealing {
         // Edge
         if (actionCheckResult.marginOfSuccess() <= -6 && useEdge && doctor.getCurrentEdge() > 0) { // Permanent injury
             // manually update edge because if we pass useEdge == true, the doctor will get one free roll
-            doctor.changeCurrentEdge(-1);
+            doctor.spendEdge();
             actionCheckResult = skillCheck.resolve(false, getTextAt(RESOURCE_BUNDLE,
                   "AdvancedMedicalAlternateHealing.assistedHealing.edge"), true);
         }

--- a/MekHQ/src/mekhq/campaign/personnel/skills/ActionCheck.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/ActionCheck.java
@@ -195,8 +195,7 @@ public abstract class ActionCheck<T extends ActionCheck<T>> {
             roll = SkillCheckUtility.getRoll(hasNaturalAptitude());
             usedEdge = true;
 
-            person.changeCurrentEdge(-1);
-            MekHQ.triggerEvent(new PersonChangedEvent(person));
+            person.spendEdge();
         }
 
         int difference = targetNumber.getValue() - roll;

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/ActionCheckTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/ActionCheckTest.java
@@ -193,7 +193,7 @@ class ActionCheckTest {
         assertTrue(result.isSuccess());
         assertTrue(result.usedEdge());
         assertEquals(9, result.roll());
-        verify(person).changeCurrentEdge(-1);
+        verify(person).spendEdge();
     }
 
     @Test
@@ -210,7 +210,7 @@ class ActionCheckTest {
         assertFalse(result.isSuccess());
         assertTrue(result.usedEdge());
         assertEquals(6, result.roll());
-        verify(person).changeCurrentEdge(-1);
+        verify(person).spendEdge();
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Previously, most skill checks were using Person.changeCurrentEdge which was not generating `PersonChangeEvent`. This change makes sure the event is always generated. Additionally, log a stack trace if there's no edge to spend.