### PR TITLE
Fix local failures in action check-related tests

### DIFF
--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/ActionCheckResultTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/ActionCheckResultTest.java
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import mekhq.utilities.ReportingUtilities;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -52,7 +53,8 @@ class ActionCheckResultTest {
         assertEquals(1, result.getMarginOfSuccess());
         assertFalse(result.hasUsedEdge());
         assertEquals("Success.", result.getReport(false));
-        assertEquals("Success. <span color='#7fcf43'><i>It'll do...</i></span>", result.getReport(true));
+        assertEquals("Success. <span color='positive'><i>It'll do...</i></span>",
+              result.getReport(true).replace(ReportingUtilities.getPositiveColor(), "positive"));
     }
 
     @Test
@@ -62,7 +64,8 @@ class ActionCheckResultTest {
         assertEquals(2, result.getMarginOfSuccess());
         assertTrue(result.hasUsedEdge());
         assertEquals("Success. Used a point of <b>Edge</b>.", result.getReport(false));
-        assertEquals("Success. Used a point of <b>Edge</b>. <span color='#7fcf43'><i>Good.</i></span>", result.getReport(true));
+        assertEquals("Success. Used a point of <b>Edge</b>. <span color='positive'><i>Good.</i></span>",
+              result.getReport(true).replace(ReportingUtilities.getPositiveColor(), "positive"));
     }
 
     @ParameterizedTest

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/ActionCheckTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/ActionCheckTest.java
@@ -145,9 +145,10 @@ class ActionCheckTest {
         assertTrue(result.isSuccess());
         assertFalse(result.hasUsedEdge());
         assertEquals(8, result.getRollResult());
-        assertEquals("<a href='PERSON:link'>F L</a> <span color=\"#7fcf43\"><b>Passed</b></span> his <b>Action</b> " +
+        assertEquals("<a href='PERSON:link'>F L</a> <span color=\"positive\"><b>Passed</b></span> his <b>Action</b> " +
                            "check with a roll of <b>8</b> vs. a target number of <b>7</b>.",
-              result.getReport(false).replace(person.getId().toString(), "link"));
+              result.getReport(false).replace(person.getId().toString(), "link")
+                    .replace(ReportingUtilities.getPositiveColor(), "positive"));
     }
 
     @Test


### PR DESCRIPTION
Adjusting action-check tests to ignore color formatting. This prevents false failures caused by differences between CI and local environment reporting.