### PR TITLE
Introduce ActionCheckRoll and promote ActionCheckResult to a class

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3855,10 +3855,10 @@ public class Campaign implements ITechManager, IPlace {
                                 person != null && person.getOptions().booleanOption(useEdgeOption);
 
         ActionCheckResult skillCheckResult = skillCheck.resolve(useEdge, null);
-        if (skillCheckResult.usedEdge()) {
-            report += " and <b>fails!</b> but uses Edge to reroll...getting a " + skillCheckResult.roll() + ": ";
+        if (skillCheckResult.hasUsedEdge()) {
+            report += " and <b>fails!</b> but uses Edge to reroll...getting a " + skillCheckResult.getRollResult() + ": ";
         } else {
-            report += " and rolls " + skillCheckResult.roll() + ':';
+            report += " and rolls " + skillCheckResult.getRollResult() + ':';
         }
         int xpGained = 0;
         if (skillCheckResult.isSuccess()) {
@@ -3892,7 +3892,7 @@ public class Campaign implements ITechManager, IPlace {
             if (person != null) {
                 if (!skillCheck.getTargetNumber().isAutomaticSuccess()) {
                     person.setNTasks(person.getNTasks() + 1);
-                    if (skillCheckResult.roll() == 12) {
+                    if (skillCheckResult.getRollResult() == 12) {
                         xpGained += getCampaignOptions().getSuccessXP();
                     }
                 }
@@ -3903,7 +3903,8 @@ public class Campaign implements ITechManager, IPlace {
             }
         } else {
             report = report + acquisition.failToFind();
-            if (person != null && skillCheckResult.roll() == 2 && !skillCheck.getTargetNumber().isAutomaticFail()) {
+            if ((person != null) && (skillCheckResult.getRollResult() == 2) &&
+                      !skillCheck.getTargetNumber().isAutomaticFail()) {
                 xpGained += getCampaignOptions().getMistakeXP();
             }
         }

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
@@ -744,7 +744,7 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
                     .resolve(isUseEdge, getTextAt(RESOURCE_BUNDLE, "AtbMonthlyContractMarket.contractSkillCheck"));
         campaign.addReport(SKILL_CHECKS, actionCheckResult.getReport(true));
 
-        return connections + Math.max(0, actionCheckResult.marginOfSuccess());
+        return connections + Math.max(0, actionCheckResult.getMarginOfSuccess());
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
@@ -565,13 +565,13 @@ public class TrainingCombatTeams {
                     .resolve(isUseEdge, getTextAt(RESOURCE_BUNDLE, "trainingCombatTeam.skillCheck"));
         campaign.addReport(SKILL_CHECKS, actionCheckResult.getReport(true));
 
-        MarginOfSuccess marginOfSuccess = getMarginOfSuccessObject(actionCheckResult.marginOfSuccess());
+        MarginOfSuccess marginOfSuccess = getMarginOfSuccessObject(actionCheckResult.getMarginOfSuccess());
         String personnelReport = getFormattedTextAt(RESOURCE_BUNDLE, "learnedProgress.text",
               educator.getHyperlinkedFullTitle(), spanOpeningWithCustomColor(marginOfSuccess.getColor()),
               marginOfSuccess.getLabel(), CLOSING_SPAN_TAG);
         campaign.addReport(PERSONNEL, personnelReport);
 
-        return actionCheckResult.marginOfSuccess();
+        return actionCheckResult.getMarginOfSuccess();
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateHealing.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AdvancedMedicalAlternateHealing.java
@@ -303,13 +303,13 @@ public class AdvancedMedicalAlternateHealing {
               "AdvancedMedicalAlternateHealing.naturalHealing.normal"));
 
         // Attempt to reroll a permanent injury with edge
-        if ((result.marginOfSuccess() <= -6) && useEdge &&  (patient.getCurrentEdge() > 0)) {
+        if ((result.getMarginOfSuccess() <= -6) && useEdge &&  (patient.getCurrentEdge() > 0)) {
             // manually update edge because if we pass useEdge == true, the patient will get one free roll
             patient.spendEdge();
             result = naturalHealing.resolve(false, getTextAt(RESOURCE_BUNDLE,
                   "AdvancedMedicalAlternateHealing.naturalHealing.edge"));
         }
-        return result.marginOfSuccess();
+        return result.getMarginOfSuccess();
     }
 
     /**
@@ -402,13 +402,13 @@ public class AdvancedMedicalAlternateHealing {
               "AdvancedMedicalAlternateHealing.assistedHealing.normal"));
 
         // Edge
-        if (actionCheckResult.marginOfSuccess() <= -6 && useEdge && doctor.getCurrentEdge() > 0) { // Permanent injury
+        if (actionCheckResult.getMarginOfSuccess() <= -6 && useEdge && doctor.getCurrentEdge() > 0) { // Permanent injury
             // manually update edge because if we pass useEdge == true, the doctor will get one free roll
             doctor.spendEdge();
             actionCheckResult = skillCheck.resolve(false, getTextAt(RESOURCE_BUNDLE,
                   "AdvancedMedicalAlternateHealing.assistedHealing.edge"));
         }
-        return actionCheckResult.marginOfSuccess();
+        return actionCheckResult.getMarginOfSuccess();
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/skills/ActionCheck.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/ActionCheck.java
@@ -35,11 +35,8 @@ package mekhq.campaign.personnel.skills;
 
 import static mekhq.campaign.personnel.enums.GenderDescriptors.HIS_HER_THEIR;
 import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.BARELY_MADE_IT;
-import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.getMarginOfSuccessObjectFromMarginValue;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
-import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
-import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
 
 import java.util.List;
 
@@ -48,6 +45,7 @@ import megamek.common.annotations.Nullable;
 import megamek.common.rolls.TargetRoll;
 import megamek.logging.MMLogger;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.skills.ActionCheckRoll.RollType;
 import mekhq.campaign.personnel.skills.enums.MarginOfSuccess;
 import mekhq.utilities.ReportingUtilities;
 
@@ -178,25 +176,25 @@ public abstract class ActionCheck<T extends ActionCheck<T>> {
      * @param reason                      the reason for the check; can be {@code null}
      */
     public ActionCheckResult resolve(boolean useEdge, @Nullable String reason) {
+        RollType rollType = hasNaturalAptitude() ? RollType.ADVANTAGE : RollType.NORMAL;
 
-        int roll = SkillCheckUtility.getRoll(hasNaturalAptitude());
+        ActionCheckRoll roll = ActionCheckRoll.perform(rollType);
         boolean usedEdge = false;
-
-        boolean failed = roll < targetNumber.getValue();
+        boolean failed = roll.result() < targetNumber.getValue();
         boolean canSucceed = !targetNumber.cannotSucceed() && targetNumber.getValue() <= 12;
         boolean canSpendEdge = useEdge && person.getCurrentEdge() > 0;
 
         if (failed && canSucceed && canSpendEdge) {
             // reroll using edge
-            roll = SkillCheckUtility.getRoll(hasNaturalAptitude());
+            roll = ActionCheckRoll.perform(rollType);
             usedEdge = true;
 
             person.spendEdge();
         }
 
-        int difference = targetNumber.getValue() - roll;
+        int difference = targetNumber.getValue() - roll.result();
         int marginOfSuccess = MarginOfSuccess.getMarginOfSuccess(isCountUp() ? difference : -difference);
-        String resultsText = generateResultsText(roll, marginOfSuccess, reason);
+        String resultsText = generateResultsText(roll.result(), marginOfSuccess, reason);
 
         LOGGER.info(resultsText);
 

--- a/MekHQ/src/mekhq/campaign/personnel/skills/ActionCheckResult.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/ActionCheckResult.java
@@ -33,34 +33,53 @@
 
 package mekhq.campaign.personnel.skills;
 
-import mekhq.campaign.personnel.skills.enums.MarginOfSuccess;
-import mekhq.utilities.ReportingUtilities;
-
 import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.BARELY_MADE_IT;
 import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.getMarginOfSuccessObjectFromMarginValue;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
-import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
+
+import mekhq.campaign.personnel.skills.enums.MarginOfSuccess;
+import mekhq.utilities.ReportingUtilities;
 
 /**
- * An immutable record representing the outcome of an action check.
- *
- * @param roll            Roll result for the action check
- * @param marginOfSuccess Calculated margin of success for this action check. Represents how much better (or worse)
- *                        the roll was compared to the target number
- * @param usedEdge        Indicates whether edge was used during the action check
- * @param resultsText     A string representing the outcome of the action check
+ * An immutable record of action check outcome.
  *
  * @author Hokk
  * @since 0.51.01
  */
-public record ActionCheckResult(
-      int roll,
-      int marginOfSuccess,
-      boolean usedEdge,
-      String resultsText
-) {
+public class ActionCheckResult {
 
     private static final String RESOURCE_BUNDLE = "mekhq.resources.ActionCheck";
+
+    private final ActionCheckRoll roll;
+    private final int marginOfSuccess;
+    private final boolean usedEdge;
+    private final String resultsText;
+
+    /**
+     * @param roll            Roll result for the action check
+     * @param marginOfSuccess Calculated margin of success for this action check. Represents how much better (or worse)
+     *                        the roll was compared to the target number
+     * @param usedEdge        Indicates whether edge was used during the action check
+     * @param resultsText     A string representing the outcome of the action check
+     */
+    public ActionCheckResult(ActionCheckRoll roll, int marginOfSuccess, boolean usedEdge, String resultsText) {
+        this.roll = roll;
+        this.marginOfSuccess = marginOfSuccess;
+        this.usedEdge = usedEdge;
+        this.resultsText = resultsText;
+    }
+
+    public int getRollResult() {
+        return roll.result();
+    }
+
+    public int getMarginOfSuccess() {
+        return marginOfSuccess;
+    }
+
+    public boolean hasUsedEdge() {
+        return usedEdge;
+    }
 
     /**
      * Determines whether the action check was successful.

--- a/MekHQ/src/mekhq/campaign/personnel/skills/ActionCheckRoll.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/ActionCheckRoll.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package mekhq.campaign.personnel.skills;
+
+import java.util.List;
+
+import megamek.common.compute.Compute;
+
+/**
+ * Represents the outcome of an action check using d6.
+ *
+ * <p>Standard checks roll 2d6. Checks made with advantage or disadvantage roll 3d6, keeping the highest or lowest two
+ * results, respectively.</p>
+ *
+ * @param result         The final computed value of the roll (falls between 2 and 12, inclusive).
+ * @param individualDice An unmodifiable list of the individual dice rolled. This will contain more than two elements if
+ *                       the check was performed with advantage or disadvantage.
+ *
+ * @author Hokk
+ * @since 0.51.01
+ */
+public record ActionCheckRoll(
+      int result,
+      List<Integer> individualDice
+) {
+
+    public enum RollType {
+        NORMAL,
+        ADVANTAGE,
+        DISADVANTAGE
+    }
+
+    /**
+     * Executes an action check roll based on the provided roll type. Rolls 2 to 3 d6 dice and chooses 2 of them to
+     * calculate the final result.
+     *
+     * @param rollType Determines how the dice are rolled and evaluated.
+     *                 If {@link RollType#ADVANTAGE}, rolls 3d6 and keeps the highest 2.
+     *                 If {@link RollType#DISADVANTAGE}, rolls 3d6 and keeps the lowest 2.
+     *                 If {@link RollType#NORMAL}, rolls 2d6 and keeps both.
+     *
+     * @return An {@link ActionCheckRoll} detailing the final result and the individual dice rolled.
+     */
+    public static ActionCheckRoll perform(RollType rollType) {
+        return switch (rollType) {
+            case NORMAL -> {
+                int d1 = Compute.d6();
+                int d2 = Compute.d6();
+                int result = d1 + d2;
+                yield new ActionCheckRoll(result, List.of(d1, d2));
+            }
+            case ADVANTAGE -> {
+                int d1 = Compute.d6();
+                int d2 = Compute.d6();
+                int d3 = Compute.d6();
+                int min = Math.min(d1, Math.min(d2, d3));
+                int result = (d1 + d2 + d3) - min;
+                yield new ActionCheckRoll(result, List.of(d1, d2, d3));
+            }
+            case DISADVANTAGE -> {
+                int d1 = Compute.d6();
+                int d2 = Compute.d6();
+                int d3 = Compute.d6();
+                int max = Math.max(d1, Math.max(d2, d3));
+                int result = (d1 + d2 + d3) - max;
+                yield new ActionCheckRoll(result, List.of(d1, d2, d3));
+            }
+        };
+    }
+}

--- a/MekHQ/src/mekhq/campaign/personnel/skills/Appraisal.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Appraisal.java
@@ -81,7 +81,7 @@ public class Appraisal {
         ActionCheckResult actionCheckResult =
               person.checkSkill(S_APPRAISAL, false, false, currentDay)
                     .resolve(isUseEdge, getTextAt(RESOURCE_BUNDLE, "Appraisal.skillCheck"));
-        return getAppraisalCostMultiplier(actionCheckResult.marginOfSuccess());
+        return getAppraisalCostMultiplier(actionCheckResult.getMarginOfSuccess());
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/skills/EscapeSkills.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/EscapeSkills.java
@@ -105,7 +105,7 @@ public class EscapeSkills {
                     .resolve(useEdge, getTextAt(RESOURCE_BUNDLE, "EscapeArtist.skillCheck"));
 
         MarginOfSuccess marginOfSuccess =
-              MarginOfSuccess.getMarginOfSuccessObjectFromMarginValue(actionCheckResult.marginOfSuccess());
+              MarginOfSuccess.getMarginOfSuccessObjectFromMarginValue(actionCheckResult.getMarginOfSuccess());
 
         // Nothing happens for these cases, so we can just early exit
         List<MarginOfSuccess> noFurtherActionCases = List.of(MarginOfSuccess.IT_WILL_DO, MarginOfSuccess.BARELY_MADE_IT,

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -2146,7 +2146,7 @@ public class StratConRulesManager {
         campaign.addReport(BATTLE, String.format(resources.getString("reinforcementEvasionUnsuccessful.text"),
               spanOpeningWithCustomColor(ReportingUtilities.getNegativeColor()),
               CLOSING_SPAN_TAG,
-              actionCheckResult.roll(),
+              actionCheckResult.getRollResult(),
               9));
 
         ScenarioTemplate scenarioTemplate = getInterceptionScenarioTemplate(formation, campaign.getAllHangar());

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/ActionCheckResultTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/ActionCheckResultTest.java
@@ -41,24 +41,26 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import java.util.List;
+
 class ActionCheckResultTest {
 
     @Test
     void testGetReport_EdgeNotUsed() {
-        ActionCheckResult result = new ActionCheckResult(3, 1, false, "Success.");
-        assertEquals(3, result.roll());
-        assertEquals(1, result.marginOfSuccess());
-        assertFalse(result.usedEdge());
+        ActionCheckResult result = new ActionCheckResult(new ActionCheckRoll(3, List.of()), 1, false, "Success.");
+        assertEquals(3, result.getRollResult());
+        assertEquals(1, result.getMarginOfSuccess());
+        assertFalse(result.hasUsedEdge());
         assertEquals("Success.", result.getReport(false));
         assertEquals("Success. <span color='#7fcf43'><i>It'll do...</i></span>", result.getReport(true));
     }
 
     @Test
     void testGetReport_EdgeUsed() {
-        ActionCheckResult result = new ActionCheckResult(8, 2, true, "Success.");
-        assertEquals(8, result.roll());
-        assertEquals(2, result.marginOfSuccess());
-        assertTrue(result.usedEdge());
+        ActionCheckResult result = new ActionCheckResult(new ActionCheckRoll(8, List.of()), 2, true, "Success.");
+        assertEquals(8, result.getRollResult());
+        assertEquals(2, result.getMarginOfSuccess());
+        assertTrue(result.hasUsedEdge());
         assertEquals("Success. Used a point of <b>Edge</b>.", result.getReport(false));
         assertEquals("Success. Used a point of <b>Edge</b>. <span color='#7fcf43'><i>Good.</i></span>", result.getReport(true));
     }
@@ -66,7 +68,7 @@ class ActionCheckResultTest {
     @ParameterizedTest
     @CsvSource({ "-2, false", "-1, false", "0, true", "1, true", "12, true" })
     void testIsSuccess(int marginOfSuccess, boolean expectedResult) {
-        ActionCheckResult result = new ActionCheckResult(10, marginOfSuccess, false, "");
+        ActionCheckResult result = new ActionCheckResult(new ActionCheckRoll(10, List.of()), marginOfSuccess, false, "");
         assertEquals(expectedResult, result.isSuccess());
     }
 

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/ActionCheckRollTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/ActionCheckRollTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package mekhq.campaign.personnel.skills;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import megamek.common.compute.Compute;
+
+class ActionCheckRollTest {
+
+    @Test
+    void performNormalRoll() {
+        try (MockedStatic<Compute> compute = mockStatic(Compute.class)) {
+            compute.when(Compute::d6).thenReturn(3, 4);
+
+            ActionCheckRoll checkRoll = ActionCheckRoll.perform(ActionCheckRoll.RollType.NORMAL);
+
+            assertEquals(7, checkRoll.result());
+            assertEquals(Arrays.asList(3, 4), checkRoll.individualDice());
+        }
+    }
+
+    @Test
+    void performAdvantageRoll() {
+        try (MockedStatic<Compute> compute = mockStatic(Compute.class)) {
+            compute.when(Compute::d6).thenReturn(2, 5, 4);
+
+            ActionCheckRoll checkRoll = ActionCheckRoll.perform(ActionCheckRoll.RollType.ADVANTAGE);
+
+            assertEquals(9, checkRoll.result());
+            assertEquals(Arrays.asList(2, 5, 4), checkRoll.individualDice());
+        }
+    }
+
+    @Test
+    void performDisadvantageRoll() {
+        try (MockedStatic<Compute> compute = mockStatic(Compute.class)) {
+            compute.when(Compute::d6).thenReturn(6, 1, 4);
+
+            ActionCheckRoll checkRoll = ActionCheckRoll.perform(ActionCheckRoll.RollType.DISADVANTAGE);
+
+            assertEquals(5, checkRoll.result());
+            assertEquals(Arrays.asList(6, 1, 4), checkRoll.individualDice());
+        }
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/ActionCheckTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/ActionCheckTest.java
@@ -36,15 +36,16 @@ package mekhq.campaign.personnel.skills;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 
 import megamek.common.TargetRollModifier;
+import megamek.common.compute.Compute;
 import megamek.common.enums.Gender;
 import megamek.common.rolls.TargetRoll;
 import mekhq.campaign.personnel.Person;
@@ -91,9 +92,9 @@ class ActionCheckTest {
     }
 
     private ActionCheckResult resolveWithFixedRoll(ActionCheck<?> check, boolean useEdge,
-          int firstRoll, int secondRoll) {
-        try (MockedStatic<SkillCheckUtility> utils = mockStatic(SkillCheckUtility.class)) {
-            utils.when(() -> SkillCheckUtility.getRoll(anyBoolean())).thenReturn(firstRoll, secondRoll);
+          Integer firstRoll, Integer... otherRolls) {
+        try (MockedStatic<Compute> utils = mockStatic(Compute.class)) {
+            utils.when(Compute::d6).thenReturn(firstRoll, otherRolls);
             return check.resolve(useEdge, null);
         }
     }
@@ -139,11 +140,11 @@ class ActionCheckTest {
         Person person = new Person("F", "L", null, "Faction");
         TargetRoll target = new TargetRoll(7, "");
         ConcreteActionCheck check = new ConcreteActionCheck(person, target, false, false, "Action");
-        ActionCheckResult result = resolveWithFixedRoll(check, true, 8, 0);
+        ActionCheckResult result = resolveWithFixedRoll(check, true, 2, 6);
 
         assertTrue(result.isSuccess());
-        assertFalse(result.usedEdge());
-        assertEquals(8, result.roll());
+        assertFalse(result.hasUsedEdge());
+        assertEquals(8, result.getRollResult());
         assertEquals("<a href='PERSON:link'>F L</a> <span color=\"#7fcf43\"><b>Passed</b></span> his <b>Action</b> " +
                            "check with a roll of <b>8</b> vs. a target number of <b>7</b>.",
               result.getReport(false).replace(person.getId().toString(), "link"));
@@ -154,11 +155,11 @@ class ActionCheckTest {
         Person person = new Person("F", "L", null, "Faction");
         TargetRoll target = new TargetRoll(7, "");
         ConcreteActionCheck check = new ConcreteActionCheck(person, target, false, false, "Action");
-        ActionCheckResult result = resolveWithFixedRoll(check, false, 5, 0);
+        ActionCheckResult result = resolveWithFixedRoll(check, false, 1, 4);
 
         assertFalse(result.isSuccess());
-        assertFalse(result.usedEdge());
-        assertEquals(5, result.roll());
+        assertFalse(result.hasUsedEdge());
+        assertEquals(5, result.getRollResult());
         assertEquals("<a href='PERSON:link'>F L</a> <span color=\"negative\"><b>Failed</b></span> his <b>Action</b> " +
                            "check with a roll of <b>5</b> vs. a target number of <b>7</b>.",
               result.getReport(false).replace(person.getId().toString(), "link")
@@ -171,10 +172,10 @@ class ActionCheckTest {
         person.setCurrentEdge(0);
         TargetRoll target = new TargetRoll(7, "");
         ConcreteActionCheck check = new ConcreteActionCheck(person, target, false, false, "Action");
-        ActionCheckResult result = resolveWithFixedRoll(check, true, 5, 12);
+        ActionCheckResult result = resolveWithFixedRoll(check, true, 3, 2, 6, 6);
 
         assertFalse(result.isSuccess());
-        assertFalse(result.usedEdge());
+        assertFalse(result.hasUsedEdge());
         assertEquals("<a href='PERSON:link'>F L</a> <span color=\"negative\"><b>Failed</b></span> his <b>Action</b> " +
                            "check with a roll of <b>5</b> vs. a target number of <b>7</b>.",
               result.getReport(false).replace(person.getId().toString(), "link")
@@ -186,10 +187,10 @@ class ActionCheckTest {
         Person person = new Person("F", "L", null, "Faction");
         TargetRoll target = new TargetRoll(13, "");
         ConcreteActionCheck check = new ConcreteActionCheck(person, target, false, false, "Action");
-        ActionCheckResult result = resolveWithFixedRoll(check, true, 12, 0);
+        ActionCheckResult result = resolveWithFixedRoll(check, true, 6, 6);
 
         assertFalse(result.isSuccess());
-        assertFalse(result.usedEdge());
+        assertFalse(result.hasUsedEdge());
     }
 
     @Test
@@ -200,11 +201,11 @@ class ActionCheckTest {
         when(person.getCurrentEdge()).thenReturn(1);
         TargetRoll target = new TargetRoll(7, "");
         ConcreteActionCheck check = new ConcreteActionCheck(person, target, false, false, "Action");
-        ActionCheckResult result = resolveWithFixedRoll(check, true, 5, 9);
+        ActionCheckResult result = resolveWithFixedRoll(check, true, 4, 1, 3, 6);
 
         assertTrue(result.isSuccess());
-        assertTrue(result.usedEdge());
-        assertEquals(9, result.roll());
+        assertTrue(result.hasUsedEdge());
+        assertEquals(9, result.getRollResult());
         verify(person).spendEdge();
         assertEquals("Person <span color=\"positive\"><b>Passed</b></span> her <b>Action</b> check with a roll of " +
                            "<b>9</b> vs. a target number of <b>7</b>. Used a point of <b>Edge</b>.",
@@ -220,11 +221,11 @@ class ActionCheckTest {
 
         TargetRoll target = new TargetRoll(7, "");
         ConcreteActionCheck check = new ConcreteActionCheck(person, target, false, false, "Action");
-        ActionCheckResult result = resolveWithFixedRoll(check, true, 5, 6);
+        ActionCheckResult result = resolveWithFixedRoll(check, true, 2, 3, 4, 2);
 
         assertFalse(result.isSuccess());
-        assertTrue(result.usedEdge());
-        assertEquals(6, result.roll());
+        assertTrue(result.hasUsedEdge());
+        assertEquals(6, result.getRollResult());
         verify(person).spendEdge();
         assertEquals("Person <span color=\"negative\"><b>Failed</b></span> his <b>Action</b> check with a roll of " +
                            "<b>6</b> vs. a target number of <b>7</b>. Used a point of <b>Edge</b>.",
@@ -238,10 +239,11 @@ class ActionCheckTest {
         TargetRoll target = new TargetRoll(7, "Base");
         ConcreteActionCheck check = new ConcreteActionCheck(person, target, false, naturalAptitude, "Action");
 
-        try (MockedStatic<SkillCheckUtility> utils = mockStatic(SkillCheckUtility.class)) {
-            utils.when(() -> SkillCheckUtility.getRoll(anyBoolean())).thenReturn(8);
-            check.resolve(false, null);
-            utils.verify(() -> SkillCheckUtility.getRoll(naturalAptitude));
+        try (MockedStatic<Compute> utils = mockStatic(Compute.class)) {
+            utils.when(Compute::d6).thenReturn(3, 5, 2);
+            ActionCheckResult result = check.resolve(false, null);
+            assertEquals(8, result.getRollResult());
+            utils.verify(Compute::d6, times(naturalAptitude ? 3 : 2));
         }
     }
 }


### PR DESCRIPTION
In preparation for maintenance check migration to the new API, this refactor introduces support for normal, advantage, and disadvantage rolls and changes `ActionCheckResult` container to a class to control field access. Additionally individual dice results are not captured, enabling future UI improvements.

Details:
- Add `ActionCheckRoll` record to store individual dice and result
- Change `ActionCheckResult` from a record to a class
- Replace primitive roll integer in `ActionCheckResult` with `ActionCheckRoll`
- Update `ActionCheck.resolve` to use `ActionCheckRoll.perform` for evaluation
- Rename accessors to `getRollResult` and `getMarginOfSuccess`
- Update tests to reflect class changes and mock `Compute.d6` directly