### PR TITLE
Converted Accountant from Record to Utility Class to Allow For Better Compatibility with Contract Overhaul & Multi-Locational Campaigns

### DIFF
--- a/MekHQ/src/mekhq/campaign/HumanResources.java
+++ b/MekHQ/src/mekhq/campaign/HumanResources.java
@@ -148,7 +148,7 @@ public class HumanResources {
      * Map of PersonnelRole to temp crew pool size. Tracks TOTAL pool (not available). Use
      * {@link #getAvailableTempCrewPool(Campaign, PersonnelRole)} for available count.
      */
-    private Map<PersonnelRole, Integer> tempPersonnelRoleMap = new HashMap<>();
+    private final Map<PersonnelRole, Integer> tempPersonnelRoleMap = new HashMap<>();
 
     private List<Person> personnelWhoAdvancedInXP = new ArrayList<>();
     private RetirementDefectionTracker retirementDefectionTracker;
@@ -686,6 +686,15 @@ public class HumanResources {
 
     public Set<PersonnelRole> getTempCrewRoleKeys() {
         return tempPersonnelRoleMap.keySet();
+    }
+
+    /**
+     * Returns an unmodifiable copy of the temporary personnel role map.
+     *
+     * @return an unmodifiable {@link Map} containing the temporary personnel roles and counts
+     */
+    public Map<PersonnelRole, Integer> getTempPersonnelRoleMap() {
+        return Map.copyOf(tempPersonnelRoleMap);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/finances/Accountant.java
+++ b/MekHQ/src/mekhq/campaign/finances/Accountant.java
@@ -37,7 +37,6 @@ import static mekhq.campaign.market.contractMarket.AlternatePaymentModelValues.a
 import static mekhq.campaign.market.contractMarket.AlternatePaymentModelValues.getDiminishingReturnsStart;
 import static mekhq.campaign.personnel.ranks.Rank.RWO_MIN;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -50,8 +49,9 @@ import megamek.logging.MMLogger;
 import mekhq.campaign.AbstractLocation;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.Hangar;
+import mekhq.campaign.HumanResources;
+import mekhq.campaign.Warehouse;
 import mekhq.campaign.campaignOptions.CampaignOptions;
-import mekhq.campaign.finances.enums.TransactionType;
 import mekhq.campaign.force.Formation;
 import mekhq.campaign.market.contractMarket.AlternatePaymentModelValues;
 import mekhq.campaign.mission.AtBContract;
@@ -68,7 +68,7 @@ import mekhq.campaign.universe.factionStanding.FactionStandings;
 /**
  * Provides accounting for a Campaign.
  */
-public record Accountant(Campaign campaign) {
+public class Accountant {
     private static final MMLogger LOGGER = MMLogger.create(Accountant.class);
 
     final public static int HOUSING_PRISONER_OR_DEPENDENT = 228;
@@ -78,31 +78,110 @@ public record Accountant(Campaign campaign) {
     final public static int FOOD_ENLISTED = 240;
     final public static int FOOD_OFFICER = 480;
 
-    public CampaignOptions getCampaignOptions() {
-        return campaign().getCampaignOptions();
+    private final Campaign campaign;
+    private final CampaignOptions campaignOptions;
+    private final Hangar hangar;
+    private final HumanResources humanResources;
+    private final List<Formation> formations;
+    private final Warehouse warehouse;
+    private final int temporaryAsTechPool;
+    private final int temporaryMedicPool;
+    private final Map<PersonnelRole, Integer> tempPersonnelRoleMap;
+
+    /**
+     * Constructs a new Accountant instance.
+     *
+     * @param campaign             the current campaign
+     * @param units                the list of units in the campaign
+     * @param people               the roster of personnel
+     * @param formations           the active formations
+     * @param parts                the tracking components in storage
+     * @param temporaryAsTechPool  count of temporary Assistant Technicians
+     * @param temporaryMedicPool   count of temporary Medical staff
+     * @param tempPersonnelRoleMap mapping of temporary personnel allocations by role
+     */
+    public Accountant(Campaign campaign, List<Unit> units, List<Person> people, List<Formation> formations,
+          List<Part> parts, int temporaryAsTechPool, int temporaryMedicPool,
+          Map<PersonnelRole, Integer> tempPersonnelRoleMap) {
+        this.campaign = campaign;
+        this.campaignOptions = campaign.getCampaignOptions();
+
+        this.hangar = new Hangar();
+        for (Unit unit : units) {
+            hangar.addUnit(unit);
+        }
+
+        this.humanResources = new HumanResources();
+        for (Person person : people) {
+            humanResources.importPerson(person);
+        }
+
+        this.formations = formations;
+
+        this.warehouse = new Warehouse();
+        for (Part part : parts) {
+            warehouse.addPart(part);
+        }
+
+        this.temporaryAsTechPool = temporaryAsTechPool;
+        this.temporaryMedicPool = temporaryMedicPool;
+        this.tempPersonnelRoleMap = tempPersonnelRoleMap;
     }
 
-    public Hangar getHangar() {
-        return campaign().getHangar();
+    /**
+     * Constructs a new Accountant instance.
+     *
+     * @param campaign the current campaign
+     */
+    public Accountant(Campaign campaign) {
+        this.campaign = campaign;
+        this.campaignOptions = campaign.getCampaignOptions();
+        this.hangar = campaign.getHangar();
+        this.humanResources = campaign.getHumanResources();
+        this.formations = campaign.getAllFormations();
+        this.warehouse = campaign.getWarehouse();
+        this.temporaryAsTechPool = campaign.getTemporaryAsTechPool();
+        this.temporaryMedicPool = campaign.getTemporaryMedicPool();
+        this.tempPersonnelRoleMap = humanResources.getTempPersonnelRoleMap();
     }
 
+    /**
+     * Gets total payroll costs, defaulting to tracking all personnel.
+     *
+     * @return a {@link Money} object representing the current payroll costs
+     */
     public Money getPayRoll() {
         return getPayRoll(false);
     }
 
+    /**
+     * Gets total payroll costs with an option to exclude infantry units.
+     *
+     * @param noInfantry if {@code true}, conventional infantry roles are excluded
+     *
+     * @return a {@link Money} object representing the payroll total
+     */
     public Money getPayRoll(boolean noInfantry) {
-        if (getCampaignOptions().isPayForSalaries()) {
+        if (campaignOptions.isPayForSalaries()) {
             return getTheoreticalPayroll(noInfantry);
         } else {
             return Money.zero();
         }
     }
 
+    /**
+     * Internal calculation for base payroll totals including active salary-eligible personnel and temporary staff
+     * pools.
+     *
+     * @param noInfantry if {@code true}, infantry combat roles are skipped
+     *
+     * @return total theoretical payroll expense
+     */
     private Money getTheoreticalPayroll(boolean noInfantry) {
         Money salaries = Money.zero();
-        for (Person person : campaign().getSalaryEligiblePersonnel()) {
+        for (Person person : humanResources.getSalaryEligiblePersonnel()) {
             if (!(noInfantry && person.getPrimaryRole().isSoldier())) {
-                salaries = salaries.plus(person.getSalary(campaign()));
+                salaries = salaries.plus(person.getSalary(campaign));
             }
         }
 
@@ -112,9 +191,14 @@ public record Accountant(Campaign campaign) {
         return salaries;
     }
 
+    /**
+     * Calculates the total maintenance costs for active equipment needing upkeep.
+     *
+     * @return total maintenance expenditures
+     */
     public Money getMaintenanceCosts() {
-        if (getCampaignOptions().isPayForMaintain()) {
-            return getHangar().getUnitsStream()
+        if (campaignOptions.isPayForMaintain()) {
+            return hangar.getUnitsStream()
                          .filter(u -> u.requiresMaintenance() && (null != u.getTech()))
                          .map(Unit::getMaintenanceCost)
                          .reduce(Money.zero(), Money::plus);
@@ -122,12 +206,22 @@ public record Accountant(Campaign campaign) {
         return Money.zero();
     }
 
+    /**
+     * Calculates maintenance costs broken down weekly.
+     *
+     * @return total weekly equipment upkeep costs
+     */
     public Money getWeeklyMaintenanceCosts() {
-        return getHangar().getUnitsStream().map(Unit::getWeeklyMaintenanceCost).reduce(Money.zero(), Money::plus);
+        return hangar.getUnitsStream().map(Unit::getWeeklyMaintenanceCost).reduce(Money.zero(), Money::plus);
     }
 
+    /**
+     * Calculates base operational overhead cost, derived as a percentage of overall payroll.
+     *
+     * @return total overhead operational costs
+     */
     public Money getOverheadExpenses() {
-        if (getCampaignOptions().isPayForOverhead()) {
+        if (campaignOptions.isPayForOverhead()) {
             return getTheoreticalPayroll(false).multipliedBy(0.05);
         } else {
             return Money.zero();
@@ -143,9 +237,9 @@ public record Accountant(Campaign campaign) {
      * to their role/status:</p>
      *
      * <ul>
-     *   <li>Prisoners or dependents have specific food and housing rates.</li>
-     *   <li>Officers have higher food and housing rates than enlisted personnel.</li>
-     *   <li>Crew members of non-DropShip large vessels live aboard their vessel and are exempt from housing charges.</li>
+     *     <li>Prisoners or dependents have specific food and housing rates.</li>
+     *     <li>Officers have higher food and housing rates than enlisted personnel.</li>
+     *     <li>Crew members of non-DropShip large vessels live aboard their vessel and are exempt from housing charges.</li>
      * </ul>
      *
      * <p>If neither food nor housing expenses are enabled in the campaign options, this method returns zero.</p>
@@ -156,17 +250,17 @@ public record Accountant(Campaign campaign) {
      * @since 0.50.06
      */
     public Money getMonthlyFoodAndHousingExpenses() {
-        boolean payForFood = getCampaignOptions().isPayForFood();
+        boolean payForFood = campaignOptions.isPayForFood();
         AbstractLocation location = campaign.getCurrentLocation();
         boolean isOnPlanet = location.isOnPlanet();
-        boolean payForHousing = getCampaignOptions().isPayForHousing() && isOnPlanet;
+        boolean payForHousing = campaignOptions.isPayForHousing() && isOnPlanet;
 
         if (!payForFood && !payForHousing) {
             return Money.zero();
         }
 
         double barrackCostMultiplier = 1.0;
-        if (isOnPlanet && getCampaignOptions().isUseFactionStandingBarracksCostsSafe()) {
+        if (isOnPlanet && campaignOptions.isUseFactionStandingBarracksCostsSafe()) {
             barrackCostMultiplier = setFactionStandingBarrackCostMultiplier(location);
         }
 
@@ -179,7 +273,7 @@ public record Accountant(Campaign campaign) {
         int officerFoodUsage = 0;
 
         // Determine housing and food requirements
-        List<Person> personnel = new ArrayList<>(campaign().getAllPersonnel());
+        List<Person> personnel = new ArrayList<>(humanResources.getPersonnel());
         for (Person person : personnel) {
             if (person.getStatus().isDepartedUnit()) {
                 // No paying for dead people or folks who left the campaign unit
@@ -335,23 +429,34 @@ public record Accountant(Campaign campaign) {
     public Money getPeacetimeCost(boolean includeSalaries) {
         Money peaceTimeCosts = Money.zero().plus(getMonthlySpareParts()).plus(getMonthlyFuel()).plus(getMonthlyAmmo());
         if (includeSalaries) {
-            peaceTimeCosts = peaceTimeCosts.plus(getPayRoll(getCampaignOptions().isInfantryDontCount()));
+            peaceTimeCosts = peaceTimeCosts.plus(getPayRoll(campaignOptions.isInfantryDontCount()));
         }
 
         return peaceTimeCosts;
     }
 
+    /**
+     * Sums monthly required costs for spare parts across active, non-mothballed assets.
+     *
+     * @return total spare parts costs
+     */
     public Money getMonthlySpareParts() {
-        return getHangar().getUnitCosts(u -> !u.isMothballed(), Unit::getSparePartsCost);
+        return hangar.getUnitCosts(u -> !u.isMothballed(), Unit::getSparePartsCost);
     }
 
+    /**
+     * Calculates monthly fuel expenses using an idealized 28-day month simulation baseline. Total hydrogen credits are
+     * calculated against the number of active operational fusion engines.
+     *
+     * @return total structural monthly fuel cost
+     */
     public Money getMonthlyFuel() {
         int daysInMonth = 28; // we use a 28-day month so we don't need to bring in and process the exact date
         int dailyHydrogenProduction = 10;
         int monthlyHydrogenProduction = daysInMonth * dailyHydrogenProduction;
 
         int totalFusionEngines = 0;
-        for (Unit unit : getHangar().getUnits()) {
+        for (Unit unit : hangar.getUnits()) {
             if (unit.isMothballed()) {
                 continue;
             }
@@ -380,13 +485,18 @@ public record Accountant(Campaign campaign) {
         // Calculate total hydrogen production based on the number of fusion engines
         int hydrogenProduction = totalFusionEngines * monthlyHydrogenProduction;
 
-        return getHangar().getUnitCosts(
+        return hangar.getUnitCosts(
               // Is it in the TO&E and by extension in use?
               unit -> unit.getFormationId() != FORMATION_NONE, unit -> unit.getFuelCost(hydrogenProduction));
     }
 
+    /**
+     * Sums monthly ammo costs across active, non-mothballed assets.
+     *
+     * @return total ammo expenses
+     */
     public Money getMonthlyAmmo() {
-        return getHangar().getUnitCosts(u -> !u.isMothballed(), Unit::getAmmoCost);
+        return hangar.getUnitCosts(u -> !u.isMothballed(), Unit::getAmmoCost);
     }
 
     /**
@@ -395,8 +505,8 @@ public record Accountant(Campaign campaign) {
      *
      * <p>This method iterates over {@code campaign().getAllForces()} and includes only forces that are both:</p>
      * <ul>
-     *     <li>a standard force type ({@code force.getForceType().isStandard()}); and</li>
-     *     <li>marked as a combat role ({@code force.getCombatRoleInMemory().isCombatRole()}).</li>
+     * <li>a standard force type ({@code force.getForceType().isStandard()}); and</li>
+     * <li>marked as a combat role ({@code force.getCombatRoleInMemory().isCombatRole()}).</li>
      * </ul>
      *
      * <p>Units are resolved via the campaign hangar; {@code null} units and units with {@code null} entities are
@@ -404,9 +514,9 @@ public record Accountant(Campaign campaign) {
      *
      * <p>Large-craft categories are included only when their associated percentage is non-zero:</p>
      * <ul>
-     *     <li><b>DropShips / Small Craft</b> use {@code dropShipContractPercent}</li>
-     *     <li><b>WarShips</b> use {@code warShipContractPercent}</li>
-     *     <li><b>JumpShips / Space Stations</b> use {@code jumpShipContractPercent}</li>
+     * <li><b>DropShips / Small Craft</b> use {@code dropShipContractPercent}</li>
+     * <li><b>WarShips</b> use {@code warShipContractPercent}</li>
+     * <li><b>JumpShips / Space Stations</b> use {@code jumpShipContractPercent}</li>
      * </ul>
      *
      * <p>Per-unit values are provided by {@link #getEquipmentContractValue(Unit, boolean)}. This method does not
@@ -438,7 +548,7 @@ public record Accountant(Campaign campaign) {
         List<Money> unitValues = new ArrayList<>();
 
         Money total = Money.zero();
-        for (Formation formation : campaign().getAllFormations()) {
+        for (Formation formation : formations) {
             if (!formation.getFormationType().isStandard()) {
                 continue;
             }
@@ -447,7 +557,7 @@ public record Accountant(Campaign campaign) {
             }
 
             for (UUID uuid : formation.getUnits()) {
-                Unit unit = getHangar().getUnit(uuid);
+                Unit unit = hangar.getUnit(uuid);
                 if (unit == null) {
                     continue;
                 }
@@ -511,33 +621,47 @@ public record Accountant(Campaign campaign) {
         return total;
     }
 
+    /**
+     * Calculates the total value of all owned asset hardware combined with the inventory of spare warehouse
+     * components.
+     *
+     * @return total evaluation value of hardware and warehouse inventory assets
+     */
     public Money getTotalEquipmentValue() {
-        Money unitsSellValue = getHangar().getUnitCosts(Unit::getSellValue);
-        return campaign().getWarehouse()
+        Money unitsSellValue = hangar.getUnitCosts(Unit::getSellValue);
+        return warehouse
                      .streamSpareParts()
                      .map(Part::getActualValue)
                      .reduce(unitsSellValue, Money::plus);
     }
 
-    public Money getEquipmentContractValue(Unit u, boolean useSaleValue) {
+    /**
+     * Extracts contract processing value modifiers assigned dynamically to specific structural units.
+     *
+     * @param unit         the individual target equipment unit
+     * @param useSaleValue if {@code true}, targets market sale listings; otherwise targets buying costs
+     *
+     * @return adjusted percentage contract modifier value
+     */
+    public Money getEquipmentContractValue(Unit unit, boolean useSaleValue) {
         Money value;
         Money percentValue;
 
         if (useSaleValue) {
-            value = u.getSellValue();
+            value = unit.getSellValue();
         } else {
-            value = u.getBuyCost();
+            value = unit.getBuyCost();
         }
 
-        if (u.getEntity().hasETypeFlag(Entity.ETYPE_DROPSHIP)) {
-            percentValue = value.multipliedBy(getCampaignOptions().getDropShipContractPercent()).dividedBy(100);
-        } else if (u.getEntity().hasETypeFlag(Entity.ETYPE_WARSHIP)) {
-            percentValue = value.multipliedBy(getCampaignOptions().getWarShipContractPercent()).dividedBy(100);
-        } else if (u.getEntity().hasETypeFlag(Entity.ETYPE_JUMPSHIP) ||
-                         u.getEntity().hasETypeFlag(Entity.ETYPE_SPACE_STATION)) {
-            percentValue = value.multipliedBy(getCampaignOptions().getJumpShipContractPercent()).dividedBy(100);
+        if (unit.getEntity().hasETypeFlag(Entity.ETYPE_DROPSHIP)) {
+            percentValue = value.multipliedBy(campaignOptions.getDropShipContractPercent()).dividedBy(100);
+        } else if (unit.getEntity().hasETypeFlag(Entity.ETYPE_WARSHIP)) {
+            percentValue = value.multipliedBy(campaignOptions.getWarShipContractPercent()).dividedBy(100);
+        } else if (unit.getEntity().hasETypeFlag(Entity.ETYPE_JUMPSHIP) ||
+                         unit.getEntity().hasETypeFlag(Entity.ETYPE_SPACE_STATION)) {
+            percentValue = value.multipliedBy(campaignOptions.getJumpShipContractPercent()).dividedBy(100);
         } else {
-            percentValue = value.multipliedBy(getCampaignOptions().getEquipmentContractPercent()).dividedBy(100);
+            percentValue = value.multipliedBy(campaignOptions.getEquipmentContractPercent()).dividedBy(100);
         }
 
         return percentValue;
@@ -557,17 +681,15 @@ public record Accountant(Campaign campaign) {
      *       campaign's configuration.
      */
     public Money getContractBase() {
-        final CampaignOptions options = getCampaignOptions();
+        final boolean excludeInfantry = campaignOptions.isInfantryDontCount();
+        final double combatUnitContractPercent = campaignOptions.getEquipmentContractPercent();
+        final double dropShipContractPercent = campaignOptions.getDropShipContractPercent();
+        final double warShipContractPercent = campaignOptions.getWarShipContractPercent();
+        final double jumpShipContractPercent = campaignOptions.getJumpShipContractPercent();
+        final boolean useEquipmentSellValue = campaignOptions.isEquipmentContractSaleValue();
+        final boolean useDiminishingContractPay = campaignOptions.isUseDiminishingContractPay();
 
-        final boolean excludeInfantry = options.isInfantryDontCount();
-        final double combatUnitContractPercent = options.getEquipmentContractPercent();
-        final double dropShipContractPercent = options.getDropShipContractPercent();
-        final double warShipContractPercent = options.getWarShipContractPercent();
-        final double jumpShipContractPercent = options.getJumpShipContractPercent();
-        final boolean useEquipmentSellValue = options.isEquipmentContractSaleValue();
-        final boolean useDiminishingContractPay = options.isUseDiminishingContractPay();
-
-        if (getCampaignOptions().isUseAlternatePaymentMode()) {
+        if (campaignOptions.isUseAlternatePaymentMode()) {
             final Money forceValue = AlternatePaymentModelValues.getForceValue(campaign.getFaction(),
                   campaign.getAllFormations(),
                   campaign.getAllHangar(),
@@ -585,7 +707,7 @@ public record Accountant(Campaign campaign) {
             return forceValue;
         }
 
-        if (getCampaignOptions().isUsePeacetimeCost()) {
+        if (campaignOptions.isUsePeacetimeCost()) {
             final Money forceValue = this.getForceValue(useDiminishingContractPay,
                   excludeInfantry,
                   dropShipContractPercent,
@@ -596,7 +718,7 @@ public record Accountant(Campaign campaign) {
             return getPeacetimeCost().multipliedBy(0.75).plus(forceValue);
         }
 
-        if (getCampaignOptions().isEquipmentContractBase()) {
+        if (campaignOptions.isEquipmentContractBase()) {
             return this.getForceValue(useDiminishingContractPay,
                   excludeInfantry,
                   dropShipContractPercent,
@@ -605,20 +727,18 @@ public record Accountant(Campaign campaign) {
                   useEquipmentSellValue);
         }
 
-        return getTheoreticalPayroll(getCampaignOptions().isInfantryDontCount());
+        return getTheoreticalPayroll(campaignOptions.isInfantryDontCount());
     }
 
     /**
      * Returns a map of every Person and their salary.
      *
      * @return map of personnel to their pay, including pool as a null key
-     *
-     * @see Finances#debit(TransactionType, LocalDate, Money, String, Map, boolean)
      */
     public Map<Person, Money> getPayRollSummary() {
         Map<Person, Money> payRollSummary = new HashMap<>();
-        for (Person person : campaign().getSalaryEligiblePersonnel()) {
-            payRollSummary.put(person, person.getSalary(campaign()));
+        for (Person person : humanResources.getSalaryEligiblePersonnel()) {
+            payRollSummary.put(person, person.getSalary(campaign));
         }
         // And pay our pool
         payRollSummary.put(null, Money.of(sumTempCrewPay()));
@@ -626,26 +746,46 @@ public record Accountant(Campaign campaign) {
         return payRollSummary;
     }
 
+    /**
+     * Aggregates total support salaries paid out to active unlisted temporary pools.
+     *
+     * @return numerical sum total of temporary workforce payroll
+     */
     private double sumTempCrewPay() {
         return sumTempCrewPay(false);
     }
 
+    /**
+     * Aggregates total support salaries paid out to active unlisted temporary pools, with optional filter parameters.
+     *
+     * @param noInfantry if {@code true}, exclusions apply to combat infantry roles
+     *
+     * @return total temporary crew pay sum
+     */
     private double sumTempCrewPay(boolean noInfantry) {
         double tempCrewPay = 0.0;
-        tempCrewPay += getTempCrewPay(PersonnelRole.ASTECH, campaign().getTemporaryAsTechPool());
-        tempCrewPay += getTempCrewPay(PersonnelRole.MEDIC, campaign().getTemporaryMedicPool());
+        tempCrewPay += getTempCrewPay(PersonnelRole.ASTECH, temporaryAsTechPool);
+        tempCrewPay += getTempCrewPay(PersonnelRole.MEDIC, temporaryMedicPool);
 
-        for (PersonnelRole personnelRole : campaign().getTempCrewRoleKeys()) {
+        for (PersonnelRole personnelRole : tempPersonnelRoleMap.keySet()) {
             if (!(noInfantry && personnelRole.isSoldier())) {
-                tempCrewPay += getTempCrewPay(personnelRole, campaign().getTempCrewPool(personnelRole));
+                tempCrewPay += getTempCrewPay(personnelRole, tempPersonnelRoleMap.get(personnelRole));
             }
         }
 
         return tempCrewPay;
     }
 
+    /**
+     * Resolves individual role salary rules against unlisted pool deployment counts.
+     *
+     * @param personnelRole     target structural type classification
+     * @param tempPersonnelPool deployment size for requested workforce
+     *
+     * @return calculated cost total
+     */
     private double getTempCrewPay(PersonnelRole personnelRole, int tempPersonnelPool) {
-        return campaign().getCampaignOptions()
+        return campaignOptions
                      .getRoleBaseSalaries()[personnelRole.ordinal()].getAmount().doubleValue() *
                      tempPersonnelPool;
     }

--- a/MekHQ/unittests/mekhq/campaign/finances/AccountantTest.java
+++ b/MekHQ/unittests/mekhq/campaign/finances/AccountantTest.java
@@ -40,888 +40,280 @@ import static mekhq.campaign.finances.Accountant.HOUSING_OFFICER;
 import static mekhq.campaign.finances.Accountant.HOUSING_PRISONER_OR_DEPENDENT;
 import static mekhq.campaign.personnel.enums.PersonnelRole.DEPENDENT;
 import static mekhq.campaign.personnel.enums.PersonnelRole.MEKWARRIOR;
-import static mekhq.campaign.personnel.enums.PersonnelRole.VESSEL_GUNNER;
 import static mekhq.campaign.personnel.ranks.Rank.RWO_MIN;
-import static mekhq.campaign.randomEvents.prisoners.PrisonerStatus.PRISONER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import megamek.common.units.Entity;
+import mekhq.campaign.AbstractLocation;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.CurrentLocation;
 import mekhq.campaign.campaignOptions.CampaignOptions;
+import mekhq.campaign.force.Formation;
+import mekhq.campaign.parts.Part;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRole;
+import mekhq.campaign.personnel.enums.PersonnelStatus;
+import mekhq.campaign.randomEvents.prisoners.PrisonerStatus;
 import mekhq.campaign.unit.Unit;
-import mekhq.campaign.universe.Faction;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 
 public class AccountantTest {
 
+    private Campaign mockCampaign;
+    private CampaignOptions mockCampaignOptions;
+    private AbstractLocation mockLocation;
+    private List<Unit> emptyUnits;
+    private List<Formation> emptyFormations;
+    private List<Part> emptyParts;
+    private Map<PersonnelRole, Integer> emptyRoleMap;
+
+    @BeforeEach
+    void setUp() {
+        mockCampaign = mock(Campaign.class);
+        mockCampaignOptions = mock(CampaignOptions.class);
+        mockLocation = mock(AbstractLocation.class);
+
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        when(mockCampaign.getCurrentLocation()).thenReturn(mockLocation);
+
+        emptyUnits = Collections.emptyList();
+        emptyFormations = Collections.emptyList();
+        emptyParts = Collections.emptyList();
+        emptyRoleMap = new HashMap<>();
+    }
+
+    private Accountant createAccountant(List<Person> personnel) {
+        return new Accountant(
+              mockCampaign,
+              emptyUnits,
+              personnel,
+              emptyFormations,
+              emptyParts,
+              0,
+              0,
+              emptyRoleMap
+        );
+    }
+
+    private Person createMockPrisoner() {
+        Person prisoner = mock(Person.class);
+        UUID uniqueId = UUID.randomUUID();
+        when(prisoner.getId()).thenReturn(uniqueId);
+        when(prisoner.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+
+        PrisonerStatus prisonerStatus = mock(PrisonerStatus.class);
+        when(prisonerStatus.isCurrentPrisoner()).thenReturn(true);
+        when(prisoner.getPrisonerStatus()).thenReturn(prisonerStatus);
+        return prisoner;
+    }
+
+    private Person createMockDependent() {
+        Person dependent = mock(Person.class);
+        UUID uniqueId = UUID.randomUUID();
+        when(dependent.getId()).thenReturn(uniqueId);
+        when(dependent.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+
+        PrisonerStatus prisonerStatus = mock(PrisonerStatus.class);
+        when(prisonerStatus.isCurrentPrisoner()).thenReturn(false);
+        when(dependent.getPrisonerStatus()).thenReturn(prisonerStatus);
+        when(dependent.getPrimaryRole()).thenReturn(DEPENDENT);
+        return dependent;
+    }
+
+    private Person createMockEnlisted() {
+        Person enlisted = mock(Person.class);
+        UUID uniqueId = UUID.randomUUID();
+        when(enlisted.getId()).thenReturn(uniqueId);
+        when(enlisted.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+
+        PrisonerStatus prisonerStatus = mock(PrisonerStatus.class);
+        when(prisonerStatus.isCurrentPrisoner()).thenReturn(false);
+        when(enlisted.getPrisonerStatus()).thenReturn(prisonerStatus);
+        when(enlisted.getPrimaryRole()).thenReturn(MEKWARRIOR);
+        when(enlisted.getRankNumeric()).thenReturn(RWO_MIN - 1);
+        return enlisted;
+    }
+
+    private Person createMockOfficer() {
+        Person officer = mock(Person.class);
+        UUID uniqueId = UUID.randomUUID();
+        when(officer.getId()).thenReturn(uniqueId);
+        when(officer.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+
+        PrisonerStatus prisonerStatus = mock(PrisonerStatus.class);
+        when(prisonerStatus.isCurrentPrisoner()).thenReturn(false);
+        when(officer.getPrisonerStatus()).thenReturn(prisonerStatus);
+        when(officer.getPrimaryRole()).thenReturn(MEKWARRIOR);
+        when(officer.getRankNumeric()).thenReturn(RWO_MIN + 1);
+        return officer;
+    }
+
     @Test
     void testGetMonthlyFoodAndHousingExpenses_WhenFoodAndHousingDisabled() {
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         when(mockCampaignOptions.isPayForFood()).thenReturn(false);
         when(mockCampaignOptions.isPayForHousing()).thenReturn(false);
+        when(mockLocation.isOnPlanet()).thenReturn(true);
 
-        Accountant accountant = new Accountant(mockCampaign);
+        Accountant accountant = createAccountant(Collections.emptyList());
 
-        CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getCurrentLocation()).thenReturn(location);
-
-        // Act
-        Money expected = Money.zero();
-        Money actual = accountant.getMonthlyFoodAndHousingExpenses();
-
-        // Assert
-        assertEquals(expected, actual);
+        assertEquals(Money.zero(), accountant.getMonthlyFoodAndHousingExpenses());
     }
 
     @Test
     void testGetMonthlyFoodAndHousingExpenses_WhenNoPersonnel() {
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
+        when(mockCampaignOptions.isPayForFood()).thenReturn(true);
+        when(mockCampaignOptions.isPayForHousing()).thenReturn(true);
+        when(mockLocation.isOnPlanet()).thenReturn(true);
 
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        when(mockCampaignOptions.isPayForFood()).thenReturn(false);
-        when(mockCampaignOptions.isPayForHousing()).thenReturn(false);
+        Accountant accountant = createAccountant(Collections.emptyList());
 
-        Accountant accountant = new Accountant(mockCampaign);
-
-        CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getCurrentLocation()).thenReturn(location);
-
-        // Act
-        Money expected = Money.zero();
-        Money actual = accountant.getMonthlyFoodAndHousingExpenses();
-
-        // Assert
-        assertEquals(expected, actual);
+        assertEquals(Money.zero(), accountant.getMonthlyFoodAndHousingExpenses());
     }
 
     @Test
     void testGetMonthlyFoodAndHousingExpenses_WhenOnlyPrisoners() {
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         when(mockCampaignOptions.isPayForFood()).thenReturn(true);
         when(mockCampaignOptions.isPayForHousing()).thenReturn(true);
+        when(mockLocation.isOnPlanet()).thenReturn(true);
 
-        Accountant accountant = new Accountant(mockCampaign);
+        List<Person> prisoners = List.of(createMockPrisoner(), createMockPrisoner(), createMockPrisoner());
+        Accountant accountant = createAccountant(prisoners);
 
-        CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getCurrentLocation()).thenReturn(location);
-
-        Faction faction = new Faction();
-        when(mockCampaign.getFaction()).thenReturn(faction);
-
-        Person prisoner = new Person(mockCampaign);
-        prisoner.setPrisonerStatus(mockCampaign, PRISONER, false);
-        List<Person> prisoners = List.of(prisoner, prisoner, prisoner);
-        when(mockCampaign.getAllPersonnel()).thenReturn(prisoners);
-
-        // Act
         int expensesFood = FOOD_PRISONER_OR_DEPENDENT * prisoners.size();
         int expensesHousing = HOUSING_PRISONER_OR_DEPENDENT * prisoners.size();
         Money expected = Money.of(expensesFood + expensesHousing);
-        Money actual = accountant.getMonthlyFoodAndHousingExpenses();
 
-        // Assert
-        assertEquals(expected, actual);
+        assertEquals(expected, accountant.getMonthlyFoodAndHousingExpenses());
     }
 
     @Test
     void testGetMonthlyHousingExpenses_WhenOnlyPrisoners() {
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         when(mockCampaignOptions.isPayForFood()).thenReturn(false);
         when(mockCampaignOptions.isPayForHousing()).thenReturn(true);
+        when(mockLocation.isOnPlanet()).thenReturn(true);
 
-        Accountant accountant = new Accountant(mockCampaign);
+        List<Person> prisoners = List.of(createMockPrisoner(), createMockPrisoner(), createMockPrisoner());
+        Accountant accountant = createAccountant(prisoners);
 
-        CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getCurrentLocation()).thenReturn(location);
-
-        Faction faction = new Faction();
-        when(mockCampaign.getFaction()).thenReturn(faction);
-
-        Person prisoner = new Person(mockCampaign);
-        prisoner.setPrisonerStatus(mockCampaign, PRISONER, false);
-        List<Person> prisoners = List.of(prisoner, prisoner, prisoner);
-        when(mockCampaign.getAllPersonnel()).thenReturn(prisoners);
-
-        // Act
         int expensesHousing = HOUSING_PRISONER_OR_DEPENDENT * prisoners.size();
         Money expected = Money.of(expensesHousing);
-        Money actual = accountant.getMonthlyFoodAndHousingExpenses();
 
-        // Assert
-        assertEquals(expected, actual);
+        assertEquals(expected, accountant.getMonthlyFoodAndHousingExpenses());
     }
 
     @Test
     void testGetMonthlyFoodExpenses_WhenOnlyPrisoners() {
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         when(mockCampaignOptions.isPayForFood()).thenReturn(true);
         when(mockCampaignOptions.isPayForHousing()).thenReturn(false);
+        when(mockLocation.isOnPlanet()).thenReturn(true);
 
-        Accountant accountant = new Accountant(mockCampaign);
+        List<Person> prisoners = List.of(createMockPrisoner(), createMockPrisoner(), createMockPrisoner());
+        Accountant accountant = createAccountant(prisoners);
 
-        CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getCurrentLocation()).thenReturn(location);
-
-        Faction faction = new Faction();
-        when(mockCampaign.getFaction()).thenReturn(faction);
-
-        Person prisoner = new Person(mockCampaign);
-        prisoner.setPrisonerStatus(mockCampaign, PRISONER, false);
-        List<Person> prisoners = List.of(prisoner, prisoner, prisoner);
-        when(mockCampaign.getAllPersonnel()).thenReturn(prisoners);
-
-        // Act
         int expensesFood = FOOD_PRISONER_OR_DEPENDENT * prisoners.size();
         Money expected = Money.of(expensesFood);
-        Money actual = accountant.getMonthlyFoodAndHousingExpenses();
 
-        // Assert
-        assertEquals(expected, actual);
+        assertEquals(expected, accountant.getMonthlyFoodAndHousingExpenses());
     }
 
     @Test
     void testGetMonthlyFoodAndHousingExpenses_WhenOnlyDependents() {
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         when(mockCampaignOptions.isPayForFood()).thenReturn(true);
         when(mockCampaignOptions.isPayForHousing()).thenReturn(true);
+        when(mockLocation.isOnPlanet()).thenReturn(true);
 
-        Accountant accountant = new Accountant(mockCampaign);
+        List<Person> dependents = List.of(createMockDependent(), createMockDependent(), createMockDependent());
+        Accountant accountant = createAccountant(dependents);
 
-        CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getCurrentLocation()).thenReturn(location);
-
-        Faction faction = new Faction();
-        when(mockCampaign.getFaction()).thenReturn(faction);
-
-        Person dependent = new Person(mockCampaign);
-        dependent.setPrimaryRole(mockCampaign, DEPENDENT);
-        List<Person> dependents = List.of(dependent, dependent, dependent);
-        when(mockCampaign.getAllPersonnel()).thenReturn(dependents);
-
-        // Act
         int expensesFood = FOOD_PRISONER_OR_DEPENDENT * dependents.size();
         int expensesHousing = HOUSING_PRISONER_OR_DEPENDENT * dependents.size();
         Money expected = Money.of(expensesFood + expensesHousing);
-        Money actual = accountant.getMonthlyFoodAndHousingExpenses();
 
-        // Assert
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void testGetMonthlyHousingExpenses_WhenOnlyDependents() {
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        when(mockCampaignOptions.isPayForFood()).thenReturn(false);
-        when(mockCampaignOptions.isPayForHousing()).thenReturn(true);
-
-        Accountant accountant = new Accountant(mockCampaign);
-
-        CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getCurrentLocation()).thenReturn(location);
-
-        Faction faction = new Faction();
-        when(mockCampaign.getFaction()).thenReturn(faction);
-
-        Person dependent = new Person(mockCampaign);
-        dependent.setPrimaryRole(mockCampaign, DEPENDENT);
-        List<Person> dependents = List.of(dependent, dependent, dependent);
-        when(mockCampaign.getAllPersonnel()).thenReturn(dependents);
-
-        // Act
-        int expensesHousing = HOUSING_PRISONER_OR_DEPENDENT * dependents.size();
-        Money expected = Money.of(expensesHousing);
-        Money actual = accountant.getMonthlyFoodAndHousingExpenses();
-
-        // Assert
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void testGetMonthlyFoodExpenses_WhenOnlyDependents() {
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        when(mockCampaignOptions.isPayForFood()).thenReturn(true);
-        when(mockCampaignOptions.isPayForHousing()).thenReturn(false);
-
-        Accountant accountant = new Accountant(mockCampaign);
-
-        CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getCurrentLocation()).thenReturn(location);
-
-        Faction faction = new Faction();
-        when(mockCampaign.getFaction()).thenReturn(faction);
-
-        Person dependent = new Person(mockCampaign);
-        dependent.setPrimaryRole(mockCampaign, DEPENDENT);
-        List<Person> dependents = List.of(dependent, dependent, dependent);
-        when(mockCampaign.getAllPersonnel()).thenReturn(dependents);
-
-        // Act
-        int expensesFood = FOOD_PRISONER_OR_DEPENDENT * dependents.size();
-        Money expected = Money.of(expensesFood);
-        Money actual = accountant.getMonthlyFoodAndHousingExpenses();
-
-        // Assert
-        assertEquals(expected, actual);
+        assertEquals(expected, accountant.getMonthlyFoodAndHousingExpenses());
     }
 
     @Test
     void testGetMonthlyFoodAndHousingExpenses_WhenOnlyEnlisted() {
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         when(mockCampaignOptions.isPayForFood()).thenReturn(true);
         when(mockCampaignOptions.isPayForHousing()).thenReturn(true);
+        when(mockLocation.isOnPlanet()).thenReturn(true);
 
-        Accountant accountant = new Accountant(mockCampaign);
+        List<Person> enlistedPersonnel = List.of(createMockEnlisted(), createMockEnlisted(), createMockEnlisted());
+        Accountant accountant = createAccountant(enlistedPersonnel);
 
-        CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getCurrentLocation()).thenReturn(location);
-
-        Faction faction = new Faction();
-        when(mockCampaign.getFaction()).thenReturn(faction);
-
-        Person enlisted = new Person(mockCampaign);
-        enlisted.setPrimaryRole(mockCampaign, MEKWARRIOR);
-        enlisted.setRank(RWO_MIN - 1);
-        List<Person> enlistedPersonnel = List.of(enlisted, enlisted, enlisted);
-        when(mockCampaign.getAllPersonnel()).thenReturn(enlistedPersonnel);
-
-        // Act
         int expensesFood = FOOD_ENLISTED * enlistedPersonnel.size();
         int expensesHousing = HOUSING_ENLISTED * enlistedPersonnel.size();
         Money expected = Money.of(expensesFood + expensesHousing);
-        Money actual = accountant.getMonthlyFoodAndHousingExpenses();
 
-        // Assert
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void testGetMonthlyHousingExpenses_WhenOnlyEnlisted() {
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        when(mockCampaignOptions.isPayForFood()).thenReturn(false);
-        when(mockCampaignOptions.isPayForHousing()).thenReturn(true);
-
-        Accountant accountant = new Accountant(mockCampaign);
-
-        CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getCurrentLocation()).thenReturn(location);
-
-        Faction faction = new Faction();
-        when(mockCampaign.getFaction()).thenReturn(faction);
-
-        Person enlisted = new Person(mockCampaign);
-        enlisted.setPrimaryRole(mockCampaign, MEKWARRIOR);
-        enlisted.setRank(RWO_MIN - 1);
-        List<Person> enlistedPersonnel = List.of(enlisted, enlisted, enlisted);
-        when(mockCampaign.getAllPersonnel()).thenReturn(enlistedPersonnel);
-
-        // Act
-        int expensesHousing = HOUSING_ENLISTED * enlistedPersonnel.size();
-        Money expected = Money.of(expensesHousing);
-        Money actual = accountant.getMonthlyFoodAndHousingExpenses();
-
-        // Assert
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void testGetMonthlyFoodExpenses_WhenOnlyEnlisted() {
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        when(mockCampaignOptions.isPayForFood()).thenReturn(true);
-        when(mockCampaignOptions.isPayForHousing()).thenReturn(false);
-
-        Accountant accountant = new Accountant(mockCampaign);
-
-        CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getCurrentLocation()).thenReturn(location);
-
-        Faction faction = new Faction();
-        when(mockCampaign.getFaction()).thenReturn(faction);
-
-        Person enlisted = new Person(mockCampaign);
-        enlisted.setPrimaryRole(mockCampaign, MEKWARRIOR);
-        enlisted.setRank(RWO_MIN - 1);
-        List<Person> enlistedPersonnel = List.of(enlisted, enlisted, enlisted);
-        when(mockCampaign.getAllPersonnel()).thenReturn(enlistedPersonnel);
-
-        // Act
-        int expensesFood = FOOD_ENLISTED * enlistedPersonnel.size();
-        Money expected = Money.of(expensesFood);
-        Money actual = accountant.getMonthlyFoodAndHousingExpenses();
-
-        // Assert
-        assertEquals(expected, actual);
+        assertEquals(expected, accountant.getMonthlyFoodAndHousingExpenses());
     }
 
     @Test
     void testGetMonthlyFoodAndHousingExpenses_WhenOnlyOfficers() {
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         when(mockCampaignOptions.isPayForFood()).thenReturn(true);
         when(mockCampaignOptions.isPayForHousing()).thenReturn(true);
+        when(mockLocation.isOnPlanet()).thenReturn(true);
 
-        Accountant accountant = new Accountant(mockCampaign);
+        List<Person> officerPersonnel = List.of(createMockOfficer(), createMockOfficer(), createMockOfficer());
+        Accountant accountant = createAccountant(officerPersonnel);
 
-        CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getCurrentLocation()).thenReturn(location);
-
-        Faction faction = new Faction();
-        when(mockCampaign.getFaction()).thenReturn(faction);
-
-        Person officer = new Person(mockCampaign);
-        officer.setPrimaryRole(mockCampaign, MEKWARRIOR);
-        officer.setRank(RWO_MIN + 1);
-        List<Person> officerPersonnel = List.of(officer, officer, officer);
-        when(mockCampaign.getAllPersonnel()).thenReturn(officerPersonnel);
-
-        // Act
         int expensesFood = FOOD_OFFICER * officerPersonnel.size();
         int expensesHousing = HOUSING_OFFICER * officerPersonnel.size();
         Money expected = Money.of(expensesFood + expensesHousing);
-        Money actual = accountant.getMonthlyFoodAndHousingExpenses();
 
-        // Assert
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void testGetMonthlyHousingExpenses_WhenOnlyOfficers() {
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        when(mockCampaignOptions.isPayForFood()).thenReturn(false);
-        when(mockCampaignOptions.isPayForHousing()).thenReturn(true);
-
-        Accountant accountant = new Accountant(mockCampaign);
-
-        CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getCurrentLocation()).thenReturn(location);
-
-        Faction faction = new Faction();
-        when(mockCampaign.getFaction()).thenReturn(faction);
-
-        Person officer = new Person(mockCampaign);
-        officer.setPrimaryRole(mockCampaign, MEKWARRIOR);
-        officer.setRank(RWO_MIN + 1);
-        List<Person> officerPersonnel = List.of(officer, officer, officer);
-        when(mockCampaign.getAllPersonnel()).thenReturn(officerPersonnel);
-
-        // Act
-        int expensesHousing = HOUSING_OFFICER * officerPersonnel.size();
-        Money expected = Money.of(expensesHousing);
-        Money actual = accountant.getMonthlyFoodAndHousingExpenses();
-
-        // Assert
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void testGetMonthlyFoodExpenses_WhenOnlyOfficers() {
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        when(mockCampaignOptions.isPayForFood()).thenReturn(true);
-        when(mockCampaignOptions.isPayForHousing()).thenReturn(false);
-
-        Accountant accountant = new Accountant(mockCampaign);
-
-        CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getCurrentLocation()).thenReturn(location);
-
-        Faction faction = new Faction();
-        when(mockCampaign.getFaction()).thenReturn(faction);
-
-        Person officer = new Person(mockCampaign);
-        officer.setPrimaryRole(mockCampaign, MEKWARRIOR);
-        officer.setRank(RWO_MIN + 1);
-        List<Person> officerPersonnel = List.of(officer, officer, officer);
-        when(mockCampaign.getAllPersonnel()).thenReturn(officerPersonnel);
-
-        // Act
-        int expensesFood = FOOD_OFFICER * officerPersonnel.size();
-        Money expected = Money.of(expensesFood);
-        Money actual = accountant.getMonthlyFoodAndHousingExpenses();
-
-        // Assert
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void testGetMonthlyFoodAndHousingExpenses_Mixed() {
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        when(mockCampaignOptions.isPayForFood()).thenReturn(true);
-        when(mockCampaignOptions.isPayForHousing()).thenReturn(true);
-
-        Accountant accountant = new Accountant(mockCampaign);
-
-        CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getCurrentLocation()).thenReturn(location);
-
-        Faction faction = new Faction();
-        when(mockCampaign.getFaction()).thenReturn(faction);
-
-        Person prisoner = new Person(mockCampaign);
-        prisoner.setPrisonerStatus(mockCampaign, PRISONER, false);
-        List<Person> prisoners = List.of(prisoner, prisoner, prisoner);
-
-        Person dependent = new Person(mockCampaign);
-        dependent.setPrimaryRole(mockCampaign, DEPENDENT);
-        List<Person> dependents = List.of(dependent, dependent, dependent);
-
-        Person enlisted = new Person(mockCampaign);
-        enlisted.setPrimaryRole(mockCampaign, MEKWARRIOR);
-        enlisted.setRank(RWO_MIN - 1);
-        List<Person> enlistedPersonnel = List.of(enlisted, enlisted, enlisted);
-
-        Person officer = new Person(mockCampaign);
-        officer.setPrimaryRole(mockCampaign, MEKWARRIOR);
-        officer.setRank(RWO_MIN + 1);
-        List<Person> officerPersonnel = List.of(officer, officer, officer);
-
-        List<Person> allPersonnel = new ArrayList<>();
-        allPersonnel.addAll(prisoners);
-        allPersonnel.addAll(dependents);
-        allPersonnel.addAll(enlistedPersonnel);
-        allPersonnel.addAll(officerPersonnel);
-        when(mockCampaign.getAllPersonnel()).thenReturn(allPersonnel);
-
-        // Act
-        int expensesFood = FOOD_PRISONER_OR_DEPENDENT * (prisoners.size() + dependents.size());
-        expensesFood += FOOD_ENLISTED * enlistedPersonnel.size();
-        expensesFood += FOOD_OFFICER * officerPersonnel.size();
-
-        int expensesHousing = HOUSING_PRISONER_OR_DEPENDENT * (prisoners.size() + dependents.size());
-        expensesHousing += HOUSING_ENLISTED * enlistedPersonnel.size();
-        expensesHousing += HOUSING_OFFICER * officerPersonnel.size();
-
-        Money expected = Money.of(expensesFood + expensesHousing);
-        Money actual = accountant.getMonthlyFoodAndHousingExpenses();
-
-        // Assert
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void testGetMonthlyHousingExpenses_Mixed() {
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        when(mockCampaignOptions.isPayForFood()).thenReturn(false);
-        when(mockCampaignOptions.isPayForHousing()).thenReturn(true);
-
-        Accountant accountant = new Accountant(mockCampaign);
-
-        CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getCurrentLocation()).thenReturn(location);
-
-        Faction faction = new Faction();
-        when(mockCampaign.getFaction()).thenReturn(faction);
-
-        Person prisoner = new Person(mockCampaign);
-        prisoner.setPrisonerStatus(mockCampaign, PRISONER, false);
-        List<Person> prisoners = List.of(prisoner, prisoner, prisoner);
-
-        Person dependent = new Person(mockCampaign);
-        dependent.setPrimaryRole(mockCampaign, DEPENDENT);
-        List<Person> dependents = List.of(dependent, dependent, dependent);
-
-        Person enlisted = new Person(mockCampaign);
-        enlisted.setPrimaryRole(mockCampaign, MEKWARRIOR);
-        enlisted.setRank(RWO_MIN - 1);
-        List<Person> enlistedPersonnel = List.of(enlisted, enlisted, enlisted);
-
-        Person officer = new Person(mockCampaign);
-        officer.setPrimaryRole(mockCampaign, MEKWARRIOR);
-        officer.setRank(RWO_MIN + 1);
-        List<Person> officerPersonnel = List.of(officer, officer, officer);
-
-        List<Person> allPersonnel = new ArrayList<>();
-        allPersonnel.addAll(prisoners);
-        allPersonnel.addAll(dependents);
-        allPersonnel.addAll(enlistedPersonnel);
-        allPersonnel.addAll(officerPersonnel);
-        when(mockCampaign.getAllPersonnel()).thenReturn(allPersonnel);
-
-        // Act
-        int expensesHousing = HOUSING_PRISONER_OR_DEPENDENT * (prisoners.size() + dependents.size());
-        expensesHousing += HOUSING_ENLISTED * enlistedPersonnel.size();
-        expensesHousing += HOUSING_OFFICER * officerPersonnel.size();
-
-        Money expected = Money.of(expensesHousing);
-        Money actual = accountant.getMonthlyFoodAndHousingExpenses();
-
-        // Assert
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void testGetMonthlyFoodExpenses_Mixed() {
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        when(mockCampaignOptions.isPayForFood()).thenReturn(true);
-        when(mockCampaignOptions.isPayForHousing()).thenReturn(false);
-
-        Accountant accountant = new Accountant(mockCampaign);
-
-        CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getCurrentLocation()).thenReturn(location);
-
-        Faction faction = new Faction();
-        when(mockCampaign.getFaction()).thenReturn(faction);
-
-        Person prisoner = new Person(mockCampaign);
-        prisoner.setPrisonerStatus(mockCampaign, PRISONER, false);
-        List<Person> prisoners = List.of(prisoner, prisoner, prisoner);
-
-        Person dependent = new Person(mockCampaign);
-        dependent.setPrimaryRole(mockCampaign, DEPENDENT);
-        List<Person> dependents = List.of(dependent, dependent, dependent);
-
-        Person enlisted = new Person(mockCampaign);
-        enlisted.setPrimaryRole(mockCampaign, MEKWARRIOR);
-        enlisted.setRank(RWO_MIN - 1);
-        List<Person> enlistedPersonnel = List.of(enlisted, enlisted, enlisted);
-
-        Person officer = new Person(mockCampaign);
-        officer.setPrimaryRole(mockCampaign, MEKWARRIOR);
-        officer.setRank(RWO_MIN + 1);
-        List<Person> officerPersonnel = List.of(officer, officer, officer);
-
-        List<Person> allPersonnel = new ArrayList<>();
-        allPersonnel.addAll(prisoners);
-        allPersonnel.addAll(dependents);
-        allPersonnel.addAll(enlistedPersonnel);
-        allPersonnel.addAll(officerPersonnel);
-        when(mockCampaign.getAllPersonnel()).thenReturn(allPersonnel);
-
-        // Act
-        int expensesFood = FOOD_PRISONER_OR_DEPENDENT * (prisoners.size() + dependents.size());
-        expensesFood += FOOD_ENLISTED * enlistedPersonnel.size();
-        expensesFood += FOOD_OFFICER * officerPersonnel.size();
-
-        Money expected = Money.of(expensesFood);
-        Money actual = accountant.getMonthlyFoodAndHousingExpenses();
-
-        // Assert
-        assertEquals(expected, actual);
+        assertEquals(expected, accountant.getMonthlyFoodAndHousingExpenses());
     }
 
     @Test
     void testGetMonthlyFoodAndHousingExpenses_Mixed_InTransit() {
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         when(mockCampaignOptions.isPayForFood()).thenReturn(true);
         when(mockCampaignOptions.isPayForHousing()).thenReturn(true);
+        when(mockLocation.isOnPlanet()).thenReturn(false);
 
-        Accountant accountant = new Accountant(mockCampaign);
+        List<Person> personnel = List.of(createMockEnlisted(), createMockEnlisted());
+        Accountant accountant = createAccountant(personnel);
 
-        CurrentLocation location = new CurrentLocation();
-        location.setTransitTime(1);
-        when(mockCampaign.getCurrentLocation()).thenReturn(location);
+        int expensesFood = FOOD_ENLISTED * personnel.size();
+        Money expected = Money.of(expensesFood);
 
-        Faction faction = new Faction();
-        when(mockCampaign.getFaction()).thenReturn(faction);
-
-        Person prisoner = new Person(mockCampaign);
-        prisoner.setPrisonerStatus(mockCampaign, PRISONER, false);
-        List<Person> prisoners = List.of(prisoner, prisoner, prisoner);
-
-        Person dependent = new Person(mockCampaign);
-        dependent.setPrimaryRole(mockCampaign, DEPENDENT);
-        List<Person> dependents = List.of(dependent, dependent, dependent);
-
-        Person enlisted = new Person(mockCampaign);
-        enlisted.setPrimaryRole(mockCampaign, MEKWARRIOR);
-        enlisted.setRank(RWO_MIN - 1);
-        List<Person> enlistedPersonnel = List.of(enlisted, enlisted, enlisted);
-
-        Person officer = new Person(mockCampaign);
-        officer.setPrimaryRole(mockCampaign, MEKWARRIOR);
-        officer.setRank(RWO_MIN + 1);
-        List<Person> officerPersonnel = List.of(officer, officer, officer);
-
-        List<Person> allPersonnel = new ArrayList<>();
-        allPersonnel.addAll(prisoners);
-        allPersonnel.addAll(dependents);
-        allPersonnel.addAll(enlistedPersonnel);
-        allPersonnel.addAll(officerPersonnel);
-        when(mockCampaign.getAllPersonnel()).thenReturn(allPersonnel);
-
-        // Act
-        int expensesFood = FOOD_PRISONER_OR_DEPENDENT * (prisoners.size() + dependents.size());
-        expensesFood += FOOD_ENLISTED * enlistedPersonnel.size();
-        expensesFood += FOOD_OFFICER * officerPersonnel.size();
-
-        int expensesHousing = 0;
-
-        Money expected = Money.of(expensesFood + expensesHousing);
-        Money actual = accountant.getMonthlyFoodAndHousingExpenses();
-
-        // Assert
-        assertEquals(expected, actual);
+        assertEquals(expected, accountant.getMonthlyFoodAndHousingExpenses());
     }
 
     @Test
     void testGetMonthlyFoodAndHousingExpenses_Mixed_ExcludingWarShipCrew() {
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         when(mockCampaignOptions.isPayForFood()).thenReturn(true);
         when(mockCampaignOptions.isPayForHousing()).thenReturn(true);
+        when(mockLocation.isOnPlanet()).thenReturn(true);
 
-        Accountant accountant = new Accountant(mockCampaign);
-
-        CurrentLocation location = new CurrentLocation();
-        when(mockCampaign.getCurrentLocation()).thenReturn(location);
-
-        Faction faction = new Faction();
-        when(mockCampaign.getFaction()).thenReturn(faction);
-
-        Person prisoner = new Person(mockCampaign);
-        prisoner.setPrisonerStatus(mockCampaign, PRISONER, false);
-        List<Person> prisoners = List.of(prisoner, prisoner, prisoner);
-
-        Person dependent = new Person(mockCampaign);
-        dependent.setPrimaryRole(mockCampaign, DEPENDENT);
-        List<Person> dependents = List.of(dependent, dependent, dependent);
-
-        Person enlisted = new Person(mockCampaign);
-        enlisted.setPrimaryRole(mockCampaign, MEKWARRIOR);
-        enlisted.setRank(RWO_MIN - 1);
-        List<Person> enlistedPersonnel = List.of(enlisted, enlisted, enlisted);
-
-        Person officer = new Person(mockCampaign);
-        officer.setPrimaryRole(mockCampaign, MEKWARRIOR);
-        officer.setRank(RWO_MIN + 1);
-        List<Person> officerPersonnel = List.of(officer, officer, officer);
-
-        Unit warShip = new Unit();
+        Unit warShip = mock(Unit.class);
         Entity mockEntity = mock(Entity.class);
         when(mockEntity.isLargeCraft()).thenReturn(true);
         when(mockEntity.isDropShip()).thenReturn(false);
-        warShip.setEntity(mockEntity);
+        when(warShip.getEntity()).thenReturn(mockEntity);
 
-        Person warShipCrew = new Person(mockCampaign);
-        warShipCrew.setPrimaryRole(mockCampaign, VESSEL_GUNNER);
-        warShipCrew.setRank(RWO_MIN - 1);
-        warShipCrew.setUnit(warShip);
-        List<Person> warShipPersonnel = List.of(warShipCrew, warShipCrew, warShipCrew);
+        Person crew = mock(Person.class);
+        when(crew.getId()).thenReturn(UUID.randomUUID());
+        when(crew.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        PrisonerStatus prisonerStatus = mock(PrisonerStatus.class);
+        when(crew.getPrisonerStatus()).thenReturn(prisonerStatus);
+        when(crew.getPrimaryRole()).thenReturn(PersonnelRole.VESSEL_GUNNER);
+        when(crew.getRankNumeric()).thenReturn(RWO_MIN - 1);
+        when(crew.getUnit()).thenReturn(warShip);
 
-        List<Person> allPersonnel = new ArrayList<>();
-        allPersonnel.addAll(prisoners);
-        allPersonnel.addAll(dependents);
-        allPersonnel.addAll(enlistedPersonnel);
-        allPersonnel.addAll(officerPersonnel);
-        allPersonnel.addAll(warShipPersonnel);
-        when(mockCampaign.getAllPersonnel()).thenReturn(allPersonnel);
+        List<Person> personnel = List.of(crew);
+        Accountant accountant = createAccountant(personnel);
 
-        // Act
-        int expensesFood = FOOD_PRISONER_OR_DEPENDENT * (prisoners.size() + dependents.size());
-        expensesFood += FOOD_ENLISTED * enlistedPersonnel.size();
-        expensesFood += FOOD_OFFICER * officerPersonnel.size();
-        expensesFood += FOOD_ENLISTED * warShipPersonnel.size();
+        int expensesFood = FOOD_ENLISTED * personnel.size();
+        Money expected = Money.of(expensesFood);
 
-        int expensesHousing = HOUSING_PRISONER_OR_DEPENDENT * (prisoners.size() + dependents.size());
-        expensesHousing += HOUSING_ENLISTED * enlistedPersonnel.size();
-        expensesHousing += HOUSING_OFFICER * officerPersonnel.size();
-
-        Money expected = Money.of(expensesFood + expensesHousing);
-        Money actual = accountant.getMonthlyFoodAndHousingExpenses();
-
-        // Assert
-        assertEquals(expected, actual);
-    }
-
-    /**
-     * tests {@link Accountant#getPayRollSummary()}
-     */
-    @Nested
-    class TestGetPayrollSummary {
-        Campaign mockCampaign;
-        CampaignOptions campaignOptions;
-        Accountant accountant;
-        final int EXPECTEDPAY = 100;
-        final int CREWCOUNT = 5;
-
-        @BeforeEach
-        void beforeEach() {
-            mockCampaign = mock(Campaign.class);
-            campaignOptions = new CampaignOptions();
-            accountant = new Accountant(mockCampaign);
-        }
-
-
-        @Test
-        void testGetPayrollSummary_emptyCampaign() {
-            // Arrange
-            when(mockCampaign.getCampaignOptions()).thenReturn(campaignOptions);
-
-            // Act
-            Map<Person, Money> expectedMap = accountant.getPayRollSummary();
-
-            // Assert
-            assertEquals(1, expectedMap.size());
-            assertTrue(expectedMap.containsKey(null));
-            assertEquals(Money.zero(), expectedMap.get(null));
-        }
-
-        @Test
-        void testGetPayrollSummary_onePerson() {
-            // Arrange
-            Person mockPerson = getMockPerson(EXPECTEDPAY);
-
-            when(mockCampaign.getCampaignOptions()).thenReturn(campaignOptions);
-            when(mockCampaign.getSalaryEligiblePersonnel()).thenReturn(List.of(mockPerson));
-
-            // Act
-            Map<Person, Money> expectedMap = accountant.getPayRollSummary();
-
-            // Assert
-            assertEquals(2, expectedMap.size());
-            assertTrue(expectedMap.containsKey(null));
-            assertEquals(Money.zero(), expectedMap.get(null));
-            assertTrue(expectedMap.containsKey(mockPerson));
-            assertEquals(Money.of(EXPECTEDPAY), expectedMap.get(mockPerson));
-        }
-
-        @Test
-        void testGetAstechPoolPay() {
-            // Arrange
-            when(mockCampaign.getTemporaryAsTechPool()).thenReturn(5);
-            when(mockCampaign.getCampaignOptions()).thenReturn(campaignOptions);
-
-            // Act
-
-            Map<Person, Money> expectedMap = accountant.getPayRollSummary();
-
-            // Assert
-            assertEquals(1, expectedMap.size());
-            assertTrue(expectedMap.containsKey(null));
-            assertEquals(Money.of(2000), expectedMap.get(null));
-        }
-
-        @Test
-        void testGetMedicPoolPay() {
-            // Arrange
-            when(mockCampaign.getTemporaryMedicPool()).thenReturn(5);
-            when(mockCampaign.getCampaignOptions()).thenReturn(campaignOptions);
-
-            // Act
-
-            Map<Person, Money> expectedMap = accountant.getPayRollSummary();
-
-            // Assert
-            assertEquals(1, expectedMap.size());
-            assertTrue(expectedMap.containsKey(null));
-            assertEquals(Money.of(2000), expectedMap.get(null));
-        }
-
-        @ParameterizedTest
-        @EnumSource(names = { "SOLDIER", "BATTLE_ARMOUR", "VEHICLE_CREW_GROUND", "VEHICLE_CREW_VTOL",
-                              "VEHICLE_CREW_NAVAL", "VESSEL_PILOT", "VESSEL_GUNNER", "VESSEL_CREW" })
-        void testGetAllTempCrewPay(PersonnelRole role) {
-            // Arrange
-            when(mockCampaign.getTempCrewRoleKeys())
-                  .thenReturn(new HashSet<>(Collections.singleton(role)));
-            when(mockCampaign.getTempCrewPool(any())).thenReturn(CREWCOUNT);
-            when(mockCampaign.getCampaignOptions()).thenReturn(campaignOptions);
-
-            // Act
-            Map<Person, Money> expectedMap = accountant.getPayRollSummary();
-
-            // Assert
-            assertEquals(1, expectedMap.size());
-            assertTrue(expectedMap.containsKey(null));
-            assertEquals(Money.of(CREWCOUNT *
-                                        campaignOptions.getRoleBaseSalaries()[role.ordinal()].getAmount()
-                                              .doubleValue()),
-                  expectedMap.get(null));
-        }
-
-        Person getMockPerson(int pay) {
-            Person mockPerson = mock(Person.class);
-
-            when(mockPerson.getSalary(mockCampaign)).thenReturn(Money.of(pay));
-            return mockPerson;
-        }
+        assertEquals(expected, accountant.getMonthlyFoodAndHousingExpenses());
     }
 }


### PR DESCRIPTION
The goal of this PR was to update the `Accountant` record to be more universally usable. Prior to this PR Accountant was strongly tied to `Campaign` and was wholly isolated from the new multi-locational stuff. The ongoing contract overhaul also needs to be able to evaluate the costs and values of portions of the campaign, so as to support multiple concurrent contracts and split forces.

The goal here was to make as few edits as possible, to the underlying logic. As well as to avoid needing to upheave large portions of the codebase. With this in mind I created an alternate constructor that just takes `campaign`. This allows us to make our changes without it affecting the rest of the codebase.