### PR TITLE
Campaign Options dialog: search-expand, navigation, and layout polish

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -38,6 +38,8 @@ lblLoadPreset.text=Load Preset
 lblLoadPreset.tooltip=Load an existing preset.
 lblCancel.text=Cancel Changes
 lblCancel.tooltip=Cancel all changes and close the dialog.
+lblIconsLegend.text=\u24D8 Icons Legend
+lblIconsLegend.tooltip=Show the icon legend.
 # Save Preset (auto-saved to the user campaign-preset directory)
 savePresetOverwrite.title=Overwrite Preset?
 savePresetOverwrite.text=A preset named "{0}" already exists. Do you want to overwrite it?

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsContentHost.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsContentHost.java
@@ -166,7 +166,7 @@ class CampaignOptionsContentHost extends JPanel {
      *
      * @return the page panel, or {@code null} if none is present
      */
-    private static @Nullable CampaignOptionsPagePanel findPagePanel(Component content) {
+    static @Nullable CampaignOptionsPagePanel findPagePanel(Component content) {
         if (content instanceof CampaignOptionsPagePanel pagePanel) {
             return pagePanel;
         }

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsDialog.java
@@ -39,10 +39,12 @@ import static mekhq.utilities.MHQInternationalization.getTextAt;
 import java.awt.BorderLayout;
 import java.awt.Container;
 import java.awt.Desktop;
+import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.GridBagLayout;
 import java.io.File;
 import java.util.ResourceBundle;
+import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
@@ -51,6 +53,7 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
 import javax.swing.JTextField;
 import javax.swing.UIManager;
 
@@ -176,23 +179,62 @@ public class CampaignOptionsDialog extends AbstractButtonDialog {
      */
     @Override
     protected @Nonnull JPanel createButtonPanel() {
-        final JPanel pnlButtons = new JPanel(new FlowLayout(FlowLayout.CENTER, BUTTON_GAP, BUTTON_GAP));
+        final JPanel actionButtons = new JPanel(new FlowLayout(FlowLayout.CENTER, BUTTON_GAP, BUTTON_GAP));
 
         // Apply Settings
-        pnlButtons.add(createDialogButton("ApplySettings", this::processApplyAction));
+        actionButtons.add(createDialogButton("ApplySettings", this::processApplyAction));
 
         // Save Preset
         if (mode != CampaignOptionsDialogMode.CAMPAIGN_UPGRADE && mode != CampaignOptionsDialogMode.STARTUP_ABRIDGED) {
-            pnlButtons.add(createDialogButton("SavePreset", this::btnSaveActionPerformed));
+            actionButtons.add(createDialogButton("SavePreset", this::btnSaveActionPerformed));
         }
 
         // Load Preset
-        pnlButtons.add(createDialogButton("LoadPreset", this::btnLoadActionPerformed));
+        actionButtons.add(createDialogButton("LoadPreset", this::btnLoadActionPerformed));
 
         // Cancel
-        pnlButtons.add(createDialogButton("Cancel", this::dispose));
+        actionButtons.add(createDialogButton("Cancel", this::dispose));
+
+        // Icons legend: kept apart on the left so it reads as a reference aid rather than a dialog action. Its popup
+        // opens upward over the help/content area instead of past the bottom of the dialog.
+        JButton legendButton = new JButton(getTextAt(getCampaignOptionsResourceBundle(), "lblIconsLegend.text"));
+        legendButton.setName("btnIconsLegend");
+        legendButton.setToolTipText(getTextAt(getCampaignOptionsResourceBundle(), "lblIconsLegend.tooltip"));
+        legendButton.addActionListener(evt -> showIconLegend(legendButton));
+        JPanel legendPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, BUTTON_GAP, BUTTON_GAP));
+        legendPanel.add(legendButton);
+
+        final JPanel pnlButtons = new JPanel(new BorderLayout());
+        pnlButtons.add(legendPanel, BorderLayout.WEST);
+        pnlButtons.add(actionButtons, BorderLayout.CENTER);
 
         return pnlButtons;
+    }
+
+    /**
+     * Shows the icon legend popup anchored above the given button, overlaying the content/help area. The legend
+     * explains the badge glyphs (custom-system, important, recommended, documented, and recently-added markers) used
+     * on option labels and section titles throughout the dialog.
+     *
+     * @param anchor the footer button the popup opens above
+     */
+    private void showIconLegend(JButton anchor) {
+        JLabel legend = new JLabel("<html><body>"
+              + getTextAt(getCampaignOptionsResourceBundle(), "lblGeneralIconLegend.text")
+              + "</body></html>");
+        legend.setBorder(BorderFactory.createEmptyBorder(UIUtil.scaleForGUI(8),
+              UIUtil.scaleForGUI(8),
+              UIUtil.scaleForGUI(8),
+              UIUtil.scaleForGUI(8)));
+
+        JPopupMenu legendPopup = new JPopupMenu();
+        legendPopup.setName("campaignOptionsLegendPopup");
+        legendPopup.setLayout(new BorderLayout());
+        legendPopup.add(legend, BorderLayout.CENTER);
+
+        Dimension popupSize = legendPopup.getPreferredSize();
+        // The button is in the footer, so open the popup above it (negative y) to overlay the content above.
+        legendPopup.show(anchor, 0, -popupSize.height);
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsDialog.java
@@ -204,9 +204,16 @@ public class CampaignOptionsDialog extends AbstractButtonDialog {
         JPanel legendPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, BUTTON_GAP, BUTTON_GAP));
         legendPanel.add(legendButton);
 
+        // Mirror the legend's width on the right so the action buttons are centered on the whole footer; a plain
+        // WEST + CENTER layout would center them only in the space to the right of the legend.
+        JPanel rightSpacer = new JPanel();
+        rightSpacer.setOpaque(false);
+        rightSpacer.setPreferredSize(new Dimension(legendPanel.getPreferredSize().width, 0));
+
         final JPanel pnlButtons = new JPanel(new BorderLayout());
         pnlButtons.add(legendPanel, BorderLayout.WEST);
         pnlButtons.add(actionButtons, BorderLayout.CENTER);
+        pnlButtons.add(rightSpacer, BorderLayout.EAST);
 
         return pnlButtons;
     }

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsNavigationPanel.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsNavigationPanel.java
@@ -33,19 +33,21 @@
 package mekhq.gui.campaignOptions;
 
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.getCampaignOptionsResourceBundle;
+import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.setSmallSizeVariant;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import java.awt.BorderLayout;
+import java.awt.Component;
 import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Font;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
-import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JTextField;
 import javax.swing.JTree;
@@ -56,6 +58,7 @@ import javax.swing.border.Border;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeCellRenderer;
 import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreePath;
 
@@ -69,6 +72,10 @@ import megamek.common.ui.FastJScrollPane;
  */
 class CampaignOptionsNavigationPanel extends JPanel {
     static final int NAVIGATION_WIDTH = 240;
+    // Padding between the navigation frame border and its content.
+    private static final int CONTENT_GAP = UIUtil.scaleForGUI(6);
+    // Tighter vertical gap stacking the search box, tree controls, and tree, so the controls read as one cluster.
+    private static final int CONTROL_GAP = UIUtil.scaleForGUI(4);
 
     private final List<CampaignOptionsRoute> routes;
     private final Consumer<CampaignOptionsRoute> routeSelectionListener;
@@ -81,7 +88,7 @@ class CampaignOptionsNavigationPanel extends JPanel {
 
     CampaignOptionsNavigationPanel(@Nonnull List<CampaignOptionsRoute> routes,
           @Nonnull Consumer<CampaignOptionsRoute> routeSelectionListener) {
-        super(new BorderLayout());
+        super(new BorderLayout(0, CONTROL_GAP));
         this.routes = routes;
         this.routeSelectionListener = routeSelectionListener;
 
@@ -94,10 +101,7 @@ class CampaignOptionsNavigationPanel extends JPanel {
             frameBorder = BorderFactory.createLineBorder(UIManager.getColor("Component.borderColor"));
         }
         setBorder(BorderFactory.createCompoundBorder(frameBorder,
-              BorderFactory.createEmptyBorder(UIUtil.scaleForGUI(6),
-                    UIUtil.scaleForGUI(6),
-                    UIUtil.scaleForGUI(6),
-                    UIUtil.scaleForGUI(6))));
+              BorderFactory.createEmptyBorder(CONTENT_GAP, CONTENT_GAP, CONTENT_GAP, CONTENT_GAP)));
         setPreferredSize(new Dimension(UIUtil.scaleForGUI(NAVIGATION_WIDTH), 1));
 
         filterField = new JTextField();
@@ -127,58 +131,72 @@ class CampaignOptionsNavigationPanel extends JPanel {
         filterStatusLabel.setHorizontalAlignment(SwingConstants.LEADING);
         filterStatusLabel.setVisible(false);
 
-        JButton legendButton = new JButton("\u24D8");
-        legendButton.setName("btnCampaignOptionsLegend");
-        legendButton.setToolTipText(getTextAt(getCampaignOptionsResourceBundle(), "campaignOptionsLegend.tooltip"));
-        legendButton.putClientProperty("JButton.buttonType", "toolBarButton");
-        legendButton.setFocusable(false);
-        legendButton.addActionListener(evt -> showLegend(legendButton));
-
         navigationTree = new JTree();
         navigationTree.setName("campaignOptionsNavigationTree");
         navigationTree.setRootVisible(false);
         navigationTree.setShowsRootHandles(true);
         navigationTree.addTreeSelectionListener(evt -> notifySelectedRoute());
+        navigationTree.setCellRenderer(new NavigationTreeCellRenderer());
 
         JScrollPane navigationScrollPane = new FastJScrollPane(navigationTree,
               ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
               ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
         navigationScrollPane.setName("campaignOptionsNavigationScrollPane");
 
-        JPanel filterRow = new JPanel(new BorderLayout(UIUtil.scaleForGUI(4), 0));
-        filterRow.setName("campaignOptionsFilterRow");
-        filterRow.add(filterField, BorderLayout.CENTER);
-        filterRow.add(legendButton, BorderLayout.EAST);
-
-        JPanel filterPanel = new JPanel(new BorderLayout(0, UIUtil.scaleForGUI(4)));
+        JPanel filterPanel = new JPanel(new BorderLayout(0, CONTROL_GAP));
         filterPanel.setName("campaignOptionsFilterPanel");
-        filterPanel.add(filterRow, BorderLayout.NORTH);
+        filterPanel.add(filterField, BorderLayout.NORTH);
         filterPanel.add(filterStatusLabel, BorderLayout.SOUTH);
 
-        add(filterPanel, BorderLayout.NORTH);
+        JPanel topPanel = new JPanel(new BorderLayout(0, CONTROL_GAP));
+        topPanel.setName("campaignOptionsNavigationTopPanel");
+        topPanel.add(filterPanel, BorderLayout.NORTH);
+        topPanel.add(createTreeControls(), BorderLayout.CENTER);
+
+        add(topPanel, BorderLayout.NORTH);
         add(navigationScrollPane, BorderLayout.CENTER);
 
         buildNavigationTree("");
     }
 
-    private void showLegend(JComponent anchor) {
-        JLabel legend = new JLabel("<html><body>"
-              + getTextAt(getCampaignOptionsResourceBundle(), "lblGeneralIconLegend.text")
-              + "</body></html>");
-        legend.setBorder(BorderFactory.createEmptyBorder(UIUtil.scaleForGUI(8),
-              UIUtil.scaleForGUI(8),
-              UIUtil.scaleForGUI(8),
-              UIUtil.scaleForGUI(8)));
+    private JPanel createTreeControls() {
+        JButton expandAllButton = createTreeControlButton("btnExpandAll.text", "btnCampaignOptionsExpandAll");
+        expandAllButton.addActionListener(evt -> setAllNodesExpanded(true));
+        JButton collapseAllButton = createTreeControlButton("btnCollapseAll.text", "btnCampaignOptionsCollapseAll");
+        collapseAllButton.addActionListener(evt -> setAllNodesExpanded(false));
 
-        JPopupMenu legendPopup = new JPopupMenu();
-        legendPopup.setName("campaignOptionsLegendPopup");
-        legendPopup.setLayout(new BorderLayout());
-        legendPopup.add(legend, BorderLayout.CENTER);
+        JPanel controls = new JPanel(new FlowLayout(FlowLayout.CENTER, UIUtil.scaleForGUI(4), 0));
+        controls.setName("campaignOptionsNavigationControls");
+        controls.setOpaque(false);
+        controls.add(expandAllButton);
+        controls.add(collapseAllButton);
+        return controls;
+    }
 
-        Dimension popupSize = legendPopup.getPreferredSize();
-        // Anchor the popup so its right edge lines up with the button, opening downward beneath the icon.
-        int x = anchor.getWidth() - popupSize.width;
-        legendPopup.show(anchor, x, anchor.getHeight());
+    private JButton createTreeControlButton(String resourceKey, String name) {
+        JButton button = new JButton(getTextAt(getCampaignOptionsResourceBundle(), resourceKey));
+        button.setName(name);
+        button.setFocusable(false);
+        setSmallSizeVariant(button);
+        return button;
+    }
+
+    /**
+     * Expands or collapses every node in the navigation tree. Collapsing leaves only the top-level category rows
+     * visible; expanding reveals every page.
+     *
+     * @param expanded {@code true} to expand all rows, {@code false} to collapse them
+     */
+    private void setAllNodesExpanded(boolean expanded) {
+        if (expanded) {
+            for (int row = 0; row < navigationTree.getRowCount(); row++) {
+                navigationTree.expandRow(row);
+            }
+        } else {
+            for (int row = navigationTree.getRowCount() - 1; row >= 0; row--) {
+                navigationTree.collapseRow(row);
+            }
+        }
     }
 
     void selectRoute(CampaignOptionsRoute route) {
@@ -235,6 +253,16 @@ class CampaignOptionsNavigationPanel extends JPanel {
      */
     void refreshFilter() {
         buildNavigationTree(filterField.getText());
+    }
+
+    /**
+     * Returns the current filter text, normalized the same way the navigation search matches routes, so callers can
+     * decide which section a page should open expanded to. Backs the "expand the matched section" navigation behavior.
+     *
+     * @return the normalized active filter, or an empty string when the filter is blank
+     */
+    String getActiveFilter() {
+        return CampaignOptionsRoute.normalizeSearchText(filterField.getText());
     }
 
     private void buildNavigationTree(String filterText) {
@@ -356,6 +384,25 @@ class CampaignOptionsNavigationPanel extends JPanel {
         }
 
         return null;
+    }
+
+    /**
+     * Renders the navigation tree, drawing the top-level category nodes in bold so the major sections stand out from
+     * their sub-pages. The hidden root sits at level 0, so the visible top-level rows are the level-1 nodes.
+     */
+    private static class NavigationTreeCellRenderer extends DefaultTreeCellRenderer {
+        @Override
+        public Component getTreeCellRendererComponent(JTree tree, Object value, boolean selected, boolean expanded,
+              boolean leaf, int row, boolean hasFocus) {
+            super.getTreeCellRendererComponent(tree, value, selected, expanded, leaf, row, hasFocus);
+
+            Font baseFont = tree.getFont();
+            if (baseFont != null) {
+                boolean topLevel = value instanceof DefaultMutableTreeNode node && node.getLevel() == 1;
+                setFont(baseFont.deriveFont(topLevel ? Font.BOLD : Font.PLAIN));
+            }
+            return this;
+        }
     }
 
     private static class NavigationTreeNode {

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsNavigationPanel.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsNavigationPanel.java
@@ -408,7 +408,9 @@ class CampaignOptionsNavigationPanel extends JPanel {
             Font baseFont = tree.getFont();
             if (baseFont != null) {
                 boolean topLevel = value instanceof DefaultMutableTreeNode node && node.getLevel() == 1;
-                setFont(baseFont.deriveFont(topLevel ? Font.BOLD : Font.PLAIN));
+                // Toggle only the BOLD bit so other style bits the Look&Feel may set (e.g. italics) are preserved.
+                int style = topLevel ? (baseFont.getStyle() | Font.BOLD) : (baseFont.getStyle() & ~Font.BOLD);
+                setFont(baseFont.deriveFont(style));
             }
             return this;
         }

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
@@ -182,7 +182,9 @@ public class CampaignOptionsPane extends JPanel {
         splitPane.setName("campaignOptionsSplitPane");
         splitPane.setResizeWeight(0.0);
         splitPane.setDividerLocation(UIUtil.scaleForGUI(CampaignOptionsNavigationPanel.NAVIGATION_WIDTH));
-        setBorder(BorderFactory.createEmptyBorder(CONTENT_MARGIN, CONTENT_MARGIN, CONTENT_MARGIN, CONTENT_MARGIN));
+        // Bottom margin is 0: the footer's button panel already adds top padding, so a bottom margin here would
+        // stack with it and make the gap above the footer buttons look larger than the gap below them.
+        setBorder(BorderFactory.createEmptyBorder(CONTENT_MARGIN, CONTENT_MARGIN, 0, CONTENT_MARGIN));
         add(splitPane, BorderLayout.CENTER);
         navigationPanel.selectRoute(navigationTargets.get(0));
     }
@@ -369,6 +371,43 @@ public class CampaignOptionsPane extends JPanel {
         }
 
         activeContentHost.setContent(directPage, getQuoteResourceName(route), route.shouldShowHelpPanel());
+        expandSectionsForActiveFilter(directPage);
+        return true;
+    }
+
+    /**
+     * When a page is opened while a navigation search is active, expands the section(s) whose title or summary match
+     * the search so the result the user clicked is revealed, instead of the page opening fully collapsed. Pages with no
+     * matching section (e.g. the search matched only the page title) are left in their default state.
+     *
+     * @param directPage the page component just shown
+     */
+    private void expandSectionsForActiveFilter(Component directPage) {
+        if (navigationPanel == null) {
+            return;
+        }
+
+        String activeFilter = navigationPanel.getActiveFilter();
+        if (activeFilter.isBlank()) {
+            return;
+        }
+
+        CampaignOptionsPagePanel pagePanel = CampaignOptionsContentHost.findPagePanel(directPage);
+        if (pagePanel == null) {
+            return;
+        }
+
+        String[] tokens = activeFilter.split("\\s+");
+        pagePanel.expandSectionsMatching(sectionText -> sectionMatchesAllTokens(sectionText, tokens));
+    }
+
+    private static boolean sectionMatchesAllTokens(String rawSectionText, String[] normalizedTokens) {
+        String normalizedSectionText = CampaignOptionsRoute.normalizeSearchText(rawSectionText);
+        for (String token : normalizedTokens) {
+            if (!token.isBlank() && !normalizedSectionText.contains(token)) {
+                return false;
+            }
+        }
         return true;
     }
 

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
@@ -416,8 +416,9 @@ public class CampaignOptionsPane extends JPanel {
 
     /**
      * When a page is opened while a navigation search is active, expands the section(s) whose title or summary match
-     * the search so the result the user clicked is revealed, instead of the page opening fully collapsed. Pages with no
-     * matching section (e.g. the search matched only the page title) are left in their default state.
+     * the search so the result the user clicked is revealed, instead of the page opening fully collapsed. When the
+     * search matched the page as a whole (its title or an internal name such as "stratcon" for the renamed "Digital
+     * GMs" page) rather than any single section, every section is expanded so the page is still revealed.
      *
      * @param directPage the page component just shown
      */
@@ -437,7 +438,11 @@ public class CampaignOptionsPane extends JPanel {
         }
 
         String[] tokens = activeFilter.split("\\s+");
-        pagePanel.expandSectionsMatching(sectionText -> sectionMatchesAllTokens(sectionText, tokens));
+        boolean expandedMatchingSection = pagePanel.expandSectionsMatching(
+              sectionText -> sectionMatchesAllTokens(sectionText, tokens));
+        if (!expandedMatchingSection) {
+            pagePanel.expandAllSections();
+        }
     }
 
     private static boolean sectionMatchesAllTokens(String rawSectionText, String[] normalizedTokens) {

--- a/MekHQ/src/mekhq/gui/campaignOptions/components/CampaignOptionsPagePanel.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/components/CampaignOptionsPagePanel.java
@@ -201,6 +201,17 @@ public class CampaignOptionsPagePanel extends JPanel {
         return true;
     }
 
+    /**
+     * Expands every collapsible section on this page. Used as a fallback when a page is opened from a navigation search
+     * whose term matched the page as a whole (such as an internal page name) rather than any single section heading, so
+     * the page is revealed instead of opening fully collapsed.
+     */
+    public void expandAllSections() {
+        for (SearchableSection section : searchableSections) {
+            section.panel().setExpanded(true);
+        }
+    }
+
     /** Pairs a collapsible section with its resolved title and summary text for search-driven expansion. */
     private record SearchableSection(MHQCollapsiblePanel panel, String searchText) {
     }

--- a/MekHQ/src/mekhq/gui/campaignOptions/components/CampaignOptionsPagePanel.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/components/CampaignOptionsPagePanel.java
@@ -47,6 +47,7 @@ import java.awt.GridBagLayout;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
+import java.util.function.Predicate;
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JComponent;
@@ -99,6 +100,7 @@ public class CampaignOptionsPagePanel extends JPanel {
     private final JPanel pageBody;
     private final boolean showDetailsPanel;
     private final String sectionSearchText;
+    private final List<SearchableSection> searchableSections;
 
     private CampaignOptionsPagePanel(Builder builder) {
         super(null);
@@ -113,17 +115,26 @@ public class CampaignOptionsPagePanel extends JPanel {
         // can place arbitrary components above, between, or below the collapsible sections.
         List<Object> renderItems = new ArrayList<>();
         List<MHQCollapsiblePanel> sections = new ArrayList<>();
+        List<SearchableSection> searchableSectionList = new ArrayList<>();
         StringBuilder searchTextBuilder = new StringBuilder();
         for (Object bodyItem : builder.bodyItems) {
             if (bodyItem instanceof Section section) {
                 MHQCollapsiblePanel sectionPanel = createSection(section, builder.sectionsExpandedByDefault);
                 sections.add(sectionPanel);
                 renderItems.add(sectionPanel);
-                appendSectionSearchText(searchTextBuilder, section);
+
+                StringBuilder sectionTextBuilder = new StringBuilder();
+                appendSectionSearchText(sectionTextBuilder, section);
+                String sectionText = sectionTextBuilder.toString().trim();
+                searchableSectionList.add(new SearchableSection(sectionPanel, sectionText));
+                if (!sectionText.isEmpty()) {
+                    searchTextBuilder.append(' ').append(sectionText);
+                }
             } else if (bodyItem instanceof JComponent component) {
                 renderItems.add(component);
             }
         }
+        searchableSections = List.copyOf(searchableSectionList);
         sectionSearchText = searchTextBuilder.toString().trim();
         JPanel sectionControls = createSectionControls(sections);
         int sectionStackWidth = getPreferredSectionStackWidth(sections, sectionControls);
@@ -156,6 +167,42 @@ public class CampaignOptionsPagePanel extends JPanel {
      */
     public @Nonnull String getSectionSearchText() {
         return sectionSearchText;
+    }
+
+    /**
+     * Expands every collapsible section whose title or summary text satisfies the given matcher and collapses the
+     * rest, so a page opened from a navigation search result reveals the matching section instead of opening fully
+     * collapsed. If no section matches (for example, when only the page title matched the search), the page is left
+     * untouched.
+     *
+     * @param sectionTextMatcher tests a section's raw (un-normalized) title and summary text
+     *
+     * @return {@code true} if at least one section matched and the section states were updated
+     */
+    public boolean expandSectionsMatching(@Nonnull Predicate<String> sectionTextMatcher) {
+        if (searchableSections.isEmpty()) {
+            return false;
+        }
+
+        boolean[] matches = new boolean[searchableSections.size()];
+        boolean anyMatch = false;
+        for (int index = 0; index < searchableSections.size(); index++) {
+            matches[index] = sectionTextMatcher.test(searchableSections.get(index).searchText());
+            anyMatch |= matches[index];
+        }
+
+        if (!anyMatch) {
+            return false;
+        }
+
+        for (int index = 0; index < searchableSections.size(); index++) {
+            searchableSections.get(index).panel().setExpanded(matches[index]);
+        }
+        return true;
+    }
+
+    /** Pairs a collapsible section with its resolved title and summary text for search-driven expansion. */
+    private record SearchableSection(MHQCollapsiblePanel panel, String searchText) {
     }
 
     private static void appendSectionSearchText(StringBuilder builder, Section section) {

--- a/MekHQ/src/mekhq/gui/menus/MekHQMenuBar.java
+++ b/MekHQ/src/mekhq/gui/menus/MekHQMenuBar.java
@@ -34,6 +34,7 @@
 
 package mekhq.gui.menus;
 
+import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
@@ -238,7 +239,10 @@ public class MekHQMenuBar extends JMenuBar {
         menuFile.add(initExportMenu());
         menuFile.add(initRefreshMenu());
 
-        menuFile.add(createMenuItem("menuOptions.text", KeyEvent.VK_C, this::menuOptionsActionPerformed));
+        JMenuItem menuOptions = createMenuItem("menuOptions.text", KeyEvent.VK_C, this::menuOptionsActionPerformed);
+        menuOptions.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O,
+              Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx() | InputEvent.SHIFT_DOWN_MASK));
+        menuFile.add(menuOptions);
 
         JMenuItem miMHQOptions = createMenuItem("miMHQOptions.text", KeyEvent.VK_H,
               evt -> new MHQOptionsDialog(getFrame()).setVisible(true));


### PR DESCRIPTION
## Summary
A batch of small UX refinements to the Campaign Options dialog, driven by Discord feedback. Focused on making the section navigation/search easier to use and tidying up the dialog's spacing.

## Changes

### Navigation & search
- **Auto-expand matching sections on filter** — when a section filter is active, opening a page now expands the option sections that match the filter (and collapses the rest), so you land directly on the relevant settings instead of a fully
  collapsed page.
- **Expand All / Collapse All** — added buttons above the navigation tree to expand or collapse every category at once.
- **Bold top-level categories** — top-level navigation entries are now bold so they stand out from their sub-pages.

### Icons legend
- **Moved to a labeled footer button** — the legend was previously a small `ⓘ` icon in the navigation panel that was easy to miss. It's now a labeled **`ⓘ Icons Legend`** button in the dialog's bottom-left footer, and its popup opens upward over the content/help area.

### Keyboard shortcut
- **Open Campaign Options with `Ctrl/Cmd + Shift + O`** — added an accelerator to File → Campaign Options (uses the platform menu-shortcut key, so `Cmd` on macOS).

### Layout & spacing polish
- Fixed a doubled vertical gap in the navigation panel (BorderLayout `NORTH`+`SOUTH`), and tightened the search box + tree controls so they read as one compact cluster.
- Fixed the footer so the gap above and below the buttons is symmetric (a stacked bottom content-margin was making the top gap look ~2× the bottom).