### PR TITLE
Use MarginOfSuccess only for report generation

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3683,13 +3683,15 @@ public class Campaign implements ITechManager, IPlace {
         }
         int xpGained = 0;
         if (skillCheckResult.isSuccess()) {
-            boolean useFunctionalAppraisal = campaignOptions.isUseFunctionalAppraisal();
-            boolean isUseEdge = person != null &&
-                                      campaignOptions.isUseEdge() &&
-                                      person.getOptions().booleanOption(EDGE_ADMIN_APPRAISAL_FAIL);
-            double valueChange = useFunctionalAppraisal ? Appraisal.performAppraisalMultiplierCheck(person,
-                  currentDay, isUseEdge) : 1.0;
-            String appraisalReport = useFunctionalAppraisal ? Appraisal.getAppraisalReport(valueChange) : "";
+            double valueChange = 1.0;
+            String appraisalReport = "";
+            if (campaignOptions.isUseFunctionalAppraisal() && person != null) {
+                boolean isUseEdge = campaignOptions.isUseEdge() &&
+                                          person.getOptions().booleanOption(EDGE_ADMIN_APPRAISAL_FAIL);
+                ActionCheckResult appraisalResult = Appraisal.performAppraisalCheck(person, currentDay, isUseEdge);
+                valueChange = Appraisal.getAppraisalCostMultiplier(appraisalResult.getMarginOfSuccess());
+                appraisalReport = Appraisal.getAppraisalReport(valueChange, appraisalResult.getReportMargin());
+            }
 
             if (transitDays < 0) {
                 transitDays = calculatePartTransitTime(acquisition.getAvailability());

--- a/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
@@ -42,8 +42,6 @@ import static mekhq.campaign.personnel.PersonnelOptions.ATOW_TOUGHNESS;
 import static mekhq.campaign.personnel.PersonnelOptions.EDGE_TRAINING;
 import static mekhq.campaign.personnel.PersonnelOptions.FLAW_GLASS_JAW;
 import static mekhq.campaign.personnel.skills.SkillType.S_TRAINING;
-import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.BARELY_MADE_IT;
-import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.getMarginOfSuccessObject;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
@@ -96,8 +94,7 @@ import org.jspecify.annotations.NonNull;
  * <ol>
  *   <li>The combat team's commander makes a {@link SkillType#S_TRAINING}
  *       skill check. The raw margin of success drives the amount of XP awarded this session.</li>
- *   <li>A margin at or below {@link MarginOfSuccess#BARELY_MADE_IT}
- *       produces no XP for any trainee.</li>
+ *   <li>A failed skill check produces no XP for any trainee.</li>
  *   <li>Above that threshold, each trainee's target skill receives {@code max(1, marginOfSuccess)} XP.
  *       Accumulated XP persists across sessions until the improvement cost is met.</li>
  *   <li>When accumulated XP meets or exceeds the cost to improve (adjusted by
@@ -119,6 +116,7 @@ public class TrainingCombatTeams {
 
     private static final int EXPERIENCE_LEVEL_REDUCTION = -1;
     static final int XP_RATE_BASE_LINE = 1;
+    static final int XP_GAIN_MAX = 6;
 
     /**
      * Processes all training combat teams in the campaign.
@@ -208,9 +206,9 @@ public class TrainingCombatTeams {
         // Then build a set of their skills
         Map<String, Integer> educatorSkills = createSkillsList(campaign, educators);
 
-        int marginOfSuccess = performTrainingSkillCheck(campaign, commander);
+        ActionCheckResult actionCheckResult = performTrainingSkillCheck(campaign, commander);
 
-        performTraining(campaign, formation, commander, educatorSkills, marginOfSuccess);
+        performTraining(campaign, formation, commander, educatorSkills, actionCheckResult);
     }
 
     /**
@@ -229,16 +227,15 @@ public class TrainingCombatTeams {
      * {@code processEducationTime} helper method, using the result of the training check's {@code marginOfSuccess} to
      * determine training time awarded and progress.</p>
      *
-     * @param campaign        the current {@link Campaign} in which training is occurring
-     * @param formation       the {@link Formation} containing the units and trainees to train
-     * @param commander       the {@link Person} acting as the educator/commander providing the training
-     * @param educatorSkills  a map containing all skills and their experience levels available for teaching by the
-     *                        educator(s)
-     * @param marginOfSuccess the margin of success for the training check, as an integer (affects training
-     *                        speed/progress)
+     * @param campaign          the current {@link Campaign} in which training is occurring
+     * @param formation         the {@link Formation} containing the units and trainees to train
+     * @param commander         the {@link Person} acting as the educator/commander providing the training
+     * @param educatorSkills    a map containing all skills and their experience levels available for teaching by the
+     *                          educator(s)
+     * @param actionCheckResult the result of the training check
      */
     private static void performTraining(Campaign campaign, Formation formation, Person commander,
-          Map<String, Integer> educatorSkills, int marginOfSuccess) {
+          Map<String, Integer> educatorSkills, ActionCheckResult actionCheckResult) {
         CampaignOptions campaignOptions = campaign.getCampaignOptions();
         boolean useReasoningXPChanges = campaignOptions.isUseReasoningXpMultiplier();
         boolean isUseFatigue = campaignOptions.isUseFatigue();
@@ -293,7 +290,7 @@ public class TrainingCombatTeams {
                     continue;
                 }
 
-                String report = processTrainingTime(campaign, commander, trainee, skillsBeingTrained, marginOfSuccess,
+                String report = processTrainingTime(campaign, commander, trainee, skillsBeingTrained, actionCheckResult,
                       xpCostMultiplier, useReasoningXPChanges, campaign.getCampaignOptions().isPersonnelLogSkillGain(),
                       campaign.getLocalDate());
 
@@ -328,8 +325,7 @@ public class TrainingCombatTeams {
      *
      * <p>The method follows this sequence:</p>
      * <ol>
-     *   <li>Returns early with an empty string if training is impossible (skill check not cleared above {@link
-     *   MarginOfSuccess#BARELY_MADE_IT}, or no skills queued).</li>
+     *   <li>Returns early with an empty string if training is impossible (skill check failed, or no skills queued).</li>
      *   <li>Sorts {@code skillsBeingTrained} ascending by level and targets the lowest-level skill for improvement.</li>
      *   <li>Calculates the base XP cost to reach the next level of the target skill, applying
      *       {@code xpCostMultiplier} and optional reasoning-based adjustments.</li>
@@ -353,9 +349,8 @@ public class TrainingCombatTeams {
      *                              improvement occurs
      * @param skillsBeingTrained    the list of {@link Skill}s queued for training; sorted ascending by level in-place;
      *                              must not be {@code null}
-     * @param marginOfSuccess       the margin by which the skill check was passed; values at or below
-     *                              {@link MarginOfSuccess#BARELY_MADE_IT} immediately abort training with no XP
-     *                              applied; higher values yield proportionally more XP progress
+     * @param actionCheckResult     the result of the training check; failed skill checks immediately abort training
+     *                              with no XP applied; higher values yield proportionally more XP progress
      * @param xpCostMultiplier      a multiplier applied to the raw XP improvement cost before comparing against
      *                              progress; values below {@code 1.0} reduce the cost, values above {@code 1.0}
      *                              increase it
@@ -373,9 +368,9 @@ public class TrainingCombatTeams {
      * @since 0.51.01
      */
     private static String processTrainingTime(Campaign campaign, Person educator, Person trainee,
-          List<Skill> skillsBeingTrained, int marginOfSuccess, double xpCostMultiplier, boolean useReasoningXPChanges,
-          boolean isLogSkillChange, LocalDate today) {
-        if (isTrainingImpossible(skillsBeingTrained, marginOfSuccess)) {
+          List<Skill> skillsBeingTrained, ActionCheckResult actionCheckResult, double xpCostMultiplier,
+          boolean useReasoningXPChanges, boolean isLogSkillChange, LocalDate today) {
+        if (isTrainingImpossible(skillsBeingTrained, actionCheckResult)) {
             return "";
         }
 
@@ -388,7 +383,7 @@ public class TrainingCombatTeams {
         int baseCostToImprove = getBaseCostToImprove(trainee, xpCostMultiplier, useReasoningXPChanges,
               skillName, targetSkillLevel);
 
-        int finalXPProgress = getFinalXPProgress(marginOfSuccess, targetSkill);
+        int finalXPProgress = getFinalXPProgress(actionCheckResult, targetSkill);
 
         boolean wasTrainingCompleted = isWasTrainingCompleted(baseCostToImprove, finalXPProgress);
 
@@ -483,16 +478,17 @@ public class TrainingCombatTeams {
      * <p>Progress is at minimum 1 XP, scaled by the margin of success. Returns the skill's total accumulated XP
      * progress after applying this session's gain.</p>
      *
-     * @param marginOfSuccess the margin by which the skill check was passed, used to scale XP gain
-     * @param targetSkill     the {@link Skill} receiving the XP progress; its progress is mutated in-place
+     * @param actionCheckResult the training skill check result, used to scale XP gain
+     * @param targetSkill       the {@link Skill} receiving the XP progress; its progress is mutated in-place
      *
      * @return the skill's total accumulated XP progress after this session's contribution is applied
      *
      * @author Illiani
      * @since 0.51.01
      */
-    static int getFinalXPProgress(int marginOfSuccess, Skill targetSkill) {
-        int actualXPProgress = max(XP_RATE_BASE_LINE, (XP_RATE_BASE_LINE * marginOfSuccess));
+    public static int getFinalXPProgress(ActionCheckResult actionCheckResult, Skill targetSkill) {
+        int actualXPProgress = Math.clamp(XP_RATE_BASE_LINE * actionCheckResult.getMarginOfSuccess(),
+              XP_RATE_BASE_LINE, XP_GAIN_MAX);
         targetSkill.changeXpProgress(actualXPProgress);
 
         return targetSkill.getXpProgress();
@@ -540,22 +536,19 @@ public class TrainingCombatTeams {
      * queued for training.</p>
      *
      * @param skillsBeingTrained the list of {@link Skill}s queued for training
-     * @param marginOfSuccess    the margin by which the skill check was passed; must equal or exceed
-     *                           {@link MarginOfSuccess#BARELY_MADE_IT} for training to be possible
+     * @param actionCheckResult  the result of the training skill check; must succeed for training to be possible
      *
      * @return {@code true} if training cannot proceed; {@code false} if it can
      *
      * @author Illiani
      * @since 0.51.01
      */
-    static boolean isTrainingImpossible(List<Skill> skillsBeingTrained, int marginOfSuccess) {
-        boolean isSkillCheckFailed = marginOfSuccess < BARELY_MADE_IT.getValue();
+    static boolean isTrainingImpossible(List<Skill> skillsBeingTrained, ActionCheckResult actionCheckResult) {
         boolean isNothingBeingTrained = skillsBeingTrained.isEmpty();
-
-        return isSkillCheckFailed || isNothingBeingTrained;
+        return !actionCheckResult.isSuccess() || isNothingBeingTrained;
     }
 
-    private static int performTrainingSkillCheck(Campaign campaign, Person educator) {
+    private static ActionCheckResult performTrainingSkillCheck(Campaign campaign, Person educator) {
         final CampaignOptions campaignOptions = campaign.getCampaignOptions();
         boolean isUseEdge = campaignOptions.isUseEdge();
         isUseEdge = isUseEdge && educator.getOptions().booleanOption(EDGE_TRAINING);
@@ -565,13 +558,13 @@ public class TrainingCombatTeams {
                     .resolve(isUseEdge, getTextAt(RESOURCE_BUNDLE, "trainingCombatTeam.skillCheck"));
         campaign.addReport(SKILL_CHECKS, actionCheckResult.getReport(true));
 
-        MarginOfSuccess marginOfSuccess = getMarginOfSuccessObject(actionCheckResult.getMarginOfSuccess());
+        MarginOfSuccess reportMargin = actionCheckResult.getReportMargin();
         String personnelReport = getFormattedTextAt(RESOURCE_BUNDLE, "learnedProgress.text",
-              educator.getHyperlinkedFullTitle(), spanOpeningWithCustomColor(marginOfSuccess.getColor()),
-              marginOfSuccess.getLabel(), CLOSING_SPAN_TAG);
+              educator.getHyperlinkedFullTitle(), spanOpeningWithCustomColor(reportMargin.getColor()),
+              reportMargin.getLabel(), CLOSING_SPAN_TAG);
         campaign.addReport(PERSONNEL, personnelReport);
 
-        return actionCheckResult.getMarginOfSuccess();
+        return actionCheckResult;
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/skills/ActionCheck.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/ActionCheck.java
@@ -34,7 +34,7 @@
 package mekhq.campaign.personnel.skills;
 
 import static mekhq.campaign.personnel.enums.GenderDescriptors.HIS_HER_THEIR;
-import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.BARELY_MADE_IT;
+import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.getMarginOfSuccessObject;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 
@@ -46,8 +46,6 @@ import megamek.common.rolls.TargetRoll;
 import megamek.logging.MMLogger;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.skills.ActionCheckRoll.RollType;
-import mekhq.campaign.personnel.skills.enums.MarginOfSuccess;
-import mekhq.utilities.ReportingUtilities;
 
 /**
  * Base abstract class for configuring character skill, attribute, and other action checks.
@@ -65,6 +63,8 @@ public abstract class ActionCheck<T extends ActionCheck<T>> {
 
     private static final MMLogger LOGGER = MMLogger.create(ActionCheck.class);
     private static final String RESOURCE_BUNDLE = "mekhq.resources.ActionCheck";
+    private static final int MARGIN_OF_SUCCESS_MAX = 10;
+    private static final int MARGIN_OF_SUCCESS_MIN = -10;
 
     protected final Person person;
     protected final TargetRoll targetNumber;
@@ -164,16 +164,12 @@ public abstract class ActionCheck<T extends ActionCheck<T>> {
     /**
      * Executes action check for the specified person.
      *
-     * <p>External modifiers can optionally influence the target number, while miscellaneous modifiers
-     * alter the target based on whether the skill is classified as 'count up' or not. Using edge allows the person to
-     * attempt a re-roll if the initial roll fails. Additionally, the constructor can include margins of success text as
-     * part of the results, if desired.</p>
+     * <p>Performs a roll and determines margin of success as <code>Roll - TN</code> if <code>isCountUp ==
+     * false</code>, or <code>TN - Roll</code> otherwise. Margin of success is clamped to [-10; 10] range
+     * (inclusively). Using edge allows the person to attempt a re-roll if the initial roll fails.</p>
      *
-     * <p><b>Usage:</b> This constructor offers detailed control over the skill check process.
-     * </p>
-     *
-     * @param useEdge                     whether the person should use edge to re-roll if the initial attempt fails
-     * @param reason                      the reason for the check; can be {@code null}
+     * @param useEdge whether the person should use edge to re-roll if the initial attempt fails
+     * @param reason  the reason for the check; can be {@code null}
      */
     public ActionCheckResult resolve(boolean useEdge, @Nullable String reason) {
         RollType rollType = hasNaturalAptitude() ? RollType.ADVANTAGE : RollType.NORMAL;
@@ -192,8 +188,9 @@ public abstract class ActionCheck<T extends ActionCheck<T>> {
             person.spendEdge();
         }
 
-        int difference = targetNumber.getValue() - roll.result();
-        int marginOfSuccess = MarginOfSuccess.getMarginOfSuccess(isCountUp() ? difference : -difference);
+        long difference = (long) targetNumber.getValue() - roll.result();
+        int marginOfSuccess = Math.clamp(isCountUp() ? difference : -difference,
+              MARGIN_OF_SUCCESS_MIN, MARGIN_OF_SUCCESS_MAX);
         String resultsText = generateResultsText(roll.result(), marginOfSuccess, reason);
 
         LOGGER.info(resultsText);
@@ -233,16 +230,6 @@ public abstract class ActionCheck<T extends ActionCheck<T>> {
         String fullTitle = person.getHyperlinkedFullTitle();
         String genderedReferenced = HIS_HER_THEIR.getDescriptor(person.getGender());
 
-        String color;
-        int neutralMarginValue = BARELY_MADE_IT.getValue();
-        if (marginOfSuccess == neutralMarginValue) {
-            color = ReportingUtilities.getWarningColor();
-        } else if (marginOfSuccess < neutralMarginValue) {
-            color = ReportingUtilities.getNegativeColor();
-        } else {
-            color = ReportingUtilities.getPositiveColor();
-        }
-
         String reportKey =
               ActionCheckResult.isSuccess(marginOfSuccess) ? "actionCheckResult.success" : "actionCheckResult.failure";
 
@@ -250,7 +237,7 @@ public abstract class ActionCheck<T extends ActionCheck<T>> {
               reportKey,
               reason == null ? "" : "<b>" + reason + ":</b> ",
               fullTitle,
-              color,
+              getMarginOfSuccessObject(marginOfSuccess).getColor(),
               genderedReferenced,
               getActionName(),
               roll,

--- a/MekHQ/src/mekhq/campaign/personnel/skills/ActionCheckResult.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/ActionCheckResult.java
@@ -34,7 +34,7 @@
 package mekhq.campaign.personnel.skills;
 
 import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.BARELY_MADE_IT;
-import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.getMarginOfSuccessObjectFromMarginValue;
+import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.getMarginOfSuccessObject;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import mekhq.campaign.personnel.skills.enums.MarginOfSuccess;
@@ -102,7 +102,14 @@ public class ActionCheckResult {
      * @return {@code true} if the margin qualifies as a success, {@code false} otherwise
      */
     public static boolean isSuccess(int marginOfSuccess) {
-        return marginOfSuccess >= BARELY_MADE_IT.getValue();
+        return marginOfSuccess >= BARELY_MADE_IT.getLowerBound();
+    }
+
+    /**
+     * Returns corresponding {@link MarginOfSuccess} value for report generation.
+     */
+    public MarginOfSuccess getReportMargin() {
+        return getMarginOfSuccessObject(marginOfSuccess);
     }
 
     /**
@@ -123,18 +130,9 @@ public class ActionCheckResult {
             report.append(" ").append(getTextAt(RESOURCE_BUNDLE, "actionCheckResult.rerolled"));
         }
         if (includeMarginsOfSuccessText) {
-            String color;
-            int neutralMarginValue = BARELY_MADE_IT.getValue();
-            if (marginOfSuccess == neutralMarginValue) {
-                color = ReportingUtilities.getWarningColor();
-            } else if (marginOfSuccess < neutralMarginValue) {
-                color = ReportingUtilities.getNegativeColor();
-            } else {
-                color = ReportingUtilities.getPositiveColor();
-            }
-            MarginOfSuccess marginOfSuccessObject = getMarginOfSuccessObjectFromMarginValue(marginOfSuccess);
-            String marginOfSuccessText =
-                  ReportingUtilities.messageSurroundedBySpanWithColor(color, marginOfSuccessObject.getLabel());
+            MarginOfSuccess reportMargin = getReportMargin();
+            String marginOfSuccessText = ReportingUtilities.messageSurroundedBySpanWithColor(
+                  reportMargin.getColor(), reportMargin.getLabel());
             report.append(" ").append(marginOfSuccessText);
         }
         return report.toString();

--- a/MekHQ/src/mekhq/campaign/personnel/skills/Appraisal.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Appraisal.java
@@ -40,7 +40,6 @@ import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
 
 import java.time.LocalDate;
 
-import megamek.common.annotations.Nullable;
 import megamek.logging.MMLogger;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.skills.enums.MarginOfSuccess;
@@ -58,30 +57,25 @@ public class Appraisal {
     private static final String RESOURCE_BUNDLE = "mekhq.resources.Appraisal";
 
     private final static double MULTIPLIER_PER_MARGIN_OF_SUCCESS = 0.025;
+    private final static int MARGIN_OF_SUCCESS_MIN = -6;
+    private final static int MARGIN_OF_SUCCESS_MAX = 6;
 
     /**
-     * Performs an appraisal skill check for a given person on the specified date and calculates the appraisal cost
-     * multiplier based on the result.
+     * Performs an appraisal skill check for a given person on the specified date.
      *
-     * @param person     the {@link Person} performing the appraisal skill check; may be {@code null}, in which case no
-     *                   check is performed and the multiplier defaults to {@code 1.0}
+     * @param person     the {@link Person} performing the appraisal skill check
      * @param currentDay the current date of the appraisal check
      * @param isUseEdge  {@code true} if an Edge reroll should be used for a failed check
      *
-     * @return the calculated appraisal cost multiplier as a {@code double}
+     * @return the appraisal skill check result
      *
      * @author Illiani
      * @since 0.50.07
      */
-    public static double performAppraisalMultiplierCheck(@Nullable Person person, LocalDate currentDay,
+    public static ActionCheckResult performAppraisalCheck(Person person, LocalDate currentDay,
           boolean isUseEdge) {
-        if (person == null) {
-            return 1.0;
-        }
-        ActionCheckResult actionCheckResult =
-              person.checkSkill(S_APPRAISAL, false, false, currentDay)
+        return person.checkSkill(S_APPRAISAL, false, false, currentDay)
                     .resolve(isUseEdge, getTextAt(RESOURCE_BUNDLE, "Appraisal.skillCheck"));
-        return getAppraisalCostMultiplier(actionCheckResult.getMarginOfSuccess());
     }
 
     /**
@@ -90,15 +84,16 @@ public class Appraisal {
      * <p>The multiplier increases or decreases based on the negative margin of success from an appraisal skill
      * check.</p>
      *
-     * @param marginOfSuccessValue The return value of {@link MarginOfSuccess#getMarginValue(MarginOfSuccess)}
+     * @param marginOfSuccessValue The skill check's margin of success
      *
      * @return The appraisal cost multiplier as a {@code double}.
      *
      * @author Illiani
      * @since 0.50.07
      */
-    static double getAppraisalCostMultiplier(int marginOfSuccessValue) {
-        return 1 - (marginOfSuccessValue * MULTIPLIER_PER_MARGIN_OF_SUCCESS);
+    public static double getAppraisalCostMultiplier(int marginOfSuccessValue) {
+        int marginOfSuccessCapped = Math.clamp(marginOfSuccessValue, MARGIN_OF_SUCCESS_MIN, MARGIN_OF_SUCCESS_MAX);
+        return 1 - (marginOfSuccessCapped * MULTIPLIER_PER_MARGIN_OF_SUCCESS);
     }
 
     /**
@@ -108,16 +103,16 @@ public class Appraisal {
      * corresponding margin of success.</p>
      *
      * @param appraisalCostMultiplier The calculated appraisal cost multiplier.
+     * @param reportMargin            The {@link MarginOfSuccess} for report text generation.
      *
      * @return An HTML-formatted String describing the appraisal result.
      *
      * @author Illiani
      * @since 0.50.07
      */
-    public static String getAppraisalReport(double appraisalCostMultiplier) {
-        MarginOfSuccess marginOfSuccess = getMarginOfSuccess(appraisalCostMultiplier);
-        String reportColor = marginOfSuccess.getColor();
-        String reportKey = "Appraisal.report." + marginOfSuccess.name();
+    public static String getAppraisalReport(double appraisalCostMultiplier, MarginOfSuccess reportMargin) {
+        String reportColor = reportMargin.getColor();
+        String reportKey = "Appraisal.report." + reportMargin.name();
 
         return getFormattedTextAt(RESOURCE_BUNDLE,
               reportKey,
@@ -126,23 +121,4 @@ public class Appraisal {
               appraisalCostMultiplier * 100);
     }
 
-    /**
-     * Determines the {@link MarginOfSuccess} corresponding to the provided appraisal cost multiplier.
-     *
-     * <p>This converts the multiplier back to a margin value and looks up the appropriate result category.</p>
-     *
-     * @param appraisalCostMultiplier the appraisal cost multiplier to evaluate
-     *
-     * @return the {@link MarginOfSuccess} category for the given multiplier
-     *
-     * @author Illiani
-     * @since 0.50.07
-     */
-    static MarginOfSuccess getMarginOfSuccess(double appraisalCostMultiplier) {
-        LOGGER.debug("Appraisal report requested with multiplier: {}", appraisalCostMultiplier);
-        int normalizedMarginValue = (int) Math.round(-(appraisalCostMultiplier - 1) / MULTIPLIER_PER_MARGIN_OF_SUCCESS);
-        LOGGER.debug("Margin value: {}", normalizedMarginValue);
-
-        return MarginOfSuccess.getMarginOfSuccessObjectFromMarginValue(normalizedMarginValue);
-    }
 }

--- a/MekHQ/src/mekhq/campaign/personnel/skills/EscapeSkills.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/EscapeSkills.java
@@ -103,18 +103,15 @@ public class EscapeSkills {
         ActionCheckResult actionCheckResult =
               person.checkSkill(skillToUse, false, false, today)
                     .resolve(useEdge, getTextAt(RESOURCE_BUNDLE, "EscapeArtist.skillCheck"));
-
-        MarginOfSuccess marginOfSuccess =
-              MarginOfSuccess.getMarginOfSuccessObjectFromMarginValue(actionCheckResult.getMarginOfSuccess());
+        int marginOfSuccess = actionCheckResult.getMarginOfSuccess();
 
         // Nothing happens for these cases, so we can just early exit
-        List<MarginOfSuccess> noFurtherActionCases = List.of(MarginOfSuccess.IT_WILL_DO, MarginOfSuccess.BARELY_MADE_IT,
-              MarginOfSuccess.ALMOST);
-        if (noFurtherActionCases.contains(marginOfSuccess)) {
+        if ((MarginOfSuccess.ALMOST.getLowerBound() <= marginOfSuccess) &&
+                  (marginOfSuccess <= MarginOfSuccess.IT_WILL_DO.getUpperBound())) {
             return;
         }
 
-        processEscapeAttempt(campaign, person, marginOfSuccess, today);
+        processEscapeAttempt(campaign, person, actionCheckResult, today);
     }
 
     /**
@@ -160,29 +157,27 @@ public class EscapeSkills {
      *
      * <p>Updates prisoner status, applies failure consequences, and generates reports as appropriate.</p>
      *
-     * @param campaign        the current campaign instance
-     * @param prisoner        the {@link Person} attempting escape
-     * @param marginOfSuccess the result of the skill check
-     * @param today           the current in-game date
+     * @param campaign          the current campaign instance
+     * @param prisoner          the {@link Person} attempting escape
+     * @param actionCheckResult the escape attempt check result
+     * @param today             the current in-game date
      *
      * @author Illiani
      * @since 0.50.07
      */
-    private static void processEscapeAttempt(Campaign campaign, Person prisoner, MarginOfSuccess marginOfSuccess,
+    private static void processEscapeAttempt(Campaign campaign, Person prisoner, ActionCheckResult actionCheckResult,
           LocalDate today) {
-        String report = getEscapeAttemptReport(prisoner, marginOfSuccess);
+        String report = getEscapeAttemptReport(prisoner, actionCheckResult.getReportMargin());
         if (!report.isBlank()) {
             campaign.addReport(PERSONNEL, report);
         }
 
-        switch (marginOfSuccess) {
-            // Nothing happens for MarginOfSuccess.IT_WILL_DO, MarginOfSuccess.BARELY_MADE_IT, or MarginOfSuccess.ALMOST
-            case SPECTACULAR, EXTRAORDINARY, GOOD -> prisoner.changeStatus(campaign, today, PersonnelStatus.ACTIVE);
-            case BAD -> getEscapeAttemptReport(prisoner, MarginOfSuccess.BAD);
-            case TERRIBLE, DISASTROUS -> {
-                boolean wasDisastrous = marginOfSuccess == MarginOfSuccess.DISASTROUS;
-                processNotableFailure(campaign, prisoner, wasDisastrous);
-            }
+        int marginOfSuccess = actionCheckResult.getMarginOfSuccess();
+        if (marginOfSuccess >= MarginOfSuccess.GOOD.getLowerBound()) {
+            prisoner.changeStatus(campaign, today, PersonnelStatus.ACTIVE);
+        } else if (marginOfSuccess <= MarginOfSuccess.TERRIBLE.getUpperBound()) {
+            boolean wasDisastrous = marginOfSuccess <= MarginOfSuccess.DISASTROUS.getUpperBound();
+            processNotableFailure(campaign, prisoner, wasDisastrous);
         }
     }
 
@@ -226,17 +221,17 @@ public class EscapeSkills {
     /**
      * Retrieves a formatted report for the given prisoner's escape attempt based on the result margin.
      *
-     * @param prisoner        the {@link Person} whose escape attempt is being reported
-     * @param marginOfSuccess the margin of success result for the escape attempt
+     * @param prisoner     the {@link Person} whose escape attempt is being reported
+     * @param reportMargin the margin of success result for the escape attempt
      *
      * @return a formatted string for user display or an empty string if no report is generated
      *
      * @author Illiani
      * @since 0.50.07
      */
-    private static String getEscapeAttemptReport(Person prisoner, MarginOfSuccess marginOfSuccess) {
-        String reportColor = marginOfSuccess.getColor();
-        String reportKey = "EscapeArtist.report." + marginOfSuccess.name();
+    private static String getEscapeAttemptReport(Person prisoner, MarginOfSuccess reportMargin) {
+        String reportColor = reportMargin.getColor();
+        String reportKey = "EscapeArtist.report." + reportMargin.name();
 
         return getFormattedTextAt(RESOURCE_BUNDLE,
               reportKey,

--- a/MekHQ/src/mekhq/campaign/personnel/skills/enums/MarginOfSuccess.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/enums/MarginOfSuccess.java
@@ -59,15 +59,15 @@ import mekhq.utilities.ReportingUtilities;
  * @since 0.50.05
  */
 public enum MarginOfSuccess {
-    SPECTACULAR("SPECTACULAR", 7, Integer.MAX_VALUE, 4, ReportingUtilities.getAmazingColor()),
-    EXTRAORDINARY("EXTRAORDINARY", 5, 6, 3, ReportingUtilities.getPositiveColor()),
-    GOOD("GOOD", 3, 4, 2, ReportingUtilities.getPositiveColor()),
-    IT_WILL_DO("IT_WILL_DO", 1, 2, 1, ReportingUtilities.getWarningColor()),
-    BARELY_MADE_IT("BARELY_MADE_IT", 0, 0, 0, ReportingUtilities.getWarningColor()),
-    ALMOST("ALMOST", -2, -1, -1, ReportingUtilities.getWarningColor()),
-    BAD("BAD", -4, -3, -2, ReportingUtilities.getNegativeColor()),
-    TERRIBLE("TERRIBLE", -6, -5, -3, ReportingUtilities.getNegativeColor()),
-    DISASTROUS("DISASTROUS", Integer.MIN_VALUE, -7, -4, ReportingUtilities.getNegativeColor());
+    SPECTACULAR("SPECTACULAR", 7, Integer.MAX_VALUE, ReportingUtilities.getAmazingColor()),
+    EXTRAORDINARY("EXTRAORDINARY", 5, 6, ReportingUtilities.getPositiveColor()),
+    GOOD("GOOD", 3, 4, ReportingUtilities.getPositiveColor()),
+    IT_WILL_DO("IT_WILL_DO", 1, 2, ReportingUtilities.getWarningColor()),
+    BARELY_MADE_IT("BARELY_MADE_IT", 0, 0, ReportingUtilities.getWarningColor()),
+    ALMOST("ALMOST", -2, -1, ReportingUtilities.getWarningColor()),
+    BAD("BAD", -4, -3, ReportingUtilities.getNegativeColor()),
+    TERRIBLE("TERRIBLE", -6, -5, ReportingUtilities.getNegativeColor()),
+    DISASTROUS("DISASTROUS", Integer.MIN_VALUE, -7, ReportingUtilities.getNegativeColor());
 
     private static final MMLogger LOGGER = MMLogger.create(MarginOfSuccess.class);
     private static final String RESOURCE_BUNDLE = "mekhq.resources.MarginOfSuccess";
@@ -76,27 +76,24 @@ public enum MarginOfSuccess {
     private final String label;
     private final int lowerBound;
     private final int upperBound;
-    private final int margin;
     private final String color;
 
     /**
-     * Constructs a {@link MarginOfSuccess} enum constant with the specified bounds and margin value.
+     * Constructs a {@link MarginOfSuccess} enum constant with the specified bounds.
      *
      * @param lookupName the key used to retrieve resource bundle entries
      * @param lowerBound the lower inclusive bound for this margin of success
      * @param upperBound the upper inclusive bound for this margin of success
-     * @param margin     the margin value associated with this range
      * @param color      the color of reporting text
      *
      * @author Illiani
      * @since 0.50.05
      */
-    MarginOfSuccess(String lookupName, int lowerBound, int upperBound, int margin, String color) {
+    MarginOfSuccess(String lookupName, int lowerBound, int upperBound, String color) {
         this.lookupName = lookupName;
         this.label = generateMarginOfSuccessString();
         this.lowerBound = lowerBound;
         this.upperBound = upperBound;
-        this.margin = margin;
         this.color = color;
     }
 
@@ -116,21 +113,6 @@ public enum MarginOfSuccess {
     }
 
     /**
-     * Retrieves the margin value associated with the specified {@link MarginOfSuccess}.
-     *
-     * <p>The margin value represents the numerical value tied to a specific margin of success, typically used to
-     * measure the degree of success or failure of a skill check.</p>
-     *
-     * @return the margin value associated with the given {@link MarginOfSuccess}
-     *
-     * @author Illiani
-     * @since 0.50.05
-     */
-    public int getValue() {
-        return margin;
-    }
-
-    /**
      * Returns the color associated with the specified {@link MarginOfSuccess} value.
      *
      * <p>This method allows retrieval of a string representing a display color associated with a given margin of
@@ -145,22 +127,16 @@ public enum MarginOfSuccess {
         return color;
     }
 
-    /**
-     * Determines the margin of success as an integer based on the difference between the roll and the target.
-     *
-     * <p>This method calculates the margin of success using the given difference and returns the associated
-     * margin as an integer. Internally, it utilizes {@link #getMarginOfSuccessObject(int)} to determine the relevant
-     * margin category.</p>
-     *
-     * @param differenceBetweenRollAndTarget The difference between the roll result and the target value.
-     *
-     * @return The margin of success as an integer.
-     *
-     * @author Illiani
-     * @since 0.50.05
-     */
-    public static int getMarginOfSuccess(int differenceBetweenRollAndTarget) {
-        return getMarginOfSuccessObject(differenceBetweenRollAndTarget).margin;
+    public int getLowerBound() {
+        return lowerBound;
+    }
+
+    public int getUpperBound() {
+        return upperBound;
+    }
+
+    public String getLookupName() {
+        return lookupName;
     }
 
     /**
@@ -189,34 +165,6 @@ public enum MarginOfSuccess {
         }
         LOGGER.error("No valid MarginOfSuccess found for roll: {}. Returning DISASTROUS",
               differenceBetweenRollAndTarget);
-        return DISASTROUS;
-    }
-
-    /**
-     * Retrieves the {@link MarginOfSuccess} object corresponding to the specified margin value.
-     *
-     * <p>This method iterates through all possible {@link MarginOfSuccess} values and returns the one
-     * whose associated margin matches the provided {@code marginValue}.</p>
-     *
-     * <p>If no matching {@link MarginOfSuccess} is found, an error is logged, and the method
-     * defaults to returning {@link MarginOfSuccess#DISASTROUS}.</p>
-     *
-     * @param marginValue The integer margin value to look up.
-     *
-     * @return The {@link MarginOfSuccess} object corresponding to the given margin value, or
-     *       {@link MarginOfSuccess#DISASTROUS} if no match is found.
-     *
-     * @author Illiani
-     * @since 0.50.05
-     */
-    public static MarginOfSuccess getMarginOfSuccessObjectFromMarginValue(int marginValue) {
-        for (MarginOfSuccess marginOfSuccess : MarginOfSuccess.values()) {
-            if (marginOfSuccess.margin == marginValue) {
-                return marginOfSuccess;
-            }
-        }
-
-        LOGGER.error("No valid MarginOfSuccess found for marginValue: {}. Returning DISASTROUS", marginValue);
         return DISASTROUS;
     }
 

--- a/MekHQ/unittests/mekhq/campaign/personnel/education/TrainingCombatTeamsTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/education/TrainingCombatTeamsTest.java
@@ -38,17 +38,22 @@ import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.BARELY_MADE_
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.skills.ActionCheckResult;
 import mekhq.campaign.personnel.skills.Skill;
 import mekhq.campaign.personnel.skills.SkillType;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import testUtilities.MHQTestUtilities;
 
 class TrainingCombatTeamsTest {
@@ -155,7 +160,7 @@ class TrainingCombatTeamsTest {
     @Test
     void test_GetFinalXPProgress_ZeroMarginOfSuccess() {
         int marginOfSuccess = 0;
-        TrainingCombatTeams.getFinalXPProgress(marginOfSuccess, gunneryMek);
+        TrainingCombatTeams.getFinalXPProgress(new ActionCheckResult(null, marginOfSuccess, false, ""), gunneryMek);
 
         int expectedProgress = XP_RATE_BASE_LINE;
         int actualXPProgress = gunneryMek.getXpProgress();
@@ -166,7 +171,7 @@ class TrainingCombatTeamsTest {
     @Test
     void test_GetFinalXPProgress_NonZeroMarginOfSuccess() {
         int marginOfSuccess = 2;
-        TrainingCombatTeams.getFinalXPProgress(marginOfSuccess, gunneryMek);
+        TrainingCombatTeams.getFinalXPProgress(new ActionCheckResult(null, marginOfSuccess, false, ""), gunneryMek);
 
         int expectedProgress = XP_RATE_BASE_LINE * marginOfSuccess;
         int actualXPProgress = gunneryMek.getXpProgress();
@@ -207,27 +212,37 @@ class TrainingCombatTeamsTest {
 
     @Test
     void test_IsTrainingImpossible_NoSkills_CheckSuccessful() {
-        boolean isTrainingImpossible = TrainingCombatTeams.isTrainingImpossible(List.of(), BARELY_MADE_IT.getValue());
+        boolean isTrainingImpossible = TrainingCombatTeams.isTrainingImpossible(List.of(),
+              new ActionCheckResult(null, BARELY_MADE_IT.getLowerBound(), false, ""));
         assertTrue(isTrainingImpossible);
     }
 
     @Test
     void test_IsTrainingImpossible_YesSkills_CheckFailed() {
         boolean isTrainingImpossible = TrainingCombatTeams.isTrainingImpossible(List.of(gunneryMek),
-              ALMOST.getValue());
+              new ActionCheckResult(null, ALMOST.getLowerBound(), false, ""));
         assertTrue(isTrainingImpossible);
     }
 
     @Test
     void test_IsTrainingImpossible_NoSkills_CheckFailed() {
-        boolean isTrainingImpossible = TrainingCombatTeams.isTrainingImpossible(List.of(), ALMOST.getValue());
+        boolean isTrainingImpossible = TrainingCombatTeams.isTrainingImpossible(List.of(),
+              new ActionCheckResult(null, ALMOST.getLowerBound(), false, ""));
         assertTrue(isTrainingImpossible);
     }
 
     @Test
     void test_IsTrainingImpossible_YesSkills_CheckSuccessful() {
         boolean isTrainingImpossible = TrainingCombatTeams.isTrainingImpossible(List.of(gunneryMek),
-              BARELY_MADE_IT.getValue());
+              new ActionCheckResult(null, BARELY_MADE_IT.getLowerBound(), false, ""));
         assertFalse(isTrainingImpossible);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"0, 1", "2, 2", "4, 4", "-2, 1", "-8, 1", "100000, 6"})
+    void test_GetFinalXPProgress_(int marginOfSuccess, int xp) {
+        Skill skill = mock(Skill.class);
+        TrainingCombatTeams.getFinalXPProgress(new ActionCheckResult(null, marginOfSuccess, false, ""), skill);
+        verify(skill).changeXpProgress(xp);
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/ActionCheckResultTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/ActionCheckResultTest.java
@@ -53,8 +53,8 @@ class ActionCheckResultTest {
         assertEquals(1, result.getMarginOfSuccess());
         assertFalse(result.hasUsedEdge());
         assertEquals("Success.", result.getReport(false));
-        assertEquals("Success. <span color='positive'><i>It'll do...</i></span>",
-              result.getReport(true).replace(ReportingUtilities.getPositiveColor(), "positive"));
+        assertEquals("Success. <span color='warning'><i>It'll do...</i></span>",
+              result.getReport(true).replace(ReportingUtilities.getWarningColor(), "warning"));
     }
 
     @Test
@@ -64,8 +64,8 @@ class ActionCheckResultTest {
         assertEquals(2, result.getMarginOfSuccess());
         assertTrue(result.hasUsedEdge());
         assertEquals("Success. Used a point of <b>Edge</b>.", result.getReport(false));
-        assertEquals("Success. Used a point of <b>Edge</b>. <span color='positive'><i>Good.</i></span>",
-              result.getReport(true).replace(ReportingUtilities.getPositiveColor(), "positive"));
+        assertEquals("Success. Used a point of <b>Edge</b>. <span color='warning'><i>It'll do...</i></span>",
+              result.getReport(true).replace(ReportingUtilities.getWarningColor(), "warning"));
     }
 
     @ParameterizedTest

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/ActionCheckTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/ActionCheckTest.java
@@ -145,10 +145,10 @@ class ActionCheckTest {
         assertTrue(result.isSuccess());
         assertFalse(result.hasUsedEdge());
         assertEquals(8, result.getRollResult());
-        assertEquals("<a href='PERSON:link'>F L</a> <span color=\"positive\"><b>Passed</b></span> his <b>Action</b> " +
+        assertEquals("<a href='PERSON:link'>F L</a> <span color=\"warning\"><b>Passed</b></span> his <b>Action</b> " +
                            "check with a roll of <b>8</b> vs. a target number of <b>7</b>.",
               result.getReport(false).replace(person.getId().toString(), "link")
-                    .replace(ReportingUtilities.getPositiveColor(), "positive"));
+                    .replace(ReportingUtilities.getWarningColor(), "warning"));
     }
 
     @Test
@@ -161,10 +161,10 @@ class ActionCheckTest {
         assertFalse(result.isSuccess());
         assertFalse(result.hasUsedEdge());
         assertEquals(5, result.getRollResult());
-        assertEquals("<a href='PERSON:link'>F L</a> <span color=\"negative\"><b>Failed</b></span> his <b>Action</b> " +
+        assertEquals("<a href='PERSON:link'>F L</a> <span color=\"warning\"><b>Failed</b></span> his <b>Action</b> " +
                            "check with a roll of <b>5</b> vs. a target number of <b>7</b>.",
               result.getReport(false).replace(person.getId().toString(), "link")
-                    .replace(ReportingUtilities.getNegativeColor(), "negative"));
+                    .replace(ReportingUtilities.getWarningColor(), "warning"));
     }
 
     @Test
@@ -177,10 +177,10 @@ class ActionCheckTest {
 
         assertFalse(result.isSuccess());
         assertFalse(result.hasUsedEdge());
-        assertEquals("<a href='PERSON:link'>F L</a> <span color=\"negative\"><b>Failed</b></span> his <b>Action</b> " +
+        assertEquals("<a href='PERSON:link'>F L</a> <span color=\"warning\"><b>Failed</b></span> his <b>Action</b> " +
                            "check with a roll of <b>5</b> vs. a target number of <b>7</b>.",
               result.getReport(false).replace(person.getId().toString(), "link")
-                    .replace(ReportingUtilities.getNegativeColor(), "negative"));
+                    .replace(ReportingUtilities.getWarningColor(), "warning"));
     }
 
     @Test
@@ -208,9 +208,9 @@ class ActionCheckTest {
         assertTrue(result.hasUsedEdge());
         assertEquals(9, result.getRollResult());
         verify(person).spendEdge();
-        assertEquals("Person <span color=\"positive\"><b>Passed</b></span> her <b>Action</b> check with a roll of " +
+        assertEquals("Person <span color=\"warning\"><b>Passed</b></span> her <b>Action</b> check with a roll of " +
                            "<b>9</b> vs. a target number of <b>7</b>. Used a point of <b>Edge</b>.",
-              result.getReport(false).replace(ReportingUtilities.getPositiveColor(), "positive"));
+              result.getReport(false).replace(ReportingUtilities.getWarningColor(), "warning"));
     }
 
     @Test
@@ -228,9 +228,9 @@ class ActionCheckTest {
         assertTrue(result.hasUsedEdge());
         assertEquals(6, result.getRollResult());
         verify(person).spendEdge();
-        assertEquals("Person <span color=\"negative\"><b>Failed</b></span> his <b>Action</b> check with a roll of " +
+        assertEquals("Person <span color=\"warning\"><b>Failed</b></span> his <b>Action</b> check with a roll of " +
                            "<b>6</b> vs. a target number of <b>7</b>. Used a point of <b>Edge</b>.",
-              result.getReport(false).replace(ReportingUtilities.getNegativeColor(), "negative"));
+              result.getReport(false).replace(ReportingUtilities.getWarningColor(), "warning"));
     }
 
     @ParameterizedTest
@@ -247,4 +247,33 @@ class ActionCheckTest {
             utils.verify(Compute::d6, times(naturalAptitude ? 3 : 2));
         }
     }
+
+    @Test
+    void testMarginOfSuccessClamping_AutomaticSuccess() {
+        Person person = new Person("F", "L", null, "Faction");
+        TargetRoll target = new TargetRoll(TargetRoll.AUTOMATIC_SUCCESS, "Base");
+        ConcreteActionCheck check = new ConcreteActionCheck(person, target, false, false, "Action");
+
+        try (MockedStatic<Compute> utils = mockStatic(Compute.class)) {
+            utils.when(Compute::d6).thenReturn(2, 2);
+            ActionCheckResult result = check.resolve(false, null);
+            assertEquals(4, result.getRollResult());
+            assertEquals(10, result.getMarginOfSuccess());
+        }
+    }
+
+    @Test
+    void testMarginOfSuccessClamping_AutomaticFailure() {
+        Person person = new Person("F", "L", null, "Faction");
+        TargetRoll target = new TargetRoll(TargetRoll.AUTOMATIC_FAIL, "Base");
+        ConcreteActionCheck check = new ConcreteActionCheck(person, target, false, false, "Action");
+
+        try (MockedStatic<Compute> utils = mockStatic(Compute.class)) {
+            utils.when(Compute::d6).thenReturn(6, 6);
+            ActionCheckResult result = check.resolve(false, null);
+            assertEquals(12, result.getRollResult());
+            assertEquals(-10, result.getMarginOfSuccess());
+        }
+    }
+
 }

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/AppraisalTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/AppraisalTest.java
@@ -35,6 +35,7 @@ package mekhq.campaign.personnel.skills;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import mekhq.campaign.personnel.skills.enums.MarginOfSuccess;
+import mekhq.utilities.ReportingUtilities;
 import org.junit.jupiter.api.Test;
 
 class AppraisalTest {
@@ -57,20 +58,31 @@ class AppraisalTest {
     }
 
     @Test
-    void testGetMarginOfSuccess_withPositiveMultiplier() {
-        MarginOfSuccess marginOfSuccess = Appraisal.getMarginOfSuccess(0.9);
-        assertEquals(MarginOfSuccess.SPECTACULAR, marginOfSuccess);
+    void testGetAppraisalCostMultiplier_withAutomaticSuccess() {
+        double multiplier = Appraisal.getAppraisalCostMultiplier(100);
+        assertEquals(0.85, multiplier);
     }
 
     @Test
-    void testGetMarginOfSuccess_withNegativeMultiplier() {
-        MarginOfSuccess marginOfSuccess = Appraisal.getMarginOfSuccess(1.05);
-        assertEquals(MarginOfSuccess.BAD, marginOfSuccess);
+    void testGetAppraisalCostMultiplier_withAutomaticFailure() {
+        double multiplier = Appraisal.getAppraisalCostMultiplier(-100);
+        assertEquals(1.15, multiplier);
     }
 
     @Test
-    void testGetMarginOfSuccess_withZeroMultiplier() {
-        MarginOfSuccess marginOfSuccess = Appraisal.getMarginOfSuccess(1.0);
-        assertEquals(MarginOfSuccess.BARELY_MADE_IT, marginOfSuccess);
+    void testGetAppraisalReport_Almost() {
+        assertEquals("They got a <span color='warning'><b>Below Average</b></span> deal. " +
+                           "Margin of Failure 1, price increased to <b>105%</b>.",
+              Appraisal.getAppraisalReport(1.05, MarginOfSuccess.ALMOST)
+                    .replace(ReportingUtilities.getWarningColor(), "warning"));
     }
+
+    @Test
+    void testGetAppraisalReport_Extraordinary() {
+        assertEquals("They got an <span color='positive'><b>Extraordinary</b></span> deal! " +
+                           "Margin of Success 3, price reduced to <b>80%</b>.",
+              Appraisal.getAppraisalReport(0.8, MarginOfSuccess.EXTRAORDINARY)
+                    .replace(ReportingUtilities.getPositiveColor(), "positive"));
+    }
+
 }


### PR DESCRIPTION
Refactor skill checks and training mechanics to use raw margin of success integers instead of the `MarginOfSuccess` enum, reserving the enum strictly for report generation. Transition methods to accept `ActionCheckResult` to simplify logic and improve code maintainability.

Details:
- Use margins and reports from `ActionCheckResult` in `Campaign`
- Pass `ActionCheckResult` instead of `marginOfSuccess` in `TrainingCombatTeams`
- Clamp training XP gain to `XP_GAIN_MAX` in `getFinalXPProgress`, for extra safety, since the enum usage was removed
- Change `ActionCheck` to calculate margin of success as a raw integer
- Add `getReportMargin` to `ActionCheckResult` to retrieve reporting enums
- Modify `Appraisal.performAppraisalCheck` to return `ActionCheckResult`
- Clamp appraisal cost multiplier margin between -6 and 6 in `Appraisal`
- Refactor `EscapeSkills` to evaluate integer bounds instead of enum matching
- Remove exact margin matching and related getters from `MarginOfSuccess`
- Add bound and lookup name accessors to the `MarginOfSuccess` enum
- Improve test coverage for appraisal and training