### PR TITLE
Optimize PersonnelTable rendering performance

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -4748,6 +4748,14 @@ public class Unit implements ITechnology, ILocation {
         return new EntityImage(base, camouflage, component, getEntity()).loadPreviewImage(showDamage);
     }
 
+    public @Nullable EntityImage getEntityImage() {
+        if (MHQStaticDirectoryManager.getMekTileset() == null) {
+            return null;
+        }
+        final Image base = MHQStaticDirectoryManager.getMekTileset().imageFor(getEntity());
+        return new EntityImage(base, getUtilizedCamouflage(getCampaign()), null, getEntity());
+    }
+
     public Color determineForegroundColor(String type) {
         if (isDeployed()) {
             return MekHQ.getMHQOptions().getDeployedForeground();

--- a/MekHQ/src/mekhq/gui/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/PersonnelTab.java
@@ -344,7 +344,6 @@ public final class PersonnelTab extends CampaignGuiTab {
         personnelTable.setRowSorter(personnelSorter);
         personnelTable.setIntercellSpacing(new Dimension(0, 0));
         personnelTable.setShowGrid(false);
-        changePersonnelView();
         personnelTable.getSelectionModel().addListSelectionListener(ev -> refreshPersonnelView());
 
         scrollPersonnelView = new FastJScrollPane();
@@ -377,7 +376,8 @@ public final class PersonnelTab extends CampaignGuiTab {
 
         PersonnelTableMouseAdapter.connect(getCampaignGui(), personnelTable, personModel, splitPersonnel);
 
-        filterPersonnel();
+        changePersonnelView();
+        refreshPersonnelList();
     }
 
     private DefaultComboBoxModel<PersonnelFilter> createPersonGroupModel() {
@@ -578,7 +578,6 @@ public final class PersonnelTab extends CampaignGuiTab {
     @Subscribe
     public void handle(OptionsChangedEvent ev) {
         changePersonnelView();
-        personnelListScheduler.schedule();
     }
 
     @Subscribe

--- a/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
@@ -33,22 +33,31 @@
 package mekhq.gui.model;
 
 import static mekhq.campaign.personnel.turnoverAndRetention.Fatigue.getEffectiveFatigue;
+import static mekhq.gui.enums.PersonnelTableModelColumn.FORCE_GRAPHICAL;
+import static mekhq.gui.enums.PersonnelTableModelColumn.PERSON_GRAPHICAL;
+import static mekhq.gui.enums.PersonnelTableModelColumn.UNIT_ASSIGNMENT_GRAPHICAL;
 
 import java.awt.Component;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
 import javax.swing.ImageIcon;
 import javax.swing.JTable;
 import javax.swing.UIManager;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableCellRenderer;
 
+import io.sentry.util.Objects;
+import megamek.client.ui.tileset.EntityImage;
 import megamek.common.annotations.Nullable;
+import megamek.common.icons.Portrait;
 import mekhq.MHQOptions;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.force.Formation;
+import mekhq.campaign.icons.StandardFormationIcon;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
 import mekhq.campaign.unit.Unit;
@@ -157,6 +166,15 @@ public class PersonnelTableModel extends DataTableModel<Person> {
     }
 
     public class Renderer extends DefaultTableCellRenderer {
+
+        private static final ComponentColors DEFAULT_COLORS =
+              new ComponentColors(UIManager.getColor("Table.foreground"), UIManager.getColor("Table.background"));
+
+        private final List<String> personalStateFlags = new ArrayList<>();
+        private final Map<Portrait, ImageIcon> portraitCache = new WeakHashMap<>();
+        private final Map<Long, ImageIcon> entityImageCache = new WeakHashMap<>();
+        private final Map<StandardFormationIcon, ImageIcon> formationIconCache = new WeakHashMap<>();
+
         @Override
         public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
               boolean hasFocus, int rowIndex, int columnIndex) {
@@ -168,21 +186,22 @@ public class PersonnelTableModel extends DataTableModel<Person> {
             PersonnelTableModelColumn column = PERSONNEL_COLUMNS[table.convertColumnIndexToModel(columnIndex)];
             Person person = getPerson(modelRow);
 
-            setFont(table.getFont());
+            if (getFont() != table.getFont()) {
+                setFont(table.getFont());
+            }
             setText(column.getText(value));
             setHorizontalAlignment(column.getAlignment());
 
             setIcon(getImage(person, column));
 
-            // Collect all applicable color reasons for tooltip
-            List<String> personalStateFlags = new ArrayList<>();
+            personalStateFlags.clear(); // reuse to avoid memory allocations
             if (isSelected) {
                 setForeground(table.getSelectionForeground());
                 setBackground(table.getSelectionBackground());
             } else {
-                if (column == PersonnelTableModelColumn.PERSON_GRAPHICAL ||
-                          column == PersonnelTableModelColumn.FORCE_GRAPHICAL ||
-                          column == PersonnelTableModelColumn.UNIT_ASSIGNMENT_GRAPHICAL) {
+                if (column == PERSON_GRAPHICAL ||
+                          column == FORCE_GRAPHICAL ||
+                          column == UNIT_ASSIGNMENT_GRAPHICAL) {
                     MekHqTableCellRenderer.setupTigerStripes(this, table, rowIndex);
                 } else {
                     ComponentColors cellColors = populatePersonalStateFlags(person, personalStateFlags);
@@ -236,26 +255,36 @@ public class PersonnelTableModel extends DataTableModel<Person> {
                 colorReasonKeys.add("colorReason.personnel.healedInjuries");
                 cellColors = (cellColors == null) ? mhqOptions.getHealedInjuriesColors() : cellColors;
             }
-            return (cellColors == null) ? new ComponentColors(UIManager.getColor("Table.foreground"),
-                  UIManager.getColor("Table.background")) : cellColors;
+            return (cellColors == null) ? DEFAULT_COLORS : cellColors;
         }
 
         private ImageIcon getImage(Person person, PersonnelTableModelColumn personnelColumn) {
-            return switch (personnelColumn) {
-                case PERSON_GRAPHICAL -> person.getPortraitImageIconWithFallback(true, 54);
-                case UNIT_ASSIGNMENT_GRAPHICAL -> {
-                    Unit unit = person.getUnit();
-                    if ((unit == null) && !person.getTechUnits().isEmpty()) {
-                        unit = person.getTechUnits().getFirst();
-                    }
-                    yield (unit == null) ? null : new ImageIcon(unit.getImage(this));
+            if (personnelColumn == PERSON_GRAPHICAL) {
+                return portraitCache.computeIfAbsent(person.getPortrait(),
+                      portrait -> person.getPortraitImageIconWithFallback(true, 54));
+            } else if (personnelColumn == UNIT_ASSIGNMENT_GRAPHICAL) {
+                Unit unit = person.getUnit();
+                if ((unit == null) && !person.getTechUnits().isEmpty()) {
+                    unit = person.getTechUnits().getFirst();
                 }
-                case FORCE_GRAPHICAL -> {
-                    Formation formation = campaign.getFormationFor(person);
-                    yield  (formation == null) ? null : new ImageIcon(formation.getFormationIcon().getImage(54));
+                if (unit == null) {
+                    return null;
                 }
-                default -> null;
-            };
+                EntityImage entityImage = unit.getEntityImage();
+                long cacheKey = Objects.hash(entityImage.getBase(), entityImage.getCamouflage());
+                // key by base image and camouflage because EntityImage doesn't have an identity function
+                // since we use WeakHashMap underneath, memory leaks won't be a problem
+                return entityImageCache.computeIfAbsent(cacheKey,
+                      key -> new ImageIcon(entityImage.loadPreviewImage(true)));
+            } else if (personnelColumn == FORCE_GRAPHICAL) {
+                Formation formation = campaign.getFormationFor(person);
+                if (formation == null) {
+                    return null;
+                }
+                return formationIconCache.computeIfAbsent(formation.getFormationIcon(),
+                      formationIcon -> new ImageIcon(formationIcon.getImage(54)));
+            }
+            return null;
         }
     }
 

--- a/MekHQ/src/mekhq/gui/utilities/InstrumentedTableCellRenderer.java
+++ b/MekHQ/src/mekhq/gui/utilities/InstrumentedTableCellRenderer.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package mekhq.gui.utilities;
+
+import java.awt.Component;
+import javax.swing.JTable;
+import javax.swing.table.TableCellRenderer;
+
+import megamek.logging.MMLogger;
+
+/**
+ * A reusable decorator for {@link TableCellRenderer}s that measures rendering performance.
+ * Used for development, do not remove because it's not used in the code.
+ *
+ * @author Hokk
+ */
+public class InstrumentedTableCellRenderer implements TableCellRenderer {
+
+    private static final MMLogger LOGGER = MMLogger.create(InstrumentedTableCellRenderer.class);
+    private static final int REPORT_FREQUENCY = 5_000;
+
+    private final TableCellRenderer delegate;
+    private long totalRenderTimeNanos = 0;
+    private long renderCalls = 0;
+
+    public InstrumentedTableCellRenderer(TableCellRenderer delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
+          boolean hasFocus, int row, int column) {
+        long start = System.nanoTime();
+
+        Component result = delegate.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+
+        long end = System.nanoTime();
+        recordRenderTime(end - start);
+
+        return result;
+    }
+
+    private void recordRenderTime(long durationNanos) {
+        totalRenderTimeNanos += durationNanos;
+        renderCalls++;
+
+        if (renderCalls % REPORT_FREQUENCY == 0) {
+            double avgMillis = (totalRenderTimeNanos / (double) renderCalls) / 1_000_000.0;
+            LOGGER.info(String.format("Avg %s render time over last %,d calls: %.4f ms per cell",
+                  delegate.getClass().getSimpleName(), renderCalls, avgMillis));
+        }
+    }
+}


### PR DESCRIPTION
This PR focuses on minimizing object allocations and caching frequently rendered UI elements. This change introduces caches for portraits, entity images, and formation icons, reduces font updates during cell rendering, and adds an instrumentation utility for monitoring performance in development.

Details:
- Add `getEntityImage()` to `Unit` to simplify image caching
- Introduce caches in `PersonnelTableModel` to reduce memory overhead
- Optimize `getTableCellRendererComponent` by reducing font updates and reusing personal state flags
- Update `PersonnelTab` to use `refreshPersonnelList` and remove redundant `personnelListScheduler.schedule()` call
- Add `InstrumentedTableCellRenderer` to measure rendering performance