### PR TITLE
Return XP column to Personnel Table's general view

### DIFF
--- a/MekHQ/src/mekhq/gui/enums/PersonnelTabView.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTabView.java
@@ -50,7 +50,7 @@ public enum PersonnelTabView {
           Set.of(PERSON_GRAPHICAL, FORCE_GRAPHICAL, UNIT_ASSIGNMENT_GRAPHICAL)),
     GENERAL("PersonnelTabView.GENERAL.text", "PersonnelTabView.GENERAL.toolTipText",
           Set.of(RANK, FIRST_NAME, LAST_NAME, SKILL_LEVEL, PERSONNEL_ROLE, FORCE, DEPLOYED, INJURIES,
-                UNIT_ASSIGNMENT)),
+                UNIT_ASSIGNMENT, XP)),
     COMBAT("PersonnelTabView.COMBAT.text", "PersonnelTabView.COMBAT.toolTipText",
           Set.of(RANK, FIRST_NAME, LAST_NAME, PERSONNEL_ROLE, AGGREGATE_COMBAT, ARTILLERY, SCOUTING, LEADERSHIP,
                 TACTICS, STRATEGY)),


### PR DESCRIPTION
It was a regression caused by the recent refactoring. This PR brings it back.