### PR TITLE
Migrate acquisition skill checks to the new API

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -227,10 +227,12 @@ import mekhq.campaign.personnel.procreation.AbstractProcreation;
 import mekhq.campaign.personnel.ranks.AutoAssignRankForCompanyGenerator;
 import mekhq.campaign.personnel.ranks.RankSystem;
 import mekhq.campaign.personnel.ranks.RankValidator;
+import mekhq.campaign.personnel.skills.ActionCheckResult;
 import mekhq.campaign.personnel.skills.Appraisal;
 import mekhq.campaign.personnel.skills.Attributes;
 import mekhq.campaign.personnel.skills.RandomSkillPreferences;
 import mekhq.campaign.personnel.skills.Skill;
+import mekhq.campaign.personnel.skills.SkillCheck;
 import mekhq.campaign.personnel.skills.SkillModifierData;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.personnel.turnoverAndRetention.RetirementDefectionTracker;
@@ -3726,7 +3728,7 @@ public class Campaign implements ITechManager, IPlace {
      */
     public PartAcquisitionResult findContactForAcquisition(IAcquisitionWork acquisition, Person person,
           PlanetarySystem system) {
-        TargetRoll target = getTargetForAcquisition(acquisition, person);
+        SkillCheck skillCheck = checkAcquisition(acquisition, person);
 
         String impossibleSentencePrefix = person == null ?
                                                 "Can't search for " :
@@ -3739,7 +3741,7 @@ public class Campaign implements ITechManager, IPlace {
                                                person.getFullName() + " has found a contact for ";
 
         // if it's already impossible, don't bother with the rest
-        if (target.getValue() == TargetRoll.IMPOSSIBLE) {
+        if (skillCheck.getTargetNumber().isImpossible()) {
             if (getCampaignOptions().isPlanetAcquisitionVerbose()) {
                 addReport(ACQUISITIONS, "<font color='" +
                                               ReportingUtilities.getNegativeColor() +
@@ -3749,16 +3751,16 @@ public class Campaign implements ITechManager, IPlace {
                                               " on " +
                                               system.getPrintableName(getLocalDate()) +
                                               " because:</b></font> " +
-                                              target.getDesc());
+                                              skillCheck.getTargetNumber().getDesc());
             }
             return PartAcquisitionResult.PartInherentFailure;
         }
 
         List<TargetRollModifier> acquisitionMods = system.getPrimaryPlanet().getAcquisitionMods(
               getLocalDate(), getCampaignOptions(), getFaction(), acquisition.getTechBase() == TechBase.CLAN);
-        acquisitionMods.forEach(target::addModifier);
+        skillCheck.withExternalModifiers(acquisitionMods);
 
-        if (target.getValue() == TargetRoll.IMPOSSIBLE) {
+        if (skillCheck.getTargetNumber().isImpossible()) {
             if (getCampaignOptions().isPlanetAcquisitionVerbose()) {
                 addReport(ACQUISITIONS, "<font color='" +
                                               ReportingUtilities.getNegativeColor() +
@@ -3768,7 +3770,7 @@ public class Campaign implements ITechManager, IPlace {
                                               " on " +
                                               system.getPrintableName(getLocalDate()) +
                                               " because:</b></font> " +
-                                              target.getDesc());
+                                              skillCheck.getTargetNumber().getDesc());
             }
             return PartAcquisitionResult.PlanetSpecificFailure;
         }
@@ -3777,7 +3779,9 @@ public class Campaign implements ITechManager, IPlace {
         int techBonus = options.getPlanetTechAcquisitionBonus(socioIndustrial.tech);
         int industryBonus = options.getPlanetIndustryAcquisitionBonus(socioIndustrial.industry);
         int outputsBonus = options.getPlanetOutputAcquisitionBonus(socioIndustrial.output);
-        if (d6(2) < target.getValue()) {
+
+        ActionCheckResult skillCheckResult = skillCheck.resolve(false, null, false);
+        if (!skillCheckResult.isSuccess()) {
             // no contacts on this planet, move along
             if (getCampaignOptions().isPlanetAcquisitionVerbose()) {
                 addReport(ACQUISITIONS, "<font color='" +
@@ -3788,7 +3792,7 @@ public class Campaign implements ITechManager, IPlace {
                                               " on " +
                                               system.getPrintableName(getLocalDate()) +
                                               " at TN: " +
-                                              target.getValue() +
+                                              skillCheck.getTargetNumber().getValue() +
                                               " - Modifiers (Tech: " +
                                               (techBonus > 0 ? "+" : "") +
                                               techBonus +
@@ -3811,7 +3815,7 @@ public class Campaign implements ITechManager, IPlace {
                                               " on " +
                                               system.getPrintableName(getLocalDate()) +
                                               " at TN: " +
-                                              target.getValue() +
+                                              skillCheck.getTargetNumber().getValue() +
                                               " - Modifiers (Tech: " +
                                               (techBonus > 0 ? "+" : "") +
                                               techBonus +
@@ -3868,26 +3872,26 @@ public class Campaign implements ITechManager, IPlace {
             report += person.getHyperlinkedFullTitle() + ' ';
         }
 
-        TargetRoll target = getTargetForAcquisition(acquisition, person);
-
+        List<TargetRollModifier> extraModifiers = new ArrayList<>();
         // check on funds
         if (!canPayFor(acquisition)) {
-            target.addModifier(TargetRoll.IMPOSSIBLE, "Cannot afford this purchase");
+            extraModifiers.add(new TargetRollModifier(TargetRoll.IMPOSSIBLE, "Cannot afford this purchase"));
         }
 
-        if (null != system) {
-            List<TargetRollModifier> acquisitionMods = system.getPrimaryPlanet().getAcquisitionMods(
-                  getLocalDate(), getCampaignOptions(), getFaction(), acquisition.getTechBase() == TechBase.CLAN);
-            acquisitionMods.forEach(target::addModifier);
+        if (system != null) {
+            extraModifiers.addAll(system.getPrimaryPlanet().getAcquisitionMods(
+                  getLocalDate(), getCampaignOptions(), getFaction(), acquisition.getTechBase() == TechBase.CLAN));
         }
         report += "attempts to find " + acquisition.getAcquisitionName();
 
+        SkillCheck skillCheck = checkAcquisition(acquisition, person).withExternalModifiers(extraModifiers);
+
         // if impossible, then return
-        if (target.getValue() == TargetRoll.IMPOSSIBLE) {
+        if (skillCheck.getTargetNumber().isImpossible()) {
             report += ":<font color='" +
                             ReportingUtilities.getNegativeColor() +
                             "'><b> " +
-                            target.getDesc() +
+                            skillCheck.getTargetNumber().getDesc() +
                             "</b></font>";
             if (!getCampaignOptions().isUsePlanetaryAcquisition() ||
                       getCampaignOptions().isPlanetAcquisitionVerbose()) {
@@ -3896,32 +3900,28 @@ public class Campaign implements ITechManager, IPlace {
             return false;
         }
 
-        int roll = d6(2);
-        report += "  needs " + target.getValueAsString();
-        report += " and rolls " + roll + ':';
-        // Edge reroll, if applicable
-        int targetValue = target.getValue();
-        boolean isUseSupportEdge = getCampaignOptions().isUseSupportEdge();
-        boolean hasEdgeTrigger = isUseSupportEdge && person != null;
-        if (hasEdgeTrigger) {
-            if (targetValue >= 11) {
-                hasEdgeTrigger = person.getOptions().booleanOption(PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL_ELEVEN);
-            } else if (targetValue >= 8) {
-                hasEdgeTrigger = person.getOptions().booleanOption(PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL_EIGHT);
-            } else {
-                hasEdgeTrigger = person.getOptions().booleanOption(PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL_OTHER);
-            }
+        report += "  needs " + skillCheck.getTargetNumber().getValueAsString();
+
+        int targetValue = skillCheck.getTargetNumber().getValue();
+        String useEdgeOption;
+        if (targetValue >= 11) {
+            useEdgeOption = PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL_ELEVEN;
+        } else if (targetValue >= 8) {
+            useEdgeOption = PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL_EIGHT;
+        } else {
+            useEdgeOption = PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL_OTHER;
         }
-        if (isUseSupportEdge &&
-                  (roll < target.getValue()) &&
-                  hasEdgeTrigger &&
-                  (person.getCurrentEdge() > 0)) {
-            person.spendEdge();
-            roll = d6(2);
-            report += " <b>failed!</b> but uses Edge to reroll...getting a " + roll + ": ";
+        boolean useEdge = getCampaignOptions().isUseSupportEdge() &&
+                                person != null && person.getOptions().booleanOption(useEdgeOption);
+
+        ActionCheckResult skillCheckResult = skillCheck.resolve(useEdge, null, false);
+        if (skillCheckResult.usedEdge()) {
+            report += " and <b>fails!</b> but uses Edge to reroll...getting a " + skillCheckResult.roll() + ": ";
+        } else {
+            report += " and rolls " + skillCheckResult.roll() + ':';
         }
         int xpGained = 0;
-        if (roll >= target.getValue()) {
+        if (skillCheckResult.isSuccess()) {
             boolean useFunctionalAppraisal = campaignOptions.isUseFunctionalAppraisal();
             boolean isUseEdge = person != null &&
                                       campaignOptions.isUseSupportEdge() &&
@@ -3950,11 +3950,11 @@ public class Campaign implements ITechManager, IPlace {
                 }
             }
             if (person != null) {
-                if (roll == 12 && target.getValue() != TargetRoll.AUTOMATIC_SUCCESS) {
-                    xpGained += getCampaignOptions().getSuccessXP();
-                }
-                if (target.getValue() != TargetRoll.AUTOMATIC_SUCCESS) {
+                if (!skillCheck.getTargetNumber().isAutomaticSuccess()) {
                     person.setNTasks(person.getNTasks() + 1);
+                    if (skillCheckResult.roll() == 12) {
+                        xpGained += getCampaignOptions().getSuccessXP();
+                    }
                 }
                 if (person.getNTasks() >= getCampaignOptions().getNTasksXP()) {
                     xpGained += getCampaignOptions().getTaskXP();
@@ -3963,7 +3963,7 @@ public class Campaign implements ITechManager, IPlace {
             }
         } else {
             report = report + acquisition.failToFind();
-            if (person != null && roll == 2 && target.getValue() != TargetRoll.AUTOMATIC_FAIL) {
+            if (person != null && skillCheckResult.roll() == 2 && !skillCheck.getTargetNumber().isAutomaticFail()) {
                 xpGained += getCampaignOptions().getMistakeXP();
             }
         }
@@ -6933,40 +6933,40 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     /**
-     * Calculates the target roll for acquiring the specified item or unit using the default campaign logistics person,
+     * Prepares a skill check for acquiring the specified item or unit using the default campaign logistics person,
      * applying all standard campaign rules and options.
      *
      * @param acquisition the {@link IAcquisitionWork} describing the part, supply, or unit to be acquired
      *
-     * @return a {@link TargetRoll} indicating the outcome or difficulty of the acquisition attempt
+     * @return a {@link SkillCheck} reflecting the acquisition complexity
      */
-    public TargetRoll getTargetForAcquisition(final IAcquisitionWork acquisition) {
-        return getTargetForAcquisition(acquisition, getLogisticsPerson());
+    public SkillCheck checkAcquisition(final IAcquisitionWork acquisition) {
+        return checkAcquisition(acquisition, getLogisticsPerson());
     }
 
     /**
-     * Calculates the target roll for acquiring the specified item or unit with the given person, using default campaign
+     * Prepares a skill check for acquiring the specified item or unit with the given person, using default campaign
      * settings for other options.
      *
      * @param acquisition the {@link IAcquisitionWork} describing the part, supply, or unit to be acquired
      * @param person      the {@link Person} to attempt the acquisition, or {@code null} if unavailable
      *
-     * @return a {@link TargetRoll} indicating the outcome or difficulty of the acquisition attempt
+     * @return a {@link SkillCheck} reflecting the acquisition complexity
      */
-    public TargetRoll getTargetForAcquisition(IAcquisitionWork acquisition, @Nullable Person person) {
-        return getTargetForAcquisition(acquisition, person, false);
+    public SkillCheck checkAcquisition(IAcquisitionWork acquisition, @Nullable Person person) {
+        return checkAcquisition(acquisition, person, false);
     }
 
     /**
-     * Calculates the target roll for acquiring the specified item or unit while ignoring real acquisition
-     * personnel. A synthetic person with baseline skill is used.
+     * Prepares a skill check for acquiring the specified item or unit while ignoring real acquisition
+     * personnel. A synthetic person with baseline skills is used.
      *
      * @param acquisition the {@link IAcquisitionWork} describing the part, supply, or unit to be acquired
      *
-     * @return a {@link TargetRoll} indicating the outcome or difficulty of the acquisition attempt
+     * @return a {@link SkillCheck} reflecting the acquisition complexity
      */
-    public TargetRoll getTargetForGenericAcquisition(final IAcquisitionWork acquisition) {
-        return getTargetForAcquisition(acquisition, getGenericAcquisitionPerson(), false);
+    public SkillCheck checkGenericAcquisition(final IAcquisitionWork acquisition) {
+        return checkAcquisition(acquisition, getGenericAcquisitionPerson(), false);
     }
 
 
@@ -6978,7 +6978,7 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     /**
-     * Creates a person used for generic acquisitions. See {@link #getTargetForGenericAcquisition(IAcquisitionWork)}
+     * Creates a person used for generic acquisitions. See {@link #checkGenericAcquisition(IAcquisitionWork)}
      * @param skills the list of skills to prepopulate
      */
     private Person createGenericAcquisitionPerson(String... skills) {
@@ -7017,9 +7017,8 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     /**
-     * Calculates the target roll required for successfully acquiring a specific part or unit, factoring in campaign
-     * options, acquisition details, the person attempting the acquisition, and whether acquisitions personnel should be
-     * ignored.
+     * Prepares a skill check for acquiring a specific part or unit, factoring in campaign options, acquisition
+     * details, the person attempting the acquisition, and whether acquisitions personnel should be ignored.
      *
      * <p>This method evaluates a sequence of rules and conditions to determine whether the acquisition is possible,
      * impossible, automatically successful, or automatically fails for the period due to cooldowns. Otherwise, it
@@ -7027,7 +7026,7 @@ public class Campaign implements ITechManager, IPlace {
      * modifiers such as item attributes, availability, campaign configuration (including AtB and "Gray Monday"
      * effects), technical year, and extinction.</p>
      *
-     * <p>The possible results are:</p>
+     * <p>The possible skill check target numbers are:</p>
      * <ul>
      *   <li>{@code TargetRoll.AUTOMATIC_SUCCESS} if acquisitions are set to be automatic in the campaign options.</li>
      *   <li>{@code TargetRoll.IMPOSSIBLE} if the acquisition is forbidden due to campaign settings, unavailable technology,
@@ -7038,74 +7037,78 @@ public class Campaign implements ITechManager, IPlace {
      *   item/campaign modifiers, if the acquisition is allowed and requires a roll.</li>
      * </ul>
      *
-     * @param acquisition                 an {@link IAcquisitionWork} object describing the item or unit being requested
-     *                                    (contains info such as tech base, tech level, and availability)
-     * @param person                      the {@link Person} assigned to make the acquisition roll; may be {@code null}
-     *                                    if no one is available/allowed, or if personnel are ignored
-     * @param checkDaysToWait             if {@code true}, checks for shopping list/cooldown period before allowing the
-     *                                    roll
+     * @param acquisition     an {@link IAcquisitionWork} object describing the item or unit being requested
+     *                        (contains info such as tech base, tech level, and availability)
+     * @param person          the {@link Person} assigned to make the acquisition roll; may be {@code null} if no one
+     *                        is available/allowed, or if personnel are ignored
+     * @param checkDaysToWait if {@code true}, checks for shopping list/cooldown period before allowing the roll
      *
-     * @return a {@link TargetRoll} describing the acquisition result, either as a constant value
-     *       (automatic/impossible/fail) or a calculated result reflecting all applicable rules and modifiers
+     * @return a {@link SkillCheck} reflecting the acquisition complexity
      */
-    public TargetRoll getTargetForAcquisition(IAcquisitionWork acquisition, @Nullable Person person,
-          boolean checkDaysToWait) {
-        if (person == null) {
-            return new TargetRoll(TargetRoll.IMPOSSIBLE,
+    public SkillCheck checkAcquisition(IAcquisitionWork acquisition, @Nullable Person person, boolean checkDaysToWait) {
+        TargetRollModifier decisiveModifier = null;
+        if (getCampaignOptions().getAcquisitionType() == AcquisitionsType.AUTOMATIC) {
+            decisiveModifier = new TargetRollModifier(TargetRoll.AUTOMATIC_SUCCESS, "Automatic Success");
+        } else if (person == null) {
+            decisiveModifier = new TargetRollModifier(TargetRoll.IMPOSSIBLE,
                   "Your procurement personnel have used up all their acquisition attempts for this period");
-        } else if (campaignOptions.getAcquisitionType() == AcquisitionsType.AUTOMATIC) {
-            return new TargetRoll(TargetRoll.AUTOMATIC_SUCCESS, "Automatic Success");
         } else if (null != getShoppingList().getShoppingItem(acquisition.getNewEquipment()) && checkDaysToWait) {
-            return new TargetRoll(TargetRoll.AUTOMATIC_FAIL,
+            decisiveModifier = new TargetRollModifier(TargetRoll.AUTOMATIC_FAIL,
                   "You must wait until the new cycle to check for this part. Further" +
                         " attempts will be added to the shopping list.");
         } else if (acquisition.getTechBase() == TechBase.CLAN && !getCampaignOptions().isAllowClanPurchases()) {
-            return new TargetRoll(TargetRoll.IMPOSSIBLE, "You cannot acquire clan parts");
+            decisiveModifier = new TargetRollModifier(TargetRoll.IMPOSSIBLE, "You cannot acquire clan parts");
         } else if (acquisition.getTechBase() == TechBase.IS && !getCampaignOptions().isAllowISPurchases()) {
-            return new TargetRoll(TargetRoll.IMPOSSIBLE, "You cannot acquire inner sphere parts");
+            decisiveModifier = new TargetRollModifier(TargetRoll.IMPOSSIBLE, "You cannot acquire inner sphere parts");
         } else if (getCampaignOptions().getTechLevel() < Utilities.getSimpleTechLevel(acquisition.getTechLevel())) {
-            return new TargetRoll(TargetRoll.IMPOSSIBLE, "You cannot acquire parts of this tech level");
+            decisiveModifier = new TargetRollModifier(TargetRoll.IMPOSSIBLE,
+                  "You cannot acquire parts of this tech level");
         } else if (getCampaignOptions().isLimitByYear() &&
                   !acquisition.isIntroducedBy(getGameYear(), useClanTechBase(), getTechFaction())) {
-            return new TargetRoll(TargetRoll.IMPOSSIBLE, "It has not been invented yet!");
+            decisiveModifier = new TargetRollModifier(TargetRoll.IMPOSSIBLE, "It has not been invented yet!");
         } else if (getCampaignOptions().isDisallowExtinctStuff() &&
                   (acquisition.isExtinctIn(getGameYear(), useClanTechBase(), getTechFaction()) ||
                          acquisition.getAvailability().equals(AvailabilityValue.X))) {
-            return new TargetRoll(TargetRoll.IMPOSSIBLE, "It is extinct!");
+            decisiveModifier = new TargetRollModifier(TargetRoll.IMPOSSIBLE, "It is extinct!");
+        }
+
+        if (person == null) {
+            // default to the acquisition person if person == null was passed
+            person = getGenericAcquisitionPerson();
         }
 
         // if you change skill mappings here, make sure to update createGenericAcquisitionPerson,
         // so that it has skills for any case of campaignOptions.getAcquisitionType()
-        Skill skill = switch (campaignOptions.getAcquisitionType()) {
-            case ADMINISTRATION -> person.getSkillForWorkingOn(S_ADMIN);
-            case NEGOTIATION -> person.getSkillForWorkingOn(S_NEGOTIATION);
-            case ANY_TECH -> person.getBestTechSkill();
-            case AUTOMATIC -> null; // should never happen, because we auto-succeed above
+        SkillType skillType = switch (getCampaignOptions().getAcquisitionType()) {
+            case ADMINISTRATION -> SkillType.getType(S_ADMIN);
+            case NEGOTIATION -> SkillType.getType(S_NEGOTIATION);
+            case AUTOMATIC -> SkillType.getType(S_ADMIN); // used as a placeholder, the check succeeds automatically
+            case ANY_TECH -> {
+                Skill bestTechSkill = person.getBestTechSkill();
+                // since the person has no tech skills, we can create the skill check for any of them
+                yield (bestTechSkill == null) ? SkillType.getType(S_TECH_MECHANIC) : bestTechSkill.getType();
+            }
         };
-        if (skill == null) {
-            return new TargetRoll(TargetRoll.AUTOMATIC_FAIL, "No skill");
+        if (!person.hasSkill(skillType.getName()) && (decisiveModifier == null)) {
+            decisiveModifier = new TargetRollModifier(TargetRoll.AUTOMATIC_FAIL, "No skill");
         }
 
-        SkillModifierData skillModifierData = person.getSkillModifierData(campaignOptions.isUseAgeEffects(),
-              isClanCampaign(), currentDay);
+        if (decisiveModifier != null) {
+            return new SkillCheck(person, skillType, new TargetRoll(decisiveModifier));
+        }
 
-        TargetRoll target = new TargetRoll(skill.getFinalSkillValue(skillModifierData),
-              skill.getSkillLevel(skillModifierData).toString());
-        target.append(acquisition.getAllAcquisitionMods());
-
+        List<TargetRollModifier> modifiers = new ArrayList<>(acquisition.getAllAcquisitionMods().getModifiers());
         if (getCampaignOptions().isUseStratCon() && getCampaignOptions().isRestrictPartsByMission()) {
             int contractAvailability = findAtBPartsAvailabilityLevel();
-
             if (contractAvailability != 0) {
-                target.addModifier(contractAvailability, "Contract");
+                modifiers.add(new TargetRollModifier(contractAvailability, "Contract"));
             }
         }
-
-        if (isGrayMonday(currentDay, campaignOptions.isSimulateGrayMonday())) {
-            target.addModifier(4, "Gray Monday");
+        if (isGrayMonday(currentDay, getCampaignOptions().isSimulateGrayMonday())) {
+            modifiers.add(new TargetRollModifier(4, "Gray Monday"));
         }
 
-        return target;
+        return person.checkSkill(skillType.getName(), this).withExternalModifiers(modifiers);
     }
 
     public int findAtBPartsAvailabilityLevel() {

--- a/MekHQ/src/mekhq/gui/dialog/ChooseRefitDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ChooseRefitDialog.java
@@ -371,7 +371,7 @@ public class ChooseRefitDialog extends JDialog {
             } else if (col == COL_COST) {
                 return r.getCost().toAmountAndSymbolString();
             } else if (col == COL_TARGET) {
-                return campaign.getTargetForAcquisition(r).getValueAsString();
+                return campaign.checkAcquisition(r).getTargetNumber().getValueAsString();
             } else {
                 return "?";
             }
@@ -411,7 +411,7 @@ public class ChooseRefitDialog extends JDialog {
             }
 
             if (col == COL_TARGET) {
-                return campaign.getTargetForAcquisition(r).getDesc();
+                return campaign.checkAcquisition(r).getTargetNumber().getDesc();
             }
 
             return null;

--- a/MekHQ/src/mekhq/gui/dialog/MekHQUnitSelectorDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MekHQUnitSelectorDialog.java
@@ -274,7 +274,7 @@ public class MekHQUnitSelectorDialog extends AbstractUnitSelectorDialog {
             // Here also, we need to update the Buy and AddGM buttons  when a unit is selected.
             if (addToCampaign) {
                 buttonBuy.setEnabled(true);
-                final TargetRoll target = campaign.getTargetForAcquisition(selectedUnit);
+                TargetRoll target = campaign.checkAcquisition(selectedUnit).getTargetNumber();
                 buttonBuy.setText(Messages.getString("MekSelectorDialog.Buy", target.getValueAsString()));
                 buttonBuy.setToolTipText(target.getDesc());
                 buttonAddGM.setEnabled(true);

--- a/MekHQ/src/mekhq/gui/dialog/ShoppingListPriorityDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ShoppingListPriorityDialog.java
@@ -42,7 +42,6 @@ import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Frame;
 import java.util.List;
-import java.util.stream.IntStream;
 import javax.swing.JDialog;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -388,18 +387,11 @@ public class ShoppingListPriorityDialog extends JDialog {
                 case COL_COST -> item.getBuyCost().toAmountAndSymbolString();
                 case COL_TOTAL_COST -> item.getTotalBuyCost().toAmountAndSymbolString();
                 case COL_TARGET -> {
-                    final TargetRoll target = campaign.getTargetForGenericAcquisition(item);
-
+                    TargetRoll target = campaign.checkGenericAcquisition(item).getTargetNumber();
                     String value = target.getValueAsString();
-
-                    if (IntStream.of(
-                                TargetRoll.IMPOSSIBLE,
-                                TargetRoll.AUTOMATIC_SUCCESS,
-                                TargetRoll.AUTOMATIC_FAIL)
-                              .noneMatch(i -> target.getValue() == i)) {
+                    if (!target.cannotSucceed() && !target.isAutomaticSuccess()) {
                         value += "+";
                     }
-
                     yield value;
                 }
                 case COL_NEXT -> {

--- a/MekHQ/src/mekhq/gui/model/PartsStoreModel.java
+++ b/MekHQ/src/mekhq/gui/model/PartsStoreModel.java
@@ -318,8 +318,8 @@ public class PartsStoreModel extends AbstractTableModel {
                     shoppingItem = (IAcquisitionWork) part;
                 }
                 if (null != shoppingItem) {
-                    TargetRoll target = campaign.getTargetForAcquisition(shoppingItem, getLogisticsPerson(), true);
-                    targetProxy = new TargetProxy(target);
+                    targetProxy = new TargetProxy(
+                          campaign.checkAcquisition(shoppingItem, getLogisticsPerson(), true).getTargetNumber());
                 } else {
                     targetProxy = new TargetProxy(null);
                 }

--- a/MekHQ/src/mekhq/gui/model/ProcurementTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/ProcurementTableModel.java
@@ -36,7 +36,6 @@ import java.awt.Component;
 import java.text.DecimalFormat;
 import java.util.Optional;
 import java.util.ResourceBundle;
-import java.util.stream.IntStream;
 import javax.swing.JTable;
 import javax.swing.SwingConstants;
 import javax.swing.table.DefaultTableCellRenderer;
@@ -132,10 +131,9 @@ public class ProcurementTableModel extends DataTableModel<IAcquisitionWork> {
             case COL_TOTAL_COST:
                 return shoppingItem.getTotalBuyCost().toAmountAndSymbolString();
             case COL_TARGET:
-                final TargetRoll target = getCampaign().getTargetForGenericAcquisition(shoppingItem);
+                TargetRoll target = getCampaign().checkGenericAcquisition(shoppingItem).getTargetNumber();
                 String value = target.getValueAsString();
-                if (IntStream.of(TargetRoll.IMPOSSIBLE, TargetRoll.AUTOMATIC_SUCCESS, TargetRoll.AUTOMATIC_FAIL)
-                          .allMatch(i -> (target.getValue() != i))) {
+                if (!target.cannotSucceed() && !target.isAutomaticSuccess()) {
                     value += "+";
                 }
                 return value;
@@ -185,7 +183,7 @@ public class ProcurementTableModel extends DataTableModel<IAcquisitionWork> {
 
     private String getTooltipFor(final IAcquisitionWork shoppingItem, final int column) {
         if (column == COL_TARGET) {
-            return getCampaign().getTargetForAcquisition(shoppingItem).getDesc();
+            return getCampaign().checkAcquisition(shoppingItem).getTargetNumber().getDesc();
         }
         return resources.getString("ProcurementTableModel.defaultToolTip.toolTipText");
     }

--- a/MekHQ/src/mekhq/service/PartsAcquisitionService.java
+++ b/MekHQ/src/mekhq/service/PartsAcquisitionService.java
@@ -37,12 +37,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import megamek.common.rolls.TargetRoll;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.PartInventory;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.skills.SkillCheck;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.work.IAcquisitionWork;
 
@@ -169,7 +169,6 @@ public class PartsAcquisitionService {
         for (List<IAcquisitionWork> awList : acquisitionMap.values()) {
             IAcquisitionWork awFirst = awList.getFirst();
             Part part = awFirst.getAcquisitionPart();
-            TargetRoll target = campaign.getTargetForAcquisition(awFirst, admin, true);
             PartCountInfo pci = new PartCountInfo();
 
             PartInventory inventories = campaign.getPartInventory(part);
@@ -197,9 +196,10 @@ public class PartsAcquisitionService {
             pci.setStickerPrice(part.getStickerPrice());
             pci.setMissingCount(missing);
 
-            if (target.getValue() == TargetRoll.IMPOSSIBLE) {
+            SkillCheck skillCheck = campaign.checkAcquisition(awFirst, admin, true);
+            if (skillCheck.getTargetNumber().isImpossible()) {
                 pci.setCanBeAcquired(false);
-                pci.setFailedMessage(target.getPlainDesc());
+                pci.setFailedMessage(skillCheck.getTargetNumber().getPlainDesc());
             } else {
                 pci.setInTransitCount(inTransit);
                 pci.setOnOrderCount(onOrder);

--- a/MekHQ/unittests/mekhq/campaign/SkillCheckRulesTest.java
+++ b/MekHQ/unittests/mekhq/campaign/SkillCheckRulesTest.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package mekhq.campaign;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import megamek.common.TechConstants;
+import megamek.common.enums.TechBase;
+import megamek.common.rolls.TargetRoll;
+import mekhq.campaign.campaignOptions.AcquisitionsType;
+import mekhq.campaign.campaignOptions.CampaignOptions;
+import mekhq.campaign.market.ShoppingList;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.skills.ActionCheck;
+import mekhq.campaign.personnel.skills.SkillCheck;
+import mekhq.campaign.personnel.skills.SkillType;
+import mekhq.campaign.universe.Faction;
+import mekhq.campaign.work.IAcquisitionWork;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.lang.reflect.Field;
+
+
+public class SkillCheckRulesTest {
+
+    @Nested
+    class AcquisitionSkillChecksTest {
+
+        @BeforeAll
+        static void beforeAll() {
+            SkillType.initializeTypes();
+        }
+
+        private Campaign createCampaignMock(CampaignOptions options) {
+            Campaign campaign = mock(Campaign.class);
+            // force calling the actual implementation
+            doCallRealMethod().when(campaign).checkAcquisition(any(), any(), anyBoolean());
+            Faction faction = new Faction();
+            when(campaign.getCampaignOptions()).thenReturn(options);
+            when(campaign.getFaction()).thenReturn(faction);
+            ShoppingList shoppingList = mock(ShoppingList.class);
+            when(campaign.getShoppingList()).thenReturn(shoppingList);
+            return campaign;
+        }
+
+        @Test
+        public void testAutomaticAcquisition() {
+            CampaignOptions options = mock(CampaignOptions.class);
+            Campaign campaign = createCampaignMock(options);
+            Person person = new Person(campaign);
+            when(options.getAcquisitionType()).thenReturn(AcquisitionsType.AUTOMATIC);
+
+            SkillCheck result = campaign.checkAcquisition(mock(IAcquisitionWork.class), person, false);
+
+            assertEquals(SkillType.S_ADMIN, result.getSkillType().getName());
+            assertTrue(result.getTargetNumber().isAutomaticSuccess());
+            assertEquals("Automatic Success", result.getTargetNumber().getDesc());
+        }
+
+        @Test
+        public void testNullPerson() throws NoSuchFieldException, IllegalAccessException {
+            CampaignOptions options = mock(CampaignOptions.class);
+            Campaign campaign = createCampaignMock(options);
+            when(options.getAcquisitionType()).thenReturn(AcquisitionsType.ADMINISTRATION);
+
+            SkillCheck result = campaign.checkAcquisition(mock(IAcquisitionWork.class), null, false);
+
+            // check that the person was initialized; the field is protected and we want to keep that
+            Field personField = ActionCheck.class.getDeclaredField("person");
+            personField.setAccessible(true);
+            Person extractedPerson = (Person) personField.get(result);
+            assertEquals("Unnamed", extractedPerson.getFirstName());
+
+            assertTrue(result.getTargetNumber().isImpossible());
+            assertTrue(result.getTargetNumber().getDesc().contains("used up all their acquisition attempts"));
+        }
+
+        @Test
+        public void testNullPerson_SkillTypes() {
+            CampaignOptions options = mock(CampaignOptions.class);
+            Campaign campaign = createCampaignMock(options);
+
+            when(options.getAcquisitionType()).thenReturn(AcquisitionsType.ADMINISTRATION);
+            SkillCheck result = campaign.checkAcquisition(mock(IAcquisitionWork.class), null, false);
+            assertEquals(SkillType.S_ADMIN, result.getSkillType().getName());
+
+            when(options.getAcquisitionType()).thenReturn(AcquisitionsType.ANY_TECH);
+            result = campaign.checkAcquisition(mock(IAcquisitionWork.class), null, false);
+            assertEquals(SkillType.S_TECH_MECHANIC, result.getSkillType().getName());
+
+            when(options.getAcquisitionType()).thenReturn(AcquisitionsType.NEGOTIATION);
+            result = campaign.checkAcquisition(mock(IAcquisitionWork.class), null, false);
+            assertEquals(SkillType.S_NEGOTIATION, result.getSkillType().getName());
+
+            when(options.getAcquisitionType()).thenReturn(AcquisitionsType.AUTOMATIC);
+            result = campaign.checkAcquisition(mock(IAcquisitionWork.class), null, false);
+            assertEquals(SkillType.S_ADMIN, result.getSkillType().getName());
+        }
+
+        @Test
+        public void testAutomaticAcquisitionWithNullPerson() {
+            CampaignOptions options = mock(CampaignOptions.class);
+            Campaign campaign = createCampaignMock(options);
+            when(options.getAcquisitionType()).thenReturn(AcquisitionsType.AUTOMATIC);
+
+            SkillCheck result = campaign.checkAcquisition(mock(IAcquisitionWork.class), null, false);
+
+            assertTrue(result.getTargetNumber().isAutomaticSuccess());
+        }
+
+        @Test
+        public void testItemOnShoppingList_WaitDaysTrue() {
+            CampaignOptions options = mock(CampaignOptions.class);
+            Campaign campaign = createCampaignMock(options);
+            IAcquisitionWork acquisition = mock(IAcquisitionWork.class);
+            ShoppingList shoppingList = mock(ShoppingList.class);
+            when(campaign.getShoppingList()).thenReturn(shoppingList);
+            when(options.getAcquisitionType()).thenReturn(AcquisitionsType.ADMINISTRATION);
+            when(shoppingList.getShoppingItem(any())).thenReturn(mock(IAcquisitionWork.class));
+
+            SkillCheck result = campaign.checkAcquisition(acquisition, new Person(campaign), true);
+
+            assertTrue(result.getTargetNumber().isAutomaticFail());
+            assertTrue(result.getTargetNumber().getDesc().contains("wait until the new cycle"));
+        }
+
+        @Test
+        public void testClanTechDisallowed() {
+            CampaignOptions options = mock(CampaignOptions.class);
+            Campaign campaign = createCampaignMock(options);
+            IAcquisitionWork acquisition = mock(IAcquisitionWork.class);
+            when(options.getAcquisitionType()).thenReturn(AcquisitionsType.ADMINISTRATION);
+            when(acquisition.getTechBase()).thenReturn(TechBase.CLAN);
+            when(options.isAllowClanPurchases()).thenReturn(false);
+
+            SkillCheck result = campaign.checkAcquisition(acquisition, new Person(campaign), false);
+
+            assertTrue(result.getTargetNumber().isImpossible());
+            assertEquals("You cannot acquire clan parts", result.getTargetNumber().getDesc());
+        }
+
+        @Test
+        public void testISTechDisallowed() {
+            CampaignOptions options = mock(CampaignOptions.class);
+            Campaign campaign = createCampaignMock(options);
+            IAcquisitionWork acquisition = mock(IAcquisitionWork.class);
+            when(options.getAcquisitionType()).thenReturn(AcquisitionsType.ADMINISTRATION);
+            when(acquisition.getTechBase()).thenReturn(TechBase.IS);
+            when(options.isAllowISPurchases()).thenReturn(false);
+
+            SkillCheck result = campaign.checkAcquisition(acquisition, new Person(campaign), false);
+
+            assertTrue(result.getTargetNumber().isImpossible());
+            assertEquals("You cannot acquire inner sphere parts", result.getTargetNumber().getDesc());
+        }
+
+        @Test
+        public void testTechLevelExceedsLimit() {
+            CampaignOptions options = mock(CampaignOptions.class);
+            Campaign campaign = createCampaignMock(options);
+            IAcquisitionWork acquisition = mock(IAcquisitionWork.class);
+            when(options.getAcquisitionType()).thenReturn(AcquisitionsType.ADMINISTRATION);
+            when(options.isAllowISPurchases()).thenReturn(true);
+            when(acquisition.getTechBase()).thenReturn(TechBase.IS);
+            when(acquisition.getTechLevel()).thenReturn(TechConstants.T_IS_ADVANCED);
+            when(options.getTechLevel()).thenReturn(TechConstants.T_INTRO_BOX_SET);
+
+            SkillCheck result = campaign.checkAcquisition(acquisition, new Person(campaign), false);
+
+            assertTrue(result.getTargetNumber().isImpossible());
+            assertEquals("You cannot acquire parts of this tech level", result.getTargetNumber().getDesc());
+        }
+
+        @Test
+        public void testPartNotInvented() {
+            CampaignOptions options = mock(CampaignOptions.class);
+            Campaign campaign = createCampaignMock(options);
+            IAcquisitionWork acquisition = mock(IAcquisitionWork.class);
+            when(options.getAcquisitionType()).thenReturn(AcquisitionsType.ADMINISTRATION);
+            when(options.isLimitByYear()).thenReturn(true);
+            when(acquisition.isIntroducedBy(anyInt(), anyBoolean(), any())).thenReturn(false);
+
+            SkillCheck result = campaign.checkAcquisition(acquisition, new Person(campaign), false);
+
+            assertTrue(result.getTargetNumber().isImpossible());
+            assertEquals("It has not been invented yet!", result.getTargetNumber().getDesc());
+        }
+
+        @Test
+        public void testPartIsExtinct() {
+            CampaignOptions options = mock(CampaignOptions.class);
+            Campaign campaign = createCampaignMock(options);
+            IAcquisitionWork acquisition = mock(IAcquisitionWork.class);
+            when(options.getAcquisitionType()).thenReturn(AcquisitionsType.ADMINISTRATION);
+            when(options.isDisallowExtinctStuff()).thenReturn(true);
+            when(acquisition.isExtinctIn(anyInt(), anyBoolean(), any())).thenReturn(true);
+
+            SkillCheck result = campaign.checkAcquisition(acquisition, new Person(campaign), false);
+
+            assertTrue(result.getTargetNumber().isImpossible());
+            assertEquals("It is extinct!", result.getTargetNumber().getDesc());
+        }
+
+        @Test
+        public void testMissingRequiredSkill() {
+            CampaignOptions options = mock(CampaignOptions.class);
+            Campaign campaign = createCampaignMock(options);
+            when(options.getAcquisitionType()).thenReturn(AcquisitionsType.ADMINISTRATION);
+
+            SkillCheck result = campaign.checkAcquisition(mock(IAcquisitionWork.class), new Person(campaign), false);
+
+            assertTrue(result.getTargetNumber().isAutomaticFail());
+            assertEquals("No skill", result.getTargetNumber().getDesc());
+        }
+
+        @Test
+        public void testAnyTech_WithBestSkill() {
+            CampaignOptions options = mock(CampaignOptions.class);
+            Campaign campaign = createCampaignMock(options);
+            IAcquisitionWork acquisition = mock(IAcquisitionWork.class);
+            when(options.getAcquisitionType()).thenReturn(AcquisitionsType.ANY_TECH);
+            when(acquisition.getAllAcquisitionMods()).thenReturn(new TargetRoll());
+
+            Person person = new Person(campaign);
+            person.addSkill(SkillType.S_TECH_VESSEL, 6, 0);
+            person.addSkill(SkillType.S_TECH_BA, 5, 0);
+            person.addSkill(SkillType.S_GUN_MEK, 3, 0);
+
+            SkillCheck result = campaign.checkAcquisition(acquisition, person, false);
+
+            assertEquals(SkillType.S_TECH_BA, result.getSkillType().getName());
+        }
+
+        @Test
+        public void testAnyTech_NoBestSkill_UsesMechanicFallback() {
+            CampaignOptions options = mock(CampaignOptions.class);
+            Campaign campaign = createCampaignMock(options);
+            when(options.getAcquisitionType()).thenReturn(AcquisitionsType.ANY_TECH);
+
+            SkillCheck result = campaign.checkAcquisition(mock(IAcquisitionWork.class), new Person(campaign), false);
+
+            // Fallback to S_TECH_MECHANIC chec even though the person does not have it
+            assertEquals(SkillType.S_TECH_MECHANIC, result.getSkillType().getName());
+        }
+
+        @ParameterizedTest
+        @CsvSource({ "NEGOTIATION, Negotiation", "ANY_TECH, Tech/Mek", "ADMINISTRATION, Administration" })
+        public void testTargetNumber(String acquisitionType, String skillName) {
+            CampaignOptions options = mock(CampaignOptions.class);
+            Campaign campaign = createCampaignMock(options);
+            IAcquisitionWork acquisition = mock(IAcquisitionWork.class);
+            when(options.getAcquisitionType()).thenReturn(AcquisitionsType.valueOf(acquisitionType));
+
+            Person person = new Person(campaign);
+            person.addSkill(skillName, 5, 0);
+            when(acquisition.getAllAcquisitionMods()).thenReturn(new TargetRoll());
+
+            SkillCheck result = campaign.checkAcquisition(acquisition, person, false);
+            assertEquals(5, result.getTargetNumber().getValue());
+            assertEquals(skillName, result.getSkillType().getName());
+
+            when(acquisition.getAllAcquisitionMods()).thenReturn(new TargetRoll(2, ""));
+            result = campaign.checkAcquisition(acquisition, person, false);
+            assertEquals(7, result.getTargetNumber().getValue());
+        }
+
+    }
+}


### PR DESCRIPTION
Use the new `SkillCheck` and `ActionCheckResult` API instead of manual `TargetRoll` and dice roll calculations. This standardizes the resolution process.

Details:
- Rename `Campaign.getTargetForAcquisition` to `checkAcquisition`
- Rename `getTargetForGenericAcquisition` to `checkGenericAcquisition`
- Change return type of acquisition checks from `TargetRoll` to `SkillCheck`
- Refactor `findContactForAcquisition` to use the new API
- Delegate edge reroll logic to the `SkillCheck` resolution
- Update UI dialogs and table models to call `checkAcquisition`
- Replace manual `TargetRoll` integer checks with helper method calls
- Add extensive test coverage for `checkAcquisition`