### PR TITLE
PR: Remove Campaign's location pass-through methods

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -168,7 +168,6 @@ import mekhq.campaign.force.Formation;
 import mekhq.campaign.force.FormationType;
 import mekhq.campaign.icons.StandardFormationIcon;
 import mekhq.campaign.icons.UnitIcon;
-import mekhq.campaign.location.AcademyCampusLocation;
 import mekhq.campaign.location.ILocation;
 import mekhq.campaign.location.IPlace;
 import mekhq.campaign.location.LocationNode;
@@ -1753,37 +1752,6 @@ public class Campaign implements ITechManager, IPlace {
         getForceLocationManager().setLocation(getCampaignLocationManager(), location);
     }
 
-    public void addLocation(AbstractLocation location) {
-        getCampaignLocationManager().addLocation(location);
-    }
-
-    public void removeLocation(AbstractLocation location) {
-        getCampaignLocationManager().removeLocation(location);
-    }
-
-    public void pruneEmptyLocations() {
-        getCampaignLocationManager().pruneEmptyLocations(this);
-    }
-
-    @Nonnull
-    public List<AbstractLocation> getLocations() {
-        return getCampaignLocationManager().getLocations();
-    }
-
-
-    public void addPlayerBase(@Nullable PlayerBase base) {
-        getCampaignLocationManager().addPlayerBase(base);
-    }
-
-    public void removePlayerBase(@Nullable PlayerBase base) {
-        getCampaignLocationManager().removePlayerBase(base);
-    }
-
-    @Nonnull
-    public Set<PlayerBase> getPlayerBases() {
-        return getCampaignLocationManager().getPlayerBases();
-    }
-
     @Nonnull
     public CampaignLocationManager getCampaignLocationManager() {
         return locationManager;
@@ -1796,24 +1764,6 @@ public class Campaign implements ITechManager, IPlace {
 
     public Personnel getMainForcePersonnel() {
         return mainForcePersonnel;
-    }
-
-    @Nullable
-    public AcademyCampusLocation getOrCreateCampusLocation(String academySet, String academyName,
-          String systemId) {
-        return getCampaignLocationManager().getOrCreateCampusLocation(this, academySet, academyName, systemId);
-    }
-
-    @Nonnull
-    public AcademyCampusLocation getOrCreateLocalCampusLocation(String academySet,
-          String academyName) {
-        return getCampaignLocationManager().getOrCreateLocalCampusLocation(this, academySet, academyName);
-    }
-
-    @Nonnull
-    public AcademyCampusLocation getOrCreateCampusUnderLocation(String academySet, String academyName,
-          ILocation parent) {
-        return getCampaignLocationManager().getOrCreateCampusUnderLocation(academySet, academyName, parent);
     }
 
     public void moveToPlanetarySystem(PlanetarySystem planetarySystem) {
@@ -2147,7 +2097,7 @@ public class Campaign implements ITechManager, IPlace {
      */
     public Collection<Unit> getAllUnits() {
         List<Unit> units = new ArrayList<>();
-        for (AbstractLocation location : getLocations()) {
+        for (AbstractLocation location : getCampaignLocationManager().getLocations()) {
             Set<Unit> found = location.fetchUnitsAtLocation();
             units.addAll(found);
         }

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -464,7 +464,7 @@ public class CampaignNewDayManager {
 
         campaign.readNews();
 
-        for (AbstractLocation location : new ArrayList<>(campaign.getLocations())) {
+        for (AbstractLocation location : new ArrayList<>(campaign.getCampaignLocationManager().getLocations())) {
             location.newDay(campaign, location != updatedLocation);
         }
         updatedLocation = campaign.getCurrentLocation();
@@ -476,7 +476,7 @@ public class CampaignNewDayManager {
 
         processAllArrivals();
 
-        campaign.pruneEmptyLocations();
+        campaign.getCampaignLocationManager().pruneEmptyLocations(campaign);
 
         if (campaignOptions.isUseRandomDiseases() && campaignOptions.isUseAlternativeAdvancedMedical()) {
             PlanetarySystem currentSystem = updatedLocation.getCurrentSystem();
@@ -697,10 +697,10 @@ public class CampaignNewDayManager {
      */
 
     private void processAllArrivals() {
-        for (AbstractLocation location : new ArrayList<>(campaign.getLocations())) {
+        for (AbstractLocation location : new ArrayList<>(campaign.getCampaignLocationManager().getLocations())) {
             location.processArrivals(campaign);
         }
-        for (PlayerBase base : campaign.getPlayerBases()) {
+        for (PlayerBase base : campaign.getCampaignLocationManager().getPlayerBases()) {
             base.processArrivals(campaign);
         }
         campaign.processArrivals(campaign);

--- a/MekHQ/src/mekhq/campaign/ForceLocationManager.java
+++ b/MekHQ/src/mekhq/campaign/ForceLocationManager.java
@@ -33,6 +33,8 @@
 
 package mekhq.campaign;
 
+import static mekhq.campaign.market.contractMarket.ContractAutomation.performAutomatedActivation;
+
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,7 +47,6 @@ import mekhq.campaign.location.ILocation;
 import mekhq.campaign.location.IPlace;
 import mekhq.campaign.location.LocationDispatch;
 import mekhq.campaign.location.LocationNode;
-import mekhq.campaign.market.contractMarket.ContractAutomation;
 import mekhq.campaign.personnel.medical.advancedMedicalAlternate.Inoculations;
 import mekhq.campaign.universe.PlanetarySystem;
 
@@ -82,35 +83,27 @@ public class ForceLocationManager {
         }
 
         @Override
-        @Nonnull
         public LocationNode getLocationNode() {
             return campaign.getLocationNode();
         }
 
         @Override
-        @Nonnull
         public Hangar getHangar() {
             return campaign.getHangar();
         }
 
         @Override
-        @Nonnull
         public Warehouse getWarehouse() {
             return campaign.getWarehouse();
         }
 
         @Override
-        @Nonnull
         public Personnel getPersonnel() {
             return campaign.getMainForcePersonnel();
         }
 
         List<UUID> getAutomatedMothballUnits() {
             return campaign.getAutomatedMothballUnits();
-        }
-
-        void performAutomatedActivation() {
-            ContractAutomation.performAutomatedActivation(campaign);
         }
     }
 
@@ -160,7 +153,8 @@ public class ForceLocationManager {
                   mainForce.getPersonnel(),
                   mainForce.getHangar(),
                   mainForce.getWarehouse(),
-                  campaign);
+                  campaign,
+                  campaign.getCampaignLocationManager());
         }
     }
 
@@ -184,7 +178,7 @@ public class ForceLocationManager {
         MekHQ.triggerEvent(new LocationChangedEvent(mainForce.getCurrentLocation(), false));
 
         if (mainForce.getAutomatedMothballUnits().isEmpty()) {
-            mainForce.performAutomatedActivation();
+            performAutomatedActivation(campaign);
         }
 
         if (campaign.getCampaignOptions().isUseRandomDiseases()

--- a/MekHQ/src/mekhq/campaign/ForceLocationManager.java
+++ b/MekHQ/src/mekhq/campaign/ForceLocationManager.java
@@ -88,16 +88,19 @@ public class ForceLocationManager {
         }
 
         @Override
+        @Nonnull
         public Hangar getHangar() {
             return campaign.getHangar();
         }
 
         @Override
+        @Nonnull
         public Warehouse getWarehouse() {
             return campaign.getWarehouse();
         }
 
         @Override
+        @Nonnull
         public Personnel getPersonnel() {
             return campaign.getMainForcePersonnel();
         }

--- a/MekHQ/src/mekhq/campaign/base/PlayerBase.java
+++ b/MekHQ/src/mekhq/campaign/base/PlayerBase.java
@@ -187,7 +187,7 @@ public class PlayerBase extends AbstractBase {
                     CurrentLocation travelLocation = CurrentLocation.generateInstanceFromXML(wn2, campaign);
                     if (travelLocation != null) {
                         travelLocation.setParent(base);
-                        campaign.addLocation(travelLocation);
+                        campaign.getCampaignLocationManager().addLocation(travelLocation);
                     }
                 } else if (nodeName.equalsIgnoreCase("academyCampus")) {
                     AcademyCampusLocation campus = AcademyCampusLocation.generateInstanceFromXML(wn2);
@@ -203,7 +203,7 @@ public class PlayerBase extends AbstractBase {
                                 CurrentLocation travelNode = CurrentLocation.generateInstanceFromXML(campusChild, campaign);
                                 if (travelNode != null) {
                                     travelNode.setParent(campus);
-                                    campaign.addLocation(travelNode);
+                                    campaign.getCampaignLocationManager().addLocation(travelNode);
                                 }
                             }
                         }

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -539,7 +539,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
         // Fix campaign references for units in base hangars.
         // These units are NOT in campaign.getHangar(), so the loop above skips them.
         // They need setCampaign() and fixReferences() just like main-force units.
-        for (PlayerBase base : campaign.getPlayerBases()) {
+        for (PlayerBase base : campaign.getCampaignLocationManager().getPlayerBases()) {
             base.getBaseHangar().forEachUnit(unit -> initializeBaseUnit(unit, campaign));
         }
 
@@ -653,7 +653,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
             campaign.removeUnit(unit.getId());
         }
 
-        for (PlayerBase base : campaign.getPlayerBases()) {
+        for (PlayerBase base : campaign.getCampaignLocationManager().getPlayerBases()) {
             base.getBaseHangar().forEachUnit(unit -> {
                 unit.initializeParts(false);
                 unit.runDiagnostic(false);
@@ -799,10 +799,10 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
         // one item. If we didn't find an explicit main force location, use that one. To check for this, if we didn't
         // find a main force location, check if we have more than one location in our list (by default,
         // will set and add a location to Campaign during the constructor.
-        if ((!foundMainForceLocation) && (campaign.getLocations().size() > 1)) {
+        if ((!foundMainForceLocation) && (campaign.getCampaignLocationManager().getLocations().size() > 1)) {
             // Remove the location that was set by default, then use a valid location out of our locations list.
-            campaign.removeLocation(campaign.getCurrentLocation());
-            campaign.getLocations().stream()
+            campaign.getCampaignLocationManager().removeLocation(campaign.getCurrentLocation());
+            campaign.getCampaignLocationManager().getLocations().stream()
                   .filter(loc -> loc instanceof CurrentLocation)
                   .findFirst()
                   .ifPresent(campaign::setLocation);
@@ -1470,7 +1470,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
             }
             AbstractLocation location = AbstractLocation.generateInstanceFromXML(child, campaign);
             if (location != null) {
-                campaign.addLocation(location);
+                campaign.getCampaignLocationManager().addLocation(location);
             }
         }
     }
@@ -1508,7 +1508,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
             if (wn2.getNodeName().equalsIgnoreCase("playerBase")) {
                 PlayerBase base = PlayerBase.generateInstanceFromXML(wn2, campaign, version);
                 if (base != null) {
-                    campaign.addPlayerBase(base);
+                    campaign.getCampaignLocationManager().addPlayerBase(base);
                     for (UUID personId : base.drainPendingPersonIds()) {
                         Person person = campaign.getPerson(personId);
                         if (person != null) {
@@ -1730,7 +1730,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
      * the campaign's main collections.</p>
      */
     private static void reconnectPersonsToTravelLocations(Campaign campaign) {
-        for (AbstractLocation location : campaign.getLocations()) {
+        for (AbstractLocation location : campaign.getCampaignLocationManager().getLocations()) {
             if (location instanceof CurrentLocation currentLocation) {
                 // Orphaned, non-transiting CurrentLocations are stale transit records.
                 // They appear in <locations> (rather than inside a <playerBase>) because
@@ -1811,7 +1811,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
         }
 
         // Persons at campaign-root campuses (homeSchool) — same pattern as FixedLocation campuses above.
-        // Campaign itself is not in campaign.getLocations(), so its direct campus children are never
+        // Campaign itself is not in campaign.getCampaignLocationManager().getLocations(), so its direct campus children are never
         // visited by the loop above.
         for (ILocation location : campaign.getChildLocations()) {
             if (location instanceof AcademyCampusLocation campusLocation) {
@@ -1837,7 +1837,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
         if (unit != null) {
             return unit;
         }
-        for (PlayerBase base : campaign.getPlayerBases()) {
+        for (PlayerBase base : campaign.getCampaignLocationManager().getPlayerBases()) {
             unit = base.getBaseHangar().getUnit(unitId);
             if (unit != null) {
                 return unit;
@@ -1852,7 +1852,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
         if (part != null) {
             return part;
         }
-        for (PlayerBase base : campaign.getPlayerBases()) {
+        for (PlayerBase base : campaign.getCampaignLocationManager().getPlayerBases()) {
             part = base.getBaseWarehouse().getPart(partId);
             if (part != null) {
                 return part;
@@ -1949,7 +1949,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                           + " — skipping campus placement", person.getFullTitle(), stage);
                     continue;
                 }
-                AcademyCampusLocation campusLocation = campaign.getOrCreateCampusLocation(
+                AcademyCampusLocation campusLocation = campaign.getCampaignLocationManager().getOrCreateCampusLocation(campaign, 
                       person.getEduAcademySet(), person.getEduAcademyNameInSet(), systemId);
                 if (campusLocation != null) {
                     LOGGER.info("migrateLegacyEducationTravel: placed {} at campus '{}' in system {}",
@@ -1983,7 +1983,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                   person.getFullTitle(), stage, targetSystem.getId(), transitTime);
 
             CurrentLocation travelLocation = new CurrentLocation(targetSystem, transitTime);
-            AcademyCampusLocation campusLocation = campaign.getOrCreateCampusLocation(
+            AcademyCampusLocation campusLocation = campaign.getCampaignLocationManager().getOrCreateCampusLocation(campaign, 
                   person.getEduAcademySet(), person.getEduAcademyNameInSet(), systemId);
             if (campusLocation != null) {
                 LOGGER.info("migrateLegacyEducationTravel: parenting travel node under campus '{}' for {}",
@@ -1995,7 +1995,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                 travelLocation.setParent(campaign);
             }
             person.setParent(travelLocation);
-            campaign.addLocation(travelLocation);
+            campaign.getCampaignLocationManager().addLocation(travelLocation);
             travelMigrated++;
         }
 
@@ -2004,7 +2004,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
     }
 
     private static boolean hasFixedCampusPendingFor(Campaign campaign, Person person) {
-        for (AbstractLocation location : campaign.getLocations()) {
+        for (AbstractLocation location : campaign.getCampaignLocationManager().getLocations()) {
             if (!(location instanceof FixedLocation fixedLocation)) {
                 continue;
             }
@@ -2019,7 +2019,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
     }
 
     private static boolean hasTravelNodePendingFor(Campaign campaign, Person person) {
-        for (AbstractLocation location : campaign.getLocations()) {
+        for (AbstractLocation location : campaign.getCampaignLocationManager().getLocations()) {
             if (location instanceof CurrentLocation travelNode
                       && travelNode.containsPendingPersonId(person.getId())) {
                 return true;
@@ -2523,7 +2523,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
      * scoped to the base the unit is stationed at.
      */
     private static void rehomeBaseHangarUnitParts(Campaign campaign) {
-        for (PlayerBase base : campaign.getPlayerBases()) {
+        for (PlayerBase base : campaign.getCampaignLocationManager().getPlayerBases()) {
             Warehouse baseWarehouse = base.getBaseWarehouse();
             base.getBaseHangar().forEachUnit(unit -> {
                 for (Part part : unit.getParts()) {
@@ -2540,7 +2540,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
     private static void postProcessParts(Campaign retVal, Version version) {
         List<Part> removeParts = new ArrayList<>();
         postProcessWarehouse(retVal.getWarehouse(), retVal, removeParts);
-        for (PlayerBase base : retVal.getPlayerBases()) {
+        for (PlayerBase base : retVal.getCampaignLocationManager().getPlayerBases()) {
             postProcessWarehouse(base.getBaseWarehouse(), retVal, removeParts);
         }
         for (Part prt : removeParts) {

--- a/MekHQ/src/mekhq/campaign/location/IPlace.java
+++ b/MekHQ/src/mekhq/campaign/location/IPlace.java
@@ -188,7 +188,8 @@ public interface IPlace extends ILocation {
             if (!travelNode.hasArrived()) {
                 continue;
             }
-            LocationDispatch.landFromTravelNode(travelNode, personnel, hangar, warehouse, campaign);
+            LocationDispatch.landFromTravelNode(travelNode, personnel, hangar, warehouse, campaign,
+                  campaign.getCampaignLocationManager());
         }
     }
 }

--- a/MekHQ/src/mekhq/campaign/location/LocationDispatch.java
+++ b/MekHQ/src/mekhq/campaign/location/LocationDispatch.java
@@ -45,6 +45,7 @@ import megamek.common.annotations.Nullable;
 import megamek.logging.MMLogger;
 import mekhq.campaign.AbstractMobileLocation;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.CampaignLocationManager;
 import mekhq.campaign.CurrentLocation;
 import mekhq.campaign.Hangar;
 import mekhq.campaign.JumpPath;
@@ -109,15 +110,15 @@ public final class LocationDispatch {
      *
      * <p>Safe to call with a {@code null} argument (no-op).</p>
      *
-     * @param travelNode the node to remove, or {@code null}
-     * @param campaign   the active campaign; must not be {@code null}
+     * @param travelNode      the node to remove, or {@code null}
+     * @param locationManager the campaign's location registry; must not be {@code null}
      */
-    public static void removeTravelNode(@Nullable AbstractMobileLocation travelNode, Campaign campaign) {
+    public static void removeTravelNode(@Nullable AbstractMobileLocation travelNode, CampaignLocationManager locationManager) {
         if (travelNode == null) {
             return;
         }
         travelNode.setParent(null);
-        campaign.removeLocation(travelNode);
+        locationManager.removeLocation(travelNode);
     }
 
     /**
@@ -131,39 +132,43 @@ public final class LocationDispatch {
      *
      * @param travelNode        the completed travel node; must not be {@code null}
      * @param personDestination destination container for persons; if {@code null}, persons fall back to
-     *                          {@code campaign} with a warning
+     *                          {@code fallbackLocation} with a warning
      * @param unitDestination   destination container for units; if {@code null}, units fall back to
-     *                          {@code campaign} with a warning
+     *                          {@code fallbackLocation} with a warning
      * @param partDestination   destination container for parts; if {@code null}, parts fall back to
-     *                          {@code campaign} with a warning
-     * @param campaign          the active campaign; must not be {@code null}
+     *                          {@code fallbackLocation} with a warning
+     * @param fallbackLocation  the location to land items at when their destination is {@code null} (currently the
+     *                          campaign root); must not be {@code null}
+     * @param locationManager   the campaign's location registry, used to de-register the spent node; must not be
+     *                          {@code null}
      */
     public static void landFromTravelNode(AbstractMobileLocation travelNode,
           @Nullable ILocation personDestination,
           @Nullable ILocation unitDestination,
           @Nullable ILocation partDestination,
-          Campaign campaign) {
+          ILocation fallbackLocation,
+          CampaignLocationManager locationManager) {
         if (personDestination == null) {
-            LOGGER.warn("landFromTravelNode: null personDestination; landing persons at Campaign root");
+            LOGGER.warn("landFromTravelNode: null personDestination; landing persons at fallback location");
         }
         if (unitDestination == null) {
-            LOGGER.warn("landFromTravelNode: null unitDestination; landing units at Campaign root");
+            LOGGER.warn("landFromTravelNode: null unitDestination; landing units at fallback location");
         }
         if (partDestination == null) {
-            LOGGER.warn("landFromTravelNode: null partDestination; landing parts at Campaign root");
+            LOGGER.warn("landFromTravelNode: null partDestination; landing parts at fallback location");
         }
         landFromTravelNodeImpl(travelNode,
-              personDestination != null ? personDestination : campaign,
-              unitDestination != null ? unitDestination : campaign,
-              partDestination != null ? partDestination : campaign,
-              campaign);
+              personDestination != null ? personDestination : fallbackLocation,
+              unitDestination != null ? unitDestination : fallbackLocation,
+              partDestination != null ? partDestination : fallbackLocation,
+              locationManager);
     }
 
     private static void landFromTravelNodeImpl(AbstractMobileLocation travelNode,
           ILocation personDestination,
           ILocation unitDestination,
           ILocation partDestination,
-          Campaign campaign) {
+          CampaignLocationManager locationManager) {
         for (Person person : new ArrayList<>(travelNode.fetchPersonnelAtLocation())) {
             person.setParent(personDestination);
         }
@@ -173,7 +178,7 @@ public final class LocationDispatch {
         for (Part part : new ArrayList<>(travelNode.fetchPartsAtLocation())) {
             LocationNode.LocationManager.setLocation(part, partDestination);
         }
-        removeTravelNode(travelNode, campaign);
+        removeTravelNode(travelNode, locationManager);
     }
 
     /**
@@ -182,14 +187,14 @@ public final class LocationDispatch {
      * immediately {@code true} and {@link IPlace#processArrivals} will land all carried items on
      * its next call.
      */
-    private static CurrentLocation buildArrivedNode(PlanetarySystem system, ILocation destination, Campaign campaign,
-          String logContext) {
+    private static CurrentLocation buildArrivedNode(PlanetarySystem system, ILocation destination,
+          CampaignLocationManager locationManager, String logContext) {
         CurrentLocation arrivedLocation = new CurrentLocation(system, 0.0);
         if (!arrivedLocation.setParent(destination)) {
             LOGGER.warn("{}: setParent failed for arrivedLocation → {}",
                   logContext, destination.getClass().getSimpleName());
         }
-        campaign.addLocation(arrivedLocation);
+        locationManager.addLocation(arrivedLocation);
         return arrivedLocation;
     }
 
@@ -214,7 +219,7 @@ public final class LocationDispatch {
                   + "items may display as Main Force after save/load",
                   logContext, destination.getClass().getSimpleName());
         }
-        campaign.addLocation(travelNode);
+        campaign.getCampaignLocationManager().addLocation(travelNode);
         return Optional.of(travelNode);
     }
 
@@ -365,7 +370,8 @@ public final class LocationDispatch {
     private static void land(List<? extends ILocation> group, ILocation destination, ILocation directLandingTarget,
           PlanetarySystem system, Campaign campaign, String logMarker) {
         if (destination instanceof AbstractBase) {
-            CurrentLocation arrivedLocation = buildArrivedNode(system, destination, campaign, logMarker);
+            CurrentLocation arrivedLocation = buildArrivedNode(system, destination,
+                  campaign.getCampaignLocationManager(), logMarker);
             group.forEach(item -> reparent(item, arrivedLocation));
         } else {
             group.forEach(item -> reparent(item, directLandingTarget));

--- a/MekHQ/src/mekhq/campaign/location/LocationDispatch.java
+++ b/MekHQ/src/mekhq/campaign/location/LocationDispatch.java
@@ -347,14 +347,15 @@ public final class LocationDispatch {
 
             if (destinationSystem == null || fromSystem.equals(destinationSystem)) {
                 PlanetarySystem system = destinationSystem != null ? destinationSystem : fromSystem;
-                land(group, destination, directLandingTarget, system, campaign, logMarker);
+                land(group, destination, directLandingTarget, system, campaign.getCampaignLocationManager(), logMarker);
                 continue;
             }
 
             Optional<CurrentLocation> maybeTravelLocation = buildTravelNode(
                   fromSystem, destinationSystem, destination, campaign, logMarker);
             if (maybeTravelLocation.isEmpty()) {
-                land(group, destination, directLandingTarget, destinationSystem, campaign, logMarker);
+                land(group, destination, directLandingTarget, destinationSystem,
+                      campaign.getCampaignLocationManager(), logMarker);
                 continue;
             }
             CurrentLocation travelLocation = maybeTravelLocation.get();
@@ -368,10 +369,9 @@ public final class LocationDispatch {
      * {@code directLandingTarget}.
      */
     private static void land(List<? extends ILocation> group, ILocation destination, ILocation directLandingTarget,
-          PlanetarySystem system, Campaign campaign, String logMarker) {
+          PlanetarySystem system, CampaignLocationManager locationManager, String logMarker) {
         if (destination instanceof AbstractBase) {
-            CurrentLocation arrivedLocation = buildArrivedNode(system, destination,
-                  campaign.getCampaignLocationManager(), logMarker);
+            CurrentLocation arrivedLocation = buildArrivedNode(system, destination, locationManager, logMarker);
             group.forEach(item -> reparent(item, arrivedLocation));
         } else {
             group.forEach(item -> reparent(item, directLandingTarget));

--- a/MekHQ/src/mekhq/campaign/location/LocationNewDayUtil.java
+++ b/MekHQ/src/mekhq/campaign/location/LocationNewDayUtil.java
@@ -246,7 +246,7 @@ public final class LocationNewDayUtil {
      * location).
      */
     public static void processAllLocationUnits(Campaign campaign) {
-        for (AbstractLocation location : campaign.getLocations()) {
+        for (AbstractLocation location : campaign.getCampaignLocationManager().getLocations()) {
             for (ILocation child : location.getChildLocations()) {
                 if (child instanceof IPlace place) {
                     processNewDayUnits(place, campaign);

--- a/MekHQ/src/mekhq/campaign/location/LocationNode.java
+++ b/MekHQ/src/mekhq/campaign/location/LocationNode.java
@@ -180,7 +180,7 @@ public class LocationNode {
                                 CurrentLocation travelNode = CurrentLocation.generateInstanceFromXML(campusChild, campaign);
                                 if (travelNode != null) {
                                     LocationManager.setLocation(travelNode, campus);
-                                    campaign.addLocation(travelNode);
+                                    campaign.getCampaignLocationManager().addLocation(travelNode);
                                 }
                             }
                         }
@@ -189,7 +189,7 @@ public class LocationNode {
                     CurrentLocation travelNode = CurrentLocation.generateInstanceFromXML(wn, campaign);
                     if (travelNode != null) {
                         LocationManager.setLocation(travelNode, parent);
-                        campaign.addLocation(travelNode);
+                        campaign.getCampaignLocationManager().addLocation(travelNode);
                     }
                 } else {
                     // Person, Unit, and Part reconnection will be added here

--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -323,7 +323,7 @@ public class EducationController {
             // if the student is being homeschooled, we skip the journey to the 'academy'
             person.setEduEducationStage(EducationStage.EDUCATION);
             IPlace homeSchoolLocation = findHomeLocation(person, campaign);
-            AcademyCampusLocation campusLocation = campaign.getOrCreateCampusUnderLocation(
+            AcademyCampusLocation campusLocation = campaign.getCampaignLocationManager().getOrCreateCampusUnderLocation(
                   academy.getSet(), academy.getName(), homeSchoolLocation);
             person.setParent(campusLocation.getPersonnel());
         } else if (academy.isLocal()) {
@@ -347,7 +347,7 @@ public class EducationController {
         if (!academy.isHomeSchool() && !academy.isLocal()) {
             PlanetarySystem originSystem = person.getCurrentSystem();
             person.setEduAcademySystem(campus);
-            AcademyCampusLocation campusLocation = campaign.getOrCreateCampusLocation(academy.getSet(),
+            AcademyCampusLocation campusLocation = campaign.getCampaignLocationManager().getOrCreateCampusLocation(campaign, academy.getSet(),
                   academy.getName(), academy.getLocationSystems().getFirst());
             LocationDispatch.dispatchToLocation(List.of(person), campusLocation, campaign);
             double startTransit = originSystem != null && originSystem.equals(campaign.getCurrentSystem())
@@ -427,7 +427,7 @@ public class EducationController {
         if (academy.isHomeSchool()) {
             person.setEduEducationStage(EducationStage.EDUCATION);
             IPlace homeBase = findHomeLocation(person, campaign);
-            AcademyCampusLocation campusLocation = campaign.getOrCreateCampusUnderLocation(
+            AcademyCampusLocation campusLocation = campaign.getCampaignLocationManager().getOrCreateCampusUnderLocation(
                   academy.getSet(), academy.getName(), homeBase);
             person.setParent(campusLocation.getPersonnel());
         } else if (academy.isLocal()) {
@@ -662,13 +662,13 @@ public class EducationController {
         campaign.addReport(PERSONNEL,
               getFormattedTextAt(BUNDLE_NAME, "arrived.text", person.getHyperlinkedFullTitle()));
 
-        AcademyCampusLocation campusLocation = campaign.getOrCreateCampusLocation(
+        AcademyCampusLocation campusLocation = campaign.getCampaignLocationManager().getOrCreateCampusLocation(campaign, 
               person.getEduAcademySet(), person.getEduAcademyNameInSet(), person.getEduAcademySystem());
         if (campusLocation == null) {
             throw new IllegalStateException("Campus location must exist for system " + person.getEduAcademySystem());
         }
         person.setParent(campusLocation.getPersonnel());
-        LocationDispatch.removeTravelNode(travelLocation, campaign);
+        LocationDispatch.removeTravelNode(travelLocation, campaign.getCampaignLocationManager());
         person.setEduEducationStage(EducationStage.EDUCATION);
     }
 
@@ -919,12 +919,12 @@ public class EducationController {
             }
         }
 
-        LocationDispatch.removeTravelNode(returnLocation, campaign);
+        LocationDispatch.removeTravelNode(returnLocation, campaign.getCampaignLocationManager());
     }
 
     private static Personnel findPersonnelWhenReturningFromLocal(Campaign campaign, @Nullable String systemId) {
         if (systemId != null) {
-            for (PlayerBase base : campaign.getPlayerBases()) {
+            for (PlayerBase base : campaign.getCampaignLocationManager().getPlayerBases()) {
                 PlanetarySystem system = base.getCurrentSystem();
                 if (system != null && systemId.equals(system.getId())) {
                     return base.getPersonnel();

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -57,8 +57,15 @@ import java.io.PrintWriter;
 import java.io.Serial;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.ResourceBundle;
+import java.util.UUID;
 import java.util.stream.IntStream;
 import java.util.zip.GZIPOutputStream;
 import javax.swing.*;
@@ -1484,7 +1491,7 @@ public class CampaignGUI extends JPanel {
         DefaultComboBoxModel<LocationFilterItem> model = new DefaultComboBoxModel<>();
         model.addElement(LocationFilterItem.ALL);
         model.addElement(LocationFilterItem.MAIN_FORCE);
-        for (PlayerBase base : getCampaign().getPlayerBases()) {
+        for (PlayerBase base : getCampaign().getCampaignLocationManager().getPlayerBases()) {
             model.addElement(LocationFilterItem.forBase(base));
         }
         return model;
@@ -1636,7 +1643,7 @@ public class CampaignGUI extends JPanel {
 
     private void refreshCampaignControlButtons() {
         boolean emptyHangar = getCampaign().getUnits().isEmpty() &&
-                                    getCampaign().getPlayerBases()
+                                    getCampaign().getCampaignLocationManager().getPlayerBases()
                                           .stream()
                                           .allMatch(base -> base.getBaseHangar().getUnits().isEmpty());
         boolean noPersonnel = getCampaign().getAllPersonnel().isEmpty();

--- a/MekHQ/src/mekhq/gui/LocationsTab.java
+++ b/MekHQ/src/mekhq/gui/LocationsTab.java
@@ -437,7 +437,7 @@ public class LocationsTab extends CampaignGuiTab {
         void refresh(Campaign campaign) {
             List<IPlace> places = new ArrayList<>();
             places.add(campaign);
-            places.addAll(campaign.getPlayerBases());
+            places.addAll(campaign.getCampaignLocationManager().getPlayerBases());
             model.setData(places, campaign);
         }
 

--- a/MekHQ/src/mekhq/gui/dialog/BaseSettingsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BaseSettingsDialog.java
@@ -472,7 +472,7 @@ public class BaseSettingsDialog extends JDialog {
         base.setPlanetId(selectedPlanet != null ? selectedPlanet.getId() : null);
 
         if (existingBase == null) {
-            campaign.addPlayerBase(base);
+            campaign.getCampaignLocationManager().addPlayerBase(base);
         }
 
         result = base;

--- a/MekHQ/src/mekhq/gui/menus/SendToLocationMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/SendToLocationMenu.java
@@ -122,7 +122,7 @@ public class SendToLocationMenu extends JScrollableMenu {
 
         // One entry per player base, nested by display type
         Map<String, JMenu> pathToMenu = new HashMap<>();
-        for (PlayerBase base : campaign.getPlayerBases()) {
+        for (PlayerBase base : campaign.getCampaignLocationManager().getPlayerBases()) {
             // Use == (identity) — equals() on Personnel compares map contents, not object identity
             if (sharedCurrent == base
                   || sharedCurrent == base.getBasePersonnel()

--- a/MekHQ/src/mekhq/gui/model/LocationDisplay.java
+++ b/MekHQ/src/mekhq/gui/model/LocationDisplay.java
@@ -252,7 +252,7 @@ public final class LocationDisplay {
 
     /** Returns the player base anchored at {@code system}, or {@code null} if there is none. */
     private static @Nullable PlayerBase findBaseAtSystem(Campaign campaign, PlanetarySystem system) {
-        for (PlayerBase base : campaign.getPlayerBases()) {
+        for (PlayerBase base : campaign.getCampaignLocationManager().getPlayerBases()) {
             if (system.equals(base.getCurrentSystem())) {
                 return base;
             }

--- a/MekHQ/src/mekhq/gui/model/LocationFilterItem.java
+++ b/MekHQ/src/mekhq/gui/model/LocationFilterItem.java
@@ -109,7 +109,7 @@ public final class LocationFilterItem {
     public List<Unit> selectUnits(Campaign campaign) {
         if (isAll()) {
             List<Unit> units = new ArrayList<>(campaign.getHangar().getUnits());
-            for (PlayerBase playerBase : campaign.getPlayerBases()) {
+            for (PlayerBase playerBase : campaign.getCampaignLocationManager().getPlayerBases()) {
                 units.addAll(playerBase.getBaseHangar().getUnits());
             }
             return units;
@@ -141,7 +141,7 @@ public final class LocationFilterItem {
     public List<Part> selectSpareParts(Campaign campaign) {
         if (isAll()) {
             List<Part> parts = new ArrayList<>(campaign.getWarehouse().getSpareParts());
-            for (PlayerBase playerBase : campaign.getPlayerBases()) {
+            for (PlayerBase playerBase : campaign.getCampaignLocationManager().getPlayerBases()) {
                 parts.addAll(playerBase.getBaseWarehouse().getSpareParts());
             }
             return parts;

--- a/MekHQ/unittests/mekhq/campaign/CampaignTest.java
+++ b/MekHQ/unittests/mekhq/campaign/CampaignTest.java
@@ -1137,15 +1137,15 @@ public class CampaignTest {
 
                 campaign.setLocation(newLocation);
 
-                assertEquals(1, campaign.getLocations().size());
-                assertSame(newLocation, campaign.getLocations().get(0));
+                assertEquals(1, campaign.getCampaignLocationManager().getLocations().size());
+                assertSame(newLocation, campaign.getCampaignLocationManager().getLocations().get(0));
             }
 
             @Test
             void setLocation_null_clearsLocations() {
                 campaign.setLocation(null);
 
-                assertTrue(campaign.getLocations().isEmpty());
+                assertTrue(campaign.getCampaignLocationManager().getLocations().isEmpty());
             }
 
             @Test
@@ -1178,7 +1178,7 @@ public class CampaignTest {
                 CurrentLocation newLocation = new CurrentLocation(newSystem, 0.0);
                 campaign.setLocation(newLocation);
 
-                assertTrue(campaign.getLocations().contains(old));
+                assertTrue(campaign.getCampaignLocationManager().getLocations().contains(old));
             }
         }
 
@@ -1188,13 +1188,13 @@ public class CampaignTest {
 
             @Test
             void addLocation_appendsToExistingList() {
-                int sizeBefore = campaign.getLocations().size();
+                int sizeBefore = campaign.getCampaignLocationManager().getLocations().size();
                 PlanetarySystem system = mock(PlanetarySystem.class);
                 CurrentLocation extra = new CurrentLocation(system, 0.0);
 
-                campaign.addLocation(extra);
+                campaign.getCampaignLocationManager().addLocation(extra);
 
-                assertEquals(sizeBefore + 1, campaign.getLocations().size());
+                assertEquals(sizeBefore + 1, campaign.getCampaignLocationManager().getLocations().size());
             }
 
             @Test
@@ -1202,28 +1202,28 @@ public class CampaignTest {
                 PlanetarySystem system = mock(PlanetarySystem.class);
                 CurrentLocation extra = new CurrentLocation(system, 0.0);
 
-                campaign.addLocation(extra);
+                campaign.getCampaignLocationManager().addLocation(extra);
 
-                assertTrue(campaign.getLocations().contains(extra));
+                assertTrue(campaign.getCampaignLocationManager().getLocations().contains(extra));
             }
 
             @Test
             void addLocation_null_doesNotChangeList() {
-                int sizeBefore = campaign.getLocations().size();
+                int sizeBefore = campaign.getCampaignLocationManager().getLocations().size();
 
-                campaign.addLocation(null);
+                campaign.getCampaignLocationManager().addLocation(null);
 
-                assertEquals(sizeBefore, campaign.getLocations().size());
+                assertEquals(sizeBefore, campaign.getCampaignLocationManager().getLocations().size());
             }
 
             @Test
             void addLocation_doesNotClearPrimaryLocation() {
-                AbstractLocation primary = campaign.getLocations().get(0);
+                AbstractLocation primary = campaign.getCampaignLocationManager().getLocations().get(0);
                 PlanetarySystem system = mock(PlanetarySystem.class);
 
-                campaign.addLocation(new CurrentLocation(system, 0.0));
+                campaign.getCampaignLocationManager().addLocation(new CurrentLocation(system, 0.0));
 
-                assertSame(primary, campaign.getLocations().get(0));
+                assertSame(primary, campaign.getCampaignLocationManager().getLocations().get(0));
             }
         }
 
@@ -1237,22 +1237,22 @@ public class CampaignTest {
                 CurrentLocation extra = new CurrentLocation(system, 0.0);
 
                 assertThrows(UnsupportedOperationException.class,
-                      () -> campaign.getLocations().add(extra));
+                      () -> campaign.getCampaignLocationManager().getLocations().add(extra));
             }
 
             @Test
             void getLocations_initiallyContainsOneLocation() {
-                assertEquals(1, campaign.getLocations().size());
+                assertEquals(1, campaign.getCampaignLocationManager().getLocations().size());
             }
 
             @Test
             void getLocations_multipleCallsReflectCurrentState() {
-                int before = campaign.getLocations().size();
+                int before = campaign.getCampaignLocationManager().getLocations().size();
 
                 PlanetarySystem system = mock(PlanetarySystem.class);
-                campaign.addLocation(new CurrentLocation(system, 0.0));
+                campaign.getCampaignLocationManager().addLocation(new CurrentLocation(system, 0.0));
 
-                assertEquals(before + 1, campaign.getLocations().size());
+                assertEquals(before + 1, campaign.getCampaignLocationManager().getLocations().size());
             }
         }
     }

--- a/MekHQ/unittests/mekhq/campaign/location/LocationNodeTest.java
+++ b/MekHQ/unittests/mekhq/campaign/location/LocationNodeTest.java
@@ -50,6 +50,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import mekhq.campaign.Campaign;
+import mekhq.campaign.CampaignLocationManager;
 import mekhq.campaign.CurrentLocation;
 import mekhq.campaign.FixedLocation;
 import mekhq.campaign.base.PlayerBase;
@@ -251,11 +252,14 @@ public class LocationNodeTest {
     class ReconnectChildren {
 
         Campaign mockCampaign;
+        CampaignLocationManager mockLocationManager;
         FixedLocation parentFixed;
 
         @BeforeEach
         void setUp() {
             mockCampaign = mock(Campaign.class);
+            mockLocationManager = mock(CampaignLocationManager.class);
+            when(mockCampaign.getCampaignLocationManager()).thenReturn(mockLocationManager);
             parentFixed = new FixedLocation(mock(PlanetarySystem.class));
         }
 
@@ -333,7 +337,7 @@ public class LocationNodeTest {
 
             LocationNode.reconnectChildren(parseXml(xml), parentFixed, mockCampaign);
 
-            verify(mockCampaign).addLocation(any(CurrentLocation.class));
+            verify(mockLocationManager).addLocation(any(CurrentLocation.class));
         }
 
         @Test

--- a/MekHQ/unittests/mekhq/campaign/personnel/PersonTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/PersonTest.java
@@ -66,6 +66,7 @@ import megamek.common.units.Entity;
 import megamek.common.units.EntityWeightClass;
 import mekhq.EventSpy;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.CampaignLocationManager;
 import mekhq.campaign.CurrentLocation;
 import mekhq.campaign.FixedLocation;
 import mekhq.campaign.Hangar;
@@ -1564,6 +1565,7 @@ public class PersonTest {
             @BeforeEach
             void setUp() {
                 campaign = mock(Campaign.class);
+                when(campaign.getCampaignLocationManager()).thenReturn(mock(CampaignLocationManager.class));
                 when(campaign.getLocalDate()).thenReturn(LocalDate.of(3025, 1, 1));
 
                 CampaignOptions options = mock(CampaignOptions.class);
@@ -1582,11 +1584,11 @@ public class PersonTest {
                 PlanetarySystem currentSystem = mock(PlanetarySystem.class);
                 when(currentSystem.getId()).thenReturn("CurrentSystem");
                 when(campaign.getCurrentSystem()).thenReturn(currentSystem);
-                when(campaign.getOrCreateCampusLocation(any(), any(), any()))
+                when(campaign.getCampaignLocationManager().getOrCreateCampusLocation(any(), any(), any(), any()))
                       .thenReturn(new AcademyCampusLocation(ACADEMY_SET, ACADEMY_NAME));
-                when(campaign.getOrCreateLocalCampusLocation(any(), any()))
+                when(campaign.getCampaignLocationManager().getOrCreateLocalCampusLocation(any(), any(), any()))
                       .thenReturn(new AcademyCampusLocation(ACADEMY_SET, ACADEMY_NAME));
-                when(campaign.getOrCreateCampusUnderLocation(any(), any(), any()))
+                when(campaign.getCampaignLocationManager().getOrCreateCampusUnderLocation(any(), any(), any()))
                       .thenReturn(new AcademyCampusLocation(ACADEMY_SET, ACADEMY_NAME));
             }
 
@@ -1644,6 +1646,7 @@ public class PersonTest {
             @BeforeEach
             void setUp() {
                 campaign = mock(Campaign.class);
+                when(campaign.getCampaignLocationManager()).thenReturn(mock(CampaignLocationManager.class));
                 when(campaign.getLocalDate()).thenReturn(LocalDate.of(3025, 1, 1));
 
                 CampaignOptions options = mock(CampaignOptions.class);

--- a/MekHQ/unittests/mekhq/campaign/personnel/education/EducationControllerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/education/EducationControllerTest.java
@@ -47,6 +47,7 @@ import java.util.Collections;
 import java.util.List;
 
 import mekhq.campaign.Campaign;
+import mekhq.campaign.CampaignLocationManager;
 import mekhq.campaign.CurrentLocation;
 import mekhq.campaign.Hangar;
 import mekhq.campaign.JumpPath;
@@ -111,6 +112,8 @@ class EducationControllerTest {
         when(currentSystem.getId()).thenReturn("CurrentSystem");
         when(campaign.getCurrentSystem()).thenReturn(currentSystem);
 
+        when(campaign.getCampaignLocationManager()).thenReturn(mock(CampaignLocationManager.class));
+
         return campaign;
     }
 
@@ -135,10 +138,11 @@ class EducationControllerTest {
             person.setEduAcademySystem("TestSystem");
             person.setEduEducationStage(EducationStage.JOURNEY_TO_CAMPUS);
             campaign = mock(Campaign.class);
+            when(campaign.getCampaignLocationManager()).thenReturn(mock(CampaignLocationManager.class));
             PlanetarySystem destSystem = mock(PlanetarySystem.class);
             when(campaign.getSystemById("TestSystem")).thenReturn(destSystem);
             when(campaign.getSimplifiedTravelTime(destSystem)).thenReturn(2);
-            when(campaign.getOrCreateCampusLocation(any(), any(), any()))
+            when(campaign.getCampaignLocationManager().getOrCreateCampusLocation(any(), any(), any(), any()))
                   .thenReturn(new AcademyCampusLocation(ACADEMY_SET, ACADEMY_NAME));
         }
 
@@ -230,9 +234,10 @@ class EducationControllerTest {
 
             destSystem = mock(PlanetarySystem.class);
             campaign = mock(Campaign.class);
+            when(campaign.getCampaignLocationManager()).thenReturn(mock(CampaignLocationManager.class));
             when(campaign.getSystemById("TestSystem")).thenReturn(destSystem);
             when(campaign.getSimplifiedTravelTime(destSystem)).thenReturn(5);
-            when(campaign.getOrCreateCampusLocation(any(), any(), any()))
+            when(campaign.getCampaignLocationManager().getOrCreateCampusLocation(any(), any(), any(), any()))
                   .thenReturn(new AcademyCampusLocation(ACADEMY_SET, ACADEMY_NAME));
 
             PlanetarySystem currentSystem = mock(PlanetarySystem.class);
@@ -315,11 +320,11 @@ class EducationControllerTest {
         @BeforeEach
         void setUp() {
             campaign = buildMinimalCampaignMock();
-            when(campaign.getOrCreateCampusLocation(any(), any(), any()))
+            when(campaign.getCampaignLocationManager().getOrCreateCampusLocation(any(), any(), any(), any()))
                   .thenReturn(new AcademyCampusLocation(ACADEMY_SET, ACADEMY_NAME));
-            when(campaign.getOrCreateLocalCampusLocation(any(), any()))
+            when(campaign.getCampaignLocationManager().getOrCreateLocalCampusLocation(any(), any(), any()))
                   .thenReturn(new AcademyCampusLocation(ACADEMY_SET, ACADEMY_NAME));
-            when(campaign.getOrCreateCampusUnderLocation(any(), any(), any()))
+            when(campaign.getCampaignLocationManager().getOrCreateCampusUnderLocation(any(), any(), any()))
                   .thenReturn(new AcademyCampusLocation(ACADEMY_SET, ACADEMY_NAME));
         }
 


### PR DESCRIPTION
During the current dev cycle I've been working on locations. At the beginning, I was storing the list of all locations managed by the campaign in campaign. However, as we needed more methods and more logic added, I split this into `CampaignLocationManager` and `ForceLocationManager`. This eventually left us in a state where there were methods added to `Campaign` during the current dev cycle that's sole purpose was routing to `*LocationManager`.

In this PR, I've removed several of the methods from `Campaign` that were just delegating to `*LocationManager`. As an added bonus, I was able to update several of the methods to take `*LocationManager` instead of `Campaign` as a parameter. 