### PR TITLE
Refactor visual renderer in Personnel Table

### DIFF
--- a/MekHQ/src/mekhq/gui/enums/PersonnelTabView.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTabView.java
@@ -47,7 +47,7 @@ import mekhq.campaign.campaignOptions.CampaignOptions;
 
 public enum PersonnelTabView {
     GRAPHIC("PersonnelTabView.GRAPHIC.text", "PersonnelTabView.GRAPHIC.toolTipText",
-          Set.of(PERSON, FORCE, UNIT_ASSIGNMENT)),
+          Set.of(PERSON_GRAPHICAL, FORCE_GRAPHICAL, UNIT_ASSIGNMENT_GRAPHICAL)),
     GENERAL("PersonnelTabView.GENERAL.text", "PersonnelTabView.GENERAL.toolTipText",
           Set.of(RANK, FIRST_NAME, LAST_NAME, SKILL_LEVEL, PERSONNEL_ROLE, FORCE, DEPLOYED, INJURIES,
                 UNIT_ASSIGNMENT)),

--- a/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
@@ -47,6 +47,7 @@ import megamek.common.units.Jumpship;
 import megamek.common.units.Mek;
 import megamek.common.units.SmallCraft;
 import megamek.common.units.Tank;
+import megamek.common.units.UnitType;
 import megamek.common.util.sorter.NaturalOrderComparator;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -84,8 +85,8 @@ import org.jspecify.annotations.NonNull;
 
 public enum PersonnelTableModelColumn {
 
-    PERSON("Column.PERSON.title", Comparators.STRING_COMPARATOR,
-          person -> ""),
+    PERSON_GRAPHICAL("Column.PERSON.title", Comparators.STRING_COMPARATOR,
+          Person::getFullDesc),
     RANK("Column.RANK.title", PersonRankSorter.INSTANCE,
           person -> person, Person::getRankName),
     FIRST_NAME("Column.FIRST_NAME.title", Comparators.STRING_COMPARATOR,
@@ -119,6 +120,8 @@ public enum PersonnelTableModelColumn {
           (person, campaign) -> person.getFormatedRoleDescriptions(campaign.getLocalDate())),
     UNIT_ASSIGNMENT("Column.UNIT_ASSIGNMENT.title", Comparators.STRING_COMPARATOR,
           PersonnelTableModelColumn::getUnitAssignment),
+    UNIT_ASSIGNMENT_GRAPHICAL("Column.UNIT_ASSIGNMENT.title", Comparators.STRING_COMPARATOR,
+          PersonnelTableModelColumn::getUnitAssignmentGraphical),
     MARKET_UNIT_ASSIGNMENT("Column.UNIT_ASSIGNMENT.title", Comparators.STRING_COMPARATOR,
           (person, campaign) -> {
               PersonnelMarket market = campaign.getPersonnelMarket();
@@ -130,6 +133,8 @@ public enum PersonnelTableModelColumn {
               Formation formation = campaign.getFormationFor(person);
               return (formation == null) ? "-" : formation.getName();
           }),
+    FORCE_GRAPHICAL("Column.FORCE.title", Comparators.STRING_COMPARATOR,
+          PersonnelTableModelColumn::getForceTextGraphical),
     DEPLOYED("Column.DEPLOYED.title", Comparators.STRING_COMPARATOR,
           PersonnelTableModelColumn::getDeployedScenarioName),
     MEK("Column.MEK.title", SkillPair.COMPARATOR,
@@ -510,6 +515,24 @@ public enum PersonnelTableModelColumn {
         }
     }
 
+    private static String getForceTextGraphical(Person person, Campaign campaign) {
+        Formation formation = campaign.getFormationFor(person);
+        if (formation != null) {
+            StringBuilder desc = new StringBuilder("<html><b>").append(formation.getName()).append("</b>");
+            Formation parent = formation.getParentFormation();
+            // cut off after three lines and don't include the top level
+            int lines = 1;
+            while ((parent != null) && (parent.getParentFormation() != null) && (lines < 4)) {
+                desc.append("<br>").append(parent.getName());
+                lines++;
+                parent = parent.getParentFormation();
+            }
+            desc.append("</html>");
+            return desc.toString();
+        }
+        return "-";
+    }
+
     private static String getDeployedScenarioName(Person person, Campaign campaign) {
         Unit unit = person.getUnit();
         if (unit == null || !unit.isDeployed()) {
@@ -576,6 +599,25 @@ public enum PersonnelTableModelColumn {
             default -> "-/-";
         };
     }
+
+    private static String getUnitAssignmentGraphical(Person person) {
+        Unit unit = person.getUnit();
+        if ((unit == null) && !person.getTechUnits().isEmpty()) {
+            unit = person.getTechUnits().getFirst();
+        }
+
+        if (unit != null) {
+            String description = "<b>" + unit.getName() + "</b><br>";
+            description += unit.getEntity().getWeightClassName();
+            if ((!(unit.getEntity() instanceof SmallCraft) || !(unit.getEntity() instanceof Jumpship))) {
+                description += " " + UnitType.getTypeDisplayableName(unit.getEntity().getUnitType());
+            }
+            description += "<br>" + unit.getStatus();
+            return description;
+        }
+        return "-";
+    }
+
 
     private static String getUnitAssignment(Person person) {
         Unit unit = person.getUnit();
@@ -740,7 +782,7 @@ public enum PersonnelTableModelColumn {
      * status column.
      */
     private boolean isNameRankOrStatusColumn() {
-        return (this == PERSON) ||
+        return (this == PERSON_GRAPHICAL) ||
                      (this == FIRST_NAME) ||
                      (this == LAST_NAME) ||
                      (this == GIVEN_NAME) ||
@@ -753,7 +795,7 @@ public enum PersonnelTableModelColumn {
 
     public int getWidth() {
         return switch (this) {
-            case PERSON, UNIT_ASSIGNMENT, MARKET_UNIT_ASSIGNMENT -> 125;
+            case PERSON_GRAPHICAL, UNIT_ASSIGNMENT, MARKET_UNIT_ASSIGNMENT -> 125;
             case RANK, FIRST_NAME, GIVEN_NAME, DEPLOYED -> 70;
             case LAST_NAME, SURNAME, SURNAME_GROUPED_BY_UNIT, BLOODNAME, CALLSIGN, SKILL_LEVEL, SALARY -> 50;
             case PERSONNEL_ROLE -> 150;

--- a/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
@@ -36,7 +36,6 @@ import static mekhq.campaign.personnel.turnoverAndRetention.Fatigue.getEffective
 
 import java.awt.Component;
 import java.awt.Image;
-import java.awt.Toolkit;
 import java.util.ArrayList;
 import java.util.List;
 import javax.swing.JTable;
@@ -45,9 +44,6 @@ import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableCellRenderer;
 
 import megamek.common.annotations.Nullable;
-import megamek.common.units.Jumpship;
-import megamek.common.units.SmallCraft;
-import megamek.common.units.UnitType;
 import mekhq.MHQOptions;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -248,85 +244,32 @@ public class PersonnelTableModel extends DataTableModel<Person> {
             final PersonnelTableModelColumn personnelColumn = PERSONNEL_COLUMNS[table.convertColumnIndexToModel(column)];
             final Person person = getPerson(modelRow);
 
-            switch (personnelColumn) {
-                case PERSON:
-                    setText(person.getFullDesc(campaign));
-                    setImage(person.getPortraitImageIconWithFallback(true, 54).getImage());
-                    break;
-                case UNIT_ASSIGNMENT:
-                    Unit unit = person.getUnit();
-                    if ((unit == null) && !person.getTechUnits().isEmpty()) {
-                        unit = person.getTechUnits().getFirst();
-                    }
-
-                    if (unit != null) {
-                        String description = "<b>" + unit.getName() + "</b><br>";
-                        description += unit.getEntity().getWeightClassName();
-                        if ((!(unit.getEntity() instanceof SmallCraft) || !(unit.getEntity() instanceof Jumpship))) {
-                            description += " " + UnitType.getTypeDisplayableName(unit.getEntity().getUnitType());
-                        }
-                        description += "<br>" + unit.getStatus();
-                        setText(description);
-                        Image mekImage = unit.getImage(this);
-                        if (mekImage != null) {
-                            setImage(mekImage);
-                        } else {
-                            clearImage();
-                        }
-                    } else {
-                        clearImage();
-                    }
-                    break;
-                case FORCE:
-                    Formation formation = campaign.getFormationFor(person);
-                    if (formation != null) {
-                        StringBuilder desc = new StringBuilder("<html><b>").append(formation.getName())
-                                                   .append("</b>");
-                        Formation parent = formation.getParentFormation();
-                        // cut off after three lines and don't include the top level
-                        int lines = 1;
-                        while ((parent != null) && (parent.getParentFormation() != null) && (lines < 4)) {
-                            desc.append("<br>").append(parent.getName());
-                            lines++;
-                            parent = parent.getParentFormation();
-                        }
-                        desc.append("</html>");
-                        setHtmlText(desc.toString());
-                        final Image forceImage = formation.getFormationIcon().getImage(54);
-                        if (forceImage != null) {
-                            setImage(forceImage);
-                        } else {
-                            clearImage();
-                        }
-                    } else {
-                        clearImage();
-                    }
-                    break;
-                case INJURIES:
-                    Image hitImage = getHitsImage(person.getHits());
-                    if (hitImage != null) {
-                        setImage(hitImage);
-                    } else {
-                        clearImage();
-                    }
-                    setHtmlText("");
-                    break;
-                default:
-                    break;
+            setText(personnelColumn.getText(value));
+            Image image = getImage(person, personnelColumn);
+            if (image != null) {
+                setImage(image);
+            } else {
+                clearImage();
             }
 
             MekHqTableCellRenderer.setupTableColors(this, table, isSelected, hasFocus, row);
             return this;
         }
 
-        private @Nullable Image getHitsImage(int hits) {
-            return switch (hits) {
-                case 1 -> Toolkit.getDefaultToolkit().getImage("data/images/misc/hits/onehit.png");
-                case 2 -> Toolkit.getDefaultToolkit().getImage("data/images/misc/hits/twohits.png");
-                case 3 -> Toolkit.getDefaultToolkit().getImage("data/images/misc/hits/threehits.png");
-                case 4 -> Toolkit.getDefaultToolkit().getImage("data/images/misc/hits/fourhits.png");
-                case 5 -> Toolkit.getDefaultToolkit().getImage("data/images/misc/hits/fivehits.png");
-                case 6 -> Toolkit.getDefaultToolkit().getImage("data/images/misc/hits/sixhits.png");
+        private Image getImage(Person person, PersonnelTableModelColumn personnelColumn) {
+            return switch (personnelColumn) {
+                case PERSON_GRAPHICAL -> person.getPortraitImageIconWithFallback(true, 54).getImage();
+                case UNIT_ASSIGNMENT_GRAPHICAL -> {
+                    Unit unit = person.getUnit();
+                    if ((unit == null) && !person.getTechUnits().isEmpty()) {
+                        unit = person.getTechUnits().getFirst();
+                    }
+                    yield (unit == null) ? null : unit.getImage(this);
+                }
+                case FORCE_GRAPHICAL -> {
+                    Formation formation = campaign.getFormationFor(person);
+                    yield  (formation == null) ? null : formation.getFormationIcon().getImage(54);
+                }
                 default -> null;
             };
         }
@@ -336,7 +279,4 @@ public class PersonnelTableModel extends DataTableModel<Person> {
         this.personnelMarket = personnelMarket;
     }
 
-    public boolean isLoadAssignmentFromMarket() {
-        return personnelMarket != null;
-    }
 }

--- a/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
+++ b/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
@@ -73,7 +73,7 @@ public class PersonnelTableModelColumnTest {
     public void testGetWidth() {
         for (final PersonnelTableModelColumn personnelTableModelColumn : columns) {
             switch (personnelTableModelColumn) {
-                case PERSON:
+                case PERSON_GRAPHICAL:
                 case MARKET_UNIT_ASSIGNMENT:
                 case UNIT_ASSIGNMENT:
                     assertEquals(125, personnelTableModelColumn.getWidth());


### PR DESCRIPTION
- Move text generation into column definitions
- Extract image lookups into `VisualRenderer.getImage`
- Remove dead code, including custom graphical view logic for the `INJURIES` column