### PR TITLE
Enhance personnel tab search and highlight matching text

### DIFF
--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -1200,10 +1200,10 @@ public class CampaignGUI extends JPanel {
             logger.warn("Cannot export person if no one is selected! Ignoring.");
             return;
         }
-        Person selectedPerson = pt.getPersonModel().getPerson(pt.getPersonnelTable().convertRowIndexToModel(row));
+        Person selectedPerson = pt.getPersonnelTableModel().getPerson(pt.getPersonnelTable().convertRowIndexToModel(row));
         int[] rows = pt.getPersonnelTable().getSelectedRows();
         Person[] people = Arrays.stream(rows)
-                                .mapToObj(j -> pt.getPersonModel()
+                                .mapToObj(j -> pt.getPersonnelTableModel()
                                                      .getPerson(pt.getPersonnelTable().convertRowIndexToModel(j)))
                                 .toArray(Person[]::new);
 

--- a/MekHQ/src/mekhq/gui/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/PersonnelTab.java
@@ -42,6 +42,9 @@ import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
+import java.awt.Toolkit;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -56,6 +59,7 @@ import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.table.DefaultTableColumnModel;
 import javax.swing.table.TableColumn;
+import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableRowSorter;
 
 import megamek.client.ui.clientGUI.GUIPreferences;
@@ -107,15 +111,14 @@ public final class PersonnelTab extends CampaignGuiTab {
     public static final int PERSON_VIEW_MIN_WIDTH = 450;
     public static final int PERSON_VIEW_PREFERRED_WIDTH = 650;
 
-    private JSplitPane splitPersonnel;
     private JTable personnelTable;
-    private MMComboBox<PersonnelFilter> choicePerson;
-    private MMComboBox<PersonnelTabView> choicePersonView;
-    private JTextField txtPersonSearch;
+    private MMComboBox<PersonnelFilter> personnelFilter;
+    private MMComboBox<PersonnelTabView> personnelView;
+    private JTextField searchField;
     private JScrollPane scrollPersonnelView;
     private JCheckBox chkGroupByUnit;
 
-    private PersonnelTableModel personModel;
+    private PersonnelTableModel personnelTableModel;
     private TableRowSorter<PersonnelTableModel> personnelSorter;
 
     private final IPreferenceChangeListener scalingChangeListener = e -> changePersonnelView();
@@ -164,9 +167,9 @@ public final class PersonnelTab extends CampaignGuiTab {
         gridBagConstraints.insets = new Insets(5, 5, 0, 0);
         add(new JLabel(resourceMap.getString("lblPersonChoice.text")), gridBagConstraints);
 
-        choicePerson = new MMComboBox<>("choicePerson", createPersonGroupModel());
-        choicePerson.setSelectedItem(PersonnelFilter.ACTIVE);
-        choicePerson.setRenderer(new DefaultListCellRenderer() {
+        personnelFilter = new MMComboBox<>("personnelFilter", createPersonGroupModel());
+        personnelFilter.setSelectedItem(PersonnelFilter.ACTIVE);
+        personnelFilter.setRenderer(new DefaultListCellRenderer() {
             @Override
             public Component getListCellRendererComponent(final JList<?> list, final Object value, final int index,
                   final boolean isSelected, final boolean cellHasFocus) {
@@ -177,7 +180,7 @@ public final class PersonnelTab extends CampaignGuiTab {
                 return this;
             }
         });
-        choicePerson.addActionListener(ev -> filterPersonnel());
+        personnelFilter.addActionListener(ev -> filterPersonnel());
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 0;
@@ -186,7 +189,7 @@ public final class PersonnelTab extends CampaignGuiTab {
         gridBagConstraints.weighty = 0.0;
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         gridBagConstraints.insets = new Insets(5, 5, 0, 0);
-        add(choicePerson, gridBagConstraints);
+        add(personnelFilter, gridBagConstraints);
 
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 2;
@@ -198,9 +201,9 @@ public final class PersonnelTab extends CampaignGuiTab {
         gridBagConstraints.insets = new Insets(5, 5, 0, 0);
         add(new JLabel(resourceMap.getString("lblPersonView.text")), gridBagConstraints);
 
-        choicePersonView = new MMComboBox<>("choicePersonView", PersonnelTabView.values());
-        choicePersonView.setSelectedItem(PersonnelTabView.GENERAL);
-        choicePersonView.setRenderer(new DefaultListCellRenderer() {
+        personnelView = new MMComboBox<>("personnelView", PersonnelTabView.values());
+        personnelView.setSelectedItem(PersonnelTabView.GENERAL);
+        personnelView.setRenderer(new DefaultListCellRenderer() {
             @Override
             public Component getListCellRendererComponent(final JList<?> list, final Object value, final int index,
                   final boolean isSelected, final boolean cellHasFocus) {
@@ -211,7 +214,7 @@ public final class PersonnelTab extends CampaignGuiTab {
                 return this;
             }
         });
-        choicePersonView.addActionListener(ev -> changePersonnelView());
+        personnelView.addActionListener(ev -> changePersonnelView());
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 3;
         gridBagConstraints.gridy = 0;
@@ -220,7 +223,7 @@ public final class PersonnelTab extends CampaignGuiTab {
         gridBagConstraints.weighty = 0.0;
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         gridBagConstraints.insets = new Insets(5, 5, 0, 0);
-        add(choicePersonView, gridBagConstraints);
+        add(personnelView, gridBagConstraints);
 
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 4;
@@ -232,9 +235,9 @@ public final class PersonnelTab extends CampaignGuiTab {
         gridBagConstraints.insets = new Insets(5, 10, 0, 0);
         add(new JLabel(getTextAt(RESOURCE_BUNDLE, "lblPersonSearch.text")), gridBagConstraints);
 
-        txtPersonSearch = new JTextField(15);
-        txtPersonSearch.setToolTipText(getTextAt(RESOURCE_BUNDLE, "lblPersonSearch.tooltip"));
-        txtPersonSearch.getDocument().addDocumentListener(new DocumentListener() {
+        searchField = new JTextField(15);
+        searchField.setToolTipText(getTextAt(RESOURCE_BUNDLE, "lblPersonSearch.tooltip"));
+        searchField.getDocument().addDocumentListener(new DocumentListener() {
             @Override
             public void insertUpdate(DocumentEvent event) {
                 filterPersonnel();
@@ -258,13 +261,13 @@ public final class PersonnelTab extends CampaignGuiTab {
         gridBagConstraints.weighty = 0.0;
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         gridBagConstraints.insets = new Insets(5, 5, 0, 5);
-        add(txtPersonSearch, gridBagConstraints);
+        add(searchField, gridBagConstraints);
 
         chkGroupByUnit = new JCheckBox(resourceMap.getString("chkGroupByUnit.text"));
         chkGroupByUnit.setToolTipText(resourceMap.getString("chkGroupByUnit.toolTipText"));
         chkGroupByUnit.addActionListener(e -> {
-            personModel.setGroupByUnit(chkGroupByUnit.isSelected());
-            personModel.refreshData();
+            personnelTableModel.setGroupByUnit(chkGroupByUnit.isSelected());
+            personnelTableModel.refreshData();
             changePersonnelView();
         });
         gridBagConstraints = new GridBagConstraints();
@@ -319,17 +322,17 @@ public final class PersonnelTab extends CampaignGuiTab {
         gridBagConstraints.insets = new Insets(5, 5, 0, 0);
         add(btnMassTraining, gridBagConstraints);
 
-        personModel = new PersonnelTableModel(getCampaign());
-        personnelTable = new JTable(personModel);
+        personnelTableModel = new PersonnelTableModel(getCampaign());
+        personnelTable = new JTable(personnelTableModel);
         personnelTable.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
         XTableColumnModel personColumnModel = new XTableColumnModel();
         personnelTable.setColumnModel(personColumnModel);
         personnelTable.createDefaultColumnsFromModel();
-        personnelSorter = new TableRowSorter<>(personModel);
+        personnelSorter = new TableRowSorter<>(personnelTableModel);
         final ArrayList<SortKey> sortKeys = new ArrayList<>();
         for (final PersonnelTableModelColumn column : PersonnelTableModel.PERSONNEL_COLUMNS) {
             TableColumn tableColumn = personColumnModel.getColumnByModelIndex(column.ordinal());
-            tableColumn.setCellRenderer(personModel.getRenderer());
+            tableColumn.setCellRenderer(personnelTableModel.getRenderer());
 
             final Comparator<?> comparator = column.getComparator();
             personnelSorter.setComparator(column.ordinal(), comparator);
@@ -358,7 +361,7 @@ public final class PersonnelTab extends CampaignGuiTab {
         JPanel pnlTutorial = new TutorialHyperlinkPanel("personnelTab");
         tableAndInfoPanel.add(pnlTutorial, BorderLayout.SOUTH);
 
-        splitPersonnel = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, tableAndInfoPanel, scrollPersonnelView);
+        JSplitPane splitPersonnel = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, tableAndInfoPanel, scrollPersonnelView);
         splitPersonnel.setOneTouchExpandable(true);
         splitPersonnel.setDividerSize(15);
         splitPersonnel.setResizeWeight(1.0);
@@ -370,6 +373,8 @@ public final class PersonnelTab extends CampaignGuiTab {
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.weighty = 1.0;
         add(splitPersonnel, gridBagConstraints);
+
+        registerSearchShortcut();
 
         refreshAll();
         updateUIScaling();
@@ -384,6 +389,22 @@ public final class PersonnelTab extends CampaignGuiTab {
     }
 
     /**
+     * Registers a tab-level Ctrl/Cmd+F shortcut that moves focus to the search field.
+     */
+    private void registerSearchShortcut() {
+        int modifier = Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx();
+        InputMap inputMap = getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
+        inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_F, modifier), "focusSearch");
+        getActionMap().put("focusSearch", new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                searchField.requestFocusInWindow();
+                searchField.selectAll();
+            }
+        });
+    }
+
+    /**
      * These need to be migrated to the Suite Constants / Suite Options Setup
      */
     private void setUserPreferences() {
@@ -391,11 +412,11 @@ public final class PersonnelTab extends CampaignGuiTab {
             PreferencesNode preferences = MekHQ.getMHQPreferences().forClass(PersonnelTab.class);
             this.setName("dialog");
 
-            choicePerson.setName("personnelType");
-            preferences.manage(new JComboBoxPreference(choicePerson));
+            personnelFilter.setName("personnelType");
+            preferences.manage(new JComboBoxPreference(personnelFilter));
 
-            choicePersonView.setName("personnelView");
-            preferences.manage(new JComboBoxPreference(choicePersonView));
+            personnelView.setName("personnelView");
+            preferences.manage(new JComboBoxPreference(personnelView));
 
             chkGroupByUnit.setName("groupByUnit");
             preferences.manage(new JToggleButtonPreference(chkGroupByUnit));
@@ -412,8 +433,8 @@ public final class PersonnelTab extends CampaignGuiTab {
         return personnelTable;
     }
 
-    public PersonnelTableModel getPersonModel() {
-        return personModel;
+    public PersonnelTableModel getPersonnelTableModel() {
+        return personnelTableModel;
     }
 
     /*
@@ -428,45 +449,51 @@ public final class PersonnelTab extends CampaignGuiTab {
     }
 
     public void filterPersonnel() {
-        final PersonnelFilter filter = (choicePerson.getSelectedItem() == null) ?
+        final PersonnelFilter filter = (personnelFilter.getSelectedItem() == null) ?
                                              PersonnelFilter.ACTIVE :
-                                             choicePerson.getSelectedItem();
+                                             personnelFilter.getSelectedItem();
+        String searchText = searchField.getText();
+        personnelTableModel.getRenderer().setHighlight(searchText);
         personnelSorter.setRowFilter(new RowFilter<>() {
             @Override
             public boolean include(Entry<? extends PersonnelTableModel, ? extends Integer> entry) {
                 Person person = entry.getModel().getPerson(entry.getIdentifier());
-
-                // Existing dropdown filter
-                if (!filter.getFilteredInformation(person,
-                      getCampaignGui().getCampaign().getLocalDate())) {
+                if (!filter.getFilteredInformation(person, getCampaignGui().getCampaign().getLocalDate())) {
                     return false;
                 }
-
-                // Search filter — stacks on top of dropdown
-                String personNameAsLowerCase = person.getFullTitleAndProfessions().toLowerCase(Locale.ROOT);
-                String searchText = txtPersonSearch.getText().trim();
-                String searchAsLowerCase = searchText.toLowerCase(Locale.ROOT);
-                if (!searchText.isEmpty()) {
-                    return personNameAsLowerCase.contains(searchAsLowerCase);
+                if (searchText.isEmpty()) {
+                    return true;
                 }
+                String searchAsLowerCase = searchText.toLowerCase(Locale.ROOT);
 
-                return true;
+                TableColumnModel columnModel = personnelTable.getColumnModel();
+                int visibleColumnCount = columnModel.getColumnCount();
+
+                for (int i = 0; i < visibleColumnCount; i++) {
+                    int modelIndex = columnModel.getColumn(i).getModelIndex();
+                    PersonnelTableModelColumn column = PersonnelTableModel.PERSONNEL_COLUMNS[modelIndex];
+                    String cellText = column.getText(column.getCellValue(getCampaign(), person));
+                    if (cellText != null && cellText.toLowerCase(Locale.ROOT).contains(searchAsLowerCase)) {
+                        return true;
+                    }
+                }
+                return false;
             }
         });
     }
 
     private void changePersonnelView() {
-        PersonnelTabView view = (choicePersonView.getSelectedItem() == null) ?
+        PersonnelTabView view = (personnelView.getSelectedItem() == null) ?
                                       PersonnelTabView.GENERAL :
-                                      choicePersonView.getSelectedItem();
+                                      personnelView.getSelectedItem();
 
         Set<PersonnelTableModelColumn> visibleColumns = view.getVisibleColumns(getCampaign().getCampaignOptions());
         if (view == PersonnelTabView.FLUFF) {
             visibleColumns = visibleColumns.stream().filter(column -> {
                 if (column == SURNAME) {
-                    return !getPersonModel().isGroupByUnit();
+                    return !getPersonnelTableModel().isGroupByUnit();
                 } else if (column == SURNAME_GROUPED_BY_UNIT) {
-                    return getPersonModel().isGroupByUnit();
+                    return getPersonnelTableModel().isGroupByUnit();
                 }
                 return true;
             }).collect(Collectors.toSet());
@@ -487,21 +514,22 @@ public final class PersonnelTab extends CampaignGuiTab {
         personnelTable.setRowHeight(UIUtil.scaleForGUI((view == PersonnelTabView.GRAPHIC) ? 60 : 15));
         // reattach the updated model
         personnelTable.setColumnModel(columnModel);
+        filterPersonnel();
     }
 
     public void focusOnPerson(UUID id) {
         int row = -1;
         for (int i = 0; i < personnelTable.getRowCount(); i++) {
-            if (personModel.getPerson(personnelTable.convertRowIndexToModel(i)).getId().equals(id)) {
+            if (personnelTableModel.getPerson(personnelTable.convertRowIndexToModel(i)).getId().equals(id)) {
                 row = i;
                 break;
             }
         }
         if (row == -1) {
             // try expanding the filter to all units
-            choicePerson.setSelectedIndex(0);
+            personnelFilter.setSelectedIndex(0);
             for (int i = 0; i < personnelTable.getRowCount(); i++) {
-                if (personModel.getPerson(personnelTable.convertRowIndexToModel(i)).getId().equals(id)) {
+                if (personnelTableModel.getPerson(personnelTable.convertRowIndexToModel(i)).getId().equals(id)) {
                     row = i;
                     break;
                 }
@@ -526,7 +554,7 @@ public final class PersonnelTab extends CampaignGuiTab {
         UUID selectedUUID = null;
         int selectedRow = personnelTable.getSelectedRow();
         if (selectedRow != -1) {
-            Person person = personModel.getPerson(personnelTable.convertRowIndexToModel(selectedRow));
+            Person person = personnelTableModel.getPerson(personnelTable.convertRowIndexToModel(selectedRow));
             if (null != person) {
                 selectedUUID = person.getId();
             }
@@ -535,10 +563,10 @@ public final class PersonnelTab extends CampaignGuiTab {
         LocationFilterItem locationFilter = getCampaignGui().getActiveLocation();
 
         List<Person> people = locationFilter.selectPersonnel(getCampaign());
-        personModel.setData(people);
+        personnelTableModel.setData(people);
 
         for (int row = 0; row < personnelTable.getRowCount(); row++) {
-            Person person = personModel.getPerson(personnelTable.convertRowIndexToModel(row));
+            Person person = personnelTableModel.getPerson(personnelTable.convertRowIndexToModel(row));
             if (person != null && person.getId().equals(selectedUUID)) {
                 personnelTable.setRowSelectionInterval(row, row);
                 refreshPersonnelView();
@@ -554,7 +582,7 @@ public final class PersonnelTab extends CampaignGuiTab {
             scrollPersonnelView.setViewportView(null);
             return;
         }
-        Person selectedPerson = personModel.getPerson(personnelTable.convertRowIndexToModel(row));
+        Person selectedPerson = personnelTableModel.getPerson(personnelTable.convertRowIndexToModel(row));
         scrollPersonnelView.setViewportView(new PersonViewPanel(selectedPerson, getCampaign(), getCampaignGui()));
         // This odd code is to make sure that the scrollbar stays at the top
         // I can't just call it here, because it ends up getting reset somewhere later
@@ -566,7 +594,7 @@ public final class PersonnelTab extends CampaignGuiTab {
         List<Person> selectedPersons = new ArrayList<>();
         for (int viewRow : selectedRows) {
             int modelRow = personnelTable.convertRowIndexToModel(viewRow);
-            Person person = personModel.getPerson(modelRow);
+            Person person = personnelTableModel.getPerson(modelRow);
             if (person != null) {
                 selectedPersons.add(person);
             }
@@ -584,7 +612,7 @@ public final class PersonnelTab extends CampaignGuiTab {
 
     @Subscribe
     public void handle(MHQOptionsChangedEvent evt) {
-        choicePerson.setModel(createPersonGroupModel());
+        personnelFilter.setModel(createPersonGroupModel());
         refreshAll();
         updateUIScaling();
     }

--- a/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
@@ -46,7 +46,6 @@ import javax.swing.ImageIcon;
 import javax.swing.JTable;
 import javax.swing.UIManager;
 import javax.swing.table.DefaultTableCellRenderer;
-import javax.swing.table.TableCellRenderer;
 
 import io.sentry.util.Objects;
 import megamek.client.ui.tileset.EntityImage;
@@ -64,6 +63,7 @@ import mekhq.campaign.unit.Unit;
 import mekhq.gui.enums.PersonnelTableModelColumn;
 import mekhq.gui.utilities.ComponentColors;
 import mekhq.gui.utilities.MekHqTableCellRenderer;
+import mekhq.utilities.ReportingUtilities;
 
 /**
  * A table Model for displaying information about personnel
@@ -76,7 +76,7 @@ public class PersonnelTableModel extends DataTableModel<Person> {
 
     private final Campaign campaign;
     private boolean groupByUnit;
-    private final TableCellRenderer renderer = new Renderer();
+    private final Renderer renderer = new Renderer();
 
     public PersonnelTableModel(Campaign c) {
         data = new ArrayList<>();
@@ -161,7 +161,7 @@ public class PersonnelTableModel extends DataTableModel<Person> {
         }
     }
 
-    public TableCellRenderer getRenderer() {
+    public Renderer getRenderer() {
         return renderer;
     }
 
@@ -174,6 +174,12 @@ public class PersonnelTableModel extends DataTableModel<Person> {
         private final Map<Portrait, ImageIcon> portraitCache = new WeakHashMap<>();
         private final Map<Long, ImageIcon> entityImageCache = new WeakHashMap<>();
         private final Map<StandardFormationIcon, ImageIcon> formationIconCache = new WeakHashMap<>();
+
+        private String highlight = "";
+
+        public void setHighlight(String highlight) {
+            this.highlight = highlight;
+        }
 
         @Override
         public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
@@ -189,7 +195,8 @@ public class PersonnelTableModel extends DataTableModel<Person> {
             if (getFont() != table.getFont()) {
                 setFont(table.getFont());
             }
-            setText(column.getText(value));
+            String text = applyHighlighting(column.getText(value));
+            setText(text);
             setHorizontalAlignment(column.getAlignment());
 
             setIcon(getImage(person, column));
@@ -212,6 +219,19 @@ public class PersonnelTableModel extends DataTableModel<Person> {
             setToolTipText(column.getToolTipText(person, personalStateFlags));
 
             return this;
+        }
+
+        private String applyHighlighting(String text) {
+            if (highlight.isEmpty()) {
+                return text;
+            }
+            String highlightedText =
+                  ReportingUtilities.messageSurroundedBySpanWithColor(ReportingUtilities.getPositiveColor(), "$1");
+            text = text.replaceAll("(?i)(" + java.util.regex.Pattern.quote(highlight) + ")(?![^<>]*>)", highlightedText);
+            if (text.startsWith("<html>")) {
+                return text;
+            }
+            return "<html>" + text + "</html>";
         }
 
         /**


### PR DESCRIPTION
This commit improves the personnel tab search functionality. Now it matches across all visible columns rather than just the person's name and title. It also introduces a Ctrl/Cmd+F keyboard shortcut to quickly focus the search field and highlights the matching text within the table to improve usability.

Details:
- Implement `registerSearchShortcut` to bind the search field to Ctrl + F
- Modify `filterPersonnel` to evaluate the search text against all visible columns using `PersonnelTableModelColumn`
- Add `setHighlight` and `applyHighlighting` to the `Renderer` inner class in `PersonnelTableModel` to apply HTML color spans to matched text segments
- Rename UI variables in `PersonnelTab` for clarity, such as `choicePerson` to `personnelFilter` and `txtPersonSearch` to `searchField`
- Update references from `getPersonModel` to `getPersonnelTableModel` in `CampaignGUI` and `PersonnelTab`