### PR TITLE
Simplify ActionCheck.resolve call

### DIFF
--- a/MekHQ/resources/mekhq/resources/ActionCheck.properties
+++ b/MekHQ/resources/mekhq/resources/ActionCheck.properties
@@ -32,12 +32,12 @@
 
 actionCheck.miscModifier=Misc Modifier
 
-actionCheckResult.report={0}{1} {2}<b>{3}</b>{4} {5} <b>{6}</b> check with a roll of <b>{7}</b> vs. a target number of \
-  <b>{8}</b>.
+actionCheckResult.success={0}{1} <span color="{2}"><b>Passed</b></span> {3} <b>{4}</b> \
+check with a roll of <b>{5}</b> vs. a target number of <b>{6}</b>.
+actionCheckResult.failure={0}{1} <span color="{2}"><b>Failed</b></span> {3} <b>{4}</b> \
+check with a roll of <b>{5}</b> vs. a target number of <b>{6}</b>.
 actionCheckResult.naturalAptitude=Used Natural Aptitude.
 actionCheckResult.rerolled=Used a point of <b>Edge</b>.
-actionCheckResult.success=Passed
-actionCheckResult.failure=Failed
 
 acquisition.modifier.automaticSuccess=Automatic Success
 acquisition.modifier.clanTech=You cannot acquire clan parts
@@ -51,8 +51,8 @@ acquisition.modifier.noPersonnel=Your procurement personnel have used up all the
 acquisition.modifier.missingRequiredSkill=No skill
 acquisition.modifier.contractPartAvailability=Contract
 acquisition.modifier.grayMonday=Gray Monday
-acquisition.impossible=<font color='{0}'><b>{1} can't search for {2} on {3} because:</b></font> {4}
-acquisition.failure=<font color='{0}'><b>{1} is unable to find contacts for {2} on {3} at TN: {4}</b> \
+acquisition.impossible=<font color="{0}"><b>{1} can't search for {2} on {3} because:</b></font> {4}
+acquisition.failure=<font color="{0}"><b>{1} is unable to find contacts for {2} on {3} at TN: {4}</b> \
 - Modifiers (Tech: {5,choice,0#|0<+}{5}, Industry: {6,choice,0#|0<+}{6}, Outputs: {7,choice,0#|0<+}{7})</font>
-acquisition.success=<font color='{0}'><b>{1} has found a contact for {2} on {3} at TN: {4}</b> \
+acquisition.success=<font color="{0}"><b>{1} has found a contact for {2} on {3} at TN: {4}</b> \
 - Modifiers (Tech: {5,choice,0#|0<+}{5}, Industry: {6,choice,0#|0<+}{6}, Outputs: {7,choice,0#|0<+}{7})</font>

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3751,7 +3751,7 @@ public class Campaign implements ITechManager, IPlace {
                          PartAcquisitionResult.PlanetSpecificFailure;
         }
 
-        ActionCheckResult result = skillCheck.resolve(false, null, false);
+        ActionCheckResult result = skillCheck.resolve(false, null);
         if (getCampaignOptions().isPlanetAcquisitionVerbose()) {
             SocioIndustrialData socioIndustrial = system.getPrimaryPlanet().getSocioIndustrial(getLocalDate());
             CampaignOptions options = getCampaignOptions();
@@ -3854,7 +3854,7 @@ public class Campaign implements ITechManager, IPlace {
         boolean useEdge = getCampaignOptions().isUseEdge() &&
                                 person != null && person.getOptions().booleanOption(useEdgeOption);
 
-        ActionCheckResult skillCheckResult = skillCheck.resolve(useEdge, null, false);
+        ActionCheckResult skillCheckResult = skillCheck.resolve(useEdge, null);
         if (skillCheckResult.usedEdge()) {
             report += " and <b>fails!</b> but uses Edge to reroll...getting a " + skillCheckResult.roll() + ": ";
         } else {

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -1061,8 +1061,8 @@ public class CampaignNewDayManager {
      */
     private void embezzleFunds(Person person) {
         ActionCheckResult actionCheckResult =
-              person.checkSkill(S_ADMIN, campaign).resolve(false, getTextAt(RESOURCE_BUNDLE, "embezzle.roll"), true);
-        campaign.addReport(SKILL_CHECKS, actionCheckResult.resultsText());
+              person.checkSkill(S_ADMIN, campaign).resolve(false, getTextAt(RESOURCE_BUNDLE, "embezzle.roll"));
+        campaign.addReport(SKILL_CHECKS, actionCheckResult.getReport(true));
 
         if (actionCheckResult.isSuccess()) {
             Money currentCampaignFunds = finances.getBalance();
@@ -1804,8 +1804,8 @@ public class CampaignNewDayManager {
     private static boolean performPersonalityBreakCheck(Campaign campaign, Person person, int modifier) {
         ActionCheckResult attributeCheckResult =
               person.checkAttribute(SkillAttribute.WILLPOWER).withMiscModifier(modifier)
-                    .resolve(true, getTextAt(RESOURCE_BUNDLE, "mentalBreak.check"), true);
-        campaign.addReport(SKILL_CHECKS, attributeCheckResult.resultsText());
+                    .resolve(true, getTextAt(RESOURCE_BUNDLE, "mentalBreak.check"));
+        campaign.addReport(SKILL_CHECKS, attributeCheckResult.getReport(true));
 
         return !attributeCheckResult.isSuccess();
     }
@@ -1885,8 +1885,8 @@ public class CampaignNewDayManager {
 
         ActionCheckResult attributeCheckResult =
               person.checkAttribute(SkillAttribute.WILLPOWER).withMiscModifier(modifier)
-                    .resolve(true, getTextAt(RESOURCE_BUNDLE, "discontinuationSyndrome.check"), true);
-        campaign.addReport(SKILL_CHECKS, attributeCheckResult.resultsText());
+                    .resolve(true, getTextAt(RESOURCE_BUNDLE, "discontinuationSyndrome.check"));
+        campaign.addReport(SKILL_CHECKS, attributeCheckResult.getReport(true));
 
         boolean failedWillpowerCheck = attributeCheckResult.isSuccess();
         person.processDiscontinuationSyndrome(campaign,

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
@@ -741,10 +741,8 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
 
         ActionCheckResult actionCheckResult =
               commander.checkSkill(S_NEGOTIATION, campaign)
-                    .resolve(isUseEdge,
-                          getTextAt(RESOURCE_BUNDLE, "AtbMonthlyContractMarket.contractSkillCheck"),
-                          true);
-        campaign.addReport(SKILL_CHECKS, actionCheckResult.resultsText());
+                    .resolve(isUseEdge, getTextAt(RESOURCE_BUNDLE, "AtbMonthlyContractMarket.contractSkillCheck"));
+        campaign.addReport(SKILL_CHECKS, actionCheckResult.getReport(true));
 
         return connections + Math.max(0, actionCheckResult.marginOfSuccess());
     }

--- a/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
@@ -562,8 +562,8 @@ public class TrainingCombatTeams {
 
         ActionCheckResult actionCheckResult =
               educator.checkSkill(S_TRAINING, campaign)
-                    .resolve(isUseEdge, getTextAt(RESOURCE_BUNDLE, "trainingCombatTeam.skillCheck"), true);
-        campaign.addReport(SKILL_CHECKS, actionCheckResult.resultsText());
+                    .resolve(isUseEdge, getTextAt(RESOURCE_BUNDLE, "trainingCombatTeam.skillCheck"));
+        campaign.addReport(SKILL_CHECKS, actionCheckResult.getReport(true));
 
         MarginOfSuccess marginOfSuccess = getMarginOfSuccessObject(actionCheckResult.marginOfSuccess());
         String personnelReport = getFormattedTextAt(RESOURCE_BUNDLE, "learnedProgress.text",

--- a/MekHQ/src/mekhq/campaign/personnel/medical/MedicalController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/MedicalController.java
@@ -222,9 +222,9 @@ public class MedicalController {
         ActionCheckResult actionCheckResult =
               doctor.checkSkill(S_SURGERY, isUseAgingEffects, isClanCampaign, today)
                     .withExternalModifiers(getAdditionalHealingModifiers(patient))
-                    .resolve(isUseEdge, getTextAt(RESOURCE_BUNDLE, "MedicalController.report.skillCheck"), false);
+                    .resolve(isUseEdge, getTextAt(RESOURCE_BUNDLE, "MedicalController.report.skillCheck"));
 
-        LOGGER.debug(actionCheckResult.resultsText());
+        LOGGER.debug(actionCheckResult.getReport(false));
 
         if (actionCheckResult.isSuccess()) {
             boolean inInfirmary = !(null == patient.getDoctorId());

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateHealing.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateHealing.java
@@ -300,14 +300,14 @@ public class AdvancedMedicalAlternateHealing {
         AttributeCheck naturalHealing =
               patient.checkAttribute(BODY).withExternalModifiers(modifiers).withMiscModifier(miscPenalty);
         ActionCheckResult result = naturalHealing.resolve(false, getTextAt(RESOURCE_BUNDLE,
-              "AdvancedMedicalAlternateHealing.naturalHealing.normal"), true);
+              "AdvancedMedicalAlternateHealing.naturalHealing.normal"));
 
         // Attempt to reroll a permanent injury with edge
         if ((result.marginOfSuccess() <= -6) && useEdge &&  (patient.getCurrentEdge() > 0)) {
             // manually update edge because if we pass useEdge == true, the patient will get one free roll
             patient.spendEdge();
             result = naturalHealing.resolve(false, getTextAt(RESOURCE_BUNDLE,
-                  "AdvancedMedicalAlternateHealing.naturalHealing.edge"), true);
+                  "AdvancedMedicalAlternateHealing.naturalHealing.edge"));
         }
         return result.marginOfSuccess();
     }
@@ -399,14 +399,14 @@ public class AdvancedMedicalAlternateHealing {
                                       .withMiscModifier(miscPenalty)
                                       .withExternalModifiers(modifiers);
         ActionCheckResult actionCheckResult = skillCheck.resolve(false, getTextAt(RESOURCE_BUNDLE,
-              "AdvancedMedicalAlternateHealing.assistedHealing.normal"), true);
+              "AdvancedMedicalAlternateHealing.assistedHealing.normal"));
 
         // Edge
         if (actionCheckResult.marginOfSuccess() <= -6 && useEdge && doctor.getCurrentEdge() > 0) { // Permanent injury
             // manually update edge because if we pass useEdge == true, the doctor will get one free roll
             doctor.spendEdge();
             actionCheckResult = skillCheck.resolve(false, getTextAt(RESOURCE_BUNDLE,
-                  "AdvancedMedicalAlternateHealing.assistedHealing.edge"), true);
+                  "AdvancedMedicalAlternateHealing.assistedHealing.edge"));
         }
         return actionCheckResult.marginOfSuccess();
     }

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateImplants.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateImplants.java
@@ -210,8 +210,8 @@ public class AdvancedMedicalAlternateImplants {
         ActionCheckResult attributeCheckResult =
               person.checkAttributes(SkillAttribute.BODY, SkillAttribute.WILLPOWER)
                     .withMiscModifier(resistanceModifier)
-                    .resolve(true, getTextAt(RESOURCE_BUNDLE, "AlternateInjuries.skillCheck.degradation"), false);
-        campaign.addReport(SKILL_CHECKS, attributeCheckResult.resultsText());
+                    .resolve(true, getTextAt(RESOURCE_BUNDLE, "AlternateInjuries.skillCheck.degradation"));
+        campaign.addReport(SKILL_CHECKS, attributeCheckResult.getReport(false));
 
         if (!attributeCheckResult.isSuccess() && useAbilities) {
             String flaw = getAndApplyEIDegradationFlaw(person);

--- a/MekHQ/src/mekhq/campaign/personnel/skills/ActionCheck.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/ActionCheck.java
@@ -55,7 +55,7 @@ import mekhq.utilities.ReportingUtilities;
  * Base abstract class for configuring character skill, attribute, and other action checks.
  *
  * <p>This class utilizes a builder pattern to allow the caller to attach external modifiers
- * and miscellaneous adjustments before resolving the check via {@link #resolve(boolean, String, boolean)}.
+ * and miscellaneous adjustments before resolving the check via {@link #resolve(boolean, String)}.
  * Subclasses must implement the abstract methods to define the specific mechanics of the action being checked.</p>
  *
  * @param <T> the concrete subclass type, used to enable method chaining
@@ -176,10 +176,8 @@ public abstract class ActionCheck<T extends ActionCheck<T>> {
      *
      * @param useEdge                     whether the person should use edge to re-roll if the initial attempt fails
      * @param reason                      the reason for the check; can be {@code null}
-     * @param includeMarginsOfSuccessText whether to include detailed margins of success information in the results
      */
-    public ActionCheckResult resolve(boolean useEdge, @Nullable String reason,
-          boolean includeMarginsOfSuccessText) {
+    public ActionCheckResult resolve(boolean useEdge, @Nullable String reason) {
 
         int roll = SkillCheckUtility.getRoll(hasNaturalAptitude());
         boolean usedEdge = false;
@@ -198,8 +196,7 @@ public abstract class ActionCheck<T extends ActionCheck<T>> {
 
         int difference = targetNumber.getValue() - roll;
         int marginOfSuccess = MarginOfSuccess.getMarginOfSuccess(isCountUp() ? difference : -difference);
-        String resultsText = generateResultsText(roll, marginOfSuccess, usedEdge, person,
-              includeMarginsOfSuccessText, hasNaturalAptitude(), reason);
+        String resultsText = generateResultsText(roll, marginOfSuccess, reason);
 
         LOGGER.info(resultsText);
 
@@ -215,7 +212,6 @@ public abstract class ActionCheck<T extends ActionCheck<T>> {
      *   <li>The name of the skill being checked</li>
      *   <li>The dice roll, target number, and margin of success or failure</li>
      *   <li>A status message indicating success or failure</li>
-     *   <li>Use of edge (if applicable)</li>
      * </ul>
      *
      * <p>The results text is color-coded using custom span tags based on the margin of success:
@@ -226,67 +222,44 @@ public abstract class ActionCheck<T extends ActionCheck<T>> {
      * </ul>
      * </p>
      *
-     * <p>If edge was used to reroll the skill check, the results will include an additional note with
-     * information about the reroll. If the caller requests it, margin of success details can also be
-     * appended to the results text.</p>
+     * @param roll            Roll result for the action check
+     * @param marginOfSuccess Calculated margin of success for this action check
+     * @param reason          A string describing the reason for the action check
      *
-     * <p>If the skill name is {@code null}, the method returns a localized error message indicating that the
-     * skill name could not be resolved and that an error occurred during the results generation process.</p>
-     *
-     * @param includeMarginsOfSuccessText whether to include detailed margin of success information in the results text
-     *
-     * @return a localized and formatted {@link String} representing the outcomes of the skill check:
-     *       <ul>
-     *         <li>If successful, the string provides details of the roll, skill, and margin of success.</li>
-     *         <li>If edge was used, additional information about the reroll is included.</li>
-     *         <li>If the skill name is {@code null}, an error message is returned instead.</li>
-     *       </ul>
+     * @return a localized HTML {@link String} representing the outcomes of the skill check
      *
      * @author Illiani
      * @since 0.50.05
      */
-    private String generateResultsText(int roll, int marginOfSuccess, boolean usedEdge,
-          Person person, boolean includeMarginsOfSuccessText, boolean hasNaturalAptitude, @Nullable String reason) {
+    private String generateResultsText(int roll, int marginOfSuccess, @Nullable String reason) {
         String fullTitle = person.getHyperlinkedFullTitle();
         String genderedReferenced = HIS_HER_THEIR.getDescriptor(person.getGender());
 
-        String colorOpen;
+        String color;
         int neutralMarginValue = BARELY_MADE_IT.getValue();
         if (marginOfSuccess == neutralMarginValue) {
-            colorOpen = spanOpeningWithCustomColor(ReportingUtilities.getWarningColor());
+            color = ReportingUtilities.getWarningColor();
         } else if (marginOfSuccess < neutralMarginValue) {
-            colorOpen = spanOpeningWithCustomColor(ReportingUtilities.getNegativeColor());
+            color = ReportingUtilities.getNegativeColor();
         } else {
-            colorOpen = spanOpeningWithCustomColor(ReportingUtilities.getPositiveColor());
+            color = ReportingUtilities.getPositiveColor();
         }
 
-        String status = getTextAt(RESOURCE_BUNDLE,
-              ActionCheckResult.isSuccess(marginOfSuccess) ? "actionCheckResult.success" : "actionCheckResult.failure");
+        String reportKey =
+              ActionCheckResult.isSuccess(marginOfSuccess) ? "actionCheckResult.success" : "actionCheckResult.failure";
 
         StringBuilder resultsText = new StringBuilder(getFormattedTextAt(RESOURCE_BUNDLE,
-              "actionCheckResult.report",
+              reportKey,
               reason == null ? "" : "<b>" + reason + ":</b> ",
               fullTitle,
-              colorOpen,
-              status,
-              CLOSING_SPAN_TAG,
+              color,
               genderedReferenced,
               getActionName(),
               roll,
               targetNumber.getValue()));
 
-        if (hasNaturalAptitude) {
+        if (hasNaturalAptitude()) {
             resultsText.append(" ").append(getTextAt(RESOURCE_BUNDLE, "actionCheckResult.naturalAptitude"));
-        }
-
-        if (usedEdge) {
-            resultsText.append(" ").append(getTextAt(RESOURCE_BUNDLE, "actionCheckResult.rerolled"));
-        }
-
-        if (includeMarginsOfSuccessText) {
-            MarginOfSuccess marginOfSuccessObject = getMarginOfSuccessObjectFromMarginValue(marginOfSuccess);
-            String marginOfSuccessText = colorOpen + marginOfSuccessObject.getLabel() + CLOSING_SPAN_TAG;
-            resultsText.append(" ").append(marginOfSuccessText);
         }
 
         return resultsText.toString();

--- a/MekHQ/src/mekhq/campaign/personnel/skills/ActionCheckResult.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/ActionCheckResult.java
@@ -34,8 +34,12 @@
 package mekhq.campaign.personnel.skills;
 
 import mekhq.campaign.personnel.skills.enums.MarginOfSuccess;
+import mekhq.utilities.ReportingUtilities;
 
 import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.BARELY_MADE_IT;
+import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.getMarginOfSuccessObjectFromMarginValue;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
+import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
 
 /**
  * An immutable record representing the outcome of an action check.
@@ -55,6 +59,8 @@ public record ActionCheckResult(
       boolean usedEdge,
       String resultsText
 ) {
+
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.ActionCheck";
 
     /**
      * Determines whether the action check was successful.
@@ -78,5 +84,40 @@ public record ActionCheckResult(
      */
     public static boolean isSuccess(int marginOfSuccess) {
         return marginOfSuccess >= BARELY_MADE_IT.getValue();
+    }
+
+    /**
+     * Returns a skill check report. It takes resultsText generated during the skill check and extends it with
+     * information about edge usage and, optionally, margin of success.
+     *
+     * <p>See more in {@link AttributeCheck#generateResultsText}.</p>
+     *
+     * <p>If edge was used to reroll the skill check, the results will include an additional note with
+     * information about the reroll. If the caller requests it, margin of success details can also be
+     * appended to the results text.</p>
+     *
+     * @param includeMarginsOfSuccessText whether to include detailed margins of success information in the results
+     */
+    public String getReport(boolean includeMarginsOfSuccessText) {
+        StringBuilder report = new StringBuilder(resultsText);
+        if (usedEdge) {
+            report.append(" ").append(getTextAt(RESOURCE_BUNDLE, "actionCheckResult.rerolled"));
+        }
+        if (includeMarginsOfSuccessText) {
+            String color;
+            int neutralMarginValue = BARELY_MADE_IT.getValue();
+            if (marginOfSuccess == neutralMarginValue) {
+                color = ReportingUtilities.getWarningColor();
+            } else if (marginOfSuccess < neutralMarginValue) {
+                color = ReportingUtilities.getNegativeColor();
+            } else {
+                color = ReportingUtilities.getPositiveColor();
+            }
+            MarginOfSuccess marginOfSuccessObject = getMarginOfSuccessObjectFromMarginValue(marginOfSuccess);
+            String marginOfSuccessText =
+                  ReportingUtilities.messageSurroundedBySpanWithColor(color, marginOfSuccessObject.getLabel());
+            report.append(" ").append(marginOfSuccessText);
+        }
+        return report.toString();
     }
 }

--- a/MekHQ/src/mekhq/campaign/personnel/skills/Appraisal.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Appraisal.java
@@ -80,7 +80,7 @@ public class Appraisal {
         }
         ActionCheckResult actionCheckResult =
               person.checkSkill(S_APPRAISAL, false, false, currentDay)
-                    .resolve(isUseEdge, getTextAt(RESOURCE_BUNDLE, "Appraisal.skillCheck"), false);
+                    .resolve(isUseEdge, getTextAt(RESOURCE_BUNDLE, "Appraisal.skillCheck"));
         return getAppraisalCostMultiplier(actionCheckResult.marginOfSuccess());
     }
 

--- a/MekHQ/src/mekhq/campaign/personnel/skills/EscapeSkills.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/EscapeSkills.java
@@ -102,7 +102,7 @@ public class EscapeSkills {
         useEdge = useEdge && person.getOptions().booleanOption(EDGE_ESCAPE_ATTEMPTS);
         ActionCheckResult actionCheckResult =
               person.checkSkill(skillToUse, false, false, today)
-                    .resolve(useEdge, getTextAt(RESOURCE_BUNDLE, "EscapeArtist.skillCheck"), false);
+                    .resolve(useEdge, getTextAt(RESOURCE_BUNDLE, "EscapeArtist.skillCheck"));
 
         MarginOfSuccess marginOfSuccess =
               MarginOfSuccess.getMarginOfSuccessObjectFromMarginValue(actionCheckResult.marginOfSuccess());

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -1688,8 +1688,8 @@ public class StratConRulesManager {
                     ActionCheckResult actionCheckResult = null;
                     if (useAdvancedScouting) {
                         actionCheckResult = scoutData.skillCheck().resolve(
-                              isUseEdge, getTextAt(RESOURCE_BUNDLE, "StratConRulesManager.scoutingSkillCheck"), false);
-                        campaign.addReport(SKILL_CHECKS, actionCheckResult.resultsText());
+                              isUseEdge, getTextAt(RESOURCE_BUNDLE, "StratConRulesManager.scoutingSkillCheck"));
+                        campaign.addReport(SKILL_CHECKS, actionCheckResult.getReport(false));
                     }
 
                     remainingScans--;
@@ -2125,7 +2125,7 @@ public class StratConRulesManager {
 
         ActionCheckResult actionCheckResult =
               commander.checkSkill(S_TACTICS, campaign)
-                    .resolve(true, getTextAt(RESOURCE_BUNDLE, "StratConRulesManager.tacticsSkillCheck"), false);
+                    .resolve(true, getTextAt(RESOURCE_BUNDLE, "StratConRulesManager.tacticsSkillCheck"));
 
         if (actionCheckResult.isSuccess()) {
             String reportString = commander.getSkill(S_TACTICS) != null ?

--- a/MekHQ/src/mekhq/gui/dialog/AdvancedReplacementLimbDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AdvancedReplacementLimbDialog.java
@@ -1032,9 +1032,8 @@ public class AdvancedReplacementLimbDialog extends JDialog {
             ActionCheckResult actionCheckResult =
                   surgeon.checkSkill(S_SURGERY, campaign)
                         .withMiscModifier(spaModifier)
-                        .resolve(isUseEdge, getTextAt(RESOURCE_BUNDLE,
-                              "AdvancedReplacementLimbDialog.skillCheck"), false);
-            campaign.addReport(SKILL_CHECKS, actionCheckResult.resultsText());
+                        .resolve(isUseEdge, getTextAt(RESOURCE_BUNDLE, "AdvancedReplacementLimbDialog.skillCheck"));
+            campaign.addReport(SKILL_CHECKS, actionCheckResult.getReport(false));
             if (actionCheckResult.isSuccess()) {
                 successfulSurgeries.add(surgery);
                 MedicalLogger.successfulSurgery(patient, campaign.getLocalDate(), surgery.type.toString());

--- a/MekHQ/src/mekhq/gui/dialog/AttributeCheckDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AttributeCheckDialog.java
@@ -204,10 +204,10 @@ public class AttributeCheckDialog {
         boolean useEdge = choiceIndex == DIALOG_USE_EDGE_INDEX;
         ActionCheckResult attributeCheckResult =
               character.checkAttributes(firstAttribute, secondAttribute).withMiscModifier(selectedModifier)
-                    .resolve(useEdge, null, true);
+                    .resolve(useEdge, null);
         isSuccess = attributeCheckResult.isSuccess();
 
-        return attributeCheckResult.resultsText();
+        return attributeCheckResult.getReport(true);
     }
 
 

--- a/MekHQ/src/mekhq/gui/dialog/SkillCheckDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/SkillCheckDialog.java
@@ -165,10 +165,10 @@ public class SkillCheckDialog {
         ActionCheckResult actionCheckResult =
               character.checkSkill(skillName, isUseAgingEffects, isClanCampaign, today)
                     .withMiscModifier(selectedModifier)
-                    .resolve(useEdge, null, true);
+                    .resolve(useEdge, null);
 
         isSuccess = actionCheckResult.isSuccess();
-        return actionCheckResult.resultsText();
+        return actionCheckResult.getReport(true);
     }
 
 

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/ActionCheckResultTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/ActionCheckResultTest.java
@@ -34,6 +34,7 @@
 package mekhq.campaign.personnel.skills;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -43,12 +44,23 @@ import org.junit.jupiter.params.provider.CsvSource;
 class ActionCheckResultTest {
 
     @Test
-    void testRecord() {
-        ActionCheckResult result = new ActionCheckResult(8, 2, true, "Success");
+    void testGetReport_EdgeNotUsed() {
+        ActionCheckResult result = new ActionCheckResult(3, 1, false, "Success.");
+        assertEquals(3, result.roll());
+        assertEquals(1, result.marginOfSuccess());
+        assertFalse(result.usedEdge());
+        assertEquals("Success.", result.getReport(false));
+        assertEquals("Success. <span color='#7fcf43'><i>It'll do...</i></span>", result.getReport(true));
+    }
+
+    @Test
+    void testGetReport_EdgeUsed() {
+        ActionCheckResult result = new ActionCheckResult(8, 2, true, "Success.");
         assertEquals(8, result.roll());
         assertEquals(2, result.marginOfSuccess());
         assertTrue(result.usedEdge());
-        assertEquals("Success", result.resultsText());
+        assertEquals("Success. Used a point of <b>Edge</b>.", result.getReport(false));
+        assertEquals("Success. Used a point of <b>Edge</b>. <span color='#7fcf43'><i>Good.</i></span>", result.getReport(true));
     }
 
     @ParameterizedTest

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/ActionCheckTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/ActionCheckTest.java
@@ -48,6 +48,7 @@ import megamek.common.TargetRollModifier;
 import megamek.common.enums.Gender;
 import megamek.common.rolls.TargetRoll;
 import mekhq.campaign.personnel.Person;
+import mekhq.utilities.ReportingUtilities;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -93,7 +94,7 @@ class ActionCheckTest {
           int firstRoll, int secondRoll) {
         try (MockedStatic<SkillCheckUtility> utils = mockStatic(SkillCheckUtility.class)) {
             utils.when(() -> SkillCheckUtility.getRoll(anyBoolean())).thenReturn(firstRoll, secondRoll);
-            return check.resolve(useEdge, null, false);
+            return check.resolve(useEdge, null);
         }
     }
 
@@ -143,6 +144,9 @@ class ActionCheckTest {
         assertTrue(result.isSuccess());
         assertFalse(result.usedEdge());
         assertEquals(8, result.roll());
+        assertEquals("<a href='PERSON:link'>F L</a> <span color=\"#7fcf43\"><b>Passed</b></span> his <b>Action</b> " +
+                           "check with a roll of <b>8</b> vs. a target number of <b>7</b>.",
+              result.getReport(false).replace(person.getId().toString(), "link"));
     }
 
     @Test
@@ -155,6 +159,10 @@ class ActionCheckTest {
         assertFalse(result.isSuccess());
         assertFalse(result.usedEdge());
         assertEquals(5, result.roll());
+        assertEquals("<a href='PERSON:link'>F L</a> <span color=\"negative\"><b>Failed</b></span> his <b>Action</b> " +
+                           "check with a roll of <b>5</b> vs. a target number of <b>7</b>.",
+              result.getReport(false).replace(person.getId().toString(), "link")
+                    .replace(ReportingUtilities.getNegativeColor(), "negative"));
     }
 
     @Test
@@ -167,6 +175,10 @@ class ActionCheckTest {
 
         assertFalse(result.isSuccess());
         assertFalse(result.usedEdge());
+        assertEquals("<a href='PERSON:link'>F L</a> <span color=\"negative\"><b>Failed</b></span> his <b>Action</b> " +
+                           "check with a roll of <b>5</b> vs. a target number of <b>7</b>.",
+              result.getReport(false).replace(person.getId().toString(), "link")
+                    .replace(ReportingUtilities.getNegativeColor(), "negative"));
     }
 
     @Test
@@ -183,7 +195,7 @@ class ActionCheckTest {
     @Test
     void testResolve_UsesEdgeAndSucceeds() {
         Person person = mock(Person.class);
-        when(person.getHyperlinkedFullTitle()).thenReturn("Title");
+        when(person.getHyperlinkedFullTitle()).thenReturn("Person");
         when(person.getGender()).thenReturn(Gender.FEMALE);
         when(person.getCurrentEdge()).thenReturn(1);
         TargetRoll target = new TargetRoll(7, "");
@@ -194,12 +206,15 @@ class ActionCheckTest {
         assertTrue(result.usedEdge());
         assertEquals(9, result.roll());
         verify(person).spendEdge();
+        assertEquals("Person <span color=\"positive\"><b>Passed</b></span> her <b>Action</b> check with a roll of " +
+                           "<b>9</b> vs. a target number of <b>7</b>. Used a point of <b>Edge</b>.",
+              result.getReport(false).replace(ReportingUtilities.getPositiveColor(), "positive"));
     }
 
     @Test
     void testResolve_UsesEdgeAndFails() {
         Person person = mock(Person.class);
-        when(person.getHyperlinkedFullTitle()).thenReturn("Title");
+        when(person.getHyperlinkedFullTitle()).thenReturn("Person");
         when(person.getGender()).thenReturn(Gender.MALE);
         when(person.getCurrentEdge()).thenReturn(1);
 
@@ -211,6 +226,9 @@ class ActionCheckTest {
         assertTrue(result.usedEdge());
         assertEquals(6, result.roll());
         verify(person).spendEdge();
+        assertEquals("Person <span color=\"negative\"><b>Failed</b></span> his <b>Action</b> check with a roll of " +
+                           "<b>6</b> vs. a target number of <b>7</b>. Used a point of <b>Edge</b>.",
+              result.getReport(false).replace(ReportingUtilities.getNegativeColor(), "negative"));
     }
 
     @ParameterizedTest
@@ -222,7 +240,7 @@ class ActionCheckTest {
 
         try (MockedStatic<SkillCheckUtility> utils = mockStatic(SkillCheckUtility.class)) {
             utils.when(() -> SkillCheckUtility.getRoll(anyBoolean())).thenReturn(8);
-            check.resolve(false, null, false);
+            check.resolve(false, null);
             utils.verify(() -> SkillCheckUtility.getRoll(naturalAptitude));
         }
     }


### PR DESCRIPTION
The call was requiring `includeMarginsOfSuccessText` parameter straigt away, even though we needed it only during report generation in `ActionCheckResult`.

Changes:
- Introduce `ActionCheckResult.getReport` that builds a combined report from `resultText`, `includeMarginsOfSuccessText`, and `usedEdge`
- Remove `includeMarginsOfSuccessText` from `ActionCheck.resolve`
- Specialize result text template instead of substituting status there, inline spans
- Add test coverage for report generation
- Fix quotes in acquisition reports