### PR TITLE
Requalify person == null acquisition checks as automatic failures

### DIFF
--- a/MekHQ/resources/mekhq/resources/ActionCheck.properties
+++ b/MekHQ/resources/mekhq/resources/ActionCheck.properties
@@ -39,8 +39,20 @@ actionCheckResult.rerolled=Used a point of <b>Edge</b>.
 actionCheckResult.success=Passed
 actionCheckResult.failure=Failed
 
-contractAcquisition.impossible=<font color='{0}'><b>{1} can't search for {2} on {3} because:</b></font> {4}
-contractAcquisition.failure=<font color='{0}'><b>{1} is unable to find contacts for {2} on {3} at TN: {4}</b> \
+acquisition.modifier.automaticSuccess=Automatic Success
+acquisition.modifier.clanTech=You cannot acquire clan parts
+acquisition.modifier.ISTech=You cannot acquire inner sphere parts
+acquisition.modifier.techLevel=You cannot acquire parts of this tech level
+acquisition.modifier.notInvented=It has not been invented yet!
+acquisition.modifier.extinct=It is extinct!
+acquisition.modifier.waitForNewCycle=You must wait until the new cycle to check for this part. Further attempts \
+will be added to the shopping list.
+acquisition.modifier.noPersonnel=Your procurement personnel have used up all their acquisition attempts for this period
+acquisition.modifier.missingRequiredSkill=No skill
+acquisition.modifier.contractPartAvailability=Contract
+acquisition.modifier.grayMonday=Gray Monday
+acquisition.impossible=<font color='{0}'><b>{1} can't search for {2} on {3} because:</b></font> {4}
+acquisition.failure=<font color='{0}'><b>{1} is unable to find contacts for {2} on {3} at TN: {4}</b> \
 - Modifiers (Tech: {5,choice,0#|0<+}{5}, Industry: {6,choice,0#|0<+}{6}, Outputs: {7,choice,0#|0<+}{7})</font>
-contractAcquisition.success=<font color='{0}'><b>{1} has found a contact for {2} on {3} at TN: {4}</b> \
+acquisition.success=<font color='{0}'><b>{1} has found a contact for {2} on {3} at TN: {4}</b> \
 - Modifiers (Tech: {5,choice,0#|0<+}{5}, Industry: {6,choice,0#|0<+}{6}, Outputs: {7,choice,0#|0<+}{7})</font>

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3739,7 +3739,7 @@ public class Campaign implements ITechManager, IPlace {
         // if it's already impossible, don't bother with the rest
         if (skillCheck.getTargetNumber().isImpossible()) {
             if (getCampaignOptions().isPlanetAcquisitionVerbose()) {
-                addReport(ACQUISITIONS, getFormattedTextAt(ACTION_CHECK_BUNDLE, "contractAcquisition.impossible",
+                addReport(ACQUISITIONS, getFormattedTextAt(ACTION_CHECK_BUNDLE, "acquisition.impossible",
                       ReportingUtilities.getNegativeColor(), person.getFullName(), acquisition.getAcquisitionName(),
                       system.getPrintableName(getLocalDate()), skillCheck.getTargetNumber().getDesc()));
             }
@@ -3755,7 +3755,7 @@ public class Campaign implements ITechManager, IPlace {
             int industryBonus = options.getPlanetIndustryAcquisitionBonus(socioIndustrial.industry);
             int outputsBonus = options.getPlanetOutputAcquisitionBonus(socioIndustrial.output);
 
-            String reportType = result.isSuccess() ? "contractAcquisition.success" : "contractAcquisition.failure";
+            String reportType = result.isSuccess() ? "acquisition.success" : "acquisition.failure";
             String highlightColor = result.isSuccess() ? ReportingUtilities.getPositiveColor() :
                                  ReportingUtilities.getNegativeColor();
 
@@ -6991,28 +6991,32 @@ public class Campaign implements ITechManager, IPlace {
     public SkillCheck checkAcquisition(IAcquisitionWork acquisition, @Nullable Person person, boolean checkDaysToWait) {
         TargetRollModifier decisiveModifier = null;
         if (getCampaignOptions().getAcquisitionType() == AcquisitionsType.AUTOMATIC) {
-            decisiveModifier = new TargetRollModifier(TargetRoll.AUTOMATIC_SUCCESS, "Automatic Success");
-        } else if (person == null) {
-            decisiveModifier = new TargetRollModifier(TargetRoll.IMPOSSIBLE,
-                  "Your procurement personnel have used up all their acquisition attempts for this period");
-        } else if (null != getShoppingList().getShoppingItem(acquisition.getNewEquipment()) && checkDaysToWait) {
-            decisiveModifier = new TargetRollModifier(TargetRoll.AUTOMATIC_FAIL,
-                  "You must wait until the new cycle to check for this part. Further" +
-                        " attempts will be added to the shopping list.");
+            decisiveModifier = new TargetRollModifier(TargetRoll.AUTOMATIC_SUCCESS,
+                  getTextAt(ACTION_CHECK_BUNDLE, "acquisition.modifier.automaticSuccess"));
         } else if (acquisition.getTechBase() == TechBase.CLAN && !getCampaignOptions().isAllowClanPurchases()) {
-            decisiveModifier = new TargetRollModifier(TargetRoll.IMPOSSIBLE, "You cannot acquire clan parts");
+            decisiveModifier = new TargetRollModifier(TargetRoll.IMPOSSIBLE,
+                  getTextAt(ACTION_CHECK_BUNDLE, "acquisition.modifier.clanTech"));
         } else if (acquisition.getTechBase() == TechBase.IS && !getCampaignOptions().isAllowISPurchases()) {
-            decisiveModifier = new TargetRollModifier(TargetRoll.IMPOSSIBLE, "You cannot acquire inner sphere parts");
+            decisiveModifier = new TargetRollModifier(TargetRoll.IMPOSSIBLE,
+                  getTextAt(ACTION_CHECK_BUNDLE, "acquisition.modifier.ISTech"));
         } else if (getCampaignOptions().getTechLevel() < Utilities.getSimpleTechLevel(acquisition.getTechLevel())) {
             decisiveModifier = new TargetRollModifier(TargetRoll.IMPOSSIBLE,
-                  "You cannot acquire parts of this tech level");
+                  getTextAt(ACTION_CHECK_BUNDLE, "acquisition.modifier.techLevel"));
         } else if (getCampaignOptions().isLimitByYear() &&
                          !acquisition.isIntroducedBy(getGameYear(), useClanTechBase(), getTechFaction())) {
-            decisiveModifier = new TargetRollModifier(TargetRoll.IMPOSSIBLE, "It has not been invented yet!");
+            decisiveModifier = new TargetRollModifier(TargetRoll.IMPOSSIBLE,
+                  getTextAt(ACTION_CHECK_BUNDLE, "acquisition.modifier.notInvented"));
         } else if (getCampaignOptions().isDisallowExtinctStuff() &&
                          (acquisition.isExtinctIn(getGameYear(), useClanTechBase(), getTechFaction()) ||
                                 acquisition.getAvailability().equals(AvailabilityValue.X))) {
-            decisiveModifier = new TargetRollModifier(TargetRoll.IMPOSSIBLE, "It is extinct!");
+            decisiveModifier = new TargetRollModifier(TargetRoll.IMPOSSIBLE,
+                  getTextAt(ACTION_CHECK_BUNDLE, "acquisition.modifier.extinct"));
+        } else if (checkDaysToWait && (getShoppingList().getShoppingItem(acquisition.getNewEquipment()) != null)) {
+            decisiveModifier = new TargetRollModifier(TargetRoll.AUTOMATIC_FAIL,
+                  getTextAt(ACTION_CHECK_BUNDLE, "acquisition.modifier.waitForNewCycle"));
+        } else if (person == null) {
+            decisiveModifier = new TargetRollModifier(TargetRoll.AUTOMATIC_FAIL,
+                  getTextAt(ACTION_CHECK_BUNDLE, "acquisition.modifier.noPersonnel"));
         }
 
         if (person == null) {
@@ -7032,8 +7036,9 @@ public class Campaign implements ITechManager, IPlace {
                 yield (bestTechSkill == null) ? SkillType.getType(S_TECH_MECHANIC) : bestTechSkill.getType();
             }
         };
-        if (!person.hasSkill(skillType.getName()) && (decisiveModifier == null)) {
-            decisiveModifier = new TargetRollModifier(TargetRoll.AUTOMATIC_FAIL, "No skill");
+        if ((decisiveModifier == null) && !person.hasSkill(skillType.getName())) {
+            decisiveModifier = new TargetRollModifier(TargetRoll.AUTOMATIC_FAIL,
+                  getTextAt(ACTION_CHECK_BUNDLE, "acquisition.modifier.missingRequiredSkill"));
         }
 
         if (decisiveModifier != null) {
@@ -7044,11 +7049,12 @@ public class Campaign implements ITechManager, IPlace {
         if (getCampaignOptions().isUseStratCon() && getCampaignOptions().isRestrictPartsByMission()) {
             int contractAvailability = findAtBPartsAvailabilityLevel();
             if (contractAvailability != 0) {
-                modifiers.add(new TargetRollModifier(contractAvailability, "Contract"));
+                modifiers.add(new TargetRollModifier(contractAvailability,
+                      getTextAt(ACTION_CHECK_BUNDLE, "acquisition.modifier.contractPartAvailability")));
             }
         }
         if (isGrayMonday(currentDay, getCampaignOptions().isSimulateGrayMonday())) {
-            modifiers.add(new TargetRollModifier(4, "Gray Monday"));
+            modifiers.add(new TargetRollModifier(4, getTextAt(ACTION_CHECK_BUNDLE, "acquisition.modifier.grayMonday")));
         }
 
         return person.checkSkill(skillType.getName(), this).withExternalModifiers(modifiers);

--- a/MekHQ/unittests/mekhq/campaign/SkillCheckRulesTest.java
+++ b/MekHQ/unittests/mekhq/campaign/SkillCheckRulesTest.java
@@ -113,7 +113,7 @@ public class SkillCheckRulesTest {
             Person extractedPerson = (Person) personField.get(result);
             assertEquals("Unnamed", extractedPerson.getFirstName());
 
-            assertTrue(result.getTargetNumber().isImpossible());
+            assertTrue(result.getTargetNumber().isAutomaticFail());
             assertTrue(result.getTargetNumber().getDesc().contains("used up all their acquisition attempts"));
         }
 


### PR DESCRIPTION
A missing logistics person previously triggered an impossible roll which is now relaxed to an automatic failure. Also, modify the acquisition logic to ensure permanent impossible conditions, such as extinct or uninvented technology, take precedence over temporary failures. Additionally, move all related modifier strings to `ActionCheck.properties`

Details:
- Change the `person == null` check in `Campaign.checkAcquisition` to yield an automatic failure instead of an impossible roll
- Reorder modifier evaluations in `Campaign.checkAcquisition` to check permanent impossible conditions before temporary automatic failures
- Add new `acquisition` localization strings to `ActionCheck.properties`
- Rename `contractAcquisition` prefix to just `acquisition`