### PR TITLE
Prevent NPE when assigning kills (fixes #9441)

### DIFF
--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -72,6 +72,7 @@ import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.events.persons.PersonBattleFinishedEvent;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.enums.TransactionType;
+import mekhq.campaign.force.Formation;
 import mekhq.campaign.log.ServiceLogger;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.AtBScenario;
@@ -656,31 +657,37 @@ public class ResolveScenarioTracker {
     }
 
     public void assignKills() {
-        for (Unit u : units) {
+        for (Unit unit : units) {
             for (String killed : killCredits.keySet()) {
                 if (killCredits.get(killed).equalsIgnoreCase("None")) {
                     continue;
                 }
 
-                if (u.getId().toString().equals(killCredits.get(killed))) {
-                    for (Person p : u.getActiveCrew()) {
-                        PersonStatus status = peopleStatus.get(p.getId());
+                if (unit.getId().toString().equals(killCredits.get(killed))) {
+                    int formationId = unit.getFormationId();
+                    if (formationId == Formation.FORMATION_NONE) {
+                        logger.error("Unit {} has no actual formation when trying to assign kills",
+                              unit.getId().toString());
+                        continue;
+                    }
+                    for (Person person : unit.getActiveCrew()) {
+                        PersonStatus status = peopleStatus.get(person.getId());
 
                         if (null == status) {
                             // this shouldn't happen so report
                             logger.error("A null person status was found for person id {} when trying to assign kills",
-                                  p.getId().toString());
+                                  person.getId().toString());
                             continue;
                         }
 
-                        status.addKill(new Kill(p.getId(),
+                        status.addKill(new Kill(person.getId(),
                               killed,
-                              u.getEntity().getShortNameRaw(),
+                              unit.getEntity().getShortNameRaw(),
                               campaign.getLocalDate(),
                               getMissionId(),
                               getScenarioId(),
-                              p.getUnit().getFormationId(),
-                              u.getEntity().getEntityType()));
+                              formationId,
+                              unit.getEntity().getEntityType()));
                     }
                 }
             }


### PR DESCRIPTION
As seen in #9441 when a person that is part of the crew of a unit is no longer assigned to a unit when determining kills, a Null Pointer Exception occurs as determining the formation based on the unit fails in this case. The reason why a person is no longer assigned to a unit is unknown and can probably not be determined.

This PR prevents these NPE's from happening by not determining the formation of the unit by requesting the unit of the person, but by taking the formation directly from the unit instead since the unit is readily available. If the formation has an illogical value this is reported and the assignment of kills is skipped.

Also, the one-letter variables used here are substituted for full varible names (u->unit and p->person) to improve code readability.

Closes #9441 