### PR TITLE
Refactor and localize findContactForAcquisition

### DIFF
--- a/MekHQ/resources/mekhq/resources/ActionCheck.properties
+++ b/MekHQ/resources/mekhq/resources/ActionCheck.properties
@@ -30,7 +30,17 @@
 # affiliated with Microsoft.
 # suppress inspection "UnusedProperty" for the whole file
 
-# Target Roll Modifiers
-skillCheck.untrained.twoLinkedAttributes=Untrained Target Number (Two Linked Attributes)
-skillCheck.untrained.oneLinkedAttribute=Untrained Target Number (One Linked Attribute)
-skillCheck.untrained.skill=Untrained Skill Modifier
+actionCheck.miscModifier=Misc Modifier
+
+actionCheckResult.report={0}{1} {2}<b>{3}</b>{4} {5} <b>{6}</b> check with a roll of <b>{7}</b> vs. a target number of \
+  <b>{8}</b>.
+actionCheckResult.naturalAptitude=Used Natural Aptitude.
+actionCheckResult.rerolled=Used a point of <b>Edge</b>.
+actionCheckResult.success=Passed
+actionCheckResult.failure=Failed
+
+contractAcquisition.impossible=<font color='{0}'><b>{1} can't search for {2} on {3} because:</b></font> {4}
+contractAcquisition.failure=<font color='{0}'><b>{1} is unable to find contacts for {2} on {3} at TN: {4}</b> \
+- Modifiers (Tech: {5,choice,0#|0<+}{5}, Industry: {6,choice,0#|0<+}{6}, Outputs: {7,choice,0#|0<+}{7})</font>
+contractAcquisition.success=<font color='{0}'><b>{1} has found a contact for {2} on {3} at TN: {4}</b> \
+- Modifiers (Tech: {5,choice,0#|0<+}{5}, Industry: {6,choice,0#|0<+}{6}, Outputs: {7,choice,0#|0<+}{7})</font>

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -487,6 +487,7 @@ public class Campaign implements ITechManager, IPlace {
           MekHQ.getMHQOptions().getLocale());
 
     private static final String RESOURCE_BUNDLE = "mekhq.resources.Campaign";
+    private static final String ACTION_CHECK_BUNDLE = "mekhq.resources.ActionCheck";
 
     private HumanResources humanResources = new HumanResources();
 
@@ -3718,10 +3719,9 @@ public class Campaign implements ITechManager, IPlace {
      * Make an acquisition roll for a given planet to see if you can identify a contact. Used for planetary based
      * acquisition.
      *
-     * @param acquisition - The <code> IAcquisitionWork</code> being acquired.
-     * @param person      - The <code>Person</code> object attempting to do the acquiring. may be null if no one on the
-     *                    force has the skill or the user is using automatic acquisition.
-     * @param system      - The <code>PlanetarySystem</code> object where the acquisition is being attempted. This may
+     * @param acquisition The <code> IAcquisitionWork</code> being acquired.
+     * @param person      The <code>Person</code> object attempting to do the acquiring
+     * @param system      The <code>PlanetarySystem</code> object where the acquisition is being attempted. This may
      *                    be null if the user is not using planetary acquisition.
      *
      * @return The result of the rolls.
@@ -3729,106 +3729,40 @@ public class Campaign implements ITechManager, IPlace {
     public PartAcquisitionResult findContactForAcquisition(IAcquisitionWork acquisition, Person person,
           PlanetarySystem system) {
         SkillCheck skillCheck = checkAcquisition(acquisition, person);
-
-        String impossibleSentencePrefix = person == null ?
-                                                "Can't search for " :
-                                                person.getFullName() + " can't search for ";
-        String failedSentencePrefix = person == null ?
-                                            "No contacts available for " :
-                                            person.getFullName() + " is unable to find contacts for ";
-        String succeededSentencePrefix = person == null ?
-                                               "Possible contact for " :
-                                               person.getFullName() + " has found a contact for ";
-
-        // if it's already impossible, don't bother with the rest
-        if (skillCheck.getTargetNumber().isImpossible()) {
-            if (getCampaignOptions().isPlanetAcquisitionVerbose()) {
-                addReport(ACQUISITIONS, "<font color='" +
-                                              ReportingUtilities.getNegativeColor() +
-                                              "'><b>" +
-                                              impossibleSentencePrefix +
-                                              acquisition.getAcquisitionName() +
-                                              " on " +
-                                              system.getPrintableName(getLocalDate()) +
-                                              " because:</b></font> " +
-                                              skillCheck.getTargetNumber().getDesc());
-            }
-            return PartAcquisitionResult.PartInherentFailure;
-        }
-
+        boolean inherentFailure = skillCheck.getTargetNumber().isImpossible();
         List<TargetRollModifier> acquisitionMods = system.getPrimaryPlanet().getAcquisitionMods(
               getLocalDate(), getCampaignOptions(), getFaction(), acquisition.getTechBase() == TechBase.CLAN);
         skillCheck.withExternalModifiers(acquisitionMods);
 
+        // if it's already impossible, don't bother with the rest
         if (skillCheck.getTargetNumber().isImpossible()) {
             if (getCampaignOptions().isPlanetAcquisitionVerbose()) {
-                addReport(ACQUISITIONS, "<font color='" +
-                                              ReportingUtilities.getNegativeColor() +
-                                              "'><b>" +
-                                              impossibleSentencePrefix +
-                                              acquisition.getAcquisitionName() +
-                                              " on " +
-                                              system.getPrintableName(getLocalDate()) +
-                                              " because:</b></font> " +
-                                              skillCheck.getTargetNumber().getDesc());
+                addReport(ACQUISITIONS, getFormattedTextAt(ACTION_CHECK_BUNDLE, "contractAcquisition.impossible",
+                      ReportingUtilities.getNegativeColor(), person.getFullName(), acquisition.getAcquisitionName(),
+                      system.getPrintableName(getLocalDate()), skillCheck.getTargetNumber().getDesc()));
             }
-            return PartAcquisitionResult.PlanetSpecificFailure;
+            return inherentFailure ? PartAcquisitionResult.PartInherentFailure :
+                         PartAcquisitionResult.PlanetSpecificFailure;
         }
-        SocioIndustrialData socioIndustrial = system.getPrimaryPlanet().getSocioIndustrial(getLocalDate());
-        CampaignOptions options = getCampaignOptions();
-        int techBonus = options.getPlanetTechAcquisitionBonus(socioIndustrial.tech);
-        int industryBonus = options.getPlanetIndustryAcquisitionBonus(socioIndustrial.industry);
-        int outputsBonus = options.getPlanetOutputAcquisitionBonus(socioIndustrial.output);
 
-        ActionCheckResult skillCheckResult = skillCheck.resolve(false, null, false);
-        if (!skillCheckResult.isSuccess()) {
-            // no contacts on this planet, move along
-            if (getCampaignOptions().isPlanetAcquisitionVerbose()) {
-                addReport(ACQUISITIONS, "<font color='" +
-                                              ReportingUtilities.getNegativeColor() +
-                                              "'><b>" +
-                                              failedSentencePrefix +
-                                              acquisition.getAcquisitionName() +
-                                              " on " +
-                                              system.getPrintableName(getLocalDate()) +
-                                              " at TN: " +
-                                              skillCheck.getTargetNumber().getValue() +
-                                              " - Modifiers (Tech: " +
-                                              (techBonus > 0 ? "+" : "") +
-                                              techBonus +
-                                              ", Industry: " +
-                                              (industryBonus > 0 ? "+" : "") +
-                                              industryBonus +
-                                              ", Outputs: " +
-                                              (outputsBonus > 0 ? "+" : "") +
-                                              outputsBonus +
-                                              ") </font>");
-            }
-            return PartAcquisitionResult.PlanetSpecificFailure;
-        } else {
-            if (getCampaignOptions().isPlanetAcquisitionVerbose()) {
-                addReport(ACQUISITIONS, "<font color='" +
-                                              ReportingUtilities.getPositiveColor() +
-                                              "'>" +
-                                              succeededSentencePrefix +
-                                              acquisition.getAcquisitionName() +
-                                              " on " +
-                                              system.getPrintableName(getLocalDate()) +
-                                              " at TN: " +
-                                              skillCheck.getTargetNumber().getValue() +
-                                              " - Modifiers (Tech: " +
-                                              (techBonus > 0 ? "+" : "") +
-                                              techBonus +
-                                              ", Industry: " +
-                                              (industryBonus > 0 ? "+" : "") +
-                                              industryBonus +
-                                              ", Outputs: " +
-                                              (outputsBonus > 0 ? "+" : "") +
-                                              outputsBonus +
-                                              ") </font>");
-            }
-            return PartAcquisitionResult.Success;
+        ActionCheckResult result = skillCheck.resolve(false, null, false);
+        if (getCampaignOptions().isPlanetAcquisitionVerbose()) {
+            SocioIndustrialData socioIndustrial = system.getPrimaryPlanet().getSocioIndustrial(getLocalDate());
+            CampaignOptions options = getCampaignOptions();
+            int techBonus = options.getPlanetTechAcquisitionBonus(socioIndustrial.tech);
+            int industryBonus = options.getPlanetIndustryAcquisitionBonus(socioIndustrial.industry);
+            int outputsBonus = options.getPlanetOutputAcquisitionBonus(socioIndustrial.output);
+
+            String reportType = result.isSuccess() ? "contractAcquisition.success" : "contractAcquisition.failure";
+            String highlightColor = result.isSuccess() ? ReportingUtilities.getPositiveColor() :
+                                 ReportingUtilities.getNegativeColor();
+
+            addReport(ACQUISITIONS, getFormattedTextAt(ACTION_CHECK_BUNDLE, reportType,
+                  highlightColor, person.getFullName(), acquisition.getAcquisitionName(),
+                  system.getPrintableName(getLocalDate()), skillCheck.getTargetNumber().getValue(),
+                  techBonus,  industryBonus, outputsBonus));
         }
+        return result.isSuccess() ? PartAcquisitionResult.Success : PartAcquisitionResult.PlanetSpecificFailure;
     }
 
     /***

--- a/MekHQ/src/mekhq/campaign/personnel/skills/ActionCheck.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/ActionCheck.java
@@ -47,8 +47,6 @@ import megamek.common.TargetRollModifier;
 import megamek.common.annotations.Nullable;
 import megamek.common.rolls.TargetRoll;
 import megamek.logging.MMLogger;
-import mekhq.MekHQ;
-import mekhq.campaign.events.persons.PersonChangedEvent;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.skills.enums.MarginOfSuccess;
 import mekhq.utilities.ReportingUtilities;
@@ -68,7 +66,7 @@ import mekhq.utilities.ReportingUtilities;
 public abstract class ActionCheck<T extends ActionCheck<T>> {
 
     private static final MMLogger LOGGER = MMLogger.create(ActionCheck.class);
-    private static final String RESOURCE_BUNDLE = "mekhq.resources.SkillCheckUtility";
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.ActionCheck";
 
     protected final Person person;
     protected final TargetRoll targetNumber;
@@ -160,7 +158,7 @@ public abstract class ActionCheck<T extends ActionCheck<T>> {
      */
     public T withMiscModifier(int miscModifier) {
         int finalModifier = isCountUp() ? -miscModifier : miscModifier;
-        targetNumber.addModifier(finalModifier, getFormattedTextAt(RESOURCE_BUNDLE, "skillCheck.miscModifier"));
+        targetNumber.addModifier(finalModifier, getFormattedTextAt(RESOURCE_BUNDLE, "actionCheck.miscModifier"));
         return getThis();
     }
 
@@ -263,10 +261,10 @@ public abstract class ActionCheck<T extends ActionCheck<T>> {
         }
 
         String status = getTextAt(RESOURCE_BUNDLE,
-              ActionCheckResult.isSuccess(marginOfSuccess) ? "skillCheck.results.success" : "skillCheck.results.failure");
+              ActionCheckResult.isSuccess(marginOfSuccess) ? "actionCheckResult.success" : "actionCheckResult.failure");
 
         StringBuilder resultsText = new StringBuilder(getFormattedTextAt(RESOURCE_BUNDLE,
-              "skillCheck.results",
+              "actionCheckResult.report",
               reason == null ? "" : "<b>" + reason + ":</b> ",
               fullTitle,
               colorOpen,
@@ -278,11 +276,11 @@ public abstract class ActionCheck<T extends ActionCheck<T>> {
               targetNumber.getValue()));
 
         if (hasNaturalAptitude) {
-            resultsText.append(" ").append(getTextAt(RESOURCE_BUNDLE, "skillCheck.naturalAptitude"));
+            resultsText.append(" ").append(getTextAt(RESOURCE_BUNDLE, "actionCheckResult.naturalAptitude"));
         }
 
         if (usedEdge) {
-            resultsText.append(" ").append(getTextAt(RESOURCE_BUNDLE, "skillCheck.rerolled"));
+            resultsText.append(" ").append(getTextAt(RESOURCE_BUNDLE, "actionCheckResult.rerolled"));
         }
 
         if (includeMarginsOfSuccessText) {


### PR DESCRIPTION
This commit extracts hardcoded strings into a dedicated resource bundle and simplifies the reporting logic.

Details:
- Create `ActionCheck.properties` for action check strings
- Remove unused strings from `SkillCheckUtility.properties`
- Move `ActionCheck` strings to the new bundle and rename them accordingly
- Replace hardcoded strings in `findContactForAcquisition` with `getFormattedTextAt` calls
- Simplify early returns and reporting logic in `findContactForAcquisition`
- Update javadocs to reflect that  the method does not accept `person == null`
- Fix missing closing b tags in success and failure reports