### PR TITLE
Fix on order/in transit stats in AcquisitionsDialog

### DIFF
--- a/MekHQ/src/mekhq/service/PartsAcquisitionService.java
+++ b/MekHQ/src/mekhq/service/PartsAcquisitionService.java
@@ -195,15 +195,14 @@ public class PartsAcquisitionService {
             pci.setRequiredCount(awList.size());
             pci.setStickerPrice(part.getStickerPrice());
             pci.setMissingCount(missing);
+            pci.setOmniPodCount(omniPod);
+            pci.setInTransitCount(inTransit);
+            pci.setOnOrderCount(onOrder);
 
             SkillCheck skillCheck = campaign.checkAcquisition(awFirst, admin, true);
             if (skillCheck.getTargetNumber().isImpossible()) {
                 pci.setCanBeAcquired(false);
                 pci.setFailedMessage(skillCheck.getTargetNumber().getPlainDesc());
-            } else {
-                pci.setInTransitCount(inTransit);
-                pci.setOnOrderCount(onOrder);
-                pci.setOmniPodCount(omniPod);
             }
 
             partCountInfoMap.put(awList.getFirst().getAcquisitionDisplayName(), pci);


### PR DESCRIPTION
Current logic is not populating some fields when immediate part acquisitions are impossible. `AcquisitionsDialog` allows queuing, so we should show outstanding orders and parts in transit. The change makes in transit, on order, and omnipod counts updates unconditional.

Fixes #9481