### PR TITLE
Fixed Intermittently Failing Tests

### DIFF
--- a/MekHQ/unittests/mekhq/campaign/randomEvents/prisoners/EventEffectsManagerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/randomEvents/prisoners/EventEffectsManagerTest.java
@@ -72,6 +72,7 @@ import mekhq.campaign.randomEvents.randomEventsSystem.PrisonerEventData;
 import mekhq.campaign.randomEvents.randomEventsSystem.PrisonerResponseEntry;
 import mekhq.campaign.stratCon.StratConCampaignState;
 import mekhq.campaign.universe.Faction;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -82,21 +83,28 @@ import org.junit.jupiter.api.Test;
  * outcomes under various conditions.</p>
  */
 class EventEffectsManagerTest {
-    @Test
-    void testEventEffectPrisonerCapacity() {
-        final int MAGNITUDE = 5;
+    private Campaign mockCampaign;
+    private CampaignOptions mockCampaignOptions;
 
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
+    @BeforeEach
+    void setUp() {
+        mockCampaign = mock(Campaign.class);
         Faction campaignFaction = mock(Faction.class);
         when(campaignFaction.isMercenary()).thenReturn(true);
         when(mockCampaign.getFaction()).thenReturn(campaignFaction);
         when(campaignFaction.getShortName()).thenReturn("MERC");
 
+        mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+    }
+
+    @Test
+    void testEventEffectPrisonerCapacity() {
+        final int MAGNITUDE = 5;
+
         String report = getReport(MAGNITUDE, mockCampaign);
 
-        // Assert
-        // Because we're mocking campaign we can't check whether Prisoner Capacity was actually
+        // Because we're mocking campaign, we can't check whether Prisoner Capacity was actually
         // changed. So we check to see if the change is reflected in the report, instead.
         assertTrue(report.contains("5"));
     }
@@ -108,25 +116,13 @@ class EventEffectsManagerTest {
               List.of(eventResult));
         PrisonerEventData eventData = new PrisonerEventData(BREAKOUT, List.of(responseEntry));
 
-        // Act
         EventEffectsManager effectsManager = new EventEffectsManager(mockCampaign, eventData, 0, true);
-        String report = effectsManager.getEventReport();
-        return report;
+        return effectsManager.getEventReport();
     }
 
     @Test
     void testEventEffectInjury_NoAdvancedMedical() {
         final int MAGNITUDE = 5;
-
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-        Faction campaignFaction = mock(Faction.class);
-        when(campaignFaction.isMercenary()).thenReturn(true);
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-        when(campaignFaction.getShortName()).thenReturn("MERC");
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
 
         EventResult eventResult = new EventResult(INJURY, false, MAGNITUDE, "");
         PrisonerResponseEntry responseEntry = new PrisonerResponseEntry(RESPONSE_NEUTRAL,
@@ -137,10 +133,8 @@ class EventEffectsManagerTest {
         Person prisoner = new Person(mockCampaign);
         when(mockCampaign.getCurrentPrisoners()).thenReturn(List.of(prisoner));
 
-        // Act
         new EventEffectsManager(mockCampaign, eventData, 0, true);
 
-        // Assert
         assertEquals(MAGNITUDE, prisoner.getHits());
     }
 
@@ -148,19 +142,8 @@ class EventEffectsManagerTest {
     void testEventEffectInjury_WithAdvancedMedical() {
         final int MAGNITUDE = 10;
 
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-        Faction campaignFaction = mock(Faction.class);
-        when(campaignFaction.isMercenary()).thenReturn(true);
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-        when(campaignFaction.getShortName()).thenReturn("MERC");
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         when(mockCampaignOptions.isUseAdvancedMedical()).thenReturn(true);
-
-        LocalDate today = LocalDate.of(3151, 1, 1);
-        when(mockCampaign.getLocalDate()).thenReturn(today);
+        when(mockCampaign.getLocalDate()).thenReturn(LocalDate.of(3151, 1, 1));
 
         EventResult eventResult = new EventResult(INJURY, false, MAGNITUDE, "");
         PrisonerResponseEntry responseEntry = new PrisonerResponseEntry(RESPONSE_NEUTRAL,
@@ -171,10 +154,8 @@ class EventEffectsManagerTest {
         Person prisoner = new Person(mockCampaign);
         when(mockCampaign.getCurrentPrisoners()).thenReturn(List.of(prisoner));
 
-        // Act
         new EventEffectsManager(mockCampaign, eventData, 0, true);
 
-        // Assert
         // Advanced Medical applies a degree of randomization to the number of injuries caused by a
         // Hit. So we can't check for the exact number of injuries sustained, just that the number
         // of injuries is no longer 0.
@@ -184,16 +165,6 @@ class EventEffectsManagerTest {
     @Test
     void testEventEffectInjuryPercent_NoAdvancedMedical() {
         final int MAGNITUDE = 50;
-
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-        Faction campaignFaction = mock(Faction.class);
-        when(campaignFaction.isMercenary()).thenReturn(true);
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-        when(campaignFaction.getShortName()).thenReturn("MERC");
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
 
         EventResult eventResult = new EventResult(INJURY_PERCENT, false, MAGNITUDE, "");
         PrisonerResponseEntry responseEntry = new PrisonerResponseEntry(RESPONSE_NEUTRAL,
@@ -207,10 +178,8 @@ class EventEffectsManagerTest {
         Person prisoner3 = new Person(mockCampaign);
         when(mockCampaign.getCurrentPrisoners()).thenReturn(List.of(prisoner0, prisoner1, prisoner2, prisoner3));
 
-        // Act
         new EventEffectsManager(mockCampaign, eventData, 0, true);
 
-        // Assert
         int injuredCharacters = 0;
         for (Person person : mockCampaign.getCurrentPrisoners()) {
             if (person.getHits() > 0) {
@@ -225,19 +194,8 @@ class EventEffectsManagerTest {
     void testEventEffectInjuryPercent_WithAdvancedMedical() {
         final int MAGNITUDE = 50;
 
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-        Faction campaignFaction = mock(Faction.class);
-        when(campaignFaction.isMercenary()).thenReturn(true);
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-        when(campaignFaction.getShortName()).thenReturn("MERC");
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         when(mockCampaignOptions.isUseAdvancedMedical()).thenReturn(true);
-
-        LocalDate today = LocalDate.of(3151, 1, 1);
-        when(mockCampaign.getLocalDate()).thenReturn(today);
+        when(mockCampaign.getLocalDate()).thenReturn(LocalDate.of(3151, 1, 1));
 
         EventResult eventResult = new EventResult(INJURY_PERCENT, false, MAGNITUDE, "");
         PrisonerResponseEntry responseEntry = new PrisonerResponseEntry(RESPONSE_NEUTRAL,
@@ -251,10 +209,8 @@ class EventEffectsManagerTest {
         Person prisoner3 = new Person(mockCampaign);
         when(mockCampaign.getCurrentPrisoners()).thenReturn(List.of(prisoner0, prisoner1, prisoner2, prisoner3));
 
-        // Act
         new EventEffectsManager(mockCampaign, eventData, 0, true);
 
-        // Assert
         int injuredCharacters = 0;
         for (Person person : mockCampaign.getCurrentPrisoners()) {
             if (!person.getInjuries().isEmpty()) {
@@ -269,16 +225,6 @@ class EventEffectsManagerTest {
     void testEventEffectDeath() {
         final int MAGNITUDE = 1;
 
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-        Faction campaignFaction = mock(Faction.class);
-        when(campaignFaction.isMercenary()).thenReturn(true);
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-        when(campaignFaction.getShortName()).thenReturn("MERC");
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-
         EventResult eventResult = new EventResult(DEATH, false, MAGNITUDE, "");
         PrisonerResponseEntry responseEntry = new PrisonerResponseEntry(RESPONSE_NEUTRAL,
               List.of(eventResult),
@@ -288,11 +234,9 @@ class EventEffectsManagerTest {
         Person prisoner = new Person(mockCampaign);
         when(mockCampaign.getCurrentPrisoners()).thenReturn(List.of(prisoner));
 
-        // Act
         EventEffectsManager effectsManager = new EventEffectsManager(mockCampaign, eventData, 0, true);
         String report = effectsManager.getEventReport();
 
-        // Assert
         // Because we remove NPC Prisoners, on death, we need to instead check whether the report
         // shows they have been killed. The whitespace is deliberate, as the death count appears at
         // the beginning of the string, and we don't want the test to get confused by other numbers
@@ -304,19 +248,8 @@ class EventEffectsManagerTest {
     void testEventEffectDeathPercent() {
         final int MAGNITUDE = 50;
 
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-        Faction campaignFaction = mock(Faction.class);
-        when(campaignFaction.isMercenary()).thenReturn(true);
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-        when(campaignFaction.getShortName()).thenReturn("MERC");
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         when(mockCampaignOptions.isUseAdvancedMedical()).thenReturn(true);
-
-        LocalDate today = LocalDate.of(3151, 1, 1);
-        when(mockCampaign.getLocalDate()).thenReturn(today);
+        when(mockCampaign.getLocalDate()).thenReturn(LocalDate.of(3151, 1, 1));
 
         EventResult eventResult = new EventResult(DEATH_PERCENT, false, MAGNITUDE, "");
         PrisonerResponseEntry responseEntry = new PrisonerResponseEntry(RESPONSE_NEUTRAL,
@@ -330,11 +263,9 @@ class EventEffectsManagerTest {
         Person prisoner3 = new Person(mockCampaign);
         when(mockCampaign.getCurrentPrisoners()).thenReturn(List.of(prisoner0, prisoner1, prisoner2, prisoner3));
 
-        // Act
         EventEffectsManager effectsManager = new EventEffectsManager(mockCampaign, eventData, 0, true);
         String report = effectsManager.getEventReport();
 
-        // Assert
         // Because we remove NPC Prisoners, on death, we need to instead check whether the report
         // shows they have been killed. The whitespace is deliberate, as the death count appears at
         // the beginning of the string, and we don't want the test to get confused by other numbers
@@ -347,15 +278,6 @@ class EventEffectsManagerTest {
         final int MAGNITUDE = 5;
         final String skill = S_ADMIN;
 
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-        Faction campaignFaction = mock(Faction.class);
-        when(campaignFaction.isMercenary()).thenReturn(true);
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-        when(campaignFaction.getShortName()).thenReturn("MERC");
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         when(mockCampaignOptions.isUseLoyaltyModifiers()).thenReturn(true);
 
         EventResult eventResult = new EventResult(SKILL, false, MAGNITUDE, S_ADMIN);
@@ -369,10 +291,8 @@ class EventEffectsManagerTest {
 
         SkillType.initializeTypes();
 
-        // Act
         new EventEffectsManager(mockCampaign, eventData, 0, true);
 
-        // Assert
         assertTrue(prisoner.hasSkill(skill));
         assertEquals(MAGNITUDE, prisoner.getSkill(skill).getLevel());
     }
@@ -381,15 +301,6 @@ class EventEffectsManagerTest {
     void testEventEffectLoyaltyOne() {
         final int MAGNITUDE = 5;
 
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-        Faction campaignFaction = mock(Faction.class);
-        when(campaignFaction.isMercenary()).thenReturn(true);
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-        when(campaignFaction.getShortName()).thenReturn("MERC");
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         when(mockCampaignOptions.isUseLoyaltyModifiers()).thenReturn(true);
 
         EventResult eventResult = new EventResult(LOYALTY_ONE, false, MAGNITUDE, "");
@@ -402,29 +313,15 @@ class EventEffectsManagerTest {
         when(mockCampaign.getCurrentPrisoners()).thenReturn(List.of(prisoner));
         int oldLoyalty = prisoner.getBaseLoyalty();
 
-        // Act
         new EventEffectsManager(mockCampaign, eventData, 0, true);
 
-        // Assert
-        int expectedLoyalty = oldLoyalty + MAGNITUDE;
-        int actualLoyalty = prisoner.getBaseLoyalty();
-
-        assertEquals(expectedLoyalty, actualLoyalty);
+        assertEquals(oldLoyalty + MAGNITUDE, prisoner.getBaseLoyalty());
     }
 
     @Test
     void testEventEffectLoyaltyAll() {
         final int MAGNITUDE = 5;
 
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-        Faction campaignFaction = mock(Faction.class);
-        when(campaignFaction.isMercenary()).thenReturn(true);
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-        when(campaignFaction.getShortName()).thenReturn("MERC");
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         when(mockCampaignOptions.isUseLoyaltyModifiers()).thenReturn(true);
 
         EventResult eventResult = new EventResult(LOYALTY_ALL, false, MAGNITUDE, "");
@@ -443,32 +340,17 @@ class EventEffectsManagerTest {
               prisoner2.getBaseLoyalty(),
               prisoner3.getBaseLoyalty());
 
-        // Act
         new EventEffectsManager(mockCampaign, eventData, 0, true);
 
-        // Assert
         List<Person> currentPrisoners = mockCampaign.getCurrentPrisoners();
         for (int i = 0; i < currentPrisoners.size(); i++) {
-            int expectedLoyalty = oldLoyalties.get(i) + MAGNITUDE;
-            int actualLoyalty = currentPrisoners.get(i).getBaseLoyalty();
-
-            assertEquals(expectedLoyalty, actualLoyalty);
+            assertEquals(oldLoyalties.get(i) + MAGNITUDE, currentPrisoners.get(i).getBaseLoyalty());
         }
     }
 
     @Test
     void testEventEffectEscape() {
         final int MAGNITUDE = 1;
-
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-        Faction campaignFaction = mock(Faction.class);
-        when(campaignFaction.isMercenary()).thenReturn(true);
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-        when(campaignFaction.getShortName()).thenReturn("MERC");
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
 
         EventResult eventResult = new EventResult(ESCAPE, false, MAGNITUDE, "");
         PrisonerResponseEntry responseEntry = new PrisonerResponseEntry(RESPONSE_NEUTRAL,
@@ -482,13 +364,11 @@ class EventEffectsManagerTest {
         Person prisoner3 = new Person(mockCampaign);
         when(mockCampaign.getCurrentPrisoners()).thenReturn(List.of(prisoner0, prisoner1, prisoner2, prisoner3));
 
-        // Act
         new EventEffectsManager(mockCampaign, eventData, 0, true);
 
         EventEffectsManager effectsManager = new EventEffectsManager(mockCampaign, eventData, 0, true);
         String report = effectsManager.getEventReport();
 
-        // Assert
         // Because we remove NPC Prisoners, on escape, we need to instead check whether the report
         // shows they have escaped.
         assertTrue(report.contains("1"));
@@ -497,16 +377,6 @@ class EventEffectsManagerTest {
     @Test
     void testEventEffectEscapePercent() {
         final int MAGNITUDE = 50;
-
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-        Faction campaignFaction = mock(Faction.class);
-        when(campaignFaction.isMercenary()).thenReturn(true);
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-        when(campaignFaction.getShortName()).thenReturn("MERC");
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
 
         EventResult eventResult = new EventResult(ESCAPE_PERCENT, false, MAGNITUDE, "");
         PrisonerResponseEntry responseEntry = new PrisonerResponseEntry(RESPONSE_NEUTRAL,
@@ -520,13 +390,11 @@ class EventEffectsManagerTest {
         Person prisoner3 = new Person(mockCampaign);
         when(mockCampaign.getCurrentPrisoners()).thenReturn(List.of(prisoner0, prisoner1, prisoner2, prisoner3));
 
-        // Act
         new EventEffectsManager(mockCampaign, eventData, 0, true);
 
         EventEffectsManager effectsManager = new EventEffectsManager(mockCampaign, eventData, 0, true);
         String report = effectsManager.getEventReport();
 
-        // Assert
         // Because we remove NPC Prisoners, on escape, we need to instead check whether the report
         // shows they have escaped.
         assertTrue(report.contains("2"));
@@ -536,15 +404,6 @@ class EventEffectsManagerTest {
     void testEventEffectFatigueOne() {
         final int MAGNITUDE = 5;
 
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-        Faction campaignFaction = mock(Faction.class);
-        when(campaignFaction.isMercenary()).thenReturn(true);
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-        when(campaignFaction.getShortName()).thenReturn("MERC");
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         when(mockCampaignOptions.isUseFatigue()).thenReturn(true);
         when(mockCampaignOptions.getFatigueRate()).thenReturn(1);
 
@@ -563,29 +422,15 @@ class EventEffectsManagerTest {
         when(mockCampaign.getCurrentPrisoners()).thenReturn(List.of(prisoner));
         int oldFatigue = prisoner.getFatigueDirect();
 
-        // Act
         new EventEffectsManager(mockCampaign, eventData, 0, true);
 
-        // Assert
-        int expectedFatigue = oldFatigue + MAGNITUDE;
-        int actualFatigue = prisoner.getFatigueDirect();
-
-        assertEquals(expectedFatigue, actualFatigue);
+        assertEquals(oldFatigue + MAGNITUDE, prisoner.getFatigueDirect());
     }
 
     @Test
     void testEventEffectFatigueAll() {
         final int MAGNITUDE = 5;
 
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-        Faction campaignFaction = mock(Faction.class);
-        when(campaignFaction.isMercenary()).thenReturn(true);
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-        when(campaignFaction.getShortName()).thenReturn("MERC");
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         when(mockCampaignOptions.isUseFatigue()).thenReturn(true);
         when(mockCampaignOptions.getFatigueRate()).thenReturn(1);
 
@@ -610,16 +455,11 @@ class EventEffectsManagerTest {
               prisoner2.getFatigueDirect(),
               prisoner3.getFatigueDirect());
 
-        // Act
         new EventEffectsManager(mockCampaign, eventData, 0, true);
 
-        // Assert
         List<Person> currentPrisoners = mockCampaign.getCurrentPrisoners();
         for (int i = 0; i < currentPrisoners.size(); i++) {
-            int expectedFatigue = oldFatigues.get(i) + MAGNITUDE;
-            int actualFatigue = currentPrisoners.get(i).getFatigueDirect();
-
-            assertEquals(expectedFatigue, actualFatigue);
+            assertEquals(oldFatigues.get(i) + MAGNITUDE, currentPrisoners.get(i).getFatigueDirect());
         }
     }
 
@@ -627,15 +467,6 @@ class EventEffectsManagerTest {
     void testEventEffectSupportPoint() {
         final int MAGNITUDE = 5;
 
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-        Faction campaignFaction = mock(Faction.class);
-        when(campaignFaction.isMercenary()).thenReturn(true);
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-        when(campaignFaction.getShortName()).thenReturn("MERC");
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         when(mockCampaignOptions.isUseStratCon()).thenReturn(true);
 
         AtBContract contract = new AtBContract("Test");
@@ -649,28 +480,15 @@ class EventEffectsManagerTest {
               List.of(eventResult));
         PrisonerEventData eventData = new PrisonerEventData(BREAKOUT, List.of(responseEntry));
 
-        // Act
         new EventEffectsManager(mockCampaign, eventData, 0, true);
 
-        // Assert
-        int actualSupportPoints = contract.getStratConCampaignState().getSupportPoints();
-
-        assertEquals(MAGNITUDE, actualSupportPoints);
+        assertEquals(MAGNITUDE, contract.getStratConCampaignState().getSupportPoints());
     }
 
     @Test
     void testEventEffectUniqueBartering() {
         final int MAGNITUDE = 1;
 
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-        Faction campaignFaction = mock(Faction.class);
-        when(campaignFaction.isMercenary()).thenReturn(true);
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-        when(campaignFaction.getShortName()).thenReturn("MERC");
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         when(mockCampaignOptions.isUseStratCon()).thenReturn(true);
 
         AtBContract contract = new AtBContract("Test");
@@ -683,29 +501,15 @@ class EventEffectsManagerTest {
               List.of(eventResult));
         PrisonerEventData eventData = new PrisonerEventData(BARTERING, List.of(responseEntry));
 
-        // Act
         new EventEffectsManager(mockCampaign, eventData, 0, true);
 
-        // Assert
-        int expectedMorale = STALEMATE.ordinal() + MAGNITUDE;
-        int actualMorale = contract.getMoraleLevel().ordinal();
-
-        assertEquals(expectedMorale, actualMorale);
+        assertEquals(STALEMATE.ordinal() + MAGNITUDE, contract.getMoraleLevel().ordinal());
     }
 
     @Test
     void testEventEffectUniqueMistake() {
         final int MAGNITUDE = 1;
 
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-        Faction campaignFaction = mock(Faction.class);
-        when(campaignFaction.isMercenary()).thenReturn(true);
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-        when(campaignFaction.getShortName()).thenReturn("MERC");
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         when(mockCampaignOptions.isUseLoyaltyModifiers()).thenReturn(true);
 
         EventResult eventResult = new EventResult(UNIQUE, false, MAGNITUDE, "");
@@ -727,10 +531,8 @@ class EventEffectsManagerTest {
         prisoner.setPrimaryRole(mockCampaign, SOLDIER);
         prisoner.setSecondaryRole(ADMINISTRATOR_LOGISTICS);
 
-        // Act
         new EventEffectsManager(mockCampaign, eventData, 0, true);
 
-        // Assert
         assertNull(prisoner.getSkill(S_ADMIN));
         assertNull(prisoner.getSkill(S_SMALL_ARMS));
         assertNull(prisoner.getSkill(S_SURGERY));
@@ -743,15 +545,6 @@ class EventEffectsManagerTest {
     void testEventEffectUniqueUndercover() {
         final int MAGNITUDE = 1;
 
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-        Faction campaignFaction = mock(Faction.class);
-        when(campaignFaction.isMercenary()).thenReturn(true);
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-        when(campaignFaction.getShortName()).thenReturn("MERC");
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         when(mockCampaignOptions.isUseStratCon()).thenReturn(true);
 
         AtBContract contract = mock(AtBContract.class);
@@ -767,32 +560,18 @@ class EventEffectsManagerTest {
         PrisonerEventData eventData = new PrisonerEventData(UNDERCOVER, List.of(responseEntry));
 
         Person prisoner = new Person(mockCampaign);
-        Faction prisonerFaction = new Faction();
-        prisoner.setOriginFaction(prisonerFaction);
+        prisoner.setOriginFaction(new Faction());
         when(mockCampaign.getCurrentPrisoners()).thenReturn(List.of(prisoner));
 
-        // Act
         new EventEffectsManager(mockCampaign, eventData, 0, true);
 
-        // Assert
-        Faction actualFaction = prisoner.getOriginFaction();
-
-        assertEquals(employerFaction, actualFaction);
+        assertEquals(employerFaction, prisoner.getOriginFaction());
     }
 
     @Test
     void testEventEffectUniquePoison() {
         final int MAGNITUDE = 5;
 
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-        Faction campaignFaction = mock(Faction.class);
-        when(campaignFaction.isMercenary()).thenReturn(true);
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-        when(campaignFaction.getShortName()).thenReturn("MERC");
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         when(mockCampaignOptions.isUseFatigue()).thenReturn(true);
         when(mockCampaignOptions.getFatigueRate()).thenReturn(1);
 
@@ -813,10 +592,8 @@ class EventEffectsManagerTest {
         List<Person> potentialTargets = List.of(soldier0, soldier1, soldier2);
         when(mockCampaign.getActivePersonnel(false, true)).thenReturn(new ArrayList<>(potentialTargets));
 
-        // Act
         new EventEffectsManager(mockCampaign, eventData, 0, true);
 
-        // Assert
         int fatiguedCharacters = 0;
         for (Person character : potentialTargets) {
             if (character.getFatigueDirect() > 0) {

--- a/MekHQ/unittests/mekhq/campaign/randomEvents/prisoners/EventEffectsManagerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/randomEvents/prisoners/EventEffectsManagerTest.java
@@ -213,7 +213,7 @@ class EventEffectsManagerTest {
         // Assert
         int injuredCharacters = 0;
         for (Person person : mockCampaign.getCurrentPrisoners()) {
-            if (person.needsFixing()) {
+            if (person.getTotalInjurySeverity() > 0) {
                 injuredCharacters++;
             }
         }
@@ -257,7 +257,7 @@ class EventEffectsManagerTest {
         // Assert
         int injuredCharacters = 0;
         for (Person person : mockCampaign.getCurrentPrisoners()) {
-            if (person.needsFixing()) {
+            if (person.getTotalInjurySeverity() > 0) {
                 injuredCharacters++;
             }
         }

--- a/MekHQ/unittests/mekhq/campaign/randomEvents/prisoners/EventEffectsManagerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/randomEvents/prisoners/EventEffectsManagerTest.java
@@ -213,7 +213,7 @@ class EventEffectsManagerTest {
         // Assert
         int injuredCharacters = 0;
         for (Person person : mockCampaign.getCurrentPrisoners()) {
-            if (person.getTotalInjurySeverity() > 0) {
+            if (person.getHits() > 0) {
                 injuredCharacters++;
             }
         }
@@ -257,7 +257,7 @@ class EventEffectsManagerTest {
         // Assert
         int injuredCharacters = 0;
         for (Person person : mockCampaign.getCurrentPrisoners()) {
-            if (person.getTotalInjurySeverity() > 0) {
+            if (!person.getInjuries().isEmpty()) {
                 injuredCharacters++;
             }
         }


### PR DESCRIPTION
We were using needsFixing which ignores permanent injuries. If the injury a character gets becomes permanent it would then be falsely flagged as an uninjured character. Now we directly test whether the character has any injuries and also what their total hits are (test dependent).