### PR TITLE
Refactor EducationLevel to use internal level instead of parseToInt

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
@@ -618,8 +618,7 @@ public class Academy implements Comparable<Academy> {
      * @return the adjusted tuition value as an Integer
      */
     public int getTuitionAdjusted(Person person) {
-        double educationLevel = Math.max(1,
-              getEducationLevel(person) - (EducationLevel.parseToInt(educationLevelMin) / 4));
+        double educationLevel = Math.max(1, getEducationLevel(person) - ((double) educationLevelMin.getLevel() / 4));
 
         return (int) (tuition * educationLevel);
     }
@@ -937,8 +936,7 @@ public class Academy implements Comparable<Academy> {
      *       required, false otherwise.
      */
     public boolean isQualified(Person person) {
-        return EducationLevel.parseToInt(person.getEduHighestEducation()) >=
-                     EducationLevel.parseToInt(educationLevelMin);
+        return person.getEduHighestEducation().getLevel() >= educationLevelMin.getLevel();
     }
 
     /**
@@ -961,9 +959,9 @@ public class Academy implements Comparable<Academy> {
      * @return The education level of the qualification.
      */
     public int getEducationLevel(Person person) {
-        int currentEducationLevel = EducationLevel.parseToInt(person.getEduHighestEducation());
-        int minimumEducationLevel = EducationLevel.parseToInt(educationLevelMin);
-        int maximumEducationLevel = EducationLevel.parseToInt(educationLevelMax);
+        int currentEducationLevel = person.getEduHighestEducation().getLevel();
+        int minimumEducationLevel = educationLevelMin.getLevel();
+        int maximumEducationLevel = educationLevelMax.getLevel();
 
         int educationLevel;
 
@@ -976,13 +974,7 @@ public class Academy implements Comparable<Academy> {
         }
 
         // this probably isn't necessary, but a little insurance goes a long way
-        if (educationLevel > EducationLevel.values().length - 1) {
-            educationLevel = EducationLevel.values().length - 1;
-        } else if (educationLevel < 0) {
-            educationLevel = 0;
-        }
-
-        return educationLevel;
+        return Math.clamp(educationLevel, EducationLevel.MIN_LEVEL, EducationLevel.MAX_LEVEL);
     }
 
     /**
@@ -1088,7 +1080,7 @@ public class Academy implements Comparable<Academy> {
                     if (skillName.equalsIgnoreCase("xp")) {
                         tooltip.append(skillName.toUpperCase()).append(" (");
 
-                        if (EducationLevel.parseToInt(person.getEduHighestEducation()) >= educationLevel) {
+                        if (person.getEduHighestEducation().getLevel() >= educationLevel) {
                             tooltip.append(resources.getString("nothingToLearn.text")).append(")<br>");
                         } else {
                             tooltip.append(educationLevel * campaign.getCampaignOptions().getCurriculumXpRate())
@@ -1201,7 +1193,7 @@ public class Academy implements Comparable<Academy> {
                 tooltip.append("<b>")
                       .append(resources.getString("educationLevel.text"))
                       .append("</b> ")
-                      .append(EducationLevel.fromString(String.valueOf(getEducationLevel(person))))
+                      .append(EducationLevel.fromLevel(getEducationLevel(person)))
                       .append("<br>");
             }
 

--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -1600,7 +1600,7 @@ public class EducationController {
      */
     private static void reportMastersOrDoctorateGain(Campaign campaign, Person person, Academy academy, int education,
           ResourceBundle resources) {
-        EducationLevel educationLevel = EducationLevel.fromString(String.valueOf(education));
+        EducationLevel educationLevel = EducationLevel.fromLevel(education);
 
         String qualification = academy.getQualifications().get(person.getEduCourseIndex());
         String personName = person.getHyperlinkedFullTitle();
@@ -1757,8 +1757,8 @@ public class EducationController {
 
         int educationLevel = academy.getEducationLevel(person);
 
-        if (EducationLevel.parseToInt(person.getEduHighestEducation()) < educationLevel) {
-            person.setEduHighestEducation(EducationLevel.fromString(String.valueOf(educationLevel)));
+        if (person.getEduHighestEducation().getLevel() < educationLevel) {
+            person.setEduHighestEducation(EducationLevel.fromLevel(educationLevel));
         }
 
         if (academy.isReeducationCamp()) {
@@ -1971,7 +1971,7 @@ public class EducationController {
 
         double bonusPercentage = (double) bonusCount / 5;
 
-        if (EducationLevel.parseToInt(person.getEduHighestEducation()) < academy.getEducationLevel(person)) {
+        if (person.getEduHighestEducation().getLevel() < academy.getEducationLevel(person)) {
             int xpRate = max(1, (12 - academy.getFacultySkill()) * (academyDuration / 600));
 
             xpRate *= campaign.getCampaignOptions().getFacultyXpRate();

--- a/MekHQ/src/mekhq/campaign/personnel/enums/education/EducationLevel.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/education/EducationLevel.java
@@ -32,6 +32,7 @@
  */
 package mekhq.campaign.personnel.enums.education;
 
+import java.util.Arrays;
 import java.util.ResourceBundle;
 
 import jakarta.xml.bind.annotation.adapters.XmlAdapter;
@@ -47,19 +48,26 @@ public enum EducationLevel {
     DOCTORATE("EducationLevel.DOCTORATE.text", "EducationLevel.DOCTORATE.toolTipText", 4);
     // endregion Enum Declarations
 
+    private static final MMLogger LOGGER = MMLogger.create(EducationLevel.class);
+
+    public static final int MIN_LEVEL =
+          Arrays.stream(EducationLevel.values()).mapToInt(EducationLevel::getLevel).min().getAsInt();
+    public static final int MAX_LEVEL =
+          Arrays.stream(EducationLevel.values()).mapToInt(EducationLevel::getLevel).max().getAsInt();
+
     // region Variable Declarations
     private final String name;
     private final String toolTipText;
-    private final int order;
+    private final int level;
     // endregion Variable Declarations
 
     // region Constructors
-    EducationLevel(final String name, final String toolTipText, final int order) {
+    EducationLevel(String name, String toolTipText, int level) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
               MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
-        this.order = order;
+        this.level = level;
     }
     // endregion Constructors
 
@@ -68,8 +76,8 @@ public enum EducationLevel {
         return toolTipText;
     }
 
-    public int getOrder() {
-        return order;
+    public int getLevel() {
+        return level;
     }
     // endregion Getters
 
@@ -106,7 +114,7 @@ public enum EducationLevel {
      * <p>This method attempts to map the input string to an {@link EducationLevel} in multiple ways:</p>
      * <ul>
      *   <li>First, it checks if the string matches an enum name exactly.</li>
-     *   <li>Next, it attempts to parse the string as an integer and map it to the ordinal of the enum.</li>
+     *   <li>Next, it attempts to parse the string as an integer and map it to the level of the enum.</li>
      *   <li>Finally, it checks for a case-insensitive match against the enum names.</li>
      * </ul>
      *
@@ -125,8 +133,13 @@ public enum EducationLevel {
         }
 
         try {
-            return EducationLevel.values()[Integer.parseInt(text)];
-        } catch (Exception ignored) {
+            int level = Integer.parseInt(text);
+            for (EducationLevel education : EducationLevel.values()) {
+                if (education.level == level) {
+                    return education;
+                }
+            }
+        } catch (NumberFormatException ignored) {
         }
 
         try {
@@ -138,30 +151,18 @@ public enum EducationLevel {
         } catch (Exception ignored) {
         }
 
-
-        MMLogger logger = MMLogger.create(EducationLevel.class);
-        logger.error("Unknown EducationLevel ordinal: {} - returning {}.", text, EARLY_CHILDHOOD);
-
+        LOGGER.error("Unknown education level: {} - returning {}.", text, EARLY_CHILDHOOD);
         return EARLY_CHILDHOOD;
     }
 
-    /**
-     * Parses the given EducationLevel enum value to an integer.
-     *
-     * @param educationLevel the EducationLevel enum value to be parsed
-     *
-     * @return the integer value representing the parsed EducationLevel
-     *
-     * @throws IllegalStateException if the given EducationLevel is unexpected
-     */
-    public static int parseToInt(final EducationLevel educationLevel) {
-        return switch (educationLevel) {
-            case EARLY_CHILDHOOD -> 0;
-            case HIGH_SCHOOL -> 1;
-            case COLLEGE -> 2;
-            case POST_GRADUATE -> 3;
-            case DOCTORATE -> 4;
-        };
+    public static EducationLevel fromLevel(int level) {
+        for (EducationLevel education : EducationLevel.values()) {
+            if (education.level == level) {
+                return education;
+            }
+        }
+        LOGGER.error("Unknown education level: {}", level, new IllegalArgumentException());
+        return EARLY_CHILDHOOD;
     }
     // endregion File I/O
 

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -2867,8 +2867,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                                                 }
 
                                                 if (skillName.equalsIgnoreCase("xp")) {
-                                                    if (EducationLevel.parseToInt(person.getEduHighestEducation()) <
-                                                              educationLevel) {
+                                                    if (person.getEduHighestEducation().getLevel() < educationLevel) {
                                                         improvementPossible++;
                                                     }
                                                 } else {

--- a/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
@@ -327,8 +327,7 @@ public enum PersonnelTableModelColumn {
               Academy currentAcademy = EducationController.getAcademy(person.getEduAcademySet(),
                     person.getEduAcademyNameInSet());
               return currentAcademy == null ? "" :
-                           EducationLevel.fromString(String.valueOf(currentAcademy.getEducationLevel(person)))
-                                 .toString();
+                           EducationLevel.fromLevel(currentAcademy.getEducationLevel(person)).toString();
           }),
     ACADEMY("Column.ACADEMY.title", NaturalOrderComparator.INSTANCE,
           person -> {

--- a/MekHQ/src/mekhq/gui/sorter/EducationLevelSorter.java
+++ b/MekHQ/src/mekhq/gui/sorter/EducationLevelSorter.java
@@ -42,7 +42,7 @@ import mekhq.campaign.personnel.enums.education.EducationLevel;
  *
  * <p>This comparator relies on the {@link EducationLevel#fromString(String)} method to convert string
  * representations into {@link EducationLevel} objects, and then orders them based on their
- * {@link EducationLevel#getOrder()} value.</p>
+ * {@link EducationLevel#getLevel()} value.</p>
  *
  * <p>If either string cannot be parsed into a valid {@code EducationLevel}, an error will be logged and the
  * malformed string will be placed after valid entries.</p>
@@ -61,13 +61,13 @@ public class EducationLevelSorter implements Comparator<String> {
         int firstOrder;
         int secondOrder;
         try {
-            firstOrder = EducationLevel.fromString(firstString).getOrder();
+            firstOrder = EducationLevel.fromString(firstString).getLevel();
         } catch (Exception e) {
             LOGGER.error("Error parsing education level: {}", firstString, e);
             firstOrder = Integer.MAX_VALUE;
         }
         try {
-            secondOrder = EducationLevel.fromString(secondString).getOrder();
+            secondOrder = EducationLevel.fromString(secondString).getLevel();
         } catch (Exception e) {
             LOGGER.error("Error parsing education level: {}", secondString, e);
             secondOrder = Integer.MAX_VALUE;

--- a/MekHQ/unittests/mekhq/campaign/personnel/education/AcademyTests.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/education/AcademyTests.java
@@ -146,7 +146,7 @@ class AcademyTests {
         academy.setEducationLevelMax(EducationLevel.POST_GRADUATE);
         Person person = Mockito.mock(Person.class);
         when(person.getEduHighestEducation()).thenReturn(EducationLevel.COLLEGE);
-        assertEquals(3000, academy.getTuitionAdjusted(person));
+        assertEquals(2750, academy.getTuitionAdjusted(person));
     }
 
     @Test


### PR DESCRIPTION
Historically, education levels relied on a hardcoded `parseToInt` method for numeric evaluations, while a separate `order` field existed for sorting. Since these values align, this commit removes `parseToInt` and renames `order` to `level`, centralizing the logic into a getter for improved safety and clarity. It also fixes a math bug in tuition calculation and introduces safer enum lookups.

Details:
- Rename `order` field to `level` in `EducationLevel` and add `getLevel`
- Introduce `MIN_LEVEL` and `MAX_LEVEL` constants
- Remove `parseToInt` from `EducationLevel` and replace with `getLevel` across the codebase
- Add `fromLevel` to `EducationLevel` for safe integer-based enum lookups
- Fix a computation bug in `Academy.getTuitionAdjusted` by casting `level` to double
- Replace manual bounds checking in `Academy.getEducationLevel` with `Math.clamp` using the new min and max constants
- Refactor `fromString` in `EducationLevel` to match by level instead of unsafe array index access
- Update `EducationLevelSorter` and table UI models to utilize the new `getLevel` and `fromLevel` methods