### PR TITLE
Refactor PersonnelTableModel renderers

### DIFF
--- a/MekHQ/src/mekhq/MHQOptions.java
+++ b/MekHQ/src/mekhq/MHQOptions.java
@@ -42,6 +42,7 @@ import megamek.common.annotations.Nullable;
 import mekhq.campaign.universe.enums.CompanyGenerationMethod;
 import mekhq.gui.enums.FormationIconOperationalStatusStyle;
 import mekhq.gui.enums.PersonnelFilterStyle;
+import mekhq.gui.utilities.ComponentColors;
 
 public final class MHQOptions extends SuiteOptions {
     // region Display Tab
@@ -258,6 +259,11 @@ public final class MHQOptions extends SuiteOptions {
     // endregion Display Tab
 
     // region Colours
+
+    public ComponentColors getDeployedColors() {
+        return new ComponentColors(getDeployedForeground(), getDeployedBackground());
+    }
+
     public Color getDeployedForeground() {
         return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
                                .getInt(MHQConstants.DEPLOYED_FOREGROUND, Color.BLACK.getRGB()));
@@ -479,6 +485,10 @@ public final class MHQOptions extends SuiteOptions {
         userPreferences.node(MHQConstants.DISPLAY_NODE).putInt(MHQConstants.LOAN_OVERDUE_BACKGROUND, value.getRGB());
     }
 
+    public ComponentColors getInjuredColors() {
+        return new ComponentColors(getInjuredForeground(), getInjuredBackground());
+    }
+
     public Color getInjuredForeground() {
         return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
                                .getInt(MHQConstants.INJURED_FOREGROUND, Color.BLACK.getRGB()));
@@ -495,6 +505,10 @@ public final class MHQOptions extends SuiteOptions {
 
     public void setInjuredBackground(Color value) {
         userPreferences.node(MHQConstants.DISPLAY_NODE).putInt(MHQConstants.INJURED_BACKGROUND, value.getRGB());
+    }
+
+    public ComponentColors getHealedInjuriesColors() {
+        return new ComponentColors(getHealedInjuriesForeground(), getHealedInjuriesBackground());
     }
 
     public Color getHealedInjuriesForeground() {
@@ -515,6 +529,10 @@ public final class MHQOptions extends SuiteOptions {
         userPreferences.node(MHQConstants.DISPLAY_NODE).putInt(MHQConstants.HEALED_INJURIES_BACKGROUND, value.getRGB());
     }
 
+    public ComponentColors getPregnantColors() {
+        return new ComponentColors(getPregnantForeground(), getPregnantBackground());
+    }
+
     public Color getPregnantForeground() {
         return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
                                .getInt(MHQConstants.PREGNANT_FOREGROUND, Color.BLACK.getRGB()));
@@ -531,6 +549,10 @@ public final class MHQOptions extends SuiteOptions {
 
     public void setPregnantBackground(Color value) {
         userPreferences.node(MHQConstants.DISPLAY_NODE).putInt(MHQConstants.PREGNANT_BACKGROUND, value.getRGB());
+    }
+
+    public ComponentColors getGoneColors() {
+        return new ComponentColors(getGoneForeground(), getGoneBackground());
     }
 
     public Color getGoneForeground() {
@@ -551,6 +573,10 @@ public final class MHQOptions extends SuiteOptions {
         userPreferences.node(MHQConstants.DISPLAY_NODE).putInt(MHQConstants.GONE_BACKGROUND, value.getRGB());
     }
 
+    public ComponentColors getAbsentColors() {
+        return new ComponentColors(getAbsentForeground(), getAbsentBackground());
+    }
+
     public Color getAbsentForeground() {
         return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
                                .getInt(MHQConstants.ABSENT_FOREGROUND, 0x000000));
@@ -569,6 +595,10 @@ public final class MHQOptions extends SuiteOptions {
         userPreferences.node(MHQConstants.DISPLAY_NODE).putInt(MHQConstants.ABSENT_BACKGROUND, value.getRGB());
     }
 
+    public ComponentColors getFatiguedColors() {
+        return new ComponentColors(getFatiguedForeground(), getFatiguedBackground());
+    }
+
     public Color getFatiguedForeground() {
         return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
                                .getInt(MHQConstants.FATIGUED_FOREGROUND, 0x000000));
@@ -585,6 +615,10 @@ public final class MHQOptions extends SuiteOptions {
 
     public void setFatiguedBackground(Color value) {
         userPreferences.node(MHQConstants.DISPLAY_NODE).putInt(MHQConstants.FATIGUED_BACKGROUND, value.getRGB());
+    }
+
+    public ComponentColors getAwayFromMainForceColors() {
+        return new ComponentColors(getAwayFromMainForceForeground(), getAwayFromMainForceBackground());
     }
 
     public Color getAwayFromMainForceForeground() {

--- a/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/Fatigue.java
+++ b/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/Fatigue.java
@@ -184,8 +184,7 @@ public class Fatigue {
      * @param person   the person whose fatigue actions are being processed.
      */
     public static void processFatigueActions(Campaign campaign, Person person) {
-        int effectiveFatigue = getEffectiveFatigue(person.getAdjustedFatigue(), person.getPermanentFatigue(),
-              person.isClanPersonnel(), person.getSkillLevel(campaign, false, true));
+        int effectiveFatigue = getEffectiveFatigue(person, campaign);
 
         CampaignOptions campaignOptions = campaign.getCampaignOptions();
         if (!campaignOptions.isUseFatigue()) {
@@ -288,13 +287,7 @@ public class Fatigue {
                 }
 
                 for (Person person : unit.getCrew()) {
-                    int fatigue = person.getAdjustedFatigue();
-                    int permanentFatigue = person.getPermanentFatigue();
-                    boolean isClan = person.isClanPersonnel();
-                    SkillLevel experienceLevel = person.getSkillLevel(campaign, false, true);
-                    int effectiveFatigue = getEffectiveFatigue(fatigue, permanentFatigue, isClan, experienceLevel);
-
-                    if (effectiveFatigue >= leaveThreshold) {
+                    if (getEffectiveFatigue(person, campaign) >= leaveThreshold) {
                         fatiguedUnits++;
                         break;
                     }
@@ -318,7 +311,7 @@ public class Fatigue {
     }
 
     /**
-     * Calculates the effective fatigue level for a given person based on various modifiers.
+     * Calculates the effective fatigue level based on various modifiers.
      *
      * <p>The base fatigue level is adjusted by factors such as:</p>
      * <ul>
@@ -335,7 +328,7 @@ public class Fatigue {
      *
      * @return the calculated effective fatigue value.
      */
-    public static int getEffectiveFatigue(int fatigue, int permanentFatigueLoss, boolean isClan,
+    private static int getEffectiveFatigue(int fatigue, int permanentFatigueLoss, boolean isClan,
           SkillLevel skillLevel) {
         int effectiveFatigue = fatigue + permanentFatigueLoss;
 
@@ -350,6 +343,26 @@ public class Fatigue {
         }
 
         return effectiveFatigue;
+    }
+
+    /**
+     * Calculates the effective fatigue level for a given person based on various modifiers.
+     *
+     * <p>The base fatigue level is adjusted by factors such as:</p>
+     * <ul>
+     *     <li>Whether the person is classified as Clan personnel.</li>
+     *     <li>The person's skill level, with higher-skilled personnel suffering less fatigue.</li>
+     *     <li>Whether field kitchens are operating within their required capacity.</li>
+     * </ul>
+     *
+     * @param person   the {@link Person} to get the fatigue level for
+     * @param campaign the {@link Campaign} context
+     *
+     * @return the calculated effective fatigue value.
+     */
+    public static int getEffectiveFatigue(Person person, Campaign campaign) {
+        return getEffectiveFatigue(person.getAdjustedFatigue(), person.getPermanentFatigue(),
+              person.isClanPersonnel(), person.getSkillLevel(campaign, false, true));
     }
 
     @Deprecated(since = "0.50.07", forRemoval = true)

--- a/MekHQ/src/mekhq/gui/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/PersonnelTab.java
@@ -484,7 +484,7 @@ public final class PersonnelTab extends CampaignGuiTab {
             tableColumn.setPreferredWidth(column.getWidth());
             columnModel.setColumnVisible(tableColumn, visibleColumns.contains(column));
         }
-
+        personnelTable.setRowHeight(UIUtil.scaleForGUI((view == PersonnelTabView.GRAPHIC) ? 60 : 15));
         // reattach the updated model
         personnelTable.setColumnModel(columnModel);
     }

--- a/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
@@ -32,8 +32,6 @@
  */
 package mekhq.gui.enums;
 
-import static mekhq.campaign.personnel.turnoverAndRetention.Fatigue.getEffectiveFatigue;
-
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.function.BiFunction;
@@ -72,6 +70,7 @@ import mekhq.campaign.personnel.skills.Skill;
 import mekhq.campaign.personnel.skills.SkillModifierData;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.personnel.skills.enums.SkillAttribute;
+import mekhq.campaign.personnel.turnoverAndRetention.Fatigue;
 import mekhq.campaign.randomEvents.personalities.PersonalityTrait;
 import mekhq.campaign.randomEvents.personalities.Reasoning;
 import mekhq.campaign.unit.Unit;
@@ -305,10 +304,7 @@ public enum PersonnelTableModelColumn {
     BLOODMARK("Column.BLOODMARK.title", Comparators.INT_COMPARATOR,
           Person::getBloodmark, Object::toString),
     FATIGUE("Column.FATIGUE.title", Comparators.INT_COMPARATOR,
-          (person, campaign) ->
-                getEffectiveFatigue(person.getAdjustedFatigue(),
-                      person.getPermanentFatigue(), person.isClanPersonnel(),
-                      person.getSkillLevel(campaign, false, true)), Object::toString),
+          Fatigue::getEffectiveFatigue, Object::toString),
     SPA_COUNT("Column.SPA_COUNT.title", Comparators.INT_COMPARATOR,
           person -> person.countOptions(PersonnelOptions.LVL3_ADVANTAGES), Object::toString),
     MODIFICATION_COUNT("Column.MODIFICATION_COUNT.title", Comparators.INT_COMPARATOR,

--- a/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
@@ -45,10 +45,10 @@ import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableCellRenderer;
 
 import megamek.common.annotations.Nullable;
-import megamek.common.units.Entity;
 import megamek.common.units.Jumpship;
 import megamek.common.units.SmallCraft;
 import megamek.common.units.UnitType;
+import mekhq.MHQOptions;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.campaignOptions.CampaignOptions;
@@ -60,6 +60,7 @@ import mekhq.campaign.unit.Unit;
 import mekhq.gui.BasicInfo;
 import mekhq.gui.enums.PersonnelTabView;
 import mekhq.gui.enums.PersonnelTableModelColumn;
+import mekhq.gui.utilities.ComponentColors;
 import mekhq.gui.utilities.MekHqTableCellRenderer;
 
 /**
@@ -176,86 +177,62 @@ public class PersonnelTableModel extends DataTableModel<Person> {
 
             setText(personnelColumn.getText(value));
 
-            // Colouring - determine color and collect ALL applicable color reasons
-            boolean personIsDamaged;
-            final CampaignOptions campaignOptions = campaign.getCampaignOptions();
-            if (campaignOptions.isUseAdvancedMedical()) {
-                personIsDamaged = person.hasInjuries(true);
-            } else {
-                personIsDamaged = person.getHits() > 0;
-            }
-            boolean personIsFatigued = (campaignOptions.isUseFatigue()
-                                              &&
-                                              (getEffectiveFatigue(person.getAdjustedFatigue(),
-                                                    person.getPermanentFatigue(),
-                                                    person.isClanPersonnel(),
-                                                    person.getSkillLevel(campaign, false, true)) >= 5));
-            boolean personIsAwayFromMainForce = PersonnelStatus.computeIsAwayFromMainForce(campaign, person);
-
             // Collect all applicable color reasons for tooltip
-            List<String> colorReasonKeys = new ArrayList<>();
-
-            boolean isUseAlternateAdvancedMedical = campaignOptions.isUseAlternativeAdvancedMedical();
+            List<String> personalStateFlags = new ArrayList<>();
             if (!isSelected) {
-                // Set color based on priority (first match wins for display color)
-                // But collect ALL applicable reasons for tooltip
-                if (person.getStatus().isAbsent()) {
-                    setBackground(MekHQ.getMHQOptions().getAbsentBackground());
-                    setForeground(MekHQ.getMHQOptions().getAbsentForeground());
-                } else if (person.getStatus().isDepartedUnit()) {
-                    setBackground(MekHQ.getMHQOptions().getGoneBackground());
-                    setForeground(MekHQ.getMHQOptions().getGoneForeground());
-                } else if (person.isDeployed()) {
-                    setForeground(MekHQ.getMHQOptions().getDeployedForeground());
-                    setBackground(MekHQ.getMHQOptions().getDeployedBackground());
-                } else if (personIsAwayFromMainForce) {
-                    setForeground(MekHQ.getMHQOptions().getAwayFromMainForceForeground());
-                    setBackground(MekHQ.getMHQOptions().getAwayFromMainForceBackground());
-                } else if (personIsDamaged) {
-                    setForeground(MekHQ.getMHQOptions().getInjuredForeground());
-                    setBackground(MekHQ.getMHQOptions().getInjuredBackground());
-                } else if (person.isPregnant()) {
-                    setForeground(MekHQ.getMHQOptions().getPregnantForeground());
-                    setBackground(MekHQ.getMHQOptions().getPregnantBackground());
-                } else if (personIsFatigued) {
-                    setForeground(MekHQ.getMHQOptions().getFatiguedForeground());
-                    setBackground(MekHQ.getMHQOptions().getFatiguedBackground());
-                } else if (person.hasNonProstheticPermanentInjuries(isUseAlternateAdvancedMedical)) {
-                    setForeground(MekHQ.getMHQOptions().getHealedInjuriesForeground());
-                    setBackground(MekHQ.getMHQOptions().getHealedInjuriesBackground());
-                } else {
-                    setBackground(UIManager.getColor("Table.background"));
-                    setForeground(UIManager.getColor("Table.foreground"));
-                }
-
-                // Now collect ALL applicable reasons (not mutually exclusive)
-                if (person.getStatus().isAbsent()) {
-                    colorReasonKeys.add("colorReason.personnel.absent");
-                }
-                if (person.getStatus().isDepartedUnit()) {
-                    colorReasonKeys.add("colorReason.personnel.departed");
-                }
-                if (person.isDeployed()) {
-                    colorReasonKeys.add("colorReason.personnel.deployed");
-                }
-                if (personIsDamaged) {
-                    colorReasonKeys.add("colorReason.personnel.injured");
-                }
-                if (person.isPregnant()) {
-                    colorReasonKeys.add("colorReason.personnel.pregnant");
-                }
-                if (personIsFatigued) {
-                    colorReasonKeys.add("colorReason.personnel.fatigued");
-                }
-                if (person.hasNonProstheticPermanentInjuries(isUseAlternateAdvancedMedical)) {
-                    colorReasonKeys.add("colorReason.personnel.healedInjuries");
-                }
+                ComponentColors cellColors = populatePersonalStateFlags(person, personalStateFlags);
+                setForeground(cellColors.foreground());
+                setBackground(cellColors.background());
             }
-
             // Tool Tips - includes all applicable color reasons for name/rank/status columns
-            setToolTipText(personnelColumn.getToolTipText(person, colorReasonKeys));
+            setToolTipText(personnelColumn.getToolTipText(person, personalStateFlags));
 
             return this;
+        }
+
+        /**
+         * Populates a list with personal state flags. Selects a color for the most important state.
+         */
+        private ComponentColors populatePersonalStateFlags(Person person, List<String> colorReasonKeys) {
+            // Set color based on priority (first match wins for display color)
+            // But collect ALL applicable reasons for tooltip
+            MHQOptions mhqOptions = MekHQ.getMHQOptions();
+            CampaignOptions campaignOptions = campaign.getCampaignOptions();
+
+            ComponentColors cellColors = null;
+            if (person.getStatus().isAbsent()) {
+                colorReasonKeys.add("colorReason.personnel.absent");
+                cellColors = mhqOptions.getAbsentColors();
+            }
+            if (person.getStatus().isDepartedUnit()) {
+                colorReasonKeys.add("colorReason.personnel.departed");
+                cellColors = (cellColors == null) ? mhqOptions.getGoneColors() : cellColors;
+            }
+            if (person.isDeployed()) {
+                colorReasonKeys.add("colorReason.personnel.deployed");
+                cellColors = (cellColors == null) ? mhqOptions.getDeployedColors() : cellColors;
+            }
+            if (PersonnelStatus.computeIsAwayFromMainForce(campaign, person)) {
+                cellColors = (cellColors == null) ? mhqOptions.getAwayFromMainForceColors() : cellColors;
+            }
+            if (campaignOptions.isUseAdvancedMedical() ? person.hasInjuries(true) : (person.getHits() > 0)) {
+                colorReasonKeys.add("colorReason.personnel.injured");
+                cellColors = (cellColors == null) ? mhqOptions.getInjuredColors() : cellColors;
+            }
+            if (person.isPregnant()) {
+                colorReasonKeys.add("colorReason.personnel.pregnant");
+                cellColors = (cellColors == null) ? mhqOptions.getPregnantColors() : cellColors;
+            }
+            if (campaignOptions.isUseFatigue() && (getEffectiveFatigue(person, campaign) >= 5)) {
+                colorReasonKeys.add("colorReason.personnel.fatigued");
+                cellColors = (cellColors == null) ? mhqOptions.getFatiguedColors() : cellColors;
+            }
+            if (person.hasNonProstheticPermanentInjuries(campaignOptions.isUseAlternativeAdvancedMedical())) {
+                colorReasonKeys.add("colorReason.personnel.healedInjuries");
+                cellColors = (cellColors == null) ? mhqOptions.getHealedInjuriesColors() : cellColors;
+            }
+            return (cellColors == null) ? new ComponentColors(UIManager.getColor("Table.foreground"),
+                  UIManager.getColor("Table.background")) : cellColors;
         }
     }
 
@@ -271,19 +248,10 @@ public class PersonnelTableModel extends DataTableModel<Person> {
             final PersonnelTableModelColumn personnelColumn = PERSONNEL_COLUMNS[table.convertColumnIndexToModel(column)];
             final Person person = getPerson(modelRow);
 
-            setText(String.valueOf(getValueAt(person, personnelColumn)));
-
             switch (personnelColumn) {
-                case RANK:
-                    setHtmlText(person.getRankName());
-                    break;
                 case PERSON:
                     setText(person.getFullDesc(campaign));
                     setImage(person.getPortraitImageIconWithFallback(true, 54).getImage());
-                    break;
-                case MARKET_UNIT_ASSIGNMENT:
-                    Entity entity = campaign.getPersonnelMarket().getAttachedEntity(person);
-                    setText((entity != null) ? entity.getDisplayName() : "-");
                     break;
                 case UNIT_ASSIGNMENT:
                     Unit unit = person.getUnit();

--- a/MekHQ/src/mekhq/gui/stratCon/ScenarioWizardLanceRenderer.java
+++ b/MekHQ/src/mekhq/gui/stratCon/ScenarioWizardLanceRenderer.java
@@ -119,14 +119,7 @@ public class ScenarioWizardLanceRenderer extends JLabel implements ListCellRende
                 }
 
                 for (Person person : unit.getCrew()) {
-                    int personFatigue = getEffectiveFatigue(person.getAdjustedFatigue(),
-                          person.getPermanentFatigue(),
-                          person.isClanPersonnel(),
-                          person.getSkillLevel(campaign, false, true));
-
-                    if (personFatigue > highestFatigue) {
-                        highestFatigue = personFatigue;
-                    }
+                    highestFatigue = Math.max(highestFatigue, getEffectiveFatigue(person, campaign));
                 }
             }
             fatigueReport = getFormattedTextAt(RESOURCE_BUNDLE, "fatigueReport.string", highestFatigue);

--- a/MekHQ/src/mekhq/gui/utilities/ComponentColors.java
+++ b/MekHQ/src/mekhq/gui/utilities/ComponentColors.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package mekhq.gui.utilities;
+
+import java.awt.Color;
+
+/**
+ * Holds component color settings.
+ */
+public record ComponentColors(Color foreground, Color background) {}

--- a/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
@@ -535,8 +535,7 @@ public class ForceViewPanel extends JScrollablePanel {
             }
         }
 
-        int effectiveFatigue = getEffectiveFatigue(person.getAdjustedFatigue(), person.getPermanentFatigue(),
-              person.isClanPersonnel(), person.getSkillLevel(campaign, false, true));
+        int effectiveFatigue = getEffectiveFatigue(person, campaign);
         if (campaign.getCampaignOptions().isUseFatigue() && (effectiveFatigue > 0)) {
             isFatigued = true;
             if (isInjured) {

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -2635,8 +2635,7 @@ public class PersonViewPanel extends JScrollablePanel {
 
         JLabel lblFatigue = null;
         int baseFatigue = person.getAdjustedFatigue();
-        int effectiveFatigue = getEffectiveFatigue(baseFatigue, person.getPermanentFatigue(),
-              person.isClanPersonnel(), person.getSkillLevel(campaign, false, true));
+        int effectiveFatigue = getEffectiveFatigue(person, campaign);
         if (campaignOptions.isUseFatigue() && (baseFatigue != 0 || effectiveFatigue != 0)) {
             StringBuilder fatigueDisplay = new StringBuilder("<html>");
             int fatigueTurnoverModifier = Math.clamp(((effectiveFatigue - 1) / 4) - 1, 0, 3);


### PR DESCRIPTION
- Extract personal state logic from `Renderer` into a separate method
- Remove dead code from `VisualRenderer`
- Introduce a shortcut method for fatigue calculations
- Introduce helper methods in `MHQOptions`
- Return `setRowHeight` statement that was lost in the personnel table view refactoring