### PR TITLE
Refactor Campaign.getTargetForAcquisition

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -104,6 +104,7 @@ import megamek.codeUtilities.ObjectUtility;
 import megamek.codeUtilities.StringUtility;
 import megamek.common.Player;
 import megamek.common.SimpleTechLevel;
+import megamek.common.TargetRollModifier;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.AvailabilityValue;
 import megamek.common.enums.Gender;
@@ -383,6 +384,8 @@ public class Campaign implements ITechManager, IPlace {
     private boolean fieldKitchenWithinCapacity;
     private int mashTheatreCapacity;
     private int repairBaysRented;
+
+    private Person genericAcquisitionPerson;
 
     // this is updated and used per gaming session, it is enabled/disabled via the Campaign options we're re-using
     // the LogEntry class used to store Personnel entries
@@ -3751,12 +3754,9 @@ public class Campaign implements ITechManager, IPlace {
             return PartAcquisitionResult.PartInherentFailure;
         }
 
-        target = system.getPrimaryPlanet()
-                       .getAcquisitionMods(target,
-                             getLocalDate(),
-                             getCampaignOptions(),
-                             getFaction(),
-                             acquisition.getTechBase() == TechBase.CLAN);
+        List<TargetRollModifier> acquisitionMods = system.getPrimaryPlanet().getAcquisitionMods(
+              getLocalDate(), getCampaignOptions(), getFaction(), acquisition.getTechBase() == TechBase.CLAN);
+        acquisitionMods.forEach(target::addModifier);
 
         if (target.getValue() == TargetRoll.IMPOSSIBLE) {
             if (getCampaignOptions().isPlanetAcquisitionVerbose()) {
@@ -3838,7 +3838,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return a boolean indicating whether the attempt to acquire equipment was
      *         successful.
      */
-    public boolean acquireEquipment(IAcquisitionWork acquisition, Person person) {
+    public boolean acquireEquipment(IAcquisitionWork acquisition, @Nullable Person person) {
         return acquireEquipment(acquisition, person, null, -1);
     }
 
@@ -3859,7 +3859,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return a boolean indicating whether the attempt to acquire equipment was
      *         successful.
      */
-    private boolean acquireEquipment(IAcquisitionWork acquisition, Person person, PlanetarySystem system,
+    private boolean acquireEquipment(IAcquisitionWork acquisition, @Nullable Person person, PlanetarySystem system,
           int transitDays) {
         boolean found = false;
         String report = "";
@@ -3876,12 +3876,9 @@ public class Campaign implements ITechManager, IPlace {
         }
 
         if (null != system) {
-            target = system.getPrimaryPlanet()
-                           .getAcquisitionMods(target,
-                                 getLocalDate(),
-                                 getCampaignOptions(),
-                                 getFaction(),
-                                 acquisition.getTechBase() == TechBase.CLAN);
+            List<TargetRollModifier> acquisitionMods = system.getPrimaryPlanet().getAcquisitionMods(
+                  getLocalDate(), getCampaignOptions(), getFaction(), acquisition.getTechBase() == TechBase.CLAN);
+            acquisitionMods.forEach(target::addModifier);
         }
         report += "attempts to find " + acquisition.getAcquisitionName();
 
@@ -6956,24 +6953,40 @@ public class Campaign implements ITechManager, IPlace {
      *
      * @return a {@link TargetRoll} indicating the outcome or difficulty of the acquisition attempt
      */
-    public TargetRoll getTargetForAcquisition(final IAcquisitionWork acquisition, final @Nullable Person person) {
-        return getTargetForAcquisition(acquisition, person, false, false);
+    public TargetRoll getTargetForAcquisition(IAcquisitionWork acquisition, @Nullable Person person) {
+        return getTargetForAcquisition(acquisition, person, false);
     }
 
     /**
-     * Calculates the target roll for acquiring the specified item or unit while optionally ignoring real acquisitions
-     * personnel. A synthetic person with baseline skill is used if personnel are ignored.
+     * Calculates the target roll for acquiring the specified item or unit while ignoring real acquisition
+     * personnel. A synthetic person with baseline skill is used.
      *
-     * @param acquisition                 the {@link IAcquisitionWork} describing the part, supply, or unit to be
-     *                                    acquired
-     * @param ignoreAcquisitionsPersonnel if {@code true}, ignores available personnel and uses a synthetic baseline
-     *                                    person for the roll
+     * @param acquisition the {@link IAcquisitionWork} describing the part, supply, or unit to be acquired
      *
      * @return a {@link TargetRoll} indicating the outcome or difficulty of the acquisition attempt
      */
-    public TargetRoll getTargetForAcquisition(final IAcquisitionWork acquisition,
-          final boolean ignoreAcquisitionsPersonnel) {
-        return getTargetForAcquisition(acquisition, null, false, ignoreAcquisitionsPersonnel);
+    public TargetRoll getTargetForGenericAcquisition(final IAcquisitionWork acquisition) {
+        return getTargetForAcquisition(acquisition, getGenericAcquisitionPerson(), false);
+    }
+
+
+    private Person getGenericAcquisitionPerson() {
+        if (genericAcquisitionPerson == null) {
+            genericAcquisitionPerson = createGenericAcquisitionPerson(S_NEGOTIATION, S_ADMIN, S_TECH_MECHANIC);
+        }
+        return genericAcquisitionPerson;
+    }
+
+    /**
+     * Creates a person used for generic acquisitions. See {@link #getTargetForGenericAcquisition(IAcquisitionWork)}
+     * @param skills the list of skills to prepopulate
+     */
+    private Person createGenericAcquisitionPerson(String... skills) {
+        Person person = new Person(this);
+        Arrays.stream(skills).forEach(skillName -> {
+            person.addSkill(skillName, SkillType.getType(skillName).getRegularLevel(), 0);
+        });
+        return person;
     }
 
     public PlanetaryConditions getCurrentPlanetaryConditions(Scenario scenario) {
@@ -7031,72 +7044,46 @@ public class Campaign implements ITechManager, IPlace {
      *                                    if no one is available/allowed, or if personnel are ignored
      * @param checkDaysToWait             if {@code true}, checks for shopping list/cooldown period before allowing the
      *                                    roll
-     * @param ignoreAcquisitionsPersonnel if {@code true}, constructs a synthetic person with default skill for the
-     *                                    roll, ignoring actual acquisitions personnel and their availability
      *
      * @return a {@link TargetRoll} describing the acquisition result, either as a constant value
      *       (automatic/impossible/fail) or a calculated result reflecting all applicable rules and modifiers
      */
-    public TargetRoll getTargetForAcquisition(final IAcquisitionWork acquisition, @Nullable Person person,
-          final boolean checkDaysToWait, final boolean ignoreAcquisitionsPersonnel) {
-        if (getCampaignOptions().getAcquisitionType() == AcquisitionsType.AUTOMATIC) {
-            return new TargetRoll(TargetRoll.AUTOMATIC_SUCCESS, "Automatic Success");
-        }
-
-        final AcquisitionsType acquisitionsType = campaignOptions.getAcquisitionType();
-        String fixedSkillName = "";
-        boolean isAnyTech = false;
-
-        switch (acquisitionsType) {
-            case ADMINISTRATION -> fixedSkillName = S_ADMIN;
-            case ANY_TECH -> isAnyTech = true;
-            case AUTOMATIC -> {
-                return null;
-            }
-            case NEGOTIATION -> fixedSkillName = S_NEGOTIATION;
-        }
-
-        if (ignoreAcquisitionsPersonnel) {
-            person = new Person(this);
-            fixedSkillName = acquisitionsType == AcquisitionsType.ANY_TECH ? S_TECH_MECHANIC : fixedSkillName;
-            SkillType skillType = getType(fixedSkillName);
-            if (skillType != null) {
-                int regularLevel = skillType.getRegularLevel();
-                person.addSkill(fixedSkillName, regularLevel, 0);
-            }
-        }
-
-        if (null == person) {
+    public TargetRoll getTargetForAcquisition(IAcquisitionWork acquisition, @Nullable Person person,
+          boolean checkDaysToWait) {
+        if (person == null) {
             return new TargetRoll(TargetRoll.IMPOSSIBLE,
                   "Your procurement personnel have used up all their acquisition attempts for this period");
-        }
-
-        final Skill skill = isAnyTech ? person.getBestTechSkill() : person.getSkillForWorkingOn(fixedSkillName);
-        if (skill == null) {
-            return new TargetRoll(TargetRoll.AUTOMATIC_FAIL, "No skill");
-        }
-        if (null != getShoppingList().getShoppingItem(acquisition.getNewEquipment()) && checkDaysToWait) {
+        } else if (campaignOptions.getAcquisitionType() == AcquisitionsType.AUTOMATIC) {
+            return new TargetRoll(TargetRoll.AUTOMATIC_SUCCESS, "Automatic Success");
+        } else if (null != getShoppingList().getShoppingItem(acquisition.getNewEquipment()) && checkDaysToWait) {
             return new TargetRoll(TargetRoll.AUTOMATIC_FAIL,
                   "You must wait until the new cycle to check for this part. Further" +
                         " attempts will be added to the shopping list.");
-        }
-        if (acquisition.getTechBase() == TechBase.CLAN && !getCampaignOptions().isAllowClanPurchases()) {
+        } else if (acquisition.getTechBase() == TechBase.CLAN && !getCampaignOptions().isAllowClanPurchases()) {
             return new TargetRoll(TargetRoll.IMPOSSIBLE, "You cannot acquire clan parts");
-        }
-        if (acquisition.getTechBase() == TechBase.IS && !getCampaignOptions().isAllowISPurchases()) {
+        } else if (acquisition.getTechBase() == TechBase.IS && !getCampaignOptions().isAllowISPurchases()) {
             return new TargetRoll(TargetRoll.IMPOSSIBLE, "You cannot acquire inner sphere parts");
-        }
-        if (getCampaignOptions().getTechLevel() < Utilities.getSimpleTechLevel(acquisition.getTechLevel())) {
+        } else if (getCampaignOptions().getTechLevel() < Utilities.getSimpleTechLevel(acquisition.getTechLevel())) {
             return new TargetRoll(TargetRoll.IMPOSSIBLE, "You cannot acquire parts of this tech level");
-        }
-        if (getCampaignOptions().isLimitByYear() &&
+        } else if (getCampaignOptions().isLimitByYear() &&
                   !acquisition.isIntroducedBy(getGameYear(), useClanTechBase(), getTechFaction())) {
             return new TargetRoll(TargetRoll.IMPOSSIBLE, "It has not been invented yet!");
-        }
-        if (getCampaignOptions().isDisallowExtinctStuff() &&
+        } else if (getCampaignOptions().isDisallowExtinctStuff() &&
                   (acquisition.isExtinctIn(getGameYear(), useClanTechBase(), getTechFaction()) ||
                          acquisition.getAvailability().equals(AvailabilityValue.X))) {
             return new TargetRoll(TargetRoll.IMPOSSIBLE, "It is extinct!");
+        }
+
+        // if you change skill mappings here, make sure to update createGenericAcquisitionPerson,
+        // so that it has skills for any case of campaignOptions.getAcquisitionType()
+        Skill skill = switch (campaignOptions.getAcquisitionType()) {
+            case ADMINISTRATION -> person.getSkillForWorkingOn(S_ADMIN);
+            case NEGOTIATION -> person.getSkillForWorkingOn(S_NEGOTIATION);
+            case ANY_TECH -> person.getBestTechSkill();
+            case AUTOMATIC -> null; // should never happen, because we auto-succeed above
+        };
+        if (skill == null) {
+            return new TargetRoll(TargetRoll.AUTOMATIC_FAIL, "No skill");
         }
 
         SkillModifierData skillModifierData = person.getSkillModifierData(campaignOptions.isUseAgeEffects(),

--- a/MekHQ/src/mekhq/campaign/universe/Planet.java
+++ b/MekHQ/src/mekhq/campaign/universe/Planet.java
@@ -45,6 +45,7 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.util.StdConverter;
 import megamek.codeUtilities.ObjectUtility;
+import megamek.common.TargetRollModifier;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.TechRating;
 import megamek.common.rolls.TargetRoll;
@@ -785,14 +786,14 @@ public class Planet {
      * A function to return any planetary related modifiers to a target roll for acquiring parts. Feeds in the campaign
      * options because this will include important information about these mods as well as faction information.
      *
-     * @param target  - current TargetRoll for acquisitions
      * @param when    - a LocalDate object for the campaign to retrieve information from the planet
      * @param options - the campaign options from which important values need to be determined
      *
      * @return an updated TargetRoll with planet specific mods
      */
-    public TargetRoll getAcquisitionMods(TargetRoll target, LocalDate when, CampaignOptions options, Faction faction,
-          boolean clanPart) {
+    public List<TargetRollModifier> getAcquisitionMods(LocalDate when, CampaignOptions options,
+          Faction faction, boolean clanPart) {
+        List<TargetRollModifier> result = new ArrayList<>();
         // check faction limitations
         Set<Faction> planetFactions = getFactionSet(when);
         if (null != planetFactions) {
@@ -828,23 +829,26 @@ public class Planet {
                           !neutrals &&
                           !allies &&
                           !options.getPlanetAcquisitionFactionLimit().generateOnEnemyPlanets()) {
-                    return new TargetRoll(TargetRoll.IMPOSSIBLE, "No supplies from enemy planets");
+                    return List.of(new TargetRollModifier(TargetRoll.IMPOSSIBLE, "No supplies from enemy planets"));
                 } else if (neutrals &&
                                  !allies &&
                                  !options.getPlanetAcquisitionFactionLimit().generateOnNeutralPlanets()) {
-                    return new TargetRoll(TargetRoll.IMPOSSIBLE, "No supplies from neutral planets");
+                    return List.of(new TargetRollModifier(TargetRoll.IMPOSSIBLE, "No supplies from neutral planets"));
                 } else if (allies && !options.getPlanetAcquisitionFactionLimit().generateOnAlliedPlanets()) {
-                    return new TargetRoll(TargetRoll.IMPOSSIBLE, "No supplies from allied planets");
+                    return List.of(new TargetRollModifier(TargetRoll.IMPOSSIBLE, "No supplies from allied planets"));
                 } else if (clanCrossover && options.isPlanetAcquisitionNoClanCrossover()) {
-                    return new TargetRoll(TargetRoll.IMPOSSIBLE, "The clans and inner sphere do not trade supplies");
+                    return List.of(new TargetRollModifier(TargetRoll.IMPOSSIBLE,
+                          "The clans and inner sphere do not trade supplies"));
                 }
             }
 
             if (noClansPresent && clanPart) {
                 if (options.isNoClanPartsFromIS()) {
-                    return new TargetRoll(TargetRoll.IMPOSSIBLE, "No clan parts from non-clan factions");
+                    return List.of(new TargetRollModifier(TargetRoll.IMPOSSIBLE,
+                          "No clan parts from non-clan factions"));
                 }
-                target.addModifier(options.getPenaltyClanPartsFromIS(), "clan parts from non-clan faction");
+                result.add(new TargetRollModifier(options.getPenaltyClanPartsFromIS(),
+                      "clan parts from non-clan faction"));
             }
         }
 
@@ -858,18 +862,17 @@ public class Planet {
         if ((socioIndustrial.tech == PlanetarySophistication.REGRESSED) ||
                   (socioIndustrial.industry == PlanetaryRating.F) ||
                   (socioIndustrial.output == PlanetaryRating.F)) {
-            return new TargetRoll(TargetRoll.IMPOSSIBLE, "Regressed: Pre-industrial world");
+            return List.of(new TargetRollModifier(TargetRoll.IMPOSSIBLE, "Regressed: Pre-industrial world"));
         }
 
-        target.addModifier(options.getPlanetTechAcquisitionBonus(socioIndustrial.tech),
-              "planet tech: " + socioIndustrial.tech.getName());
-        target.addModifier(options.getPlanetIndustryAcquisitionBonus(socioIndustrial.industry),
-              "planet industry: " + socioIndustrial.industry.getName());
-        target.addModifier(options.getPlanetOutputAcquisitionBonus(socioIndustrial.output),
-              "planet output: " + socioIndustrial.output.getName());
+        result.add(new TargetRollModifier(options.getPlanetTechAcquisitionBonus(socioIndustrial.tech),
+              "planet tech: " + socioIndustrial.tech.getName()));
+        result.add(new TargetRollModifier(options.getPlanetIndustryAcquisitionBonus(socioIndustrial.industry),
+              "planet industry: " + socioIndustrial.industry.getName()));
+        result.add(new TargetRollModifier(options.getPlanetOutputAcquisitionBonus(socioIndustrial.output),
+              "planet output: " + socioIndustrial.output.getName()));
 
-        return target;
-
+        return result;
     }
 
     @Override

--- a/MekHQ/src/mekhq/gui/dialog/ShoppingListPriorityDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ShoppingListPriorityDialog.java
@@ -388,7 +388,7 @@ public class ShoppingListPriorityDialog extends JDialog {
                 case COL_COST -> item.getBuyCost().toAmountAndSymbolString();
                 case COL_TOTAL_COST -> item.getTotalBuyCost().toAmountAndSymbolString();
                 case COL_TARGET -> {
-                    final TargetRoll target = campaign.getTargetForAcquisition(item, true);
+                    final TargetRoll target = campaign.getTargetForGenericAcquisition(item);
 
                     String value = target.getValueAsString();
 

--- a/MekHQ/src/mekhq/gui/model/PartsStoreModel.java
+++ b/MekHQ/src/mekhq/gui/model/PartsStoreModel.java
@@ -318,8 +318,7 @@ public class PartsStoreModel extends AbstractTableModel {
                     shoppingItem = (IAcquisitionWork) part;
                 }
                 if (null != shoppingItem) {
-                    TargetRoll target = campaign.getTargetForAcquisition(shoppingItem, getLogisticsPerson(), true,
-                          false);
+                    TargetRoll target = campaign.getTargetForAcquisition(shoppingItem, getLogisticsPerson(), true);
                     targetProxy = new TargetProxy(target);
                 } else {
                     targetProxy = new TargetProxy(null);

--- a/MekHQ/src/mekhq/gui/model/ProcurementTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/ProcurementTableModel.java
@@ -132,7 +132,7 @@ public class ProcurementTableModel extends DataTableModel<IAcquisitionWork> {
             case COL_TOTAL_COST:
                 return shoppingItem.getTotalBuyCost().toAmountAndSymbolString();
             case COL_TARGET:
-                final TargetRoll target = getCampaign().getTargetForAcquisition(shoppingItem, true);
+                final TargetRoll target = getCampaign().getTargetForGenericAcquisition(shoppingItem);
                 String value = target.getValueAsString();
                 if (IntStream.of(TargetRoll.IMPOSSIBLE, TargetRoll.AUTOMATIC_SUCCESS, TargetRoll.AUTOMATIC_FAIL)
                           .allMatch(i -> (target.getValue() != i))) {

--- a/MekHQ/src/mekhq/service/PartsAcquisitionService.java
+++ b/MekHQ/src/mekhq/service/PartsAcquisitionService.java
@@ -169,7 +169,7 @@ public class PartsAcquisitionService {
         for (List<IAcquisitionWork> awList : acquisitionMap.values()) {
             IAcquisitionWork awFirst = awList.getFirst();
             Part part = awFirst.getAcquisitionPart();
-            TargetRoll target = campaign.getTargetForAcquisition(awFirst, admin, true, false);
+            TargetRoll target = campaign.getTargetForAcquisition(awFirst, admin, true);
             PartCountInfo pci = new PartCountInfo();
 
             PartInventory inventories = campaign.getPartInventory(part);


### PR DESCRIPTION
Clean up `Campaign.getTargetForAcquisition` family of methods by removing `ignoreAcquisitionsPersonnel` flag from method signatures and separating generic acquisition logic. Instead of dynamically constructing a synthetic person on every call when ignoring real acquisition personnel, we now maintain a statically initialized generic procurement person. Additionally, `Planet.getAcquisitionMods` is refactored to return a list of target modifiers rather than mutating its parameters.

Specifics:
- Add `genericAcquisitionPerson` field in `Campaign`
- Replace `getTargetForAcquisition(ignoreAcquisitionsPersonnel == true)` with explicit `getTargetForGenericAcquisition` and simplify its signature
- Update `Planet.getAcquisitionMods` to return a list of `TargetRollModifier`
- Clean up conditional logic inside `getTargetForAcquisition`
- Update `ShoppingListPriorityDialog`, `ProcurementTableModel`, `PartsStoreModel`, and `PartsAcquisitionService` to use updated methods
- Mark all `@Nullable person` cases in acquisition call chains