### PR TITLE
Fix unskilled crews not doing scouting checks

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/skills/ScoutingSkills.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/ScoutingSkills.java
@@ -44,6 +44,8 @@ public class ScoutingSkills {
     public static final List<String> SCOUTING_SKILLS = List.of(SkillType.S_COMMUNICATIONS,
           SkillType.S_PERCEPTION, SkillType.S_SENSOR_OPERATIONS, SkillType.S_STEALTH, SkillType.S_TRACKING);
 
+    public static final String DEFAULT_UNSKILLED_CHECK = SkillType.S_SENSOR_OPERATIONS;
+
     public static @Nullable String getBestScoutingSkill(Person person) {
         String bestSkill = null;
         int highestLevel = -1;

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -1905,7 +1905,8 @@ public class StratConRulesManager {
                 boolean hasEagleEyes = crewMember.getOptions().booleanOption(OptionsConstants.MISC_EAGLE_EYES);
                 String scoutSkillName = ScoutingSkills.getBestScoutingSkill(crewMember);
                 if (scoutSkillName == null) {
-                    continue;
+                    // default to unskilled check
+                    scoutSkillName = ScoutingSkills.DEFAULT_UNSKILLED_CHECK;
                 }
 
                 List<TargetRollModifier> mods = getAllScoutRollModifiers(

--- a/MekHQ/unittests/mekhq/campaign/stratCon/StratConRulesManagerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/stratCon/StratConRulesManagerTest.java
@@ -762,6 +762,15 @@ class StratConRulesManagerTest {
         }
 
         @Test
+        void testBuildScoutMap_Unskilled() {
+            Person person = mockPerson(null, false);
+            ScoutRecord bestScout = getBestScoutForUnit(List.of(person), 45, 5, false, false);
+            assertEquals(person, bestScout.scout());
+            assertEquals(S_SENSOR_OPERATIONS, bestScout.skillCheck().getSkillType().getName());
+            assertEquals(12, bestScout.skillCheck().getTargetNumber().getValue());
+        }
+
+        @Test
         void testBuildScoutMap_Sorting_EqualTN() {
             Person person1 = mockPerson(1, false);
             Person person2 = mockPerson(1, false);
@@ -847,11 +856,13 @@ class StratConRulesManagerTest {
             assertTrue(scouts.isEmpty());
         }
 
-        private Person mockPerson(int sensorOperationsSkill, boolean hasEagleEye) {
+        private Person mockPerson(Integer sensorOperationsSkill, boolean hasEagleEye) {
             Person person = new Person("GivenName", "Surname", null, "Faction");
-            Skill skill = mock(Skill.class);
-            when(skill.getFinalSkillValue(any(SkillModifierData.class))).thenReturn(sensorOperationsSkill);
-            person.addSkill(S_SENSOR_OPERATIONS, skill);
+            if (sensorOperationsSkill != null) {
+                Skill skill = mock(Skill.class);
+                when(skill.getFinalSkillValue(any(SkillModifierData.class))).thenReturn(sensorOperationsSkill);
+                person.addSkill(S_SENSOR_OPERATIONS, skill);
+            }
             PersonnelOptions options = mock(PersonnelOptions.class);
             when(options.booleanOption(OptionsConstants.MISC_EAGLE_EYES)).thenReturn(hasEagleEye);
             person.setOptions(options);
@@ -889,15 +900,11 @@ class StratConRulesManagerTest {
             when(entity.getWeight()).thenReturn(unitWeight);
 
             try (MockedStatic<AtBDynamicScenarioFactory> scenarioFactory = mockStatic(AtBDynamicScenarioFactory.class);
-                  MockedStatic<EntityUtilities> entityUtils = mockStatic(EntityUtilities.class);
-                  MockedStatic<ScoutingSkills> scoutingSkills = mockStatic(ScoutingSkills.class)) {
+                  MockedStatic<EntityUtilities> entityUtils = mockStatic(EntityUtilities.class)) {
 
                 scenarioFactory.when(() -> AtBDynamicScenarioFactory.calculateAtBSpeed(entity)).thenReturn(unitSpeed);
                 entityUtils.when(() -> EntityUtilities.hasImprovedSensors(entity)).thenReturn(hasImprovedSensors);
                 entityUtils.when(() -> EntityUtilities.hasActiveProbe(entity)).thenReturn(hasActiveProbe);
-                crew.forEach(crewMember -> scoutingSkills.when(() ->
-                                                                     ScoutingSkills.getBestScoutingSkill(crewMember))
-                                                 .thenReturn(S_SENSOR_OPERATIONS));
 
                 Campaign campaign = mockCampaign(useAgingEffects, isClanCampaign);
                 List<ScoutRecord> scouts = StratConRulesManager.buildScoutMap(formation, hangar, campaign);


### PR DESCRIPTION
It is a regression after #9246. The logic is now changed to fall back to unskilled Sensor Operations check if a crew member lacks scouting skills.