### PR TITLE
Campaign Options: restore preset "Apply" abridged view and add Ctrl/Cmd+F search shortcut

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsNavigationPanel.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsNavigationPanel.java
@@ -237,6 +237,15 @@ class CampaignOptionsNavigationPanel extends JPanel {
         buildNavigationTree(filterField.getText());
     }
 
+    /**
+     * Moves keyboard focus to the navigation filter field and selects any existing text, so a fresh query replaces
+     * it. Backs the dialog's Ctrl/Cmd+F shortcut.
+     */
+    void focusSearchField() {
+        filterField.requestFocusInWindow();
+        filterField.selectAll();
+    }
+
     private void buildNavigationTree(String filterText) {
         String normalizedFilter = filterText == null ? "" : CampaignOptionsRoute.normalizeSearchText(filterText);
         List<CampaignOptionsRoute> matchingRoutes = getMatchingRoutes(normalizedFilter);

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
@@ -52,6 +52,9 @@ import static mekhq.utilities.spaUtilities.enums.AbilityCategory.UTILITY_ABILITY
 
 import java.awt.BorderLayout;
 import java.awt.Component;
+import java.awt.Toolkit;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -59,10 +62,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
+import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
+import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JSplitPane;
 import javax.swing.JPanel;
+import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 
 import jakarta.annotation.Nonnull;
@@ -176,15 +182,41 @@ public class CampaignOptionsPane extends JPanel {
         registerRoutes(generalPage);
         CampaignOptionsRoute initialRoute = navigationTargets.get(0);
 
+        setBorder(BorderFactory.createEmptyBorder(CONTENT_MARGIN, CONTENT_MARGIN, CONTENT_MARGIN, CONTENT_MARGIN));
+        CampaignOptionsContentHost contentHost = createContentHost(generalPage, initialRoute);
+
+        // Abridged startup (preset "Apply") shows only the General page, so skip the navigation tree and its search
+        // entirely and let the content fill the dialog.
+        if (mode == STARTUP_ABRIDGED) {
+            add(contentHost, BorderLayout.CENTER);
+            return;
+        }
+
         JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,
                 createNavigationPanel(),
-                createContentHost(generalPage, initialRoute));
+                contentHost);
         splitPane.setName("campaignOptionsSplitPane");
         splitPane.setResizeWeight(0.0);
         splitPane.setDividerLocation(UIUtil.scaleForGUI(CampaignOptionsNavigationPanel.NAVIGATION_WIDTH));
-        setBorder(BorderFactory.createEmptyBorder(CONTENT_MARGIN, CONTENT_MARGIN, CONTENT_MARGIN, CONTENT_MARGIN));
         add(splitPane, BorderLayout.CENTER);
         navigationPanel.selectRoute(navigationTargets.get(0));
+        registerSearchShortcut();
+    }
+
+    /**
+     * Registers a window-level Ctrl/Cmd+F shortcut that moves focus to the navigation search field, regardless of
+     * which control inside the dialog currently has focus.
+     */
+    private void registerSearchShortcut() {
+        KeyStroke findKeyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_F,
+                Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx());
+        getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(findKeyStroke, "focusCampaignOptionsSearch");
+        getActionMap().put("focusCampaignOptionsSearch", new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                navigationPanel.focusSearchField();
+            }
+        });
     }
 
     private CampaignOptionsNavigationPanel createNavigationPanel() {
@@ -202,6 +234,13 @@ public class CampaignOptionsPane extends JPanel {
 
     private void registerRoutes(JPanel generalPage) {
         registerDirectRoute("general", () -> generalPage, "generalPanel");
+
+        // Abridged startup (preset "Apply") shows only the General landing page, so users who just want a preset
+        // aren't faced with the full options tree. The preset's other options are still applied in full via
+        // ensureAllSectionsLoaded() when the dialog is accepted.
+        if (mode == STARTUP_ABRIDGED) {
+            return;
+        }
 
         registerParentRoute("human-resources", "humanResourcesCategory");
         registerParentRoute("human-resources.personnel", "humanResourcesCategory", "personnelCategory");

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPresetPicker.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPresetPicker.java
@@ -125,16 +125,6 @@ public class CampaignOptionsPresetPicker extends JDialog {
     }
 
     /**
-     * Indicates if the user selected the 'customize' option.
-     *
-     * @return {@code true} if 'customize' was selected, {@code false} otherwise
-     */
-    @Deprecated(since = "0.51.0", forRemoval = true)
-    public boolean wasCustomized() {
-        return returnState == PresetSelection.CUSTOMIZE.getValue();
-    }
-
-    /**
      * Gets the selected campaign preset.
      *
      * @return the selected {@link CampaignPreset}, or {@code null} if none selected


### PR DESCRIPTION
### Fix: preset "Apply" behaved like "Customize"
When creating a new campaign, the preset picker's **Apply** and **Customize** buttons had become identical — both opened the full Campaign Options dialog. This restores the intended distinction:

- **Apply** — applies the selected preset and opens the dialog on **only the General landing page**, with the navigation tree and search hidden, so players who just want a preset aren't shown the full options tree.
- **Customize** — applies the preset and opens the **full** dialog.

### Feature: Ctrl/Cmd+F focuses the search box
Pressing the platform Find shortcut (Ctrl on Windows/Linux, Cmd on macOS, + F) anywhere in the Campaign Options dialog now moves focus to the left navigation search field and selects any existing text.

### Cleanup
Removed the unused, `@Deprecated(forRemoval = true)` `CampaignOptionsPresetPicker.wasCustomized()` method (the startup flow reads `wasApplied()`).