### PR TITLE
Fixed Infantry Deploying Without Survival Gear

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -815,16 +815,16 @@ public class AtBDynamicScenarioFactory {
                         }
                     } else {
                         generatedLance = generateLance(factionCode, skill, quality, unitTypes, requiredRoles, campaign);
+                    }
 
-                        // If extreme temperatures are present and XCT infantry is not being generated,
-                        // swap out standard armor for snowsuits or heat suits as appropriate
-                        if (actualUnitType == INFANTRY) {
-                            for (Entity curPlatoon : generatedLance) {
-                                changeInfantryKit((ConvInfantry) curPlatoon,
-                                      isLowPressure,
-                                      isTainted,
-                                      scenario.getTemperature());
-                            }
+                    // If extreme temperatures are present and XCT infantry is not being generated,
+                    // swap out standard armor for snowsuits or heat suits as appropriate
+                    if (actualUnitType == INFANTRY) {
+                        for (Entity currentPlatoon : generatedLance) {
+                            changeInfantryKit((ConvInfantry) currentPlatoon,
+                                  isLowPressure,
+                                  isTainted,
+                                  scenario.getTemperature());
                         }
                     }
                 }


### PR DESCRIPTION
The infantry kit logic was incorrectly housed inside a conditional clause, causing it to not run. Now it does.