### PR TITLE
PR: Ground Transit Location

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -1936,6 +1936,7 @@ LocationDisplay.inTransit.toJumpPoint.text=In Transit ({0} days to jump point)
 LocationDisplay.inTransit.recharging.text=In Transit ({0} days recharging)
 LocationDisplay.inTransit.readyToJump.text=In Transit (ready to jump)
 LocationDisplay.inTransit.toPlanet.text=In Transit ({0} days to planet)
+LocationDisplay.inTransit.overland.text=In Transit ({0} days overland)
 ## LocationFilterItem
 LocationFilterItem.allMainForce.text=All (Main Force)
 LocationFilterItem.mainForce.text=Main Force

--- a/MekHQ/resources/mekhq/resources/GroundTransitLocation.properties
+++ b/MekHQ/resources/mekhq/resources/GroundTransitLocation.properties
@@ -1,0 +1,32 @@
+# Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+#
+# This file is part of MekHQ.
+#
+# MekHQ is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (GPL),
+# version 3 or (at your option) any later version,
+# as published by the Free Software Foundation.
+#
+# MekHQ is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# A copy of the GPL should have been included with this project;
+# if not, see <https://www.gnu.org/licenses/>.
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+getReport.newDay.timeTraveling=Convoy spent {0} hours traveling overland
+getReport.newDay.destination=Destination reached.

--- a/MekHQ/src/mekhq/campaign/AbstractLocation.java
+++ b/MekHQ/src/mekhq/campaign/AbstractLocation.java
@@ -316,11 +316,22 @@ public abstract class AbstractLocation implements IPlace {
         return switch (wn.getNodeName().toLowerCase()) {
             case "location" -> CurrentLocation.generateInstanceFromXML(wn, campaign);
             case "fixedlocation" -> FixedLocation.generateInstanceFromXML(wn, campaign);
+            case "groundtransitlocation" -> GroundTransitLocation.generateInstanceFromXML(wn, campaign);
             default -> {
                 logger.warn("Unrecognized location node '{}' — skipping", wn.getNodeName());
                 yield null;
             }
         };
+    }
+
+    /**
+     * Returns {@code true} if {@code nodeName} is the XML element name of a serialized travel node — an
+     * interplanetary {@code <location>} ({@link CurrentLocation}) or an on-planet {@code <groundTransitLocation>}
+     * ({@link GroundTransitLocation}). Both deserialize via {@link #generateInstanceFromXML} to an
+     * {@link AbstractMobileLocation}.
+     */
+    public static boolean isTravelNodeTag(String nodeName) {
+        return nodeName.equalsIgnoreCase("location") || nodeName.equalsIgnoreCase("groundTransitLocation");
     }
 
     static class PlanetarySystemAdapter extends XmlAdapter<String, PlanetarySystem> {

--- a/MekHQ/src/mekhq/campaign/CampaignLocationManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignLocationManager.java
@@ -34,15 +34,7 @@
 package mekhq.campaign;
 
 import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 import jakarta.annotation.Nonnull;
 import megamek.common.annotations.Nullable;
@@ -155,8 +147,30 @@ public class CampaignLocationManager {
             return;
         }
         for (ILocation traveler : travelers) {
+            removeExistingPendingTravel(traveler);
             TravelRoute route = new TravelRoute(traveler.getCurrentLocation(), destination);
             pendingTravel.computeIfAbsent(route, key -> new ArrayList<>()).add(traveler);
+        }
+    }
+
+    /**
+     * Removes {@code traveler} from any route it is already queued on, logging at debug level when it is found. Called
+     * before re-queuing so a later {@link #queueTravel} supersedes an earlier one rather than leaving the traveler
+     * bound to two destinations (which would dispatch it twice). A route left empty by the removal is dropped so it
+     * does not linger in {@link #pendingTravel}.
+     */
+    private void removeExistingPendingTravel(ILocation traveler) {
+        Iterator<Map.Entry<TravelRoute, List<ILocation>>> iterator = pendingTravel.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<TravelRoute, List<ILocation>> entry = iterator.next();
+            if (entry.getValue().remove(traveler)) {
+                LOGGER.debug("queueTravel: {} was already queued for travel to {} — removing prior pending travel",
+                      traveler.getClass().getSimpleName(), entry.getKey().destination());
+                if (entry.getValue().isEmpty()) {
+                    iterator.remove();
+                }
+                return;
+            }
         }
     }
 
@@ -252,7 +266,7 @@ public class CampaignLocationManager {
                       || !location.fetchUnitsAtLocation().isEmpty()) {
                 return false;
             }
-            if (location instanceof CurrentLocation) {
+            if (location instanceof AbstractMobileLocation) {
                 location.setParent(null);
             } else if (location instanceof FixedLocation) {
                 for (ILocation child : new ArrayList<>(location.getChildLocations())) {

--- a/MekHQ/src/mekhq/campaign/ForceLocationManager.java
+++ b/MekHQ/src/mekhq/campaign/ForceLocationManager.java
@@ -141,15 +141,16 @@ public class ForceLocationManager {
     }
 
     /**
-     * Processes {@link CurrentLocation} travel nodes that are parented directly to the campaign and have completed
-     * their journey (i.e. are on-planet), landing their passengers into the campaign's main force resources.
+     * Processes {@link AbstractMobileLocation} travel nodes (interplanetary {@link CurrentLocation} or on-planet
+     * {@link GroundTransitLocation}) that are parented directly to the campaign and have completed their journey,
+     * landing their passengers into the campaign's main force resources.
      */
     public void processArrivals(Campaign campaign) {
         for (ILocation child : new ArrayList<>(mainForce.getChildLocations())) {
-            if (!(child instanceof CurrentLocation travelLocation)) {
+            if (!(child instanceof AbstractMobileLocation travelLocation)) {
                 continue;
             }
-            if (!travelLocation.isOnPlanet()) {
+            if (!travelLocation.hasArrived()) {
                 continue;
             }
             LocationDispatch.landFromTravelNode(travelLocation,

--- a/MekHQ/src/mekhq/campaign/GroundTransitLocation.java
+++ b/MekHQ/src/mekhq/campaign/GroundTransitLocation.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign;
+
+import static mekhq.campaign.enums.DailyReportType.GENERAL;
+
+import java.io.PrintWriter;
+import java.util.UUID;
+
+import megamek.logging.MMLogger;
+import mekhq.MekHQ;
+import mekhq.campaign.events.TransitCompleteEvent;
+import mekhq.campaign.events.TransitStatusChangedEvent;
+import mekhq.campaign.location.ILocation;
+import mekhq.campaign.parts.Part;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.unit.Unit;
+import mekhq.campaign.universe.PlanetarySystem;
+import mekhq.utilities.MHQXMLUtility;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * A moving location that tracks on-planet ground transport, such as an overland convoy travelling
+ * between two sites on the same planet.
+ *
+ * <p>Unlike {@link CurrentLocation}, a {@code GroundTransitLocation} never leaves the planet — it is
+ * always considered on-planet ({@link #isOnPlanet()} stays {@code true} for the whole journey) and
+ * has no jump points or JumpShip recharge. It only carries a remaining ground {@link #transitTime}
+ * (in days) that counts down day-by-day until it arrives.</p>
+ */
+public class GroundTransitLocation extends AbstractMobileLocation {
+    private static final MMLogger logger = MMLogger.create(GroundTransitLocation.class);
+
+    // total length of the journey in days, used to report travel progress
+    private double totalTransitTime;
+
+    public GroundTransitLocation() {
+        this(null, 0d);
+    }
+
+    public GroundTransitLocation(PlanetarySystem system, double transitTime) {
+        super(system, transitTime);
+        this.totalTransitTime = transitTime;
+    }
+
+    @Override
+    public boolean isInTransit() {
+        return transitTime > 0;
+    }
+
+    @Override
+    public double getPercentageTransit() {
+        return totalTransitTime <= 0 ? 1.0 : 1 - transitTime / totalTransitTime;
+    }
+
+    /**
+     * Advances the overland journey by up to one day. When the remaining transit time reaches zero
+     * the convoy has arrived: a {@link TransitCompleteEvent} fires and each child place is notified
+     * of arrival.
+     */
+    @Override
+    public void newDay(Campaign campaign, boolean isSilentProcessing) {
+        if (transitTime <= 0) {
+            return;
+        }
+
+        double daysTravelled = Math.min(1.0, transitTime);
+        transitTime -= daysTravelled;
+        if (!isSilentProcessing) {
+            campaign.addReport(GENERAL, "Convoy spent " +
+                                              (Math.round(100.0 * 24.0 * daysTravelled) / 100.0) +
+                                              " hours travelling overland");
+        }
+
+        if (transitTime <= 0) {
+            transitTime = 0;
+            if (!isSilentProcessing) {
+                campaign.addReport(GENERAL, "Destination reached.");
+            }
+            MekHQ.triggerEvent(new TransitCompleteEvent(this));
+            notifyChildrenArrived(campaign, isSilentProcessing);
+        } else {
+            MekHQ.triggerEvent(new TransitStatusChangedEvent(this));
+        }
+    }
+
+    @Override
+    public void writeToXML(final PrintWriter pw, int indent) {
+        MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "groundTransitLocation");
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "currentSystemId", currentSystem.getId());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "transitTime", transitTime);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "totalTransitTime", totalTransitTime);
+        for (ILocation child : getChildLocations()) {
+            if (child instanceof Person person) {
+                MHQXMLUtility.writeSimpleXMLTag(pw, indent, "personId", person.getId().toString());
+            } else if (child instanceof Unit unit) {
+                MHQXMLUtility.writeSimpleXMLTag(pw, indent, "unitId", unit.getId().toString());
+            } else if (child instanceof Part part) {
+                MHQXMLUtility.writeSimpleXMLTag(pw, indent, "partId", String.valueOf(part.getId()));
+            }
+        }
+        MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "groundTransitLocation");
+    }
+
+    public static GroundTransitLocation generateInstanceFromXML(Node wn, Campaign c) {
+        GroundTransitLocation retVal = null;
+
+        try {
+            retVal = new GroundTransitLocation();
+            NodeList nl = wn.getChildNodes();
+
+            for (int x = 0; x < nl.getLength(); x++) {
+                Node wn2 = nl.item(x);
+                if (wn2.getNodeName().equalsIgnoreCase("currentSystemId")) {
+                    PlanetarySystem p = c.getSystemById(wn2.getTextContent());
+                    if (null == p) {
+                        // Whoops, we can't find your planet man, back to Earth
+                        logger.error("Couldn't find planet named {}", wn2.getTextContent());
+                        p = c.getSystemByName("Terra");
+                        if (null == p) {
+                            // If that doesn't work then give the first planet we have
+                            p = c.getSystems().getFirst();
+                        }
+                    }
+                    retVal.currentSystem = p;
+                } else if (wn2.getNodeName().equalsIgnoreCase("transitTime")) {
+                    retVal.transitTime = Double.parseDouble(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("totalTransitTime")) {
+                    retVal.totalTransitTime = Double.parseDouble(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("personId")) {
+                    retVal.pendingPersonIds.add(UUID.fromString(wn2.getTextContent().trim()));
+                } else if (wn2.getNodeName().equalsIgnoreCase("unitId")) {
+                    retVal.pendingUnitIds.add(UUID.fromString(wn2.getTextContent().trim()));
+                } else if (wn2.getNodeName().equalsIgnoreCase("partId")) {
+                    retVal.pendingPartIds.add(Integer.parseInt(wn2.getTextContent().trim()));
+                }
+            }
+        } catch (Exception ex) {
+            logger.error("", ex);
+        }
+
+        return retVal;
+    }
+}

--- a/MekHQ/src/mekhq/campaign/GroundTransitLocation.java
+++ b/MekHQ/src/mekhq/campaign/GroundTransitLocation.java
@@ -46,6 +46,7 @@ import mekhq.campaign.parts.Part;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.PlanetarySystem;
+import mekhq.utilities.MHQInternationalization;
 import mekhq.utilities.MHQXMLUtility;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -97,16 +98,16 @@ public class GroundTransitLocation extends AbstractMobileLocation {
 
         double daysTravelled = Math.min(1.0, transitTime);
         transitTime -= daysTravelled;
+
         if (!isSilentProcessing) {
-            campaign.addReport(GENERAL, "Convoy spent " +
-                                              (Math.round(100.0 * 24.0 * daysTravelled) / 100.0) +
-                                              " hours travelling overland");
+            campaign.addReport(GENERAL, MHQInternationalization.getFormattedText("getReport.newDay.timeTraveling",
+                  (Math.round(100.0 * 24.0 * daysTravelled) / 100.0)));
         }
 
         if (transitTime <= 0) {
             transitTime = 0;
             if (!isSilentProcessing) {
-                campaign.addReport(GENERAL, "Destination reached.");
+                campaign.addReport(GENERAL, MHQInternationalization.getText("getReport.newDay.destination"));
             }
             MekHQ.triggerEvent(new TransitCompleteEvent(this));
             notifyChildrenArrived(campaign, isSilentProcessing);
@@ -116,60 +117,60 @@ public class GroundTransitLocation extends AbstractMobileLocation {
     }
 
     @Override
-    public void writeToXML(final PrintWriter pw, int indent) {
-        MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "groundTransitLocation");
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "currentSystemId", currentSystem.getId());
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "transitTime", transitTime);
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "totalTransitTime", totalTransitTime);
+    public void writeToXML(final PrintWriter printWriter, int indent) {
+        MHQXMLUtility.writeSimpleXMLOpenTag(printWriter, indent++, "groundTransitLocation");
+        MHQXMLUtility.writeSimpleXMLTag(printWriter, indent, "currentSystemId", currentSystem.getId());
+        MHQXMLUtility.writeSimpleXMLTag(printWriter, indent, "transitTime", transitTime);
+        MHQXMLUtility.writeSimpleXMLTag(printWriter, indent, "totalTransitTime", totalTransitTime);
         for (ILocation child : getChildLocations()) {
             if (child instanceof Person person) {
-                MHQXMLUtility.writeSimpleXMLTag(pw, indent, "personId", person.getId().toString());
+                MHQXMLUtility.writeSimpleXMLTag(printWriter, indent, "personId", person.getId().toString());
             } else if (child instanceof Unit unit) {
-                MHQXMLUtility.writeSimpleXMLTag(pw, indent, "unitId", unit.getId().toString());
+                MHQXMLUtility.writeSimpleXMLTag(printWriter, indent, "unitId", unit.getId().toString());
             } else if (child instanceof Part part) {
-                MHQXMLUtility.writeSimpleXMLTag(pw, indent, "partId", String.valueOf(part.getId()));
+                MHQXMLUtility.writeSimpleXMLTag(printWriter, indent, "partId", String.valueOf(part.getId()));
             }
         }
-        MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "groundTransitLocation");
+        MHQXMLUtility.writeSimpleXMLCloseTag(printWriter, --indent, "groundTransitLocation");
     }
 
-    public static GroundTransitLocation generateInstanceFromXML(Node wn, Campaign c) {
-        GroundTransitLocation retVal = null;
+    public static GroundTransitLocation generateInstanceFromXML(Node workingNode, Campaign campaign) {
+        GroundTransitLocation returnValue = null;
 
         try {
-            retVal = new GroundTransitLocation();
-            NodeList nl = wn.getChildNodes();
+            returnValue = new GroundTransitLocation();
+            NodeList nodeList = workingNode.getChildNodes();
 
-            for (int x = 0; x < nl.getLength(); x++) {
-                Node wn2 = nl.item(x);
-                if (wn2.getNodeName().equalsIgnoreCase("currentSystemId")) {
-                    PlanetarySystem p = c.getSystemById(wn2.getTextContent());
-                    if (null == p) {
+            for (int x = 0; x < nodeList.getLength(); x++) {
+                Node workingNode2 = nodeList.item(x);
+                if (workingNode2.getNodeName().equalsIgnoreCase("currentSystemId")) {
+                    PlanetarySystem planetarySystem = campaign.getSystemById(workingNode2.getTextContent());
+                    if (null == planetarySystem) {
                         // Whoops, we can't find your planet man, back to Earth
-                        logger.error("Couldn't find planet named {}", wn2.getTextContent());
-                        p = c.getSystemByName("Terra");
-                        if (null == p) {
+                        logger.error("Couldn't find planet named {}", workingNode2.getTextContent());
+                        planetarySystem = campaign.getSystemByName("Terra");
+                        if (null == planetarySystem) {
                             // If that doesn't work then give the first planet we have
-                            p = c.getSystems().getFirst();
+                            planetarySystem = campaign.getSystems().getFirst();
                         }
                     }
-                    retVal.currentSystem = p;
-                } else if (wn2.getNodeName().equalsIgnoreCase("transitTime")) {
-                    retVal.transitTime = Double.parseDouble(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("totalTransitTime")) {
-                    retVal.totalTransitTime = Double.parseDouble(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("personId")) {
-                    retVal.pendingPersonIds.add(UUID.fromString(wn2.getTextContent().trim()));
-                } else if (wn2.getNodeName().equalsIgnoreCase("unitId")) {
-                    retVal.pendingUnitIds.add(UUID.fromString(wn2.getTextContent().trim()));
-                } else if (wn2.getNodeName().equalsIgnoreCase("partId")) {
-                    retVal.pendingPartIds.add(Integer.parseInt(wn2.getTextContent().trim()));
+                    returnValue.currentSystem = planetarySystem;
+                } else if (workingNode2.getNodeName().equalsIgnoreCase("transitTime")) {
+                    returnValue.transitTime = Double.parseDouble(workingNode2.getTextContent());
+                } else if (workingNode2.getNodeName().equalsIgnoreCase("totalTransitTime")) {
+                    returnValue.totalTransitTime = Double.parseDouble(workingNode2.getTextContent());
+                } else if (workingNode2.getNodeName().equalsIgnoreCase("personId")) {
+                    returnValue.pendingPersonIds.add(UUID.fromString(workingNode2.getTextContent().trim()));
+                } else if (workingNode2.getNodeName().equalsIgnoreCase("unitId")) {
+                    returnValue.pendingUnitIds.add(UUID.fromString(workingNode2.getTextContent().trim()));
+                } else if (workingNode2.getNodeName().equalsIgnoreCase("partId")) {
+                    returnValue.pendingPartIds.add(Integer.parseInt(workingNode2.getTextContent().trim()));
                 }
             }
         } catch (Exception ex) {
             logger.error("", ex);
         }
 
-        return retVal;
+        return returnValue;
     }
 }

--- a/MekHQ/src/mekhq/campaign/GroundTransitLocation.java
+++ b/MekHQ/src/mekhq/campaign/GroundTransitLocation.java
@@ -63,6 +63,8 @@ import org.w3c.dom.NodeList;
 public class GroundTransitLocation extends AbstractMobileLocation {
     private static final MMLogger logger = MMLogger.create(GroundTransitLocation.class);
 
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.GroundTransitLocation";
+
     // total length of the journey in days, used to report travel progress
     private double totalTransitTime;
 
@@ -100,14 +102,15 @@ public class GroundTransitLocation extends AbstractMobileLocation {
         transitTime -= daysTravelled;
 
         if (!isSilentProcessing) {
-            campaign.addReport(GENERAL, MHQInternationalization.getFormattedText("getReport.newDay.timeTraveling",
-                  (Math.round(100.0 * 24.0 * daysTravelled) / 100.0)));
+            campaign.addReport(GENERAL, MHQInternationalization.getFormattedTextAt(RESOURCE_BUNDLE,
+                  "getReport.newDay.timeTraveling", (Math.round(100.0 * 24.0 * daysTravelled) / 100.0)));
         }
 
         if (transitTime <= 0) {
             transitTime = 0;
             if (!isSilentProcessing) {
-                campaign.addReport(GENERAL, MHQInternationalization.getText("getReport.newDay.destination"));
+                campaign.addReport(GENERAL,
+                      MHQInternationalization.getTextAt(RESOURCE_BUNDLE, "getReport.newDay.destination"));
             }
             MekHQ.triggerEvent(new TransitCompleteEvent(this));
             notifyChildrenArrived(campaign, isSilentProcessing);

--- a/MekHQ/src/mekhq/campaign/base/PlayerBase.java
+++ b/MekHQ/src/mekhq/campaign/base/PlayerBase.java
@@ -39,8 +39,9 @@ import java.util.UUID;
 
 import megamek.Version;
 import megamek.common.annotations.Nullable;
+import mekhq.campaign.AbstractLocation;
+import mekhq.campaign.AbstractMobileLocation;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.CurrentLocation;
 import mekhq.campaign.FixedLocation;
 import mekhq.campaign.location.AcademyCampusLocation;
 import mekhq.campaign.location.ILocation;
@@ -122,10 +123,10 @@ public class PlayerBase extends AbstractBase {
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent, "personId", person.getId().toString());
             }
         }
-        // Travel nodes (CurrentLocation) and homeSchool campuses sit directly under the base.
+        // Travel nodes (CurrentLocation / GroundTransitLocation) and homeSchool campuses sit directly under the base.
         for (ILocation child : getChildLocations()) {
-            if (child instanceof CurrentLocation currentLocation) {
-                currentLocation.writeToXML(pw, indent);
+            if (child instanceof AbstractMobileLocation travelNode) {
+                travelNode.writeToXML(pw, indent);
             } else if (child instanceof AcademyCampusLocation campus) {
                 campus.writeToXML(pw, indent);
             }
@@ -203,12 +204,12 @@ public class PlayerBase extends AbstractBase {
                     // Already handled in pre-scan above.
                 } else if (nodeName.equalsIgnoreCase("personId")) {
                     base.pendingPersonIds.add(UUID.fromString(wn2.getTextContent().trim()));
-                } else if (nodeName.equalsIgnoreCase("location")) {
+                } else if (AbstractLocation.isTravelNodeTag(nodeName)) {
                     // Travel nodes sit directly under the base (not under basePersonnel).
-                    CurrentLocation travelLocation = CurrentLocation.generateInstanceFromXML(wn2, campaign);
-                    if (travelLocation != null) {
-                        travelLocation.setParent(base);
-                        campaign.getCampaignLocationManager().addLocation(travelLocation);
+                    if (AbstractLocation.generateInstanceFromXML(wn2, campaign)
+                              instanceof AbstractMobileLocation travelNode) {
+                        travelNode.setParent(base);
+                        campaign.getCampaignLocationManager().addLocation(travelNode);
                     }
                 } else if (nodeName.equalsIgnoreCase("academyCampus")) {
                     AcademyCampusLocation campus = AcademyCampusLocation.generateInstanceFromXML(wn2);
@@ -220,12 +221,11 @@ public class PlayerBase extends AbstractBase {
                             if (campusChild.getNodeType() != Node.ELEMENT_NODE) {
                                 continue;
                             }
-                            if (campusChild.getNodeName().equalsIgnoreCase("location")) {
-                                CurrentLocation travelNode = CurrentLocation.generateInstanceFromXML(campusChild, campaign);
-                                if (travelNode != null) {
-                                    travelNode.setParent(campus);
-                                    campaign.getCampaignLocationManager().addLocation(travelNode);
-                                }
+                            if (AbstractLocation.isTravelNodeTag(campusChild.getNodeName())
+                                      && AbstractLocation.generateInstanceFromXML(campusChild, campaign)
+                                                 instanceof AbstractMobileLocation travelNode) {
+                                travelNode.setParent(campus);
+                                campaign.getCampaignLocationManager().addLocation(travelNode);
                             }
                         }
                     }

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -91,15 +91,7 @@ import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.NullEntityException;
 import mekhq.Utilities;
-import mekhq.campaign.AbstractLocation;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.CampaignFactory;
-import mekhq.campaign.CampaignLocationManager;
-import mekhq.campaign.CurrentLocation;
-import mekhq.campaign.FixedLocation;
-import mekhq.campaign.Kill;
-import mekhq.campaign.Personnel;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.*;
 import mekhq.campaign.againstTheBot.AtBConfiguration;
 import mekhq.campaign.base.PlayerBase;
 import mekhq.campaign.camOpsReputation.ReputationController;
@@ -1740,21 +1732,20 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
      */
     private static void reconnectPersonsToTravelLocations(Campaign campaign) {
         for (AbstractLocation location : campaign.getCampaignLocationManager().getLocations()) {
-            if (location instanceof CurrentLocation currentLocation) {
-                // Orphaned, non-transiting CurrentLocations are stale transit records.
+            if (location instanceof AbstractMobileLocation travelLocation) {
+                // Orphaned, non-transiting travel nodes are stale transit records.
                 // They appear in <locations> (rather than inside a <playerBase>) because
                 // setParent() failed at dispatch time, leaving their locationNode unparented.
                 // Items that arrived (processPlayerBaseNodes already re-homed them) must NOT
                 // be re-parented here, as that would detach them from their base. Items whose
                 // save pre-dates the arrival-tracking fix fall back to main force so they
                 // remain visible rather than becoming invisible.
-                boolean isOrphaned = !currentLocation.isParented();
-                boolean isActivelyInTransit = currentLocation.getJumpPath() != null
-                                                    && !currentLocation.getJumpPath().isEmpty();
+                boolean isOrphaned = !travelLocation.isParented();
+                boolean isActivelyInTransit = isActivelyInTransit(travelLocation);
                 if (isOrphaned && !isActivelyInTransit) {
                     // Drain pending IDs so the loop below is skipped. Any person not already
                     // re-homed by processPlayerBaseNodes falls back to main force.
-                    for (UUID personId : currentLocation.drainPendingPersonIds()) {
+                    for (UUID personId : travelLocation.drainPendingPersonIds()) {
                         Person person = campaign.getPerson(personId);
                         if (person != null && !person.isParented()) {
                             person.setParent(campaign.getMainForcePersonnel());
@@ -1762,7 +1753,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                                   + "(orphaned arrived node); re-homed to main force", personId);
                         }
                     }
-                    for (UUID unitId : currentLocation.drainPendingUnitIds()) {
+                    for (UUID unitId : travelLocation.drainPendingUnitIds()) {
                         Unit unit = findUnitAnywhere(campaign, unitId);
                         if (unit != null && !unit.isParented()) {
                             LocationNode.LocationManager.setLocation(unit, campaign.getHangar());
@@ -1770,7 +1761,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                                   + "(orphaned arrived node); re-homed to main hangar", unitId);
                         }
                     }
-                    for (int partId : currentLocation.drainPendingPartIds()) {
+                    for (int partId : travelLocation.drainPendingPartIds()) {
                         Part part = campaign.getCampaignLocationManager().findPartAnywhere(campaign, partId);
                         if (part != null && !part.isParented()) {
                             LocationNode.LocationManager.setLocation(part, campaign.getWarehouse());
@@ -1781,29 +1772,29 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                     continue;
                 }
 
-                // Persons traveling — parented under a CurrentLocation
-                for (UUID personId : currentLocation.drainPendingPersonIds()) {
+                // Persons traveling — parented under the travel node
+                for (UUID personId : travelLocation.drainPendingPersonIds()) {
                     Person person = campaign.getPerson(personId);
                     if (person != null) {
-                        person.setParent(currentLocation);
+                        person.setParent(travelLocation);
                     } else {
                         LOGGER.warn("reconnectPersonsToTravelLocations: person {} not found in campaign", personId);
                     }
                 }
 
-                // Units in transit — in base hangar data structure, but LocationNode under CurrentLocation
-                for (UUID unitId : currentLocation.drainPendingUnitIds()) {
+                // Units in transit — in base hangar data structure, but LocationNode under the travel node
+                for (UUID unitId : travelLocation.drainPendingUnitIds()) {
                     Unit unit = findUnitAnywhere(campaign, unitId);
                     if (unit != null) {
-                        LocationNode.LocationManager.setLocation(unit, currentLocation);
+                        LocationNode.LocationManager.setLocation(unit, travelLocation);
                     }
                 }
 
-                // Parts in transit — in base warehouse data structure, but LocationNode under CurrentLocation
-                for (int partId : currentLocation.drainPendingPartIds()) {
+                // Parts in transit — in base warehouse data structure, but LocationNode under the travel node
+                for (int partId : travelLocation.drainPendingPartIds()) {
                     Part part = campaign.getCampaignLocationManager().findPartAnywhere(campaign, partId);
                     if (part != null) {
-                        LocationNode.LocationManager.setLocation(part, currentLocation);
+                        LocationNode.LocationManager.setLocation(part, travelLocation);
                     }
                 }
 
@@ -1838,6 +1829,18 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                 LOGGER.warn("drainCampusPersons: person {} not found in campaign", personId);
             }
         }
+    }
+
+    /**
+     * A travel node is actively in transit when it still has a live journey: an interplanetary {@link CurrentLocation}
+     * with a non-empty jump path, or a {@link mekhq.campaign.GroundTransitLocation} still counting down its overland
+     * transit time. Arrived-but-not-yet-drained nodes are not.
+     */
+    private static boolean isActivelyInTransit(AbstractMobileLocation travelLocation) {
+        if (travelLocation instanceof CurrentLocation currentLocation) {
+            return currentLocation.getJumpPath() != null && !currentLocation.getJumpPath().isEmpty();
+        }
+        return travelLocation.isInTransit();
     }
 
     /** Searches campaign hangar then all base hangars for a unit by UUID. */

--- a/MekHQ/src/mekhq/campaign/location/LocationDispatch.java
+++ b/MekHQ/src/mekhq/campaign/location/LocationDispatch.java
@@ -42,10 +42,12 @@ import java.util.stream.Collectors;
 
 import megamek.common.annotations.Nullable;
 import megamek.logging.MMLogger;
+import mekhq.campaign.AbstractLocation;
 import mekhq.campaign.AbstractMobileLocation;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignLocationManager;
 import mekhq.campaign.CurrentLocation;
+import mekhq.campaign.GroundTransitLocation;
 import mekhq.campaign.Hangar;
 import mekhq.campaign.JumpPath;
 import mekhq.campaign.Warehouse;
@@ -69,6 +71,9 @@ public final class LocationDispatch {
     private static final String LOG_DISPATCH_PERSONS = "dispatchToLocation";
     private static final String LOG_DISPATCH_UNITS = "dispatchUnitsToLocation";
     private static final String LOG_DISPATCH_PARTS = "dispatchPartsToLocation";
+
+    /** Overland transit time, in days, for a same-planet move to a different root location. */
+    private static final double GROUND_TRANSIT_DAYS = 2.0;
 
     private LocationDispatch() {}
 
@@ -189,6 +194,39 @@ public final class LocationDispatch {
         }
         campaign.getCampaignLocationManager().addLocation(travelNode);
         return Optional.of(travelNode);
+    }
+
+    /**
+     * Builds an on-planet overland travel node at {@code system} (a fixed {@link #GROUND_TRANSIT_DAYS}
+     * day journey, no jump path), parented under {@code destination}, and registers it with the
+     * campaign. Used for same-planet moves to a different root location.
+     */
+    private static GroundTransitLocation buildGroundTransitNode(PlanetarySystem system, ILocation destination,
+          Campaign campaign, String logContext) {
+        GroundTransitLocation groundNode = new GroundTransitLocation(system, GROUND_TRANSIT_DAYS);
+        if (!groundNode.setParent(destination)) {
+            LOGGER.warn("{}: setParent failed for groundTransitNode → {}; "
+                  + "items may display as Main Force after save/load",
+                  logContext, destination.getClass().getSimpleName());
+        }
+        campaign.getCampaignLocationManager().addLocation(groundNode);
+        return groundNode;
+    }
+
+    /**
+     * Returns {@code true} if {@code item} and {@code destination} hang under the same root
+     * {@link AbstractLocation} — i.e. they are already at the same location and no travel node is
+     * needed. Each base, campus, and the main force is its own root {@code AbstractLocation}, so
+     * identity comparison distinguishes them. When either root can't be resolved, returns
+     * {@code true} so callers fall back to direct landing (preserving legacy behavior).
+     */
+    private static boolean sharesRootLocation(ILocation item, ILocation destination) {
+        AbstractLocation itemRoot = item.getCurrentLocation();
+        AbstractLocation destinationRoot = destination.getCurrentLocation();
+        if (itemRoot == null || destinationRoot == null) {
+            return true;
+        }
+        return itemRoot == destinationRoot;
     }
 
     /**
@@ -351,7 +389,21 @@ public final class LocationDispatch {
 
             if (destinationSystem == null || fromSystem.equals(destinationSystem)) {
                 PlanetarySystem system = destinationSystem != null ? destinationSystem : fromSystem;
-                land(group, destination, directLandingTarget, system, campaign.getCampaignLocationManager(), logMarker);
+                // Same planet: items already at the destination's root location land immediately;
+                // items at a different root on the same planet take a GroundTransitLocation overland trip.
+                List<T> alreadyThere = new ArrayList<>();
+                List<T> needGroundTransit = new ArrayList<>();
+                for (T item : group) {
+                    (sharesRootLocation(item, destination) ? alreadyThere : needGroundTransit).add(item);
+                }
+                if (!alreadyThere.isEmpty()) {
+                    land(alreadyThere, destination, directLandingTarget, system,
+                          campaign.getCampaignLocationManager(), logMarker);
+                }
+                if (!needGroundTransit.isEmpty()) {
+                    GroundTransitLocation groundNode = buildGroundTransitNode(system, destination, campaign, logMarker);
+                    needGroundTransit.forEach(item -> reparent(item, groundNode));
+                }
                 continue;
             }
 

--- a/MekHQ/src/mekhq/campaign/location/LocationNode.java
+++ b/MekHQ/src/mekhq/campaign/location/LocationNode.java
@@ -42,7 +42,6 @@ import megamek.logging.MMLogger;
 import mekhq.campaign.AbstractLocation;
 import mekhq.campaign.AbstractMobileLocation;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.CurrentLocation;
 import mekhq.utilities.MHQXMLUtility;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -176,21 +175,13 @@ public class LocationNode {
                             if (campusChild.getNodeType() != Node.ELEMENT_NODE) {
                                 continue;
                             }
-                            if (campusChild.getNodeName().equalsIgnoreCase("location")) {
-                                CurrentLocation travelNode = CurrentLocation.generateInstanceFromXML(campusChild, campaign);
-                                if (travelNode != null) {
-                                    LocationManager.setLocation(travelNode, campus);
-                                    campaign.getCampaignLocationManager().addLocation(travelNode);
-                                }
+                            if (AbstractLocation.isTravelNodeTag(campusChild.getNodeName())) {
+                                readAndRegisterTravelNode(campusChild, campus, campaign);
                             }
                         }
                     }
-                } else if (wn.getNodeName().equalsIgnoreCase("location")) {
-                    CurrentLocation travelNode = CurrentLocation.generateInstanceFromXML(wn, campaign);
-                    if (travelNode != null) {
-                        LocationManager.setLocation(travelNode, parent);
-                        campaign.getCampaignLocationManager().addLocation(travelNode);
-                    }
+                } else if (AbstractLocation.isTravelNodeTag(wn.getNodeName())) {
+                    readAndRegisterTravelNode(wn, parent, campaign);
                 } else {
                     // Person, Unit, and Part reconnection will be added here
                     logger.warn("Unrecognized locationNodeChildren element '{}' — skipping", wn.getNodeName());
@@ -198,6 +189,19 @@ public class LocationNode {
             } catch (Exception ex) {
                 logger.error("", ex);
             }
+        }
+    }
+
+    /**
+     * Reads a serialized travel node (a {@link mekhq.campaign.CurrentLocation} or a
+     * {@link mekhq.campaign.GroundTransitLocation}), parents it under {@code parent}, and registers it with the
+     * campaign. Node-internal helper; external callers deserialize via
+     * {@link AbstractLocation#generateInstanceFromXML} and attach with {@link ILocation#setParent}.
+     */
+    private static void readAndRegisterTravelNode(Node wn, ILocation parent, Campaign campaign) {
+        if (AbstractLocation.generateInstanceFromXML(wn, campaign) instanceof AbstractMobileLocation travelNode) {
+            LocationManager.setLocation(travelNode, parent);
+            campaign.getCampaignLocationManager().addLocation(travelNode);
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/location/LocationUtils.java
+++ b/MekHQ/src/mekhq/campaign/location/LocationUtils.java
@@ -38,6 +38,7 @@ import java.util.Objects;
 import megamek.common.annotations.Nullable;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CurrentLocation;
+import mekhq.campaign.GroundTransitLocation;
 import mekhq.campaign.JumpPath;
 import mekhq.campaign.base.AbstractBase;
 import mekhq.campaign.universe.PlanetarySystem;
@@ -123,13 +124,15 @@ public final class LocationUtils {
     }
 
     /**
-     * Returns {@code true} if the item — or any of its ancestors in the {@link LocationNode} tree — is a
-     * {@link CurrentLocation} with an active {@link mekhq.campaign.JumpPath} (i.e. the item is currently traveling).
+     * Returns {@code true} if the item — or any of its ancestors in the {@link LocationNode} tree — is
+     * currently traveling: a {@link CurrentLocation} with an active {@link mekhq.campaign.JumpPath}, or a
+     * {@link GroundTransitLocation} still counting down its overland transit time.
      *
-     * <p>This intentionally checks for a non-empty {@link mekhq.campaign.JumpPath} rather than
-     * {@link ILocation#isInTransit()}, which only returns {@code true} once the ship has actually
+     * <p>For interplanetary travel this intentionally checks for a non-empty {@link mekhq.campaign.JumpPath}
+     * rather than {@link ILocation#isInTransit()}, which only returns {@code true} once the ship has actually
      * started moving (transit time &gt; 0). An item with an assigned but not-yet-started journey
-     * must also be treated as in transit for co-location and assignment purposes.</p>
+     * must also be treated as in transit for co-location and assignment purposes. A ground convoy has no
+     * jump path, so it is judged by its own {@link GroundTransitLocation#isInTransit()}.</p>
      *
      * @param location the location item to inspect
      *
@@ -141,8 +144,14 @@ public final class LocationUtils {
         }
         LocationNode node = location.getLocationNode();
         while (node != null) {
-            if (node.getLocatable() instanceof CurrentLocation currentLocation
+            ILocation locatable = node.getLocatable();
+            if (locatable instanceof CurrentLocation currentLocation
                       && currentLocation.getJumpPath() != null && !currentLocation.getJumpPath().isEmpty()) {
+                return true;
+            }
+            // A GroundTransitLocation has no jump path; it is in transit while its overland
+            // transit time is still counting down.
+            if (locatable instanceof GroundTransitLocation groundTransit && groundTransit.isInTransit()) {
                 return true;
             }
             node = node.getParent();

--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -69,6 +69,7 @@ import megamek.common.annotations.Nullable;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.AbstractLocation;
+import mekhq.campaign.AbstractMobileLocation;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CurrentLocation;
 import mekhq.campaign.JumpPath;
@@ -319,12 +320,15 @@ public class EducationController {
         // Resolve the campus before mutating any person state, so an unresolvable academy system aborts the
         // enrollment cleanly instead of queueing travel to a null destination.
         AcademyCampusLocation campusLocation = null;
-        if (!academy.isHomeSchool() && !academy.isLocal()) {
+        if (!academy.isHomeSchool()) {
+            String campusSystemId = academy.isLocal()
+                                          ? localCampusSystemId(person, campaign)
+                                          : academy.getLocationSystems().getFirst();
             campusLocation = campaign.getCampaignLocationManager().getOrCreateCampusLocation(campaign, academy.getSet(),
-                  academy.getName(), academy.getLocationSystems().getFirst());
+                  academy.getName(), campusSystemId);
             if (campusLocation == null) {
                 LOGGER.error("enrollPerson: could not resolve campus system {} for academy {} — aborting enrollment",
-                      academy.getLocationSystems().getFirst(), academy.getName());
+                      campusSystemId, academy.getName());
                 return;
             }
         }
@@ -342,12 +346,12 @@ public class EducationController {
             person.setParent(homeSchoolCampus.getPersonnel());
         } else if (academy.isLocal()) {
             person.setEduEducationStage(EducationStage.JOURNEY_TO_CAMPUS);
-            PlanetarySystem personSystem = person.getCurrentSystem();
-            String systemId = personSystem != null
-                                    ? personSystem.getId()
-                                    : campaign.getCurrentSystem().getId();
-            person.setEduAcademySystem(systemId);
+            person.setEduAcademySystem(localCampusSystemId(person, campaign));
+            // Overland transit to the local campus (a different root location on the same planet) is
+            // dispatched as a GroundTransitLocation next new day. The journey time is retained only for
+            // the travel-progress display; arrival is driven by the travel node, not this counter.
             person.setEduJourneyTime(2);
+            campaign.getCampaignLocationManager().queueTravel(List.of(person), campusLocation);
         } else {
             person.setEduEducationStage(EducationStage.JOURNEY_TO_CAMPUS);
         }
@@ -424,6 +428,12 @@ public class EducationController {
               campaign.getLocalDate(),
               person.getEduAcademyName(),
               academy.getQualifications().get(person.getEduCourseIndex()));
+    }
+
+    /** The planetary-system id a local academy's campus sits at: the student's current system, or the campaign's. */
+    private static String localCampusSystemId(Person person, Campaign campaign) {
+        PlanetarySystem personSystem = person.getCurrentSystem();
+        return personSystem != null ? personSystem.getId() : campaign.getCurrentSystem().getId();
     }
 
     /**
@@ -671,7 +681,7 @@ public class EducationController {
     }
 
     private static void landAtCampus(Campaign campaign, Person person,
-          @Nullable CurrentLocation travelLocation) {
+          @Nullable AbstractMobileLocation travelLocation) {
         campaign.addReport(PERSONNEL,
               getFormattedTextAt(BUNDLE_NAME, "arrived.text", person.getHyperlinkedFullTitle()));
 
@@ -784,11 +794,13 @@ public class EducationController {
         }
 
         if (academy.isLocal()) {
-            // Local academy: the campus is on the person's own system. The return is a 2-day
-            // local transit — no inter-system dispatch needed, and the person stays in their
-            // current base location rather than being moved to main force.
+            // Local academy: the campus is a different root location, usually on the same planet as the
+            // campaign. Queue the return trip so it dispatches as a GroundTransitLocation next new day (or
+            // a jump, if the campaign has since moved off-system). The journey time is retained only for
+            // the travel-progress display; arrival is driven by the travel node.
             person.setEduJourneyTime(2);
             person.setEduDaysOfTravel(0);
+            campaign.getCampaignLocationManager().queueTravel(List.of(person), campaign);
             campaign.addReport(PERSONNEL, String.format(resources.getString("returningFromSchool.text"),
                   person.getHyperlinkedFullTitle(), 2));
             person.setEduEducationStage(EducationStage.JOURNEY_FROM_CAMPUS);
@@ -867,14 +879,16 @@ public class EducationController {
     private static void processJourney(Campaign campaign, Person person,
           @Nullable PlanetarySystem targetSystem,
           Runnable onDayCounterArrival,
-          Consumer<CurrentLocation> onTravelArrival) {
+          Consumer<AbstractMobileLocation> onTravelArrival) {
         person.incrementEduDaysOfTravel();
 
-        AbstractLocation travelLocation = person.getCurrentLocation();
+        AbstractLocation location = person.getCurrentLocation();
 
-        if (!(travelLocation instanceof CurrentLocation currentLocation)) {
-            // Local academies are same-system 2-day transits; their travel time must not be
-            // recalculated from the campaign's current position (which may be on a different planet).
+        if (!(location instanceof AbstractMobileLocation travelNode)) {
+            // No travel node: dispatch either landed the student directly (already at the campus root) or
+            // this is a legacy save. Fall back to the day counter.
+            // Local academies are same-system transits; their travel time must not be recalculated from
+            // the campaign's current position (which may be on a different planet).
             Academy fallbackAcademy = getAcademy(person.getEduAcademySet(), person.getEduAcademyNameInSet());
             if (fallbackAcademy == null || !fallbackAcademy.isLocal()) {
                 int travelTime = max(2,
@@ -889,31 +903,39 @@ public class EducationController {
             return;
         }
 
-        if (!currentLocation.isOnPlanet()) {
-            return;
-        }
-
-        if (targetSystem == null) {
-            LOGGER.warn("Null target system for person {} during education travel; skipping path correction",
-                  person.getFullName());
-            return;
-        }
-
-        if (!currentLocation.getCurrentSystem().equals(targetSystem)) {
-            JumpPath newPath = LocationUtils.planJumpPath(currentLocation.getCurrentSystem(), targetSystem, campaign);
-            if (newPath != null) {
-                currentLocation.setJumpPath(newPath);
-                person.setEduJourneyTime(LocationUtils.computeJourneyDays(
-                      newPath, campaign.getLocalDate(), currentLocation.getTransitTime()));
+        // Interplanetary travel: wait for the JumpShip to reach a planet, correcting the jump path when
+        // the campaign has drifted off-course (e.g. it moved while the student was away).
+        if (travelNode instanceof CurrentLocation currentLocation) {
+            if (!currentLocation.isOnPlanet()) {
+                return;
             }
+            if (targetSystem == null) {
+                LOGGER.warn("Null target system for person {} during education travel; skipping path correction",
+                      person.getFullName());
+                return;
+            }
+            if (!currentLocation.getCurrentSystem().equals(targetSystem)) {
+                JumpPath newPath = LocationUtils.planJumpPath(currentLocation.getCurrentSystem(), targetSystem, campaign);
+                if (newPath != null) {
+                    currentLocation.setJumpPath(newPath);
+                    person.setEduJourneyTime(LocationUtils.computeJourneyDays(
+                          newPath, campaign.getLocalDate(), currentLocation.getTransitTime()));
+                }
+                return;
+            }
+            onTravelArrival.accept(currentLocation);
             return;
         }
 
-        onTravelArrival.accept(currentLocation);
+        // On-planet overland travel (GroundTransitLocation): no jump path — just wait for arrival.
+        if (!travelNode.hasArrived()) {
+            return;
+        }
+        onTravelArrival.accept(travelNode);
     }
 
     private static void arriveHome(Campaign campaign, Person person,
-          @Nullable CurrentLocation returnLocation) {
+          @Nullable AbstractMobileLocation returnLocation) {
         Academy returningFromAcademy = getAcademy(person.getEduAcademySet(), person.getEduAcademyNameInSet());
         boolean isLocal = returningFromAcademy != null && returningFromAcademy.isLocal();
         Personnel arrivingAtPersonnel = isLocal ?

--- a/MekHQ/src/mekhq/gui/LocationsTab.java
+++ b/MekHQ/src/mekhq/gui/LocationsTab.java
@@ -50,8 +50,8 @@ import megamek.codeUtilities.MathUtility;
 import megamek.common.event.Subscribe;
 import megamek.common.ui.FastJScrollPane;
 import megamek.common.units.UnitType;
+import mekhq.campaign.AbstractMobileLocation;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.CurrentLocation;
 import mekhq.campaign.base.AbstractBase;
 import mekhq.campaign.base.PlayerBase;
 import mekhq.campaign.events.LocationEvent;
@@ -309,7 +309,7 @@ public class LocationsTab extends CampaignGuiTab {
 
         @FunctionalInterface
         private interface TransitCounter {
-            int count(CurrentLocation node);
+            int count(AbstractMobileLocation node);
         }
 
         private static int countInTransit(IPlace place, TransitCounter counter) {
@@ -318,7 +318,9 @@ public class LocationsTab extends CampaignGuiTab {
             }
             int total = 0;
             for (ILocation child : place.getChildLocations()) {
-                if (child instanceof CurrentLocation travel && !travel.isOnPlanet()) {
+                // getTransitTime() > 0 covers both an interplanetary jump ship (equivalent to its former
+                // !isOnPlanet() check, including while recharging at a jump point) and an on-planet convoy.
+                if (child instanceof AbstractMobileLocation travel && travel.getTransitTime() > 0) {
                     total += counter.count(travel);
                 }
             }

--- a/MekHQ/src/mekhq/gui/model/LocationDisplay.java
+++ b/MekHQ/src/mekhq/gui/model/LocationDisplay.java
@@ -40,8 +40,8 @@ import java.util.Objects;
 
 import megamek.common.annotations.Nullable;
 import mekhq.campaign.AbstractLocation;
+import mekhq.campaign.AbstractMobileLocation;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.CurrentLocation;
 import mekhq.campaign.JumpPath;
 import mekhq.campaign.base.AbstractBase;
 import mekhq.campaign.base.PlayerBase;
@@ -101,9 +101,9 @@ public final class LocationDisplay {
         if (isUnderMainForce(item, campaign)) {
             return campaign.getName();
         }
-        if (item.getCurrentLocation() instanceof CurrentLocation currentLocation
-                  && currentLocation.getJumpPath() != null && !currentLocation.getJumpPath().isEmpty()) {
-            return getTravelStatus(currentLocation, campaign, today);
+        if (item.getCurrentLocation() instanceof AbstractMobileLocation mobileLocation
+                  && mobileLocation.getTransitTime() > 0) {
+            return getTravelStatus(mobileLocation, campaign, today);
         }
 
         AbstractBase base = LocationUtils.findEffectiveBase(item);
@@ -118,17 +118,29 @@ public final class LocationDisplay {
     }
 
     /**
-     * The "In Transit (…)" status line for an actively traveling node: recharging or ready to
-     * jump at a jump point, days to the destination planet on the final leg, or days to the
-     * origin jump point otherwise.
+     * The "In Transit (…)" status line for a traveling node: the jump-travel status for an interplanetary jump
+     * ship with a jump path, or the remaining overland days for an on-planet convoy.
      */
-    private static String getTravelStatus(CurrentLocation currentLocation, Campaign campaign, LocalDate today) {
-        JumpPath path = currentLocation.getJumpPath();
-        PlanetarySystem system = currentLocation.getCurrentSystem();
+    private static String getTravelStatus(AbstractMobileLocation mobileLocation, Campaign campaign, LocalDate today) {
+        JumpPath path = mobileLocation.getJumpPath();
+        if (path != null && !path.isEmpty()) {
+            return getJumpTravelStatus(mobileLocation, path, campaign, today);
+        }
+        int days = (int) Math.ceil(mobileLocation.getTransitTime());
+        return getFormattedTextAt(RESOURCE_BUNDLE, "LocationDisplay.inTransit.overland.text", days);
+    }
 
-        if (path.size() > 1 && currentLocation.isAtJumpPoint()) {
-            double neededHours = system.getRechargeTime(today, currentLocation.computeIsUseCommandCircuit(campaign));
-            double remainingHours = neededHours - currentLocation.getRechargeTime();
+    /**
+     * The jump-travel status line: recharging or ready to jump at a jump point, days to the destination planet on
+     * the final leg, or days to the origin jump point otherwise.
+     */
+    private static String getJumpTravelStatus(AbstractMobileLocation mobileLocation, JumpPath path, Campaign campaign,
+          LocalDate today) {
+        PlanetarySystem system = mobileLocation.getCurrentSystem();
+
+        if (path.size() > 1 && mobileLocation.isAtJumpPoint()) {
+            double neededHours = system.getRechargeTime(today, mobileLocation.computeIsUseCommandCircuit(campaign));
+            double remainingHours = neededHours - mobileLocation.getRechargeTime();
             if (remainingHours > 0) {
                 int days = (int) Math.ceil(remainingHours / HOURS_PER_DAY);
                 return getFormattedTextAt(RESOURCE_BUNDLE, "LocationDisplay.inTransit.recharging.text", days);
@@ -136,10 +148,10 @@ public final class LocationDisplay {
             return getTextAt(RESOURCE_BUNDLE, "LocationDisplay.inTransit.readyToJump.text");
         }
         if (path.size() == 1) {
-            int days = (int) Math.ceil(currentLocation.getTransitTime());
+            int days = (int) Math.ceil(mobileLocation.getTransitTime());
             return getFormattedTextAt(RESOURCE_BUNDLE, "LocationDisplay.inTransit.toPlanet.text", days);
         }
-        double daysToJP = system.getTimeToJumpPoint(1.0) - currentLocation.getTransitTime();
+        double daysToJP = system.getTimeToJumpPoint(1.0) - mobileLocation.getTransitTime();
         int days = (int) Math.ceil(daysToJP);
         return getFormattedTextAt(RESOURCE_BUNDLE, "LocationDisplay.inTransit.toJumpPoint.text", days);
     }
@@ -197,21 +209,18 @@ public final class LocationDisplay {
     /**
      * A human-readable label for the item's <em>destination</em> when in transit.
      *
-     * <p>Walks the {@link CurrentLocation}'s parent chain for an {@link AbstractBase}; if found
-     * returns the base's display name, otherwise the last system in the {@link JumpPath}.
-     * Returns {@code "-"} when the item is not traveling.</p>
+     * <p>Walks the travel node's parent chain for an {@link AbstractBase}; if found returns the base's display name,
+     * otherwise the transit destination system (the last {@link JumpPath} system for a jump ship, or the current
+     * system for an on-planet convoy). Returns {@code "-"} when the item is not traveling.</p>
      */
     public static String getDestinationName(ILocation item, Campaign campaign, LocalDate today) {
-        if (!(getNearestAbstractLocation(item) instanceof CurrentLocation currentLocation)) {
+        if (!(getNearestAbstractLocation(item) instanceof AbstractMobileLocation mobileLocation)
+                  || mobileLocation.getTransitTime() <= 0) {
             return "-";
         }
-        JumpPath path = currentLocation.getJumpPath();
-        if (path == null || path.isEmpty()) {
-            return "-";
-        }
-        PlanetarySystem destination = path.getLastSystem();
+        PlanetarySystem destination = getTransitDestination(item);
 
-        String ancestorName = getDestinationNameFromAncestors(currentLocation, destination, campaign);
+        String ancestorName = getDestinationNameFromAncestors(mobileLocation, destination, campaign);
         if (ancestorName != null) {
             return ancestorName;
         }
@@ -230,9 +239,9 @@ public final class LocationDisplay {
      *
      * @return the destination label, or {@code null} when no ancestor decides it
      */
-    private static @Nullable String getDestinationNameFromAncestors(CurrentLocation currentLocation,
+    private static @Nullable String getDestinationNameFromAncestors(AbstractMobileLocation mobileLocation,
           @Nullable PlanetarySystem destination, Campaign campaign) {
-        for (ILocation cursor = currentLocation.getParentLocation(); cursor != null; cursor = cursor.getParentLocation()) {
+        for (ILocation cursor = mobileLocation.getParentLocation(); cursor != null; cursor = cursor.getParentLocation()) {
             if (cursor instanceof AbstractBase base) {
                 return formatBaseName(base);
             }
@@ -264,7 +273,7 @@ public final class LocationDisplay {
      * The printable name of the destination system when in transit, or {@code "-"} otherwise.
      */
     public static String getDestinationSystem(ILocation item, LocalDate today) {
-        PlanetarySystem destination = getJumpDestination(item);
+        PlanetarySystem destination = getTransitDestination(item);
         return destination != null ? destination.getPrintableName(today) : "-";
     }
 
@@ -273,7 +282,7 @@ public final class LocationDisplay {
      * or {@code "-"} otherwise.
      */
     public static String getDestinationPlanet(ILocation item, LocalDate today) {
-        PlanetarySystem destination = getJumpDestination(item);
+        PlanetarySystem destination = getTransitDestination(item);
         if (destination != null) {
             Planet planet = destination.getPrimaryPlanet();
             return planet != null ? planet.getPrintableName(today) : "-";
@@ -282,19 +291,20 @@ public final class LocationDisplay {
     }
 
     /**
-     * Returns the last system in {@code item}'s active {@link JumpPath}, or {@code null} if the item has no active
-     * travel node or the path is empty/null.
+     * Returns the system {@code item} is traveling toward, or {@code null} if it has no active travel node. For a
+     * jump ship this is the last system in its {@link JumpPath}; for an on-planet convoy it is the current (same)
+     * system, since overland transit never leaves the planet.
      */
-    private static @Nullable PlanetarySystem getJumpDestination(ILocation item) {
-        AbstractLocation location = getNearestAbstractLocation(item);
-        if (!(location instanceof CurrentLocation currentLocation)) {
+    private static @Nullable PlanetarySystem getTransitDestination(ILocation item) {
+        if (!(getNearestAbstractLocation(item) instanceof AbstractMobileLocation mobileLocation)
+                  || mobileLocation.getTransitTime() <= 0) {
             return null;
         }
-        JumpPath path = currentLocation.getJumpPath();
-        if (path == null || path.isEmpty()) {
-            return null;
+        JumpPath path = mobileLocation.getJumpPath();
+        if (path != null && !path.isEmpty()) {
+            return path.getLastSystem();
         }
-        return path.getLastSystem();
+        return mobileLocation.getCurrentSystem();
     }
 
     private static AbstractLocation getNearestAbstractLocation(ILocation item) {

--- a/MekHQ/unittests/mekhq/campaign/CampaignLocationManagerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/CampaignLocationManagerTest.java
@@ -36,11 +36,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.UUID;
 
+import mekhq.campaign.location.ILocation;
 import mekhq.campaign.location.LocationDispatch;
 import mekhq.campaign.unit.Unit;
 import org.junit.jupiter.api.Test;
@@ -103,5 +105,27 @@ class CampaignLocationManagerTest {
             dispatch.verify(() -> LocationDispatch.dispatchTravelers(List.of(unit), campaign, campaign));
         }
         assertFalse(manager.isQueuedForTravel(unit));
+    }
+
+    @Test
+    void queueTravel_reQueueRemovesPriorPendingTravel() {
+        CampaignLocationManager manager = new CampaignLocationManager();
+        Campaign campaign = mock(Campaign.class);
+        ILocation firstDestination = mock(ILocation.class);
+        ILocation secondDestination = mock(ILocation.class);
+        Unit unit = mock(Unit.class);
+        UUID unitId = UUID.randomUUID();
+        when(unit.getId()).thenReturn(unitId);
+        when(campaign.getUnit(unitId)).thenReturn(unit);
+
+        manager.queueTravel(List.of(unit), firstDestination);
+        manager.queueTravel(List.of(unit), secondDestination);
+
+        try (MockedStatic<LocationDispatch> dispatch = mockStatic(LocationDispatch.class)) {
+            manager.dispatchPendingTravel(campaign);
+            dispatch.verify(() -> LocationDispatch.dispatchTravelers(List.of(unit), secondDestination, campaign));
+            dispatch.verify(() -> LocationDispatch.dispatchTravelers(List.of(unit), firstDestination, campaign),
+                  never());
+        }
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/GroundTransitLocationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/GroundTransitLocationTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign;
+
+import static mekhq.campaign.enums.DailyReportType.GENERAL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.UUID;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import mekhq.MekHQ;
+import mekhq.campaign.events.TransitCompleteEvent;
+import mekhq.campaign.events.TransitStatusChangedEvent;
+import mekhq.campaign.universe.PlanetarySystem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.w3c.dom.Node;
+
+public class GroundTransitLocationTest {
+
+    PlanetarySystem system;
+
+    @BeforeEach
+    void setUp() {
+        system = mock(PlanetarySystem.class);
+    }
+
+    /** A ground convoy is always considered on-planet, even mid-journey. */
+    @Nested
+    class IsOnPlanet {
+        @Test
+        void trueWhenStationary() {
+            assertTrue(new GroundTransitLocation(system, 0.0).isOnPlanet());
+        }
+
+        @Test
+        void trueWhileTravelling() {
+            assertTrue(new GroundTransitLocation(system, 5.0).isOnPlanet());
+        }
+    }
+
+    /** Tests for {@link GroundTransitLocation#isInTransit()}. */
+    @Nested
+    class IsInTransit {
+        @Test
+        void trueWhileTransitTimeRemains() {
+            assertTrue(new GroundTransitLocation(system, 5.0).isInTransit());
+        }
+
+        @Test
+        void falseWhenArrived() {
+            assertFalse(new GroundTransitLocation(system, 0.0).isInTransit());
+        }
+    }
+
+    /** Tests for {@link GroundTransitLocation#getPercentageTransit()}. */
+    @Nested
+    class GetPercentageTransit {
+        @Test
+        void zeroAtStartOfJourney() {
+            // total == remaining → no progress yet
+            assertEquals(0.0, new GroundTransitLocation(system, 4.0).getPercentageTransit(), 1e-9);
+        }
+
+        @Test
+        void oneWhenTotalIsZero() {
+            assertEquals(1.0, new GroundTransitLocation(system, 0.0).getPercentageTransit(), 1e-9);
+        }
+
+        @Test
+        void halfwayWhenHalfElapsed() {
+            GroundTransitLocation loc = new GroundTransitLocation(system, 4.0);
+            loc.setTransitTime(2.0);
+            assertEquals(0.5, loc.getPercentageTransit(), 1e-9);
+        }
+    }
+
+    /** Tests for {@link GroundTransitLocation#newDay(Campaign, boolean)}. */
+    @Nested
+    class NewDay {
+        Campaign campaign;
+
+        @BeforeEach
+        void setUp() {
+            campaign = mock(Campaign.class);
+        }
+
+        @Test
+        void countsDownOneDayAndReports() {
+            GroundTransitLocation loc = new GroundTransitLocation(system, 3.0);
+            try (MockedStatic<MekHQ> mekHQ = mockStatic(MekHQ.class)) {
+                loc.newDay(campaign, false);
+
+                assertEquals(2.0, loc.getTransitTime(), 1e-9);
+                assertTrue(loc.isInTransit());
+                verify(campaign).addReport(eq(GENERAL), contains("travelling overland"));
+                mekHQ.verify(() -> MekHQ.triggerEvent(isA(TransitStatusChangedEvent.class)), times(1));
+                mekHQ.verify(() -> MekHQ.triggerEvent(isA(TransitCompleteEvent.class)), never());
+            }
+        }
+
+        @Test
+        void firesTransitCompleteOnArrival() {
+            GroundTransitLocation loc = new GroundTransitLocation(system, 1.0);
+            try (MockedStatic<MekHQ> mekHQ = mockStatic(MekHQ.class)) {
+                loc.newDay(campaign, false);
+
+                assertEquals(0.0, loc.getTransitTime(), 1e-9);
+                assertFalse(loc.isInTransit());
+                assertTrue(loc.isOnPlanet());
+                verify(campaign).addReport(eq(GENERAL), contains("Destination reached"));
+                mekHQ.verify(() -> MekHQ.triggerEvent(isA(TransitCompleteEvent.class)), times(1));
+            }
+        }
+
+        @Test
+        void noOpWhenAlreadyArrived() {
+            GroundTransitLocation loc = new GroundTransitLocation(system, 0.0);
+            try (MockedStatic<MekHQ> mekHQ = mockStatic(MekHQ.class)) {
+                loc.newDay(campaign, false);
+
+                verify(campaign, never()).addReport(any(), any());
+                mekHQ.verify(() -> MekHQ.triggerEvent(any()), never());
+            }
+        }
+    }
+
+    /** Round-trips a {@link GroundTransitLocation} through XML. */
+    @Nested
+    class XmlRoundTrip {
+        @Test
+        void writeToXmlContainsExpectedFields() {
+            when(system.getId()).thenReturn("Outreach");
+            GroundTransitLocation loc = new GroundTransitLocation(system, 4.0);
+            loc.setTransitTime(2.5);
+
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            loc.writeToXML(new PrintWriter(baos, true), 0);
+            String xml = baos.toString();
+
+            assertTrue(xml.contains("<groundTransitLocation>"));
+            assertTrue(xml.contains("Outreach"));
+            assertTrue(xml.contains("<transitTime>2.5</transitTime>"));
+            assertTrue(xml.contains("<totalTransitTime>4.0</totalTransitTime>"));
+            assertTrue(xml.contains("</groundTransitLocation>"));
+        }
+
+        @Test
+        void generateInstanceFromXmlRestoresState() throws Exception {
+            String xml = "<groundTransitLocation><currentSystemId>Outreach</currentSystemId>"
+                               + "<transitTime>2.5</transitTime>"
+                               + "<totalTransitTime>4.0</totalTransitTime></groundTransitLocation>";
+            Node node = parseXml(xml);
+
+            Campaign mockCampaign = mock(Campaign.class);
+            when(mockCampaign.getSystemById("Outreach")).thenReturn(system);
+
+            GroundTransitLocation loc = GroundTransitLocation.generateInstanceFromXML(node, mockCampaign);
+
+            assertNotNull(loc);
+            assertEquals(2.5, loc.getTransitTime(), 1e-9);
+            assertEquals(0.375, loc.getPercentageTransit(), 1e-9); // 1 - 2.5 / 4.0
+            assertTrue(loc.isInTransit());
+            assertTrue(loc.isOnPlanet());
+        }
+
+        @Test
+        void generateInstanceFromXmlPopulatesPendingPersonIds() throws Exception {
+            UUID personId = UUID.randomUUID();
+            String xml = "<groundTransitLocation><currentSystemId>Outreach</currentSystemId>"
+                               + "<transitTime>1.0</transitTime>"
+                               + "<personId>" + personId + "</personId></groundTransitLocation>";
+            Node node = parseXml(xml);
+
+            Campaign mockCampaign = mock(Campaign.class);
+            when(mockCampaign.getSystemById("Outreach")).thenReturn(system);
+
+            GroundTransitLocation loc = GroundTransitLocation.generateInstanceFromXML(node, mockCampaign);
+            assertNotNull(loc);
+
+            List<UUID> ids = loc.drainPendingPersonIds();
+            assertEquals(1, ids.size());
+            assertEquals(personId, ids.get(0));
+        }
+
+        private Node parseXml(String xml) throws Exception {
+            DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+            return db.parse(new ByteArrayInputStream(xml.getBytes())).getDocumentElement();
+        }
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/GroundTransitLocationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/GroundTransitLocationTest.java
@@ -143,7 +143,7 @@ public class GroundTransitLocationTest {
 
                 assertEquals(2.0, loc.getTransitTime(), 1e-9);
                 assertTrue(loc.isInTransit());
-                verify(campaign).addReport(eq(GENERAL), contains("travelling overland"));
+                verify(campaign).addReport(eq(GENERAL), contains("traveling"));
                 mekHQ.verify(() -> MekHQ.triggerEvent(isA(TransitStatusChangedEvent.class)), times(1));
                 mekHQ.verify(() -> MekHQ.triggerEvent(isA(TransitCompleteEvent.class)), never());
             }

--- a/MekHQ/unittests/mekhq/campaign/GroundTransitLocationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/GroundTransitLocationTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
@@ -143,7 +143,7 @@ public class GroundTransitLocationTest {
 
                 assertEquals(2.0, loc.getTransitTime(), 1e-9);
                 assertTrue(loc.isInTransit());
-                verify(campaign).addReport(eq(GENERAL), contains("traveling"));
+                verify(campaign).addReport(eq(GENERAL), anyString());
                 mekHQ.verify(() -> MekHQ.triggerEvent(isA(TransitStatusChangedEvent.class)), times(1));
                 mekHQ.verify(() -> MekHQ.triggerEvent(isA(TransitCompleteEvent.class)), never());
             }
@@ -158,7 +158,6 @@ public class GroundTransitLocationTest {
                 assertEquals(0.0, loc.getTransitTime(), 1e-9);
                 assertFalse(loc.isInTransit());
                 assertTrue(loc.isOnPlanet());
-                verify(campaign).addReport(eq(GENERAL), contains("Destination reached"));
                 mekHQ.verify(() -> MekHQ.triggerEvent(isA(TransitCompleteEvent.class)), times(1));
             }
         }

--- a/MekHQ/unittests/mekhq/campaign/location/LocationDispatchTest.java
+++ b/MekHQ/unittests/mekhq/campaign/location/LocationDispatchTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.location;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import mekhq.campaign.Campaign;
+import mekhq.campaign.CampaignLocationManager;
+import mekhq.campaign.CurrentLocation;
+import mekhq.campaign.FixedLocation;
+import mekhq.campaign.GroundTransitLocation;
+import mekhq.campaign.JumpPath;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.universe.PlanetarySystem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/** Verifies how {@link LocationDispatch} chooses a travel node based on system and root location. */
+class LocationDispatchTest {
+
+    Campaign campaign;
+    CampaignLocationManager locationManager;
+    PlanetarySystem system;
+
+    @BeforeEach
+    void setUp() {
+        locationManager = new CampaignLocationManager();
+        system = mock(PlanetarySystem.class);
+        campaign = mock(Campaign.class);
+        when(campaign.getCampaignLocationManager()).thenReturn(locationManager);
+        when(campaign.getCurrentSystem()).thenReturn(system);
+    }
+
+    private static Person newPerson() {
+        return new Person("First", "Last", null, "MERC");
+    }
+
+    private GroundTransitLocation registeredGroundTransit() {
+        return locationManager.getLocations().stream()
+              .filter(GroundTransitLocation.class::isInstance)
+              .map(GroundTransitLocation.class::cast)
+              .findFirst()
+              .orElse(null);
+    }
+
+    /** Same planet, different root location → a 2-day overland GroundTransitLocation. */
+    @Nested
+    class SamePlanetDifferentRoot {
+        @Test
+        void createsGroundTransitNodeCarryingTheTraveler() {
+            FixedLocation origin = new FixedLocation(system);
+            FixedLocation destination = new FixedLocation(system);
+            Person person = newPerson();
+            person.setParent(origin);
+
+            LocationDispatch.dispatchTravelers(List.of(person), destination, campaign);
+
+            GroundTransitLocation groundNode = registeredGroundTransit();
+            assertInstanceOf(GroundTransitLocation.class, person.getCurrentLocation());
+            assertSame(groundNode, person.getCurrentLocation());
+            assertEquals(2.0, groundNode.getTransitTime(), 1e-9);
+        }
+    }
+
+    /** Already at the destination's root → land directly, no travel node. */
+    @Nested
+    class SameRoot {
+        @Test
+        void landsDirectlyWithoutTravelNode() {
+            FixedLocation destination = new FixedLocation(system);
+            Person person = newPerson();
+            person.setParent(destination);
+
+            LocationDispatch.dispatchTravelers(List.of(person), destination, campaign);
+
+            assertNull(registeredGroundTransit());
+            assertSame(destination, person.getCurrentLocation());
+        }
+    }
+
+    /** Different system → an interplanetary CurrentLocation, not a ground node. */
+    @Nested
+    class DifferentSystem {
+        @Test
+        void createsInterplanetaryTravelNode() {
+            PlanetarySystem destinationSystem = mock(PlanetarySystem.class);
+            when(system.getTimeToJumpPoint(1.0)).thenReturn(5.0);
+            JumpPath path = mock(JumpPath.class);
+            when(path.isEmpty()).thenReturn(false);
+            when(campaign.calculateJumpPath(system, destinationSystem)).thenReturn(path);
+
+            FixedLocation origin = new FixedLocation(system);
+            FixedLocation destination = new FixedLocation(destinationSystem);
+            Person person = newPerson();
+            person.setParent(origin);
+
+            LocationDispatch.dispatchTravelers(List.of(person), destination, campaign);
+
+            assertNull(registeredGroundTransit());
+            assertInstanceOf(CurrentLocation.class, person.getCurrentLocation());
+        }
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/location/LocationUtilsTest.java
+++ b/MekHQ/unittests/mekhq/campaign/location/LocationUtilsTest.java
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.when;
 
 import mekhq.campaign.CurrentLocation;
 import mekhq.campaign.FixedLocation;
+import mekhq.campaign.GroundTransitLocation;
 import mekhq.campaign.JumpPath;
 import mekhq.campaign.base.PlayerBase;
 import mekhq.campaign.universe.PlanetarySystem;
@@ -100,6 +101,20 @@ public class LocationUtilsTest {
 
             travelNode.setParent(base);
             assertFalse(LocationUtils.isInTransit(travelNode));
+        }
+
+        @Test
+        void locationUnderTravellingGroundTransitNode_returnsTrue() {
+            GroundTransitLocation groundNode = new GroundTransitLocation(mock(PlanetarySystem.class), 2.0);
+            base.setParent(groundNode);
+            assertTrue(LocationUtils.isInTransit(base.getBaseHangar()));
+        }
+
+        @Test
+        void locationUnderArrivedGroundTransitNode_returnsFalse() {
+            GroundTransitLocation groundNode = new GroundTransitLocation(mock(PlanetarySystem.class), 0.0);
+            base.setParent(groundNode);
+            assertFalse(LocationUtils.isInTransit(base.getBaseHangar()));
         }
     }
 

--- a/MekHQ/unittests/mekhq/gui/model/LocationDisplayTest.java
+++ b/MekHQ/unittests/mekhq/gui/model/LocationDisplayTest.java
@@ -48,6 +48,7 @@ import java.util.List;
 
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CurrentLocation;
+import mekhq.campaign.GroundTransitLocation;
 import mekhq.campaign.JumpPath;
 import mekhq.campaign.location.AcademyCampusLocation;
 import mekhq.campaign.location.LocationNode;
@@ -108,6 +109,17 @@ public class LocationDisplayTest {
             Person person = buildTravelingPerson(List.of(academySys), 3.5);
 
             assertEquals(getFormattedText("LocationDisplay.inTransit.toPlanet.text", 4),
+                  LocationDisplay.getLocationName(person, mock(Campaign.class, RETURNS_DEEP_STUBS), LocalDate.EPOCH));
+        }
+
+        @Test
+        void locationName_overland() {
+            GroundTransitLocation ground = new GroundTransitLocation(mock(PlanetarySystem.class), 1.5);
+            LocationNode.LocationManager.setLocation(ground, new AcademyCampusLocation("Set", "Name"));
+            Person person = new Person("GivenName", "Surname", null, "Faction");
+            LocationNode.LocationManager.setLocation(person, ground);
+
+            assertEquals(getFormattedText("LocationDisplay.inTransit.overland.text", 2),
                   LocationDisplay.getLocationName(person, mock(Campaign.class, RETURNS_DEEP_STUBS), LocalDate.EPOCH));
         }
     }


### PR DESCRIPTION
Introduces `GroundTransitLocation`, a new `AbstractMobileLocation` implementation meant for travel on the same planet. `CurrentLocation` was having some issues handling travel to local academies, so this is introduced as a dedicated type of location that moves but also doesn't have a jump path - used for traveling on a planet. 

This should clear up some of the bugs we're seeing with students traveling to local schools. 