### PR TITLE
Improve accessibility and UI scaling in Personnel Tab

### DIFF
--- a/MekHQ/src/mekhq/gui/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/PersonnelTab.java
@@ -32,7 +32,6 @@
  */
 package mekhq.gui;
 
-import static java.lang.Math.round;
 import static mekhq.gui.enums.PersonnelTableModelColumn.SURNAME;
 import static mekhq.gui.enums.PersonnelTableModelColumn.SURNAME_GROUPED_BY_UNIT;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
@@ -85,7 +84,6 @@ import mekhq.campaign.events.scenarios.ScenarioResolvedEvent;
 import mekhq.campaign.events.units.UnitRemovedEvent;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.skills.QuickTrain;
-import mekhq.gui.adapter.PersonnelTableMouseAdapter;
 import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
 import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
 import mekhq.gui.dialog.BatchXPDialog;
@@ -106,7 +104,8 @@ public final class PersonnelTab extends CampaignGuiTab {
     private static final MMLogger LOGGER = MMLogger.create(PersonnelTab.class);
     private static final String RESOURCE_BUNDLE = "mekhq.resources.CampaignGUI";
 
-    public static final int PERSONNEL_VIEW_WIDTH = UIUtil.scaleForGUI(700);
+    public static final int PERSON_VIEW_MIN_WIDTH = 450;
+    public static final int PERSON_VIEW_PREFERRED_WIDTH = 650;
 
     private JSplitPane splitPersonnel;
     private JTable personnelTable;
@@ -323,7 +322,6 @@ public final class PersonnelTab extends CampaignGuiTab {
         personModel = new PersonnelTableModel(getCampaign());
         personnelTable = new JTable(personModel);
         personnelTable.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
-        personnelTable.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
         XTableColumnModel personColumnModel = new XTableColumnModel();
         personnelTable.setColumnModel(personColumnModel);
         personnelTable.createDefaultColumnsFromModel();
@@ -348,8 +346,6 @@ public final class PersonnelTab extends CampaignGuiTab {
 
         scrollPersonnelView = new FastJScrollPane();
         scrollPersonnelView.setBorder(RoundedLineBorder.createRoundedLineBorder());
-        scrollPersonnelView.setMinimumSize(new Dimension((int) round(PERSONNEL_VIEW_WIDTH * 0.9), 600));
-        scrollPersonnelView.setPreferredSize(new Dimension(PERSONNEL_VIEW_WIDTH, 600));
         scrollPersonnelView.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
         scrollPersonnelView.setViewportView(null);
 
@@ -364,6 +360,7 @@ public final class PersonnelTab extends CampaignGuiTab {
 
         splitPersonnel = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, tableAndInfoPanel, scrollPersonnelView);
         splitPersonnel.setOneTouchExpandable(true);
+        splitPersonnel.setDividerSize(15);
         splitPersonnel.setResizeWeight(1.0);
         splitPersonnel.addPropertyChangeListener(JSplitPane.DIVIDER_LOCATION_PROPERTY, ev -> refreshPersonnelView());
         gridBagConstraints.gridx = 0;
@@ -374,10 +371,8 @@ public final class PersonnelTab extends CampaignGuiTab {
         gridBagConstraints.weighty = 1.0;
         add(splitPersonnel, gridBagConstraints);
 
-        PersonnelTableMouseAdapter.connect(getCampaignGui(), personnelTable, personModel, splitPersonnel);
-
-        changePersonnelView();
-        refreshPersonnelList();
+        refreshAll();
+        updateUIScaling();
     }
 
     private DefaultComboBoxModel<PersonnelFilter> createPersonGroupModel() {
@@ -483,7 +478,10 @@ public final class PersonnelTab extends CampaignGuiTab {
 
         for (PersonnelTableModelColumn column : PersonnelTableModel.PERSONNEL_COLUMNS) {
             TableColumn tableColumn = columnModel.getColumnByModelIndex(column.ordinal());
-            tableColumn.setPreferredWidth(column.getWidth());
+            Integer width = column.getPreferredWidth();
+            if (width != null) {
+                tableColumn.setPreferredWidth(width);
+            }
             columnModel.setColumnVisible(tableColumn, visibleColumns.contains(column));
         }
         personnelTable.setRowHeight(UIUtil.scaleForGUI((view == PersonnelTabView.GRAPHIC) ? 60 : 15));
@@ -492,7 +490,6 @@ public final class PersonnelTab extends CampaignGuiTab {
     }
 
     public void focusOnPerson(UUID id) {
-        splitPersonnel.resetToPreferredSizes();
         int row = -1;
         for (int i = 0; i < personnelTable.getRowCount(); i++) {
             if (personModel.getPerson(personnelTable.convertRowIndexToModel(i)).getId().equals(id)) {
@@ -515,6 +512,11 @@ public final class PersonnelTab extends CampaignGuiTab {
             personnelTable.setRowSelectionInterval(row, row);
             personnelTable.scrollRectToVisible(personnelTable.getCellRect(row, 0, true));
         }
+    }
+
+    private void updateUIScaling() {
+        scrollPersonnelView.setMinimumSize(new Dimension(UIUtil.scaleForGUI(PERSON_VIEW_MIN_WIDTH, 0)));
+        scrollPersonnelView.setPreferredSize(new Dimension(UIUtil.scaleForGUI(PERSON_VIEW_PREFERRED_WIDTH), 0));
     }
 
     /**
@@ -583,7 +585,8 @@ public final class PersonnelTab extends CampaignGuiTab {
     @Subscribe
     public void handle(MHQOptionsChangedEvent evt) {
         choicePerson.setModel(createPersonGroupModel());
-        personnelListScheduler.schedule();
+        refreshAll();
+        updateUIScaling();
     }
 
     @Subscribe

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -83,7 +83,6 @@ import static mekhq.utilities.spaUtilities.SpaUtilities.getSpaCategory;
 import java.awt.Color;
 import java.awt.Dialog;
 import java.awt.event.ActionEvent;
-import java.awt.event.MouseEvent;
 import java.time.LocalDate;
 import java.util.*;
 import java.util.function.BiConsumer;
@@ -96,7 +95,6 @@ import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;
-import javax.swing.JSplitPane;
 import javax.swing.JTable;
 
 import megamek.client.generator.RandomCallsignGenerator;
@@ -167,7 +165,6 @@ import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Planet;
 import mekhq.campaign.universe.factionStanding.FactionStandings;
 import mekhq.gui.CampaignGUI;
-import mekhq.gui.PersonnelTab;
 import mekhq.gui.baseComponents.JScrollableMenu;
 import mekhq.gui.control.EditLogControl.LogType;
 import mekhq.gui.dialog.*;
@@ -343,27 +340,6 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
     private CampaignOptions getCampaignOptions() {
         return getCampaign().getCampaignOptions();
-    }
-
-    public static void connect(CampaignGUI gui, JTable personnelTable, PersonnelTableModel personnelModel,
-          JSplitPane splitPersonnel) {
-        new PersonnelTableMouseAdapter(gui, personnelTable, personnelModel) {
-            @Override
-            public void mouseClicked(MouseEvent e) {
-                if ((e.getButton() == MouseEvent.BUTTON1) && (e.getClickCount() == 2)) {
-                    int width = splitPersonnel.getSize().width;
-                    int location = splitPersonnel.getDividerLocation();
-                    int size = splitPersonnel.getDividerSize();
-                    if ((width - location + size) < PersonnelTab.PERSONNEL_VIEW_WIDTH) {
-                        // expand
-                        splitPersonnel.resetToPreferredSizes();
-                    } else {
-                        // collapse
-                        splitPersonnel.setDividerLocation(1.0);
-                    }
-                }
-            }
-        }.connect(personnelTable);
     }
 
     private String makeCommand(String... parts) {

--- a/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
@@ -142,7 +142,10 @@ public final class BatchXPDialog extends JDialog {
                 continue;
             }
 
-            tableColumn.setPreferredWidth(column.getWidth());
+            Integer width = column.getPreferredWidth();
+            if (width != null) {
+                tableColumn.setPreferredWidth(width);
+            }
             tableColumn.setCellRenderer(getRenderer());
             columnModel.setColumnVisible(tableColumn, true);
 

--- a/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
@@ -273,7 +273,10 @@ public class PersonnelMarketDialog extends JDialog {
                 continue;
             }
 
-            tableColumn.setPreferredWidth(column.getWidth());
+            Integer width = column.getPreferredWidth();
+            if (width != null) {
+                tableColumn.setPreferredWidth(width);
+            }
             tableColumn.setCellRenderer(getRenderer());
             columnModel.setColumnVisible(tableColumn, true);
 

--- a/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
 import javax.swing.SortOrder;
 import javax.swing.SwingConstants;
 
+import megamek.client.ui.util.UIUtil;
 import megamek.codeUtilities.StringUtility;
 import megamek.common.annotations.Nullable;
 import megamek.common.units.Entity;
@@ -793,17 +794,23 @@ public enum PersonnelTableModelColumn {
                      (this == PERSONNEL_STATUS);
     }
 
-    public int getWidth() {
-        return switch (this) {
-            case PERSON_GRAPHICAL, UNIT_ASSIGNMENT, MARKET_UNIT_ASSIGNMENT -> 125;
-            case RANK, FIRST_NAME, GIVEN_NAME, DEPLOYED -> 70;
-            case LAST_NAME, SURNAME, SURNAME_GROUPED_BY_UNIT, BLOODNAME, CALLSIGN, SKILL_LEVEL, SALARY -> 50;
-            case PERSONNEL_ROLE -> 150;
-            case FORCE -> 100;
-            case LOCATION_SYSTEM, LOCATION_PLANET, DESTINATION_SYSTEM, DESTINATION_PLANET -> 100;
-            case LOCATION_NAME, DESTINATION_NAME -> 150;
-            default -> 20;
+    /**
+     * Returns optional preferred size.
+     * @return null if the column has no size preference, a preferred width otherwise.
+     */
+    @Nullable
+    public Integer getPreferredWidth() {
+        Integer preferredWidth = switch (this) {
+            case RANK -> 60;
+            case FIRST_NAME -> 50;
+            case LAST_NAME -> 70;
+            case SKILL_LEVEL -> 45;
+            case PERSONNEL_ROLE -> 120;
+            case UNIT_ASSIGNMENT -> 140;
+            case LOCATION_NAME -> 140;
+            default -> null;
         };
+        return (preferredWidth == null) ? null : UIUtil.scaleForGUI(preferredWidth);
     }
 
     public int getAlignment() {

--- a/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
+++ b/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
@@ -34,6 +34,7 @@ package mekhq.gui.enums;
 
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -73,42 +74,19 @@ public class PersonnelTableModelColumnTest {
     public void testGetWidth() {
         for (final PersonnelTableModelColumn personnelTableModelColumn : columns) {
             switch (personnelTableModelColumn) {
-                case PERSON_GRAPHICAL:
-                case MARKET_UNIT_ASSIGNMENT:
-                case UNIT_ASSIGNMENT:
-                    assertEquals(125, personnelTableModelColumn.getWidth());
-                    break;
                 case RANK:
                 case FIRST_NAME:
-                case GIVEN_NAME:
-                case DEPLOYED:
-                    assertEquals(70, personnelTableModelColumn.getWidth());
-                    break;
                 case LAST_NAME:
-                case SURNAME:
-                case SURNAME_GROUPED_BY_UNIT:
-                case BLOODNAME:
-                case CALLSIGN:
-                case SKILL_LEVEL:
-                case SALARY:
-                    assertEquals(50, personnelTableModelColumn.getWidth());
-                    break;
-                case PERSONNEL_ROLE:
-                    assertEquals(150, personnelTableModelColumn.getWidth());
+                    // fixed size for the most important columns
+                    assertNotNull(personnelTableModelColumn.getPreferredWidth());
                     break;
                 case FORCE:
-                case LOCATION_SYSTEM:
-                case LOCATION_PLANET:
-                case DESTINATION_SYSTEM:
-                case DESTINATION_PLANET:
-                    assertEquals(100, personnelTableModelColumn.getWidth());
-                    break;
-                case LOCATION_NAME:
-                case DESTINATION_NAME:
-                    assertEquals(150, personnelTableModelColumn.getWidth());
-                    break;
-                default:
-                    assertEquals(20, personnelTableModelColumn.getWidth());
+                case BODY:
+                case AGGRESSION:
+                case XP:
+                case KILLS:
+                case MEDTECH:
+                    assertNull(personnelTableModelColumn.getPreferredWidth());
                     break;
             }
         }


### PR DESCRIPTION
Refactor the Personnel Tab layout and column width calculation, trust Swing's automatic resizing, and support UI scaling. By shifting away  from hardcoded values, the interface becomes more resilient across different screen resolutions and accessibility settings. The custom, click-based panel expansion adapter is replaced with standard UI behaviors, and the column width system is simplified to let the layout manager handle non-essential columns dynamically.

- Replace `PERSONNEL_VIEW_WIDTH` with scalable `PERSON_VIEW_MIN_WIDTH` and `PERSON_VIEW_PREFERRED_WIDTH`
- Remove `PersonnelTableMouseAdapter` and its double-click layout adjustment logic to stick to standard `JSplitPane` behavior
- Enable default column resizing behavior for the table
- Introduce `updateUIScaling` method in `PersonnelTab` to dynamically apply GUI scaling
- Convert `getWidth` to `getPreferredWidth` in `PersonnelTableModelColumn` to provide nullable, UI-scaled sizes only for key columns
- Update unit tests in `PersonnelTableModelColumnTest` to align with the new preferred width contract
- Fix UI scaling not applying until the next reload

80% scale before:
<img width="1728" height="1053" alt="80 before" src="https://github.com/user-attachments/assets/3236caa6-420f-4996-ac54-db3a1e74b923" />

80% scale after:
<img width="1728" height="1051" alt="80 after" src="https://github.com/user-attachments/assets/f50f0fe2-8294-4ccb-9902-228b4c875575" />

160% scale before:
<img width="1728" height="1051" alt="160 before" src="https://github.com/user-attachments/assets/d8a2cf1c-a9e2-4790-bf1f-35c0fda58010" />

160% scale after:
<img width="1728" height="1050" alt="160 after" src="https://github.com/user-attachments/assets/b798c28e-0597-4b76-ab83-c2167b1cbcf9" />

