### PR TITLE
Simplify column alignment logic in Personnel Table

### DIFF
--- a/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
@@ -87,53 +87,53 @@ import org.jspecify.annotations.NonNull;
 
 public enum PersonnelTableModelColumn {
 
-    PERSON("Column.PERSON.title", NaturalOrderComparator.INSTANCE,
+    PERSON("Column.PERSON.title", Comparators.STRING_COMPARATOR,
           person -> ""),
     RANK("Column.RANK.title", PersonRankSorter.INSTANCE,
           person -> person, Person::getRankName),
-    FIRST_NAME("Column.FIRST_NAME.title", NaturalOrderComparator.INSTANCE,
+    FIRST_NAME("Column.FIRST_NAME.title", Comparators.STRING_COMPARATOR,
           Person::getFirstName),
-    LAST_NAME("Column.LAST_NAME.title", NaturalOrderComparator.INSTANCE,
+    LAST_NAME("Column.LAST_NAME.title", Comparators.STRING_COMPARATOR,
           Person::getLastName),
-    PRE_NOMINAL("Column.PRE_NOMINAL.title", NaturalOrderComparator.INSTANCE,
+    PRE_NOMINAL("Column.PRE_NOMINAL.title", Comparators.STRING_COMPARATOR,
           Person::getPreNominal),
-    GIVEN_NAME("Column.GIVEN_NAME.title", NaturalOrderComparator.INSTANCE,
+    GIVEN_NAME("Column.GIVEN_NAME.title", Comparators.STRING_COMPARATOR,
           Person::getGivenName),
-    SURNAME("Column.SURNAME.title", NaturalOrderComparator.INSTANCE,
+    SURNAME("Column.SURNAME.title", Comparators.STRING_COMPARATOR,
           person -> StringUtility.isNullOrBlank(person.getSurname()) ? "" : person.getSurname()),
-    SURNAME_GROUPED_BY_UNIT("Column.SURNAME.title", NaturalOrderComparator.INSTANCE,
+    SURNAME_GROUPED_BY_UNIT("Column.SURNAME.title", Comparators.STRING_COMPARATOR,
           PersonnelTableModelColumn::getSurnameGroupedByUnit),
-    BLOODNAME("Column.BLOODNAME.title", NaturalOrderComparator.INSTANCE,
+    BLOODNAME("Column.BLOODNAME.title", Comparators.STRING_COMPARATOR,
           Person::getBloodname),
-    POST_NOMINAL("Column.POST_NOMINAL.title", NaturalOrderComparator.INSTANCE,
+    POST_NOMINAL("Column.POST_NOMINAL.title", Comparators.STRING_COMPARATOR,
           Person::getPostNominal),
-    CALLSIGN("Column.CALLSIGN.title", NaturalOrderComparator.INSTANCE,
+    CALLSIGN("Column.CALLSIGN.title", Comparators.STRING_COMPARATOR,
           Person::getCallsign),
     AGE("Column.AGE.title", Comparators.INT_COMPARATOR,
           (person, campaign) -> person.getAge(campaign.getLocalDate()), Object::toString),
     PERSONNEL_STATUS("Column.PERSONNEL_STATUS.title", fieldBasedSorter(PersonnelStatus::getLabel),
           Person::getStatus, PersonnelStatus::getLabel),
-    GENDER("Column.GENDER.title", NaturalOrderComparator.INSTANCE,
+    GENDER("Column.GENDER.title", Comparators.STRING_COMPARATOR,
           person -> GenderDescriptors.MALE_FEMALE_OTHER.getDescriptorCapitalized(person.getGender())),
     SKILL_LEVEL("Column.SKILL_LEVEL.title", Comparators.INT_COMPARATOR,
           (person, campaign) -> person.getExperienceLevel(campaign, false, true),
           level -> "<html>" + SkillType.getColoredExperienceLevelName(level) + "</html>"),
-    PERSONNEL_ROLE("Column.PERSONNEL_ROLE.title", NaturalOrderComparator.INSTANCE,
+    PERSONNEL_ROLE("Column.PERSONNEL_ROLE.title", Comparators.STRING_COMPARATOR,
           (person, campaign) -> person.getFormatedRoleDescriptions(campaign.getLocalDate())),
-    UNIT_ASSIGNMENT("Column.UNIT_ASSIGNMENT.title", NaturalOrderComparator.INSTANCE,
+    UNIT_ASSIGNMENT("Column.UNIT_ASSIGNMENT.title", Comparators.STRING_COMPARATOR,
           PersonnelTableModelColumn::getUnitAssignment),
-    MARKET_UNIT_ASSIGNMENT("Column.UNIT_ASSIGNMENT.title", NaturalOrderComparator.INSTANCE,
+    MARKET_UNIT_ASSIGNMENT("Column.UNIT_ASSIGNMENT.title", Comparators.STRING_COMPARATOR,
           (person, campaign) -> {
               PersonnelMarket market = campaign.getPersonnelMarket();
               Entity entity = (market == null) ? null : market.getAttachedEntity(person);
               return (entity == null) ? "-" : entity.getDisplayName();
           }),
-    FORCE("Column.FORCE.title", NaturalOrderComparator.INSTANCE,
+    FORCE("Column.FORCE.title", Comparators.STRING_COMPARATOR,
           (person, campaign) -> {
               Formation formation = campaign.getFormationFor(person);
               return (formation == null) ? "-" : formation.getName();
           }),
-    DEPLOYED("Column.DEPLOYED.title", NaturalOrderComparator.INSTANCE,
+    DEPLOYED("Column.DEPLOYED.title", Comparators.STRING_COMPARATOR,
           PersonnelTableModelColumn::getDeployedScenarioName),
     MEK("Column.MEK.title", SkillPair.COMPARATOR,
           skillPairModelExtractor(SkillType.S_GUN_MEK, SkillType.S_PILOT_MEK), SkillPair::toString),
@@ -223,11 +223,11 @@ public enum PersonnelTableModelColumn {
           Person::getSalary, Money::toAmountAndSymbolString),
     XP("Column.XP.title", Comparators.INT_COMPARATOR,
           Person::getXP, Object::toString),
-    ORIGIN_FACTION("Column.ORIGIN_FACTION.title", NaturalOrderComparator.INSTANCE,
+    ORIGIN_FACTION("Column.ORIGIN_FACTION.title", Comparators.STRING_COMPARATOR,
           (person, campaign) ->
                 person.getOriginFaction() == null ? "-" :
                       person.getOriginFaction().getFullName(campaign.getGameYear())),
-    ORIGIN_PLANET("Column.ORIGIN_PLANET.title", NaturalOrderComparator.INSTANCE,
+    ORIGIN_PLANET("Column.ORIGIN_PLANET.title", Comparators.STRING_COMPARATOR,
           (person, campaign) -> {
               Planet originPlanet = person.getOriginPlanet();
               return (originPlanet == null) ? "" : originPlanet.getName(campaign.getLocalDate());
@@ -329,13 +329,13 @@ public enum PersonnelTableModelColumn {
               return (academy == null) ? null : EducationLevel.fromLevel(academy.getEducationLevel(person));
           },
           level -> (level == null) ? "" : level.toString()),
-    ACADEMY("Column.ACADEMY.title", NaturalOrderComparator.INSTANCE,
+    ACADEMY("Column.ACADEMY.title", Comparators.STRING_COMPARATOR,
           person -> {
               Academy currentAcademy = EducationController.getAcademy(person.getEduAcademySet(),
                     person.getEduAcademyNameInSet());
               return currentAcademy == null ? "" : currentAcademy.getName();
           }),
-    COURSE("Column.COURSE.title", NaturalOrderComparator.INSTANCE,
+    COURSE("Column.COURSE.title", Comparators.STRING_COMPARATOR,
           person -> {
               Academy currentAcademy = EducationController.getAcademy(person.getEduAcademySet(),
                     person.getEduAcademyNameInSet());
@@ -373,49 +373,49 @@ public enum PersonnelTableModelColumn {
           attributeExtractor(SkillAttribute.CHARISMA), Object::toString),
     EDGE("Column.EDGE.title", SkillAttributeCell.COMPARATOR,
           attributeExtractor(SkillAttribute.EDGE), Object::toString),
-    SHIP_TRANSPORT("Column.SHIP_TRANSPORT.title", NaturalOrderComparator.INSTANCE,
+    SHIP_TRANSPORT("Column.SHIP_TRANSPORT.title", Comparators.STRING_COMPARATOR,
           person -> {
               if (person.getUnit() == null || person.getUnit().getTransportShipAssignment() == null) {
                   return "-";
               }
               return person.getUnit().getTransportShipAssignment().getTransportShip().getName();
           }),
-    TACTICAL_TRANSPORT("Column.TACTICAL_TRANSPORT.title", NaturalOrderComparator.INSTANCE,
+    TACTICAL_TRANSPORT("Column.TACTICAL_TRANSPORT.title", Comparators.STRING_COMPARATOR,
           person -> {
               if (person.getUnit() == null || person.getUnit().getTacticalTransportAssignment() == null) {
                   return "-";
               }
               return person.getUnit().getTacticalTransportAssignment().getTransport().getName();
           }),
-    LOCATION_SYSTEM("Column.LOCATION_SYSTEM.title", NaturalOrderComparator.INSTANCE,
+    LOCATION_SYSTEM("Column.LOCATION_SYSTEM.title", Comparators.STRING_COMPARATOR,
           (person, campaign) -> LocationDisplay.getLocationSystem(person, campaign.getLocalDate(), campaign)),
-    LOCATION_PLANET("Column.LOCATION_PLANET.title", NaturalOrderComparator.INSTANCE,
+    LOCATION_PLANET("Column.LOCATION_PLANET.title", Comparators.STRING_COMPARATOR,
           (person, campaign) -> LocationDisplay.getLocationPlanet(person, campaign.getLocalDate(), campaign)),
-    LOCATION_NAME("Column.LOCATION_NAME.title", NaturalOrderComparator.INSTANCE,
+    LOCATION_NAME("Column.LOCATION_NAME.title", Comparators.STRING_COMPARATOR,
           (person, campaign) -> LocationDisplay.getLocationName(person, campaign, campaign.getLocalDate())),
-    DESTINATION_SYSTEM("Column.DESTINATION_SYSTEM.title", NaturalOrderComparator.INSTANCE,
+    DESTINATION_SYSTEM("Column.DESTINATION_SYSTEM.title", Comparators.STRING_COMPARATOR,
           (person, campaign) -> LocationDisplay.getDestinationSystem(person, campaign.getLocalDate())),
-    DESTINATION_PLANET("Column.DESTINATION_PLANET.title", NaturalOrderComparator.INSTANCE,
+    DESTINATION_PLANET("Column.DESTINATION_PLANET.title", Comparators.STRING_COMPARATOR,
           (person, campaign) -> LocationDisplay.getDestinationPlanet(person, campaign.getLocalDate())),
-    DESTINATION_NAME("Column.DESTINATION_NAME.title", NaturalOrderComparator.INSTANCE,
+    DESTINATION_NAME("Column.DESTINATION_NAME.title", Comparators.STRING_COMPARATOR,
           (person, campaign) -> LocationDisplay.getDestinationName(person, campaign, campaign.getLocalDate())),
     IS_MARRIED("Column.IS_MARRIED.title", Comparators.YES_NO_NA_COMPARATOR,
           person -> person.getGenealogy().hasSpouse(), PersonnelTableModelColumn::convertBooleanToYesNoNA),
-    FORMER_SPOUSES("Column.FORMER_SPOUSES.title", Integer::compare,
+    FORMER_SPOUSES("Column.FORMER_SPOUSES.title", Comparators.INT_COMPARATOR,
           person -> person.getGenealogy().getFormerSpouses().size(), Object::toString),
-    CHILDREN("Column.CHILDREN.title", Integer::compare,
+    CHILDREN("Column.CHILDREN.title", Comparators.INT_COMPARATOR,
           person -> person.getGenealogy().getChildren().size(), Object::toString),
-    SIBLINGS("Column.SIBLINGS.title", Integer::compare,
+    SIBLINGS("Column.SIBLINGS.title", Comparators.INT_COMPARATOR,
           person -> person.getGenealogy().getSiblingCount(), Object::toString),
-    PARENTS("Column.PARENTS.title", Integer::compare,
+    PARENTS("Column.PARENTS.title", Comparators.INT_COMPARATOR,
           person -> person.getGenealogy().getParentsCount(), Object::toString),
-    GRANDCHILDREN("Column.GRANDCHILDREN.title", Integer::compare,
+    GRANDCHILDREN("Column.GRANDCHILDREN.title", Comparators.INT_COMPARATOR,
           person -> person.getGenealogy().getGrandchildrenCount(), Object::toString),
-    GRANDPARENTS("Column.GRANDPARENTS.title", Integer::compare,
+    GRANDPARENTS("Column.GRANDPARENTS.title", Comparators.INT_COMPARATOR,
           person -> person.getGenealogy().getGrandparentsCount(), Object::toString),
-    AUNTS_OR_UNCLES("Column.AUNTS_OR_UNCLES.title", Integer::compare,
+    AUNTS_OR_UNCLES("Column.AUNTS_OR_UNCLES.title", Comparators.INT_COMPARATOR,
           person -> person.getGenealogy().getAuntsAndUnclesCount(), Object::toString),
-    COUSINS("Column.COUSINS.title", Integer::compare,
+    COUSINS("Column.COUSINS.title", Comparators.INT_COMPARATOR,
           person -> person.getGenealogy().getCousinsCount(), Object::toString);
 
     private static final String RESOURCE_BUNDLE = "mekhq.resources.PersonnelTable";
@@ -772,32 +772,14 @@ public enum PersonnelTableModelColumn {
 
     public int getAlignment() {
         return switch (this) {
-            case PERSON,
-                 RANK,
-                 FIRST_NAME,
-                 LAST_NAME,
-                 PRE_NOMINAL,
-                 GIVEN_NAME,
-                 SURNAME,
-                 SURNAME_GROUPED_BY_UNIT,
-                 BLOODNAME,
-                 POST_NOMINAL,
-                 CALLSIGN,
-                 GENDER,
-                 SKILL_LEVEL,
-                 PERSONNEL_ROLE,
-                 UNIT_ASSIGNMENT,
-                 MARKET_UNIT_ASSIGNMENT,
-                 FORCE,
-                 DEPLOYED,
-                 LOCATION_SYSTEM,
-                 LOCATION_PLANET,
-                 LOCATION_NAME,
-                 DESTINATION_SYSTEM,
-                 DESTINATION_PLANET,
-                 DESTINATION_NAME -> SwingConstants.LEFT;
-            case SALARY -> SwingConstants.RIGHT;
-            default -> SwingConstants.CENTER;
+            case RANK, SKILL_LEVEL -> SwingConstants.LEFT;
+            case SALARY, TECH_MINUTES -> SwingConstants.RIGHT;
+            default -> {
+                if (modelComparator.equals(Comparators.STRING_COMPARATOR)) {
+                    yield SwingConstants.LEFT;
+                }
+                yield SwingConstants.CENTER;
+            }
         };
     }
 
@@ -1081,6 +1063,7 @@ public enum PersonnelTableModelColumn {
     private static class Comparators {
         private static final Comparator<Integer> SKILL_COMPARATOR = Comparator.reverseOrder();
         private static final Comparator<Integer> INT_COMPARATOR = Comparator.nullsLast(Comparator.naturalOrder());
+        private static final Comparator<String> STRING_COMPARATOR = Comparator.nullsLast(Comparator.naturalOrder());
         private static final Comparator<LocalDate> DATE_COMPARATOR = Comparator.nullsLast(Comparator.naturalOrder());
         private static final Comparator<Boolean> YES_NO_NA_COMPARATOR = Comparator.nullsLast(Comparator.naturalOrder());
     }

--- a/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
+++ b/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
@@ -35,6 +35,7 @@ package mekhq.gui.enums;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
@@ -115,40 +116,31 @@ public class PersonnelTableModelColumnTest {
 
     @Test
     public void testGetAlignment() {
+        // check overrides and a few columns of different types
         for (final PersonnelTableModelColumn personnelTableModelColumn : columns) {
             switch (personnelTableModelColumn) {
-                case PERSON:
-                case RANK:
-                case FIRST_NAME:
-                case LAST_NAME:
-                case PRE_NOMINAL:
-                case GIVEN_NAME:
-                case SURNAME:
-                case SURNAME_GROUPED_BY_UNIT:
-                case BLOODNAME:
-                case POST_NOMINAL:
-                case CALLSIGN:
-                case GENDER:
-                case SKILL_LEVEL:
-                case PERSONNEL_ROLE:
-                case UNIT_ASSIGNMENT:
-                case MARKET_UNIT_ASSIGNMENT:
-                case FORCE:
-                case DEPLOYED:
-                case LOCATION_SYSTEM:
-                case LOCATION_PLANET:
-                case LOCATION_NAME:
-                case DESTINATION_SYSTEM:
-                case DESTINATION_PLANET:
-                case DESTINATION_NAME:
+                case RANK, SKILL_LEVEL ->
                     assertEquals(SwingConstants.LEFT, personnelTableModelColumn.getAlignment());
-                    break;
-                case SALARY:
+                case SALARY, TECH_MINUTES ->
                     assertEquals(SwingConstants.RIGHT, personnelTableModelColumn.getAlignment());
-                    break;
-                default:
+                case FIRST_NAME -> // String
+                    assertEquals(SwingConstants.LEFT, personnelTableModelColumn.getAlignment());
+                case AGE -> // Int
                     assertEquals(SwingConstants.CENTER, personnelTableModelColumn.getAlignment());
-                    break;
+                case VTOL -> // SkillPair
+                    assertEquals(SwingConstants.CENTER, personnelTableModelColumn.getAlignment());
+                case BIRTHDAY -> // Date
+                    assertEquals(SwingConstants.CENTER, personnelTableModelColumn.getAlignment());
+                case COMMANDER -> // Boolean
+                    assertEquals(SwingConstants.CENTER, personnelTableModelColumn.getAlignment());
+                case HIGHEST_EDUCATION -> // field
+                    assertEquals(SwingConstants.CENTER, personnelTableModelColumn.getAlignment());
+                case AGGRESSION -> // PersonalityTrait
+                    assertEquals(SwingConstants.CENTER, personnelTableModelColumn.getAlignment());
+                case REFLEXES -> // SkillAttribute
+                    assertEquals(SwingConstants.CENTER, personnelTableModelColumn.getAlignment());
+                default ->
+                    assertTrue(SwingConstants.RIGHT != personnelTableModelColumn.getAlignment());
             }
         }
     }


### PR DESCRIPTION
Recent changes in column definitions enable more generic reasoning about column contents. Instead of relying on per-column definitions for column alignment, now we can be define it based on column model. This PR changes defaults to: LEFT for strings, CENTER otherwise, and a few manual overrides.

Additionally, `NaturalOrderComparator` was replaced with more performant string comparator.