### PR TITLE
Introduce MHQTable and use it for Personnel Table

### DIFF
--- a/MekHQ/src/mekhq/gui/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/PersonnelTab.java
@@ -45,7 +45,6 @@ import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -53,17 +52,12 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.swing.*;
-import javax.swing.RowSorter.SortKey;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
-import javax.swing.table.DefaultTableColumnModel;
-import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
-import javax.swing.table.TableRowSorter;
 
 import megamek.client.ui.clientGUI.GUIPreferences;
 import megamek.client.ui.comboBoxes.MMComboBox;
-import megamek.client.ui.models.XTableColumnModel;
 import megamek.client.ui.preferences.JComboBoxPreference;
 import megamek.client.ui.preferences.JTablePreference;
 import megamek.client.ui.preferences.JToggleButtonPreference;
@@ -90,6 +84,7 @@ import mekhq.campaign.personnel.skills.QuickTrain;
 import mekhq.gui.adapter.PersonnelTableMouseAdapter;
 import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
 import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
+import mekhq.gui.baseComponents.tables.MHQTable;
 import mekhq.gui.dialog.BatchXPDialog;
 import mekhq.gui.dialog.QuickTrainDialog;
 import mekhq.gui.enums.MHQTabType;
@@ -111,15 +106,12 @@ public final class PersonnelTab extends CampaignGuiTab {
     public static final int PERSON_VIEW_MIN_WIDTH = 450;
     public static final int PERSON_VIEW_PREFERRED_WIDTH = 650;
 
-    private JTable personnelTable;
+    private MHQTable<Person, PersonnelTableModelColumn, PersonnelTableModel> personnelTable;
     private MMComboBox<PersonnelFilter> personnelFilter;
     private MMComboBox<PersonnelTabView> personnelView;
     private JTextField searchField;
     private JScrollPane scrollPersonnelView;
     private JCheckBox chkGroupByUnit;
-
-    private PersonnelTableModel personnelTableModel;
-    private TableRowSorter<PersonnelTableModel> personnelSorter;
 
     private final IPreferenceChangeListener scalingChangeListener = e -> changePersonnelView();
 
@@ -266,8 +258,8 @@ public final class PersonnelTab extends CampaignGuiTab {
         chkGroupByUnit = new JCheckBox(resourceMap.getString("chkGroupByUnit.text"));
         chkGroupByUnit.setToolTipText(resourceMap.getString("chkGroupByUnit.toolTipText"));
         chkGroupByUnit.addActionListener(e -> {
-            personnelTableModel.setGroupByUnit(chkGroupByUnit.isSelected());
-            personnelTableModel.refreshData();
+            getPersonnelTableModel().setGroupByUnit(chkGroupByUnit.isSelected());
+            getPersonnelTableModel().refreshData();
             changePersonnelView();
         });
         gridBagConstraints = new GridBagConstraints();
@@ -322,29 +314,8 @@ public final class PersonnelTab extends CampaignGuiTab {
         gridBagConstraints.insets = new Insets(5, 5, 0, 0);
         add(btnMassTraining, gridBagConstraints);
 
-        personnelTableModel = new PersonnelTableModel(getCampaign());
-        personnelTable = new JTable(personnelTableModel);
+        personnelTable = new MHQTable<>(new PersonnelTableModel(getCampaign()));
         personnelTable.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
-        XTableColumnModel personColumnModel = new XTableColumnModel();
-        personnelTable.setColumnModel(personColumnModel);
-        personnelTable.createDefaultColumnsFromModel();
-        personnelSorter = new TableRowSorter<>(personnelTableModel);
-        final ArrayList<SortKey> sortKeys = new ArrayList<>();
-        for (final PersonnelTableModelColumn column : PersonnelTableModel.PERSONNEL_COLUMNS) {
-            TableColumn tableColumn = personColumnModel.getColumnByModelIndex(column.ordinal());
-            tableColumn.setCellRenderer(personnelTableModel.getRenderer());
-
-            final Comparator<?> comparator = column.getComparator();
-            personnelSorter.setComparator(column.ordinal(), comparator);
-            final SortOrder sortOrder = column.getDefaultSortOrder();
-            if (sortOrder != null) {
-                sortKeys.add(new SortKey(column.ordinal(), sortOrder));
-            }
-        }
-        personnelSorter.setSortKeys(sortKeys);
-        personnelTable.setRowSorter(personnelSorter);
-        personnelTable.setIntercellSpacing(new Dimension(0, 0));
-        personnelTable.setShowGrid(false);
         personnelTable.getSelectionModel().addListSelectionListener(ev -> refreshPersonnelView());
 
         scrollPersonnelView = new FastJScrollPane();
@@ -379,7 +350,7 @@ public final class PersonnelTab extends CampaignGuiTab {
 
         registerSearchShortcut();
 
-        PersonnelTableMouseAdapter.connect(getCampaignGui(), personnelTable, personnelTableModel, splitPersonnel);
+        PersonnelTableMouseAdapter.connect(getCampaignGui(), personnelTable, getPersonnelTableModel(), splitPersonnel);
 
         refreshAll();
         updateUIScaling();
@@ -439,7 +410,7 @@ public final class PersonnelTab extends CampaignGuiTab {
     }
 
     public PersonnelTableModel getPersonnelTableModel() {
-        return personnelTableModel;
+        return personnelTable.getModel();
     }
 
     /*
@@ -458,11 +429,11 @@ public final class PersonnelTab extends CampaignGuiTab {
                                              PersonnelFilter.ACTIVE :
                                              personnelFilter.getSelectedItem();
         String searchText = searchField.getText();
-        personnelTableModel.getRenderer().setHighlight(searchText);
-        personnelSorter.setRowFilter(new RowFilter<>() {
+        getPersonnelTableModel().setHighlight(searchText);
+        personnelTable.setRowFilter(new RowFilter<>() {
             @Override
             public boolean include(Entry<? extends PersonnelTableModel, ? extends Integer> entry) {
-                Person person = entry.getModel().getPerson(entry.getIdentifier());
+                Person person = entry.getModel().getRow(entry.getIdentifier());
                 if (!filter.getFilteredInformation(person, getCampaignGui().getCampaign().getLocalDate())) {
                     return false;
                 }
@@ -476,7 +447,7 @@ public final class PersonnelTab extends CampaignGuiTab {
 
                 for (int i = 0; i < visibleColumnCount; i++) {
                     int modelIndex = columnModel.getColumn(i).getModelIndex();
-                    PersonnelTableModelColumn column = PersonnelTableModel.PERSONNEL_COLUMNS[modelIndex];
+                    PersonnelTableModelColumn column = getPersonnelTableModel().getAllColumns().get(modelIndex);
                     String cellText = column.getText(column.getCellValue(getCampaign(), person));
                     if (cellText != null && cellText.toLowerCase(Locale.ROOT).contains(searchAsLowerCase)) {
                         return true;
@@ -504,28 +475,15 @@ public final class PersonnelTab extends CampaignGuiTab {
             }).collect(Collectors.toSet());
         }
 
-        XTableColumnModel columnModel = (XTableColumnModel) getPersonnelTable().getColumnModel();
-        // replace the model with a dummy to suspend UI repaints
-        getPersonnelTable().setColumnModel(new DefaultTableColumnModel());
-
-        for (PersonnelTableModelColumn column : PersonnelTableModel.PERSONNEL_COLUMNS) {
-            TableColumn tableColumn = columnModel.getColumnByModelIndex(column.ordinal());
-            Integer width = column.getPreferredWidth();
-            if (width != null) {
-                tableColumn.setPreferredWidth(width);
-            }
-            columnModel.setColumnVisible(tableColumn, visibleColumns.contains(column));
-        }
+        personnelTable.setView(visibleColumns);
         personnelTable.setRowHeight(UIUtil.scaleForGUI((view == PersonnelTabView.GRAPHIC) ? 60 : 15));
-        // reattach the updated model
-        personnelTable.setColumnModel(columnModel);
         filterPersonnel();
     }
 
     public void focusOnPerson(UUID id) {
         int row = -1;
         for (int i = 0; i < personnelTable.getRowCount(); i++) {
-            if (personnelTableModel.getPerson(personnelTable.convertRowIndexToModel(i)).getId().equals(id)) {
+            if (getPersonnelTableModel().getRow(personnelTable.convertRowIndexToModel(i)).getId().equals(id)) {
                 row = i;
                 break;
             }
@@ -534,7 +492,7 @@ public final class PersonnelTab extends CampaignGuiTab {
             // try expanding the filter to all units
             personnelFilter.setSelectedIndex(0);
             for (int i = 0; i < personnelTable.getRowCount(); i++) {
-                if (personnelTableModel.getPerson(personnelTable.convertRowIndexToModel(i)).getId().equals(id)) {
+                if (getPersonnelTableModel().getRow(personnelTable.convertRowIndexToModel(i)).getId().equals(id)) {
                     row = i;
                     break;
                 }
@@ -559,7 +517,7 @@ public final class PersonnelTab extends CampaignGuiTab {
         UUID selectedUUID = null;
         int selectedRow = personnelTable.getSelectedRow();
         if (selectedRow != -1) {
-            Person person = personnelTableModel.getPerson(personnelTable.convertRowIndexToModel(selectedRow));
+            Person person = getPersonnelTableModel().getRow(personnelTable.convertRowIndexToModel(selectedRow));
             if (null != person) {
                 selectedUUID = person.getId();
             }
@@ -568,10 +526,10 @@ public final class PersonnelTab extends CampaignGuiTab {
         LocationFilterItem locationFilter = getCampaignGui().getActiveLocation();
 
         List<Person> people = locationFilter.selectPersonnel(getCampaign());
-        personnelTableModel.setData(people);
+        getPersonnelTableModel().setData(people);
 
         for (int row = 0; row < personnelTable.getRowCount(); row++) {
-            Person person = personnelTableModel.getPerson(personnelTable.convertRowIndexToModel(row));
+            Person person = getPersonnelTableModel().getRow(personnelTable.convertRowIndexToModel(row));
             if (person != null && person.getId().equals(selectedUUID)) {
                 personnelTable.setRowSelectionInterval(row, row);
                 refreshPersonnelView();
@@ -587,7 +545,7 @@ public final class PersonnelTab extends CampaignGuiTab {
             scrollPersonnelView.setViewportView(null);
             return;
         }
-        Person selectedPerson = personnelTableModel.getPerson(personnelTable.convertRowIndexToModel(row));
+        Person selectedPerson = getPersonnelTableModel().getRow(personnelTable.convertRowIndexToModel(row));
         scrollPersonnelView.setViewportView(new PersonViewPanel(selectedPerson, getCampaign(), getCampaignGui()));
         // This odd code is to make sure that the scrollbar stays at the top
         // I can't just call it here, because it ends up getting reset somewhere later
@@ -599,7 +557,7 @@ public final class PersonnelTab extends CampaignGuiTab {
         List<Person> selectedPersons = new ArrayList<>();
         for (int viewRow : selectedRows) {
             int modelRow = personnelTable.convertRowIndexToModel(viewRow);
-            Person person = personnelTableModel.getPerson(modelRow);
+            Person person = getPersonnelTableModel().getRow(modelRow);
             if (person != null) {
                 selectedPersons.add(person);
             }

--- a/MekHQ/src/mekhq/gui/baseComponents/tables/MHQTable.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/tables/MHQTable.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package mekhq.gui.baseComponents.tables;
+
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Set;
+import javax.swing.JTable;
+import javax.swing.RowFilter;
+import javax.swing.RowSorter;
+import javax.swing.SortOrder;
+import javax.swing.table.DefaultTableColumnModel;
+import javax.swing.table.JTableHeader;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableRowSorter;
+
+import megamek.client.ui.models.XTableColumnModel;
+
+
+/**
+ * A specialized extension of {@link JTable} designed to work with {@link MHQTableModel} and
+ * {@link MHQTableColumn}. It automatically handles common UI boilerplate for MekHQ tables, such as:
+ * <ul>
+ *   <li>Managing column visibility via {@link XTableColumnModel}.</li>
+ *   <li>Setting up row sorting and applying default sort orders based on the model.</li>
+ *   <li>Providing smart tooltips on column headers that only appear if the header text is truncated.</li>
+ *   <li>Applying default UI settings.</li>
+ * </ul>
+ *
+ * @param <DataModel>   The type of the object representing a single row of data
+ * @param <ColumnModel> The type of the column definition, which must extend {@link MHQTableColumn}
+ * @param <TableModel>  The specific {@link MHQTableModel} implementation used by this table
+ *
+ * @author Hokk
+ * @since 0.51.01
+ */
+public class MHQTable<DataModel,
+                      ColumnModel extends MHQTableColumn,
+                      TableModel extends MHQTableModel<DataModel, ColumnModel>
+                     > extends JTable {
+
+    private final TableRowSorter<TableModel> sorter;
+
+    /**
+     * Constructs a new MHQTable using the provided model. Initializes default visual settings, attaches
+     * custom cell renderers, and configures the row sorter based on the model's properties.
+     *
+     * @param tableModel The underlying table model containing the data and column definitions
+     */
+    public MHQTable(TableModel tableModel) {
+        super(tableModel, new XTableColumnModel());
+        createDefaultColumnsFromModel();
+        setIntercellSpacing(new Dimension(0, 0));
+        setShowGrid(false);
+
+        sorter = new TableRowSorter<>(tableModel);
+        ArrayList<RowSorter.SortKey> sortKeys = new ArrayList<>();
+
+        Map<ColumnModel, SortOrder> defaultSortOrder = getModel().getDefaultSortOrder();
+        for (ColumnModel column : tableModel.getAllColumns()) {
+            TableColumn tableColumn = getColumnModel().getColumnByModelIndex(column.getIndex());
+            tableColumn.setCellRenderer(tableModel.getRenderer());
+
+            Comparator<?> comparator = column.getComparator();
+            sorter.setComparator(column.getIndex(), comparator);
+            SortOrder sortOrder = defaultSortOrder.get(column);
+            if (sortOrder != null) {
+                sortKeys.add(new RowSorter.SortKey(column.getIndex(), sortOrder));
+            }
+        }
+
+        sorter.setSortKeys(sortKeys);
+        sorter.setSortsOnUpdates(true);
+        setRowSorter(sorter);
+    }
+
+    @Override
+    public XTableColumnModel getColumnModel() {
+        return (XTableColumnModel) super.getColumnModel();
+    }
+
+    @Override
+    public TableModel getModel() {
+        return (TableModel) super.getModel();
+    }
+
+    /**
+     * Updates the visibility and preferred widths of the table's columns.
+     *
+     * @param visibleColumns A set containing the {@code ColumnModel} definitions that should be visible
+     */
+    public void setView(Set<ColumnModel> visibleColumns) {
+        XTableColumnModel columnModel = getColumnModel();
+        // replace the model with a dummy to suspend UI repaints
+        setColumnModel(new DefaultTableColumnModel());
+
+        for (ColumnModel column : getModel().getAllColumns()) {
+            TableColumn tableColumn = columnModel.getColumnByModelIndex(column.getIndex());
+            Integer width = column.getPreferredWidth();
+            if (width != null) {
+                tableColumn.setPreferredWidth(width);
+            }
+            columnModel.setColumnVisible(tableColumn, visibleColumns.contains(column));
+        }
+        // reattach the updated model
+        setColumnModel(columnModel);
+    }
+
+    /**
+     * Creates and returns a custom table header. The overridden header logic provides a tooltip that displays the
+     * full column name only if the column's current width is too small to display the entire header text.
+     *
+     * @return A customized {@link JTableHeader}
+     */
+    @Override
+    protected JTableHeader createDefaultTableHeader() {
+        return new JTableHeader(columnModel) {
+            @Override
+            public String getToolTipText(MouseEvent event) {
+                int index = columnModel.getColumnIndexAtX(event.getPoint().x);
+                if (index == -1) {
+                    return super.getToolTipText(event);
+                }
+
+                TableColumn column = columnModel.getColumn(index);
+                Object headerValue = column.getHeaderValue();
+                if (headerValue == null) {
+                    // no header
+                    return super.getToolTipText(event);
+                }
+
+                TableCellRenderer renderer = column.getHeaderRenderer();
+                if (renderer == null) {
+                    renderer = getDefaultRenderer();
+                }
+                Component header = renderer.getTableCellRendererComponent(
+                      getTable(), headerValue, false, false, -1, index);
+
+                int preferredWidth = header.getPreferredSize().width;
+                if (preferredWidth > column.getWidth()) {
+                    return headerValue.toString();
+                }
+
+                return super.getToolTipText(event);
+            }
+        };
+    }
+
+    /**
+     * Applies a row filter.
+     *
+     * @param rowFilter The {@link RowFilter} to apply, or null to clear the filter
+     */
+    public void setRowFilter(RowFilter<TableModel, Integer> rowFilter) {
+        sorter.setRowFilter(rowFilter);
+    }
+
+    /**
+     * Forces the row sorter to re-sort the table data. Useful when the underlying data has
+     * changed in a way that affects sorting, but no table events were fired.
+     */
+    public void refresh() {
+        sorter.sort();
+    }
+}

--- a/MekHQ/src/mekhq/gui/baseComponents/tables/MHQTableColumn.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/tables/MHQTableColumn.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package mekhq.gui.baseComponents.tables;
+
+import java.util.Comparator;
+
+/**
+ * Defines the contract for column definitions used within an {@link MHQTableModel} and displayed by an
+ * {@link MHQTable}. Implementations of this interface encapsulate the methods required to render, sort, and align a
+ * specific column in the UI.
+ *
+ * @author Hokk
+ * @since 0.51.01
+ */
+public interface MHQTableColumn {
+
+    /**
+     * Returns the index of this column model.
+     */
+    int getIndex();
+
+    /**
+     * Generates string representation of the column cell.
+     *
+     * @param model The underlying data object for a cell
+     *
+     * @return The formatted string to be displayed in the UI for this cell
+     */
+    String getText(Object model);
+
+    /**
+     * Returns the comparator used to sort the data in this column.
+     */
+    Comparator<?> getComparator();
+
+    /**
+     * Retrieves the preferred visual width of the column in pixels.
+     *
+     * @return The preferred width as an {@code Integer}, or null if the column should use default sizing logic
+     */
+    Integer getPreferredWidth();
+
+    /**
+     * Retrieves the horizontal text alignment for the cells within this column.
+     *
+     * @return An integer representing a {@link javax.swing.SwingConstants} value
+     */
+    int getAlignment();
+
+}

--- a/MekHQ/src/mekhq/gui/baseComponents/tables/MHQTableModel.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/tables/MHQTableModel.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package mekhq.gui.baseComponents.tables;
+
+import java.awt.Component;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.swing.JTable;
+import javax.swing.SortOrder;
+import javax.swing.table.AbstractTableModel;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.TableCellRenderer;
+
+import megamek.common.annotations.Nullable;
+import mekhq.utilities.ReportingUtilities;
+
+/**
+ * An abstract base class for table models within the MekHQ UI. This class maps a list of data objects
+ * to table rows and a list of {@link MHQTableColumn} definitions to table columns.
+ *
+ * @param <DataModel>   The type of the object representing a single row of data
+ * @param <ColumnModel> The type of the column definition, which must extend {@link MHQTableColumn}
+ *
+ * @author Hokk
+ * @since 0.51.01
+ */
+public abstract class MHQTableModel<DataModel, ColumnModel extends MHQTableColumn> extends AbstractTableModel {
+
+
+    /** The underlying data for the table, where each element represents a row.
+     */
+    protected List<DataModel> data = Collections.emptyList();
+
+    /** Columns defined for the table model.
+     */
+    protected final List<ColumnModel> columns;
+
+    private Map<ColumnModel, SortOrder> defaultSortOrder = new HashMap<>();
+
+    /**
+     * Constructs a new MHQTableModel with the specified columns.
+     *
+     * @param columns A list of column definitions for this table
+     */
+    public MHQTableModel(List<ColumnModel> columns) {
+        this.columns = columns;
+    }
+
+    /**
+     * Retrieves the custom cell renderer for this table model.
+     *
+     * @return The {@link TableCellRenderer} used to render the cells in this table
+     */
+    protected abstract TableCellRenderer getRenderer();
+
+    /**
+     * Retrieves the value to be displayed in a specific cell, determined by the intersection of the
+     * provided row data and column definition.
+     *
+     * @param data   The data object representing the row
+     * @param column The column definition representing the column
+     *
+     * @return The object value to be rendered in the cell
+     */
+    protected abstract Object getCellValue(DataModel data, ColumnModel column);
+
+    @Override
+    public int getRowCount() {
+        return data.size();
+    }
+
+    @Override
+    public int getColumnCount() {
+        return columns.size();
+    }
+
+    @Override
+    public String getColumnName(int columnIndex) {
+        return columns.get(columnIndex).toString();
+    }
+
+    @Override
+    public Object getValueAt(int rowIndex, int columnIndex) {
+        DataModel row = getRow(rowIndex);
+        if (row == null) {
+            return "?";
+        }
+        ColumnModel column = columns.get(columnIndex);
+        return getCellValue(row, column);
+    }
+
+    /**
+     * Sets the underlying data list for this table model. Does not automatically fire a table data changed event.
+     *
+     * @param data The new list of row data objects
+     */
+    public void setData(List<DataModel> data) {
+        this.data = data;
+    }
+
+    public Map<ColumnModel, SortOrder> getDefaultSortOrder() {
+        return defaultSortOrder;
+    }
+
+    /**
+     * Sets the default sorting order for the columns in this model.
+     *
+     * @param defaultSortOrder A map linking column models to their desired {@link SortOrder}
+     */
+    public void setDefaultSortOrder(Map<ColumnModel, SortOrder> defaultSortOrder) {
+        this.defaultSortOrder = defaultSortOrder;
+    }
+
+    /**
+     * Retrieves the data object for a specific row index.
+     *
+     * @param rowIndex The index of the row to retrieve
+     *
+     * @return The data object for the row, or null if the index is out of bounds
+     */
+    @Nullable
+    public DataModel getRow(int rowIndex) {
+        return ((0 <= rowIndex) && (rowIndex < data.size())) ? data.get(rowIndex) : null;
+    }
+
+    /**
+     * Retrieves the list of all column definitions used by this model.
+     *
+     * @return A list of {@code ColumnModel} objects
+     */
+    public List<ColumnModel> getAllColumns() {
+        return columns;
+    }
+
+    /**
+     * A custom {@link DefaultTableCellRenderer}. Handles text rendering based on the {@link MHQTableColumn}
+     * definitions and provides support for dynamic text highlighting (mainly intended for search support).
+     */
+    public class Renderer extends DefaultTableCellRenderer {
+
+        private String highlight = "";
+
+        public void setHighlight(String highlight) {
+            this.highlight = highlight;
+        }
+
+        @Override
+        public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
+              boolean hasFocus, int rowIndex, int columnIndex) {
+            if (table == null) {
+                return this;
+            }
+
+            if (getFont() != table.getFont()) {
+                setFont(table.getFont());
+            }
+            ColumnModel column = getAllColumns().get(table.convertColumnIndexToModel(columnIndex));
+            String text = applyHighlighting(column.getText(value));
+            setText(text);
+            setHorizontalAlignment(column.getAlignment());
+
+            return this;
+        }
+
+        /**
+         * Applies HTML-based visual highlighting to the specified string.
+         *
+         * @param text The original cell text
+         *
+         * @return An HTML-formatted string with the target text highlighted
+         */
+        private String applyHighlighting(String text) {
+            if (highlight.isEmpty()) {
+                return text;
+            }
+            String highlightedText =
+                  ReportingUtilities.messageSurroundedBySpanWithColor(ReportingUtilities.getPositiveColor(), "$1");
+            text = text.replaceAll("(?i)(" + java.util.regex.Pattern.quote(highlight) + ")(?![^<>]*>)", highlightedText);
+            if (text.startsWith("<html>")) {
+                return text;
+            }
+            return "<html>" + text + "</html>";
+        }
+
+    }
+}

--- a/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
@@ -40,17 +40,12 @@ import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.GridLayout;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.ResourceBundle;
+import java.util.Set;
 import javax.swing.*;
-import javax.swing.RowSorter.SortKey;
-import javax.swing.table.TableCellRenderer;
-import javax.swing.table.TableColumn;
-import javax.swing.table.TableRowSorter;
 
-import megamek.client.ui.models.XTableColumnModel;
 import megamek.common.enums.SkillLevel;
 import megamek.common.ui.FastJScrollPane;
 import megamek.logging.MMLogger;
@@ -63,6 +58,7 @@ import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.ranks.Rank;
 import mekhq.campaign.personnel.skills.Skill;
 import mekhq.campaign.personnel.skills.SkillType;
+import mekhq.gui.baseComponents.tables.MHQTable;
 import mekhq.gui.enums.PersonnelTableModelColumn;
 import mekhq.gui.model.PersonnelTableModel;
 
@@ -70,11 +66,9 @@ public final class BatchXPDialog extends JDialog {
     private static final MMLogger LOGGER = MMLogger.create(BatchXPDialog.class);
 
     private final Campaign campaign;
-    private final PersonnelTableModel personnelModel;
-    private TableRowSorter<PersonnelTableModel> personnelSorter;
-    private PersonnelFilter personnelFilter;
+    private final PersonnelFilter personnelFilter;
 
-    private JTable personnelTable;
+    private final MHQTable<Person, PersonnelTableModelColumn, PersonnelTableModel> personnelTable;
     private JComboBox<PersonTypeItem> choiceType;
     private JComboBox<PersonTypeItem> choiceExp;
     private JComboBox<PersonTypeItem> choiceRank;
@@ -85,7 +79,8 @@ public final class BatchXPDialog extends JDialog {
     private JCheckBox allowPrisoners;
     private JButton buttonSpendXP;
 
-    private final List<PersonnelTableModelColumn> batchXPColumns = List.of(PersonnelTableModelColumn.RANK,
+    private final static Set<PersonnelTableModelColumn> BATCH_XP_COLUMNS = Set.of(
+          PersonnelTableModelColumn.RANK,
           PersonnelTableModelColumn.FIRST_NAME,
           PersonnelTableModelColumn.LAST_NAME,
           PersonnelTableModelColumn.AGE,
@@ -105,68 +100,25 @@ public final class BatchXPDialog extends JDialog {
         choiceNoSkill = resourceMap.getString("skill.choice.text");
 
         this.campaign = Objects.requireNonNull(campaign);
-        this.personnelModel = new PersonnelTableModel(campaign);
-        personnelModel.refreshData();
 
-        initComponents();
-    }
-
-    private void initComponents() {
         setLayout(new BorderLayout());
 
-        add(getPersonnelTable(), BorderLayout.CENTER);
+        personnelTable = new MHQTable<>(new PersonnelTableModel(campaign));
+        personnelTable.setCellSelectionEnabled(false);
+        personnelTable.getModel().refreshData();
+
+        personnelFilter = new PersonnelFilter(campaign);
+        personnelTable.setRowFilter(personnelFilter);
+        personnelTable.setView(BATCH_XP_COLUMNS);
+
+        JScrollPane personnelScrollPane = new FastJScrollPane(personnelTable);
+        personnelScrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
+        add(personnelScrollPane, BorderLayout.CENTER);
+
         add(getButtonPanel(), BorderLayout.WEST);
 
         pack();
         setLocationRelativeTo(getParent());
-    }
-
-    private JComponent getPersonnelTable() {
-        personnelTable = new JTable(personnelModel);
-        personnelTable.setCellSelectionEnabled(false);
-        personnelTable.setColumnModel(new XTableColumnModel());
-        personnelTable.createDefaultColumnsFromModel();
-        personnelTable.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
-        personnelTable.setIntercellSpacing(new Dimension(1, 0));
-        personnelTable.setShowGrid(false);
-
-        personnelSorter = new TableRowSorter<>(personnelModel);
-        personnelSorter.setSortsOnUpdates(true);
-
-        final XTableColumnModel columnModel = (XTableColumnModel) personnelTable.getColumnModel();
-        final List<SortKey> sortKeys = new ArrayList<>();
-        for (final PersonnelTableModelColumn column : PersonnelTableModel.PERSONNEL_COLUMNS) {
-            final TableColumn tableColumn = columnModel.getColumnByModelIndex(column.ordinal());
-            if (!batchXPColumns.contains(column)) {
-                columnModel.setColumnVisible(tableColumn, false);
-                continue;
-            }
-
-            Integer width = column.getPreferredWidth();
-            if (width != null) {
-                tableColumn.setPreferredWidth(width);
-            }
-            tableColumn.setCellRenderer(getRenderer());
-            columnModel.setColumnVisible(tableColumn, true);
-
-            personnelSorter.setComparator(column.ordinal(), column.getComparator());
-            final SortOrder sortOrder = column.getDefaultSortOrder();
-            if (sortOrder != null) {
-                sortKeys.add(new SortKey(column.ordinal(), sortOrder));
-            }
-        }
-        personnelSorter.setSortKeys(sortKeys);
-        personnelFilter = new PersonnelFilter(campaign);
-        personnelSorter.setRowFilter(personnelFilter);
-        personnelTable.setRowSorter(personnelSorter);
-
-        final JScrollPane pane = new FastJScrollPane(personnelTable);
-        pane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
-        return pane;
-    }
-
-    private TableCellRenderer getRenderer() {
-        return personnelModel.new Renderer();
     }
 
     private JComponent getButtonPanel() {
@@ -351,7 +303,7 @@ public final class BatchXPDialog extends JDialog {
     }
 
     private void updatePersonnelTable() {
-        personnelSorter.sort();
+        personnelTable.refresh();
         if (!choiceNoSkill.equals(choiceSkill.getSelectedItem())) {
             int rows = personnelTable.getRowCount();
             matchedPersonnelLabel.setText(String.format(resourceMap.getString("eligible.format"), rows));
@@ -383,7 +335,7 @@ public final class BatchXPDialog extends JDialog {
             for (int i = 0; i < rows; ++i) {
                 final CampaignOptions campaignOptions = campaign.getCampaignOptions();
 
-                Person person = personnelModel.getPerson(personnelTable.convertRowIndexToModel(i));
+                Person person = personnelTable.getModel().getRow(personnelTable.convertRowIndexToModel(i));
 
                 int cost = person.getCostToImprove(skillName, campaignOptions.isUseReasoningXpMultiplier());
                 double costMultiplier = campaignOptions.getXpCostMultiplier();
@@ -441,7 +393,7 @@ public final class BatchXPDialog extends JDialog {
 
         @Override
         public boolean include(Entry<? extends PersonnelTableModel, ? extends Integer> entry) {
-            Person person = entry.getModel().getPerson(entry.getIdentifier().intValue());
+            Person person = entry.getModel().getRow(entry.getIdentifier());
             if (!person.getStatus().isActiveFlexible()) {
                 return false;
             } else if (!prisoners && !person.getPrisonerStatus().isFree()) {

--- a/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
@@ -47,6 +47,7 @@ import java.awt.event.WindowEvent;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.UUID;
 import javax.swing.*;
@@ -266,7 +267,8 @@ public class PersonnelMarketDialog extends JDialog {
 
         final XTableColumnModel columnModel = (XTableColumnModel) tablePersonnel.getColumnModel();
         final ArrayList<SortKey> sortKeys = new ArrayList<>();
-        for (final PersonnelTableModelColumn column : PersonnelTableModel.PERSONNEL_COLUMNS) {
+        Map<PersonnelTableModelColumn, SortOrder> defaultSortOrder = personnelModel.getDefaultSortOrder();
+        for (PersonnelTableModelColumn column : personnelModel.getAllColumns()) {
             final TableColumn tableColumn = columnModel.getColumnByModelIndex(column.ordinal());
             if (!personnelMarketColumns.contains(column)) {
                 columnModel.setColumnVisible(tableColumn, false);
@@ -282,7 +284,7 @@ public class PersonnelMarketDialog extends JDialog {
 
             final Comparator<?> comparator = column.getComparator();
             sorter.setComparator(column.ordinal(), comparator);
-            final SortOrder sortOrder = column.getDefaultSortOrder();
+            SortOrder sortOrder = defaultSortOrder.get(column);
             if (sortOrder != null) {
                 sortKeys.add(new SortKey(column.ordinal(), sortOrder));
             }
@@ -497,7 +499,7 @@ public class PersonnelMarketDialog extends JDialog {
         sorter.setRowFilter(new RowFilter<>() {
             @Override
             public boolean include(Entry<? extends PersonnelTableModel, ? extends Integer> entry) {
-                return nGroup.getFilteredInformation(entry.getModel().getPerson(entry.getIdentifier()),
+                return nGroup.getFilteredInformation(entry.getModel().getRow(entry.getIdentifier()),
                       hqView.getCampaign().getLocalDate());
             }
         });
@@ -511,7 +513,7 @@ public class PersonnelMarketDialog extends JDialog {
             refreshPersonView();
             return;
         }
-        selectedPerson = personnelModel.getPerson(tablePersonnel.convertRowIndexToModel(view));
+        selectedPerson = personnelModel.getRow(tablePersonnel.convertRowIndexToModel(view));
         Entity en = personnelMarket.getAttachedEntity(selectedPerson);
         if (null == en) {
             unitCost = Money.zero();
@@ -585,6 +587,6 @@ public class PersonnelMarketDialog extends JDialog {
     }
 
     public TableCellRenderer getRenderer() {
-        return personnelModel.new Renderer();
+        return personnelModel.new PersonnelRenderer();
     }
 }

--- a/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
@@ -38,7 +38,6 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import javax.swing.SortOrder;
 import javax.swing.SwingConstants;
 
 import megamek.client.ui.util.UIUtil;
@@ -79,6 +78,7 @@ import mekhq.campaign.randomEvents.personalities.PersonalityTrait;
 import mekhq.campaign.randomEvents.personalities.Reasoning;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Planet;
+import mekhq.gui.baseComponents.tables.MHQTableColumn;
 import mekhq.gui.model.LocationDisplay;
 import mekhq.gui.sorter.PersonRankSorter;
 import mekhq.gui.sorter.PersonalityTraitSorter;
@@ -86,7 +86,7 @@ import mekhq.utilities.MHQInternationalization;
 import mekhq.utilities.ReportingUtilities;
 import org.jspecify.annotations.NonNull;
 
-public enum PersonnelTableModelColumn {
+public enum PersonnelTableModelColumn implements MHQTableColumn {
 
     PERSON_GRAPHICAL("Column.PERSON.title", Comparators.STRING_COMPARATOR,
           (person, campaign) -> "<html>" + person.getFullDesc(campaign) + "</html>"),
@@ -449,8 +449,14 @@ public enum PersonnelTableModelColumn {
         this(name, modelComparator, (person, campaign) -> modelExtractor.apply(person), string -> string);
     }
 
+    @Override
     public Comparator<?> getComparator() {
         return modelComparator;
+    }
+
+    @Override
+    public int getIndex() {
+        return ordinal();
     }
 
     private static String convertBooleanToYesNoNA(Boolean yesNoValue) {
@@ -472,6 +478,7 @@ public enum PersonnelTableModelColumn {
         return MHQInternationalization.getTextAt(RESOURCE_BUNDLE, key);
     }
 
+    @Override
     public String getText(Object model) {
         return modelToText.apply(model);
     }
@@ -890,6 +897,7 @@ public enum PersonnelTableModelColumn {
      * Returns optional preferred size.
      * @return null if the column has no size preference, a preferred width otherwise.
      */
+    @Override
     @Nullable
     public Integer getPreferredWidth() {
         Integer preferredWidth = switch (this) {
@@ -906,6 +914,7 @@ public enum PersonnelTableModelColumn {
         return (preferredWidth == null) ? null : UIUtil.scaleForGUI(preferredWidth);
     }
 
+    @Override
     public int getAlignment() {
         return switch (this) {
             case RANK, SKILL_LEVEL -> SwingConstants.LEFT;
@@ -916,13 +925,6 @@ public enum PersonnelTableModelColumn {
                 }
                 yield SwingConstants.CENTER;
             }
-        };
-    }
-
-    public @Nullable SortOrder getDefaultSortOrder() {
-        return switch (this) {
-            case RANK, FIRST_NAME, LAST_NAME, SKILL_LEVEL -> SortOrder.DESCENDING;
-            default -> null;
         };
     }
 

--- a/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
@@ -33,19 +33,24 @@
 package mekhq.gui.model;
 
 import static mekhq.campaign.personnel.turnoverAndRetention.Fatigue.getEffectiveFatigue;
+import static mekhq.gui.enums.PersonnelTableModelColumn.FIRST_NAME;
 import static mekhq.gui.enums.PersonnelTableModelColumn.FORCE_GRAPHICAL;
+import static mekhq.gui.enums.PersonnelTableModelColumn.LAST_NAME;
 import static mekhq.gui.enums.PersonnelTableModelColumn.PERSON_GRAPHICAL;
+import static mekhq.gui.enums.PersonnelTableModelColumn.RANK;
+import static mekhq.gui.enums.PersonnelTableModelColumn.SKILL_LEVEL;
 import static mekhq.gui.enums.PersonnelTableModelColumn.UNIT_ASSIGNMENT_GRAPHICAL;
 
 import java.awt.Component;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
 import javax.swing.ImageIcon;
 import javax.swing.JTable;
+import javax.swing.SortOrder;
 import javax.swing.UIManager;
-import javax.swing.table.DefaultTableCellRenderer;
 
 import io.sentry.util.Objects;
 import megamek.client.ui.tileset.EntityImage;
@@ -60,27 +65,34 @@ import mekhq.campaign.icons.StandardFormationIcon;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
 import mekhq.campaign.unit.Unit;
+import mekhq.gui.baseComponents.tables.MHQTableModel;
 import mekhq.gui.enums.PersonnelTableModelColumn;
 import mekhq.gui.utilities.ComponentColors;
 import mekhq.gui.utilities.MekHqTableCellRenderer;
-import mekhq.utilities.ReportingUtilities;
 
 /**
  * A table Model for displaying information about personnel
  *
  * @author Jay lawson
  */
-public class PersonnelTableModel extends DataTableModel<Person> {
+public class PersonnelTableModel extends MHQTableModel<Person, PersonnelTableModelColumn> {
 
-    public static final PersonnelTableModelColumn[] PERSONNEL_COLUMNS = PersonnelTableModelColumn.values();
+    private final static Map<PersonnelTableModelColumn, SortOrder> DEFAULT_SORT_ORDER = Map.of(
+          RANK, SortOrder.DESCENDING,
+          FIRST_NAME, SortOrder.DESCENDING,
+          LAST_NAME, SortOrder.DESCENDING,
+          SKILL_LEVEL, SortOrder.DESCENDING
+    );
 
     private final Campaign campaign;
     private boolean groupByUnit;
-    private final Renderer renderer = new Renderer();
+    private final PersonnelRenderer renderer = new PersonnelRenderer();
 
     public PersonnelTableModel(Campaign c) {
+        super(Arrays.stream(PersonnelTableModelColumn.values()).toList());
         data = new ArrayList<>();
         campaign = c;
+        setDefaultSortOrder(DEFAULT_SORT_ORDER);
     }
 
     /**
@@ -102,41 +114,8 @@ public class PersonnelTableModel extends DataTableModel<Person> {
         this.groupByUnit = groupByUnit;
     }
 
-    @Override
-    public int getColumnCount() {
-        return PERSONNEL_COLUMNS.length;
-    }
-
-    @Override
-    public String getColumnName(final int column) {
-        return PERSONNEL_COLUMNS[column].toString();
-    }
-
-    @Override
-    public Class<?> getColumnClass(int column) {
-        if (PERSONNEL_COLUMNS[column] == PersonnelTableModelColumn.RANK) {
-            return Person.class;
-        }
-        return String.class;
-    }
-
     public @Nullable Person getPerson(final int row) {
-        return (row < getRowCount()) ? (Person) getData().get(row) : null;
-    }
-
-    @Override
-    public Object getValueAt(final int row, final int column) {
-        return getValueAt(getPerson(row), PERSONNEL_COLUMNS[column]);
-    }
-
-    public Object getValueAt(@Nullable Person person, PersonnelTableModelColumn column) {
-        if (getData().isEmpty()) {
-            return "";
-        } else if (person == null) {
-            return "?";
-        } else {
-            return column.getCellValue(campaign, person);
-        }
+        return getRow(row);
     }
 
     public void refreshData() {
@@ -161,11 +140,21 @@ public class PersonnelTableModel extends DataTableModel<Person> {
         }
     }
 
-    public Renderer getRenderer() {
+    @Override
+    protected Object getCellValue(Person person, PersonnelTableModelColumn column) {
+        return column.getCellValue(campaign, person);
+    }
+
+    @Override
+    protected PersonnelRenderer getRenderer() {
         return renderer;
     }
 
-    public class Renderer extends DefaultTableCellRenderer {
+    public void setHighlight(String searchText) {
+        renderer.setHighlight(searchText);
+    }
+
+    public class PersonnelRenderer extends MHQTableModel.Renderer {
 
         private static final ComponentColors DEFAULT_COLORS =
               new ComponentColors(UIManager.getColor("Table.foreground"), UIManager.getColor("Table.background"));
@@ -175,29 +164,18 @@ public class PersonnelTableModel extends DataTableModel<Person> {
         private final Map<Long, ImageIcon> entityImageCache = new WeakHashMap<>();
         private final Map<StandardFormationIcon, ImageIcon> formationIconCache = new WeakHashMap<>();
 
-        private String highlight = "";
-
-        public void setHighlight(String highlight) {
-            this.highlight = highlight;
-        }
-
         @Override
         public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
               boolean hasFocus, int rowIndex, int columnIndex) {
             if (table == null) {
                 return this;
             }
+            
+            super.getTableCellRendererComponent(table, value, isSelected, hasFocus, rowIndex, columnIndex);
 
             int modelRow = table.convertRowIndexToModel(rowIndex);
-            PersonnelTableModelColumn column = PERSONNEL_COLUMNS[table.convertColumnIndexToModel(columnIndex)];
-            Person person = getPerson(modelRow);
-
-            if (getFont() != table.getFont()) {
-                setFont(table.getFont());
-            }
-            String text = applyHighlighting(column.getText(value));
-            setText(text);
-            setHorizontalAlignment(column.getAlignment());
+            PersonnelTableModelColumn column = getAllColumns().get(table.convertColumnIndexToModel(columnIndex));
+            Person person = getRow(modelRow);
 
             setIcon(getImage(person, column));
 
@@ -219,19 +197,6 @@ public class PersonnelTableModel extends DataTableModel<Person> {
             setToolTipText(column.getToolTipText(person, personalStateFlags));
 
             return this;
-        }
-
-        private String applyHighlighting(String text) {
-            if (highlight.isEmpty()) {
-                return text;
-            }
-            String highlightedText =
-                  ReportingUtilities.messageSurroundedBySpanWithColor(ReportingUtilities.getPositiveColor(), "$1");
-            text = text.replaceAll("(?i)(" + java.util.regex.Pattern.quote(highlight) + ")(?![^<>]*>)", highlightedText);
-            if (text.startsWith("<html>")) {
-                return text;
-            }
-            return "<html>" + text + "</html>";
         }
 
         /**

--- a/MekHQ/unittests/mekhq/gui/baseComponents/tables/MHQTableTest.java
+++ b/MekHQ/unittests/mekhq/gui/baseComponents/tables/MHQTableTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package mekhq.gui.baseComponents.tables;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.awt.Component;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import javax.swing.JLabel;
+import javax.swing.JTable;
+import javax.swing.RowFilter;
+import javax.swing.SortOrder;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableRowSorter;
+
+import org.junit.jupiter.api.Test;
+
+class MHQTableTest {
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void testConstructor() {
+        MHQTableColumn column = mock(MHQTableColumn.class);
+        when(column.getIndex()).thenReturn(0);
+        MHQTableModel tableModel = new MHQTableModel(List.of(column)) {
+            @Override protected TableCellRenderer getRenderer() { return null; }
+            @Override protected Object getCellValue(Object data, MHQTableColumn column) { return null; }
+        };
+        tableModel.setDefaultSortOrder(Collections.singletonMap(column, SortOrder.ASCENDING));
+
+        MHQTable table = new MHQTable(tableModel);
+
+        assertFalse(table.getShowHorizontalLines());
+        assertFalse(table.getShowVerticalLines());
+        assertEquals(0, table.getIntercellSpacing().width);
+        assertEquals(0, table.getIntercellSpacing().height);
+        assertNotNull(table.getRowSorter());
+        assertNotNull(table.getColumnModel());
+        assertEquals(tableModel, table.getModel());
+        assertNotNull(table.getTableHeader());
+        assertEquals(table.getColumnModel(), table.getTableHeader().getColumnModel());
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void testSetView() {
+        MHQTableColumn column = mock(MHQTableColumn.class);
+        when(column.getPreferredWidth()).thenReturn(150);
+        MHQTableModel tableModel = new MHQTableModel(List.of(column)) {
+            @Override protected TableCellRenderer getRenderer() { return null; }
+            @Override protected Object getCellValue(Object data, MHQTableColumn column) { return null; }
+        };
+
+        MHQTable table = new MHQTable(tableModel);
+        table.setView(Set.of(column));
+
+        verify(column).getPreferredWidth();
+        assertEquals(150, table.getColumnModel().getColumnByModelIndex(0).getPreferredWidth());
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void testSetRowFilter() {
+        MHQTableModel tableModel = new MHQTableModel(Collections.emptyList()) {
+            @Override protected TableCellRenderer getRenderer() { return null; }
+            @Override protected Object getCellValue(Object data, MHQTableColumn column) { return null; }
+        };
+        RowFilter rowFilter = mock(RowFilter.class);
+
+        MHQTable table = new MHQTable(tableModel);
+        table.setRowFilter(rowFilter);
+
+        TableRowSorter sorter = (TableRowSorter) table.getRowSorter();
+        assertEquals(rowFilter, sorter.getRowFilter());
+    }
+
+    @Test
+    void testRenderer() {
+        MHQTableColumn column = mock(MHQTableColumn.class);
+        when(column.getText("RawValue")).thenReturn("FormattedText");
+        when(column.getAlignment()).thenReturn(0);
+        MHQTableModel<Object, MHQTableColumn> tableModel = new MHQTableModel<>(List.of(column)) {
+            @Override protected TableCellRenderer getRenderer() { return null; }
+            @Override protected Object getCellValue(Object data, MHQTableColumn col) { return null; }
+        };
+        MHQTableModel<Object, MHQTableColumn>.Renderer renderer = tableModel.new Renderer();
+        JTable table = mock(JTable.class);
+        when(table.convertColumnIndexToModel(0)).thenReturn(0);
+
+        Component component = renderer.getTableCellRendererComponent(table, "RawValue", false, false, 0, 0);
+
+        verify(column).getText("RawValue");
+        assertInstanceOf(JLabel.class, component);
+        assertEquals("FormattedText", ((JLabel) component).getText());
+    }
+
+    @Test
+    void testGetValueAt() {
+        MHQTableColumn column = mock(MHQTableColumn.class);
+        Object validRow = new Object();
+        MHQTableModel<Object, MHQTableColumn> tableModel = new MHQTableModel<>(List.of(column)) {
+            @Override protected TableCellRenderer getRenderer() { return null; }
+            @Override
+            protected Object getCellValue(Object data, MHQTableColumn col) {
+                return (data == validRow && col == column) ? "ExpectedValue" : "Unexpected";
+            }
+        };
+        tableModel.setData(Arrays.asList(validRow, null));
+
+        Object validResult = tableModel.getValueAt(0, 0);
+        Object nullResult = tableModel.getValueAt(1, 0);
+
+        assertEquals("ExpectedValue", validResult);
+        assertEquals("?", nullResult);
+    }
+
+}

--- a/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
+++ b/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
@@ -58,10 +58,10 @@ import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.location.AcademyCampusLocation;
 import mekhq.campaign.location.ILocation;
 import mekhq.campaign.location.LocationNode;
-import mekhq.campaign.market.PersonnelMarket;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.universe.Planet;
 import mekhq.campaign.universe.PlanetarySystem;
+import mekhq.gui.model.PersonnelTableModel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -121,16 +121,19 @@ public class PersonnelTableModelColumnTest {
 
     @Test
     public void testGetDefaultSortOrder() {
-        for (final PersonnelTableModelColumn personnelTableModelColumn : columns) {
+        PersonnelTableModel personnelTableModel = new PersonnelTableModel(null);
+        for (PersonnelTableModelColumn personnelTableModelColumn : columns) {
             switch (personnelTableModelColumn) {
                 case RANK:
                 case FIRST_NAME:
                 case LAST_NAME:
                 case SKILL_LEVEL:
-                    assertEquals(SortOrder.DESCENDING, personnelTableModelColumn.getDefaultSortOrder());
+                    assertEquals(SortOrder.DESCENDING,
+                          personnelTableModel.getDefaultSortOrder().get(personnelTableModelColumn));
                     break;
                 default:
-                    assertNull(personnelTableModelColumn.getDefaultSortOrder());
+                    assertNull(
+                          personnelTableModel.getDefaultSortOrder().get(personnelTableModelColumn));
                     break;
             }
         }
@@ -157,12 +160,10 @@ public class PersonnelTableModelColumnTest {
         private static final LocalDate TODAY = LocalDate.of(3025, 1, 1);
         private static final String CAMPAIGN_NAME = "Test Mercs";
 
-        private PersonnelMarket market;
         private Personnel mainForce;
 
         @BeforeEach
         void setUp() {
-            market = mock(PersonnelMarket.class);
             mainForce = new Personnel();
         }
 


### PR DESCRIPTION
Standardize table UI management by introducing a `MHQTable` and supporting model abstractions. This refactor centralizes common table functionalities such as column visibility, sorting, and header tooltips, significantly reducing boilerplate code in `PersonnelTab` and `BatchXPDialog`.

Details:
- Create `MHQTable`, `MHQTableModel`, and `MHQTableColumn`
- Replace `JTable` with `MHQTable` in `PersonnelTab` and `BatchXPDialog`
- Delegate column management and row sorting configuration to `MHQTable`
- Add custom `JTableHeader` in `MHQTable` to show tooltips for truncated headers
- Move default sorting definitions from column model to table model
- Add test coverage for `MHQTable`