### PR TITLE
Fix #9447: Fix GM Complete Education for Travel Phases

### DIFF
--- a/MekHQ/resources/mekhq/resources/SendToLocationMenu.properties
+++ b/MekHQ/resources/mekhq/resources/SendToLocationMenu.properties
@@ -32,5 +32,6 @@ menu.location.text=Location
 menu.sendTo.text=Send To...
 menu.teleportTo.text=Teleport To... (GM)
 menuItem.completeTravel.text=Complete Travel (GM)
+menuItem.completeTravel.others.text=(+ {0,choice,1#1 other|1<{0} others})
 label.mainForce.text=Main Force
 menuItem.newBase.text=New Base...

--- a/MekHQ/resources/mekhq/resources/SendToLocationMenu.properties
+++ b/MekHQ/resources/mekhq/resources/SendToLocationMenu.properties
@@ -28,6 +28,9 @@
 # Microsoft's "Game Content Usage Rules"
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
+menu.location.text=Location
 menu.sendTo.text=Send To...
+menu.teleportTo.text=Teleport To... (GM)
+menuItem.completeTravel.text=Complete Travel (GM)
 label.mainForce.text=Main Force
 menuItem.newBase.text=New Base...

--- a/MekHQ/src/mekhq/campaign/CampaignLocationManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignLocationManager.java
@@ -34,15 +34,7 @@
 package mekhq.campaign;
 
 import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 import jakarta.annotation.Nonnull;
 import megamek.common.annotations.Nullable;
@@ -51,6 +43,10 @@ import mekhq.MekHQ;
 import mekhq.campaign.base.PlayerBase;
 import mekhq.campaign.events.LocationAddedEvent;
 import mekhq.campaign.events.LocationRemovedEvent;
+import mekhq.campaign.events.TransitCompleteEvent;
+import mekhq.campaign.events.parts.PartChangedEvent;
+import mekhq.campaign.events.persons.PersonChangedEvent;
+import mekhq.campaign.events.units.UnitChangedEvent;
 import mekhq.campaign.location.AcademyCampusLocation;
 import mekhq.campaign.location.ILocation;
 import mekhq.campaign.location.LocationDispatch;
@@ -167,7 +163,122 @@ public class CampaignLocationManager {
      */
     public boolean isQueuedForTravel(ILocation traveler) {
         for (List<ILocation> travelers : pendingTravel.values()) {
-            if (travelers.contains(traveler)) {
+            if (containsByIdentity(travelers, traveler)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * GM override: dispatches {@code items} to {@code destination} and lands them immediately, with zero transit time.
+     *
+     * <p>This composes the ordinary {@link LocationDispatch#dispatchTravelers} (which starts the journey and updates
+     * hangar/warehouse bookkeeping) with {@link #gmCompleteTravel}, which collapses the freshly-created travel node to
+     * arrived and runs the shared arrival pass. Intended to be reachable only from a GM-gated menu path.</p>
+     */
+    public void gmTeleport(Campaign campaign, Collection<? extends ILocation> items, ILocation destination) {
+        LocationDispatch.dispatchTravelers(items, destination, campaign);
+        gmCompleteTravel(campaign, items);
+    }
+
+    /**
+     * GM override: force-completes travel for {@code items} that are queued or already in transit, landing them at
+     * their destination now.
+     *
+     * <p>Selected items still sitting in the pending-travel queue are started immediately so they gain a travel node.
+     * Every selected item's in-transit node is then collapsed to arrived — mirroring the finalize in
+     * {@link CurrentLocation#newDay} — and the shared {@link #processAllArrivals} pass lands all arrived nodes through
+     * the same path the daily cycle uses. Because a travel node is shared by everyone who departed together, completing
+     * travel for one item arrives all of its co-travelers. Items that are neither queued nor traveling are left
+     * untouched. Intended to be reachable only from a GM-gated menu path.</p>
+     */
+    public void gmCompleteTravel(Campaign campaign, Collection<? extends ILocation> items) {
+        // Start any selected items still queued, so they gain a travel node to collapse below.
+        for (ILocation item : items) {
+            ILocation queuedDestination = removeFromPendingTravel(item);
+            if (queuedDestination != null) {
+                LocationDispatch.dispatchTravelers(List.of(item), queuedDestination, campaign);
+            }
+        }
+
+        // Collapse each distinct in-transit node to arrived, mirroring CurrentLocation.newDay's finalize.
+        Set<AbstractMobileLocation> arrivingNodes = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (ILocation item : items) {
+            if (item.getCurrentLocation() instanceof AbstractMobileLocation node && !node.hasArrived()) {
+                arrivingNodes.add(node);
+            }
+        }
+        for (AbstractMobileLocation node : arrivingNodes) {
+            node.setTransitTime(0);
+            if (node instanceof CurrentLocation currentLocation) {
+                currentLocation.setJumpPath(null);
+            }
+            MekHQ.triggerEvent(new TransitCompleteEvent(node));
+        }
+
+        // Land every arrived node through the shared new-day arrival pass.
+        processAllArrivals(campaign);
+
+        // Refresh the tables' location columns now — the daily cycle relies on a later full GUI refresh, but a GM
+        // override lands mid-session, so fire the per-item changed event each table listens for.
+        for (ILocation item : items) {
+            fireLocationChanged(item);
+        }
+    }
+
+    /**
+     * Fires the type-specific "changed" event for {@code item} so the personnel, hangar, and warehouse tables refresh
+     * their location columns immediately after a GM travel override. Items that are not a {@link Person}, {@link Unit},
+     * or {@link Part} have no such table and are ignored.
+     */
+    private static void fireLocationChanged(ILocation item) {
+        switch (item) {
+            case Person person -> MekHQ.triggerEvent(new PersonChangedEvent(person));
+            case Unit unit -> MekHQ.triggerEvent(new UnitChangedEvent(unit));
+            case Part part -> MekHQ.triggerEvent(new PartChangedEvent(part));
+            default -> {}
+        }
+    }
+
+    /**
+     * Removes {@code traveler} from the pending-travel queue by object identity, pruning any route left empty.
+     *
+     * @return the destination the traveler was queued for, or {@code null} if it was not queued
+     */
+    private @Nullable ILocation removeFromPendingTravel(ILocation traveler) {
+        for (Iterator<Map.Entry<TravelRoute, List<ILocation>>> it = pendingTravel.entrySet().iterator();
+                it.hasNext(); ) {
+            Map.Entry<TravelRoute, List<ILocation>> entry = it.next();
+            List<ILocation> travelers = entry.getValue();
+            if (removeByIdentity(travelers, traveler)) {
+                if (travelers.isEmpty()) {
+                    it.remove();
+                }
+                return entry.getKey().destination();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Identity ({@code ==}) membership test. {@link ILocation} subtypes such as {@code Personnel} extend
+     * {@code LinkedHashMap}, so {@link List#contains} would compare map contents rather than object identity.
+     */
+    private static boolean containsByIdentity(List<ILocation> list, ILocation target) {
+        for (ILocation candidate : list) {
+            if (candidate == target) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Identity ({@code ==}) removal of the first matching element; see {@link #containsByIdentity}. */
+    private static boolean removeByIdentity(List<ILocation> list, ILocation target) {
+        for (Iterator<ILocation> it = list.iterator(); it.hasNext(); ) {
+            if (it.next() == target) {
+                it.remove();
                 return true;
             }
         }
@@ -214,6 +325,25 @@ public class CampaignLocationManager {
             case Part part -> findPartAnywhere(campaign, part.getId()) != null;
             default -> true;
         };
+    }
+
+    /**
+     * Lands every arrived traveler: each registered {@link AbstractLocation}, then each {@link PlayerBase}, then the
+     * campaign itself has {@link ILocation#processArrivals} run, draining any travel node that has reached its
+     * destination into that destination's personnel/hangar/warehouse.
+     *
+     * <p>This is the common arrival pass shared by the daily new-day cycle and the GM travel overrides
+     * ({@link #gmTeleport}, {@link #gmCompleteTravel}); only nodes that report {@code hasArrived()} land, so it is safe
+     * to call at any time.</p>
+     */
+    public void processAllArrivals(Campaign campaign) {
+        for (AbstractLocation location : new ArrayList<>(locations)) {
+            location.processArrivals(campaign);
+        }
+        for (PlayerBase base : playerBases) {
+            base.processArrivals(campaign);
+        }
+        campaign.processArrivals(campaign);
     }
 
     /** Searches the campaign warehouse then all base warehouses for a part by ID. */

--- a/MekHQ/src/mekhq/campaign/CampaignLocationManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignLocationManager.java
@@ -202,14 +202,15 @@ public class CampaignLocationManager {
             }
         }
 
-        // Collapse each distinct in-transit node to arrived, mirroring CurrentLocation.newDay's finalize.
-        Set<AbstractMobileLocation> arrivingNodes = Collections.newSetFromMap(new IdentityHashMap<>());
-        for (ILocation item : items) {
-            if (item.getCurrentLocation() instanceof AbstractMobileLocation node && !node.hasArrived()) {
-                arrivingNodes.add(node);
-            }
-        }
-        for (AbstractMobileLocation node : arrivingNodes) {
+        // Collapse each distinct in-transit node to arrived, mirroring CurrentLocation.newDay's finalize. Capture every
+        // traveler carried by those nodes first — collapsing a shared node arrives co-travelers that were not selected,
+        // and they must be gathered before processAllArrivals empties the node.
+        Set<ILocation> toRefresh = Collections.newSetFromMap(new IdentityHashMap<>());
+        toRefresh.addAll(items);
+        for (AbstractMobileLocation node : collectInTransitNodes(items)) {
+            toRefresh.addAll(node.fetchPersonnelAtLocation());
+            toRefresh.addAll(node.fetchUnitsAtLocation());
+            toRefresh.addAll(node.fetchPartsAtLocation());
             node.setTransitTime(0);
             if (node instanceof CurrentLocation currentLocation) {
                 currentLocation.setJumpPath(null);
@@ -221,10 +222,45 @@ public class CampaignLocationManager {
         processAllArrivals(campaign);
 
         // Refresh the tables' location columns now — the daily cycle relies on a later full GUI refresh, but a GM
-        // override lands mid-session, so fire the per-item changed event each table listens for.
-        for (ILocation item : items) {
+        // override lands mid-session, so fire the per-item changed event each table listens for. Includes co-travelers
+        // swept along by a shared node, not just the selected items.
+        for (ILocation item : toRefresh) {
             fireLocationChanged(item);
         }
+    }
+
+    /**
+     * Counts the travelers a GM {@link #gmCompleteTravel} on {@code items} would also arrive but that are not themselves
+     * in {@code items} — co-travelers sharing an in-transit node with a selected item. Collapsing a shared travel node
+     * arrives everyone it carries, so this lets the menu warn the GM with a "(+ n others)" hint. Queued (not-yet-departed)
+     * items contribute nothing, since completing one queued traveler dispatches only that traveler.
+     */
+    public int countUnselectedCoTravelers(Collection<? extends ILocation> items) {
+        Set<ILocation> selected = Collections.newSetFromMap(new IdentityHashMap<>());
+        selected.addAll(items);
+
+        Set<ILocation> affected = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (AbstractMobileLocation node : collectInTransitNodes(items)) {
+            affected.addAll(node.fetchPersonnelAtLocation());
+            affected.addAll(node.fetchUnitsAtLocation());
+            affected.addAll(node.fetchPartsAtLocation());
+        }
+        affected.removeAll(selected);
+        return affected.size();
+    }
+
+    /**
+     * Returns the distinct in-transit travel nodes carrying {@code items}, keyed by object identity. An item that has
+     * arrived or is not on a mobile node contributes nothing.
+     */
+    private static Set<AbstractMobileLocation> collectInTransitNodes(Collection<? extends ILocation> items) {
+        Set<AbstractMobileLocation> nodes = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (ILocation item : items) {
+            if (item.getCurrentLocation() instanceof AbstractMobileLocation node && !node.hasArrived()) {
+                nodes.add(node);
+            }
+        }
+        return nodes;
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -110,7 +110,6 @@ import megamek.logging.MMLogger;
 import mekhq.MHQOptions;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign.AdministratorSpecialization;
-import mekhq.campaign.base.PlayerBase;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.enums.DailyReportType;
 import mekhq.campaign.events.DayEndingEvent;
@@ -699,20 +698,14 @@ public class CampaignNewDayManager {
      * @author Illiani
      * @since 0.50.10
      */
-
-    private void processAllArrivals() {
-        for (AbstractLocation location : new ArrayList<>(campaign.getCampaignLocationManager().getLocations())) {
-            location.processArrivals(campaign);
-        }
-        for (PlayerBase base : campaign.getCampaignLocationManager().getPlayerBases()) {
-            base.processArrivals(campaign);
-        }
-        campaign.processArrivals(campaign);
-    }
-
     private void updateFacilities() {
         updateFieldKitchenCapacity();
         updateMASHTheatreCapacity();
+    }
+
+
+    private void processAllArrivals() {
+        campaign.getCampaignLocationManager().processAllArrivals(campaign);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -703,7 +703,6 @@ public class CampaignNewDayManager {
         updateMASHTheatreCapacity();
     }
 
-
     private void processAllArrivals() {
         campaign.getCampaignLocationManager().processAllArrivals(campaign);
     }

--- a/MekHQ/src/mekhq/gui/adapter/PartsTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PartsTableMouseAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2014-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/gui/adapter/PartsTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PartsTableMouseAdapter.java
@@ -58,7 +58,7 @@ import mekhq.campaign.work.WorkTime;
 import mekhq.gui.CampaignGUI;
 import mekhq.gui.dialog.MRMSDialog;
 import mekhq.gui.dialog.PopupValueChoiceDialog;
-import mekhq.gui.menus.SendToLocationMenu;
+import mekhq.gui.menus.LocationMenu;
 import mekhq.gui.model.PartsTableModel;
 import mekhq.gui.utilities.JMenuHelpers;
 import mekhq.service.enums.MRMSMode;
@@ -530,9 +530,7 @@ public class PartsTableMouseAdapter extends JPopupMenuAdapter {
         List<Part> spares = Arrays.stream(parts)
                                   .filter(Part::isSpare)
                                   .collect(Collectors.toList());
-        JMenuHelpers.addMenuIfNonEmpty(popup, new SendToLocationMenu(
-              gui.getCampaign(), gui.getFrame(), spares,
-              destination -> gui.getCampaign().getCampaignLocationManager().queueTravel(spares, destination)));
+        JMenuHelpers.addMenuIfNonEmpty(popup, new LocationMenu(gui.getCampaign(), gui.getFrame(), spares));
 
         return Optional.of(popup);
     }

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -125,6 +125,7 @@ import mekhq.campaign.events.persons.PersonLogEvent;
 import mekhq.campaign.events.persons.PersonStatusChangedEvent;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.enums.TransactionType;
+import mekhq.campaign.location.LocationUtils;
 import mekhq.campaign.log.LogEntry;
 import mekhq.campaign.log.PerformanceLogger;
 import mekhq.campaign.personnel.Award;
@@ -588,8 +589,14 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                         case JOURNEY_TO_CAMPUS:
                         case JOURNEY_FROM_CAMPUS:
                             // this should be enough to ensure even the most distant academy is
-                            // reached/returned from
+                            // reached/returned from via the day-counter fallback
                             person.setEduDaysOfTravel(9999);
+                            // When the student is physically mid-journey on a travel node, the day counter alone
+                            // won't land them — force the transit to finish with the GM override so the arrival
+                            // processing below advances the education stage.
+                            if (LocationUtils.isInTransit(person)) {
+                                getCampaign().getCampaignLocationManager().gmCompleteTravel(getCampaign(), List.of(person));
+                            }
                             break;
                         case EDUCATION:
                             if (!academy.isPrepSchool()) {

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -175,7 +175,7 @@ import mekhq.gui.control.EditLogControl.LogType;
 import mekhq.gui.dialog.*;
 import mekhq.gui.displayWrappers.RankDisplay;
 import mekhq.gui.menus.AssignPersonToUnitMenu;
-import mekhq.gui.menus.SendToLocationMenu;
+import mekhq.gui.menus.LocationMenu;
 import mekhq.gui.model.PersonnelTableModel;
 import mekhq.gui.utilities.JMenuHelpers;
 import mekhq.gui.utilities.MultiLineTooltip;
@@ -2433,9 +2433,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
         JMenuHelpers.addMenuIfNonEmpty(popup, new AssignPersonToUnitMenu(getCampaign(), selected));
         List<mekhq.campaign.personnel.Person> selectedPeople = Arrays.asList(selected);
-        JMenuHelpers.addMenuIfNonEmpty(popup, new SendToLocationMenu(getCampaign(), getFrame(),
-              selectedPeople,
-              destination -> getCampaign().getCampaignLocationManager().queueTravel(selectedPeople, destination)));
+        JMenuHelpers.addMenuIfNonEmpty(popup, new LocationMenu(getCampaign(), getFrame(), selectedPeople));
 
         JMenu familyRegularMenu = new JMenu(resources.getString("family.text"));
         if (oneSelected) {

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -140,7 +140,7 @@ import mekhq.gui.dialog.reportDialogs.PartQualityReportDialog;
 import mekhq.gui.menus.AssignUnitToForceMenu;
 import mekhq.gui.menus.AssignUnitToPersonMenu;
 import mekhq.gui.menus.ExportUnitSpriteMenu;
-import mekhq.gui.menus.SendToLocationMenu;
+import mekhq.gui.menus.LocationMenu;
 import mekhq.gui.model.UnitTableModel;
 import mekhq.gui.utilities.JMenuHelpers;
 import mekhq.gui.utilities.StaticChecks;
@@ -1058,9 +1058,8 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
             JMenuHelpers.addMenuIfNonEmpty(popup, new AssignUnitToForceMenu(gui.getCampaign(), units));
 
             List<mekhq.campaign.unit.Unit> unitList = List.of(units);
-            JMenuHelpers.addMenuIfNonEmpty(popup, new SendToLocationMenu(
-                  gui.getCampaign(), gui.getFrame(), unitList,
-                  destination -> gui.getCampaign().getCampaignLocationManager().queueTravel(unitList, destination)));
+            JMenuHelpers.addMenuIfNonEmpty(popup,
+                  new LocationMenu(gui.getCampaign(), gui.getFrame(), unitList));
 
             // if we're using maintenance and have selected something that requires
             // maintenance and

--- a/MekHQ/src/mekhq/gui/menus/LocationMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/LocationMenu.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.menus;
+
+import static mekhq.utilities.MHQInternationalization.getTextAt;
+
+import java.util.List;
+import javax.swing.JFrame;
+import javax.swing.JMenuItem;
+
+import mekhq.campaign.Campaign;
+import mekhq.campaign.location.ILocation;
+import mekhq.campaign.location.LocationUtils;
+import mekhq.gui.baseComponents.JScrollableMenu;
+
+/**
+ * Top-level "Location" context menu for selected {@link ILocation} items (persons, units, or spare
+ * parts). It always offers a "Send To..." destination picker ({@link SendToLocationMenu}) that queues
+ * travel for the next day-advance.
+ *
+ * <p>When GM mode is enabled it additionally offers two GM overrides, marked with a " (GM)" label
+ * suffix per the codebase convention:</p>
+ * <ul>
+ *   <li><b>Teleport To...</b> — the same destination picker, but the items are dispatched and land at
+ *       the destination immediately (zero transit).</li>
+ *   <li><b>Complete Travel</b> — force-completes travel for the selected items already in transit or
+ *       queued; disabled when none of the selection is traveling or queued.</li>
+ * </ul>
+ */
+public class LocationMenu extends JScrollableMenu {
+
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.SendToLocationMenu";
+
+    /**
+     * @param campaign the active campaign
+     * @param frame    parent frame for any dialogs
+     * @param items    the {@link ILocation} objects to act on (persons, units, or parts)
+     */
+    public LocationMenu(Campaign campaign, JFrame frame, List<? extends ILocation> items) {
+        super("LocationMenu");
+        initialize(campaign, frame, items);
+    }
+
+    private void initialize(Campaign campaign, JFrame frame, List<? extends ILocation> items) {
+        if (items.isEmpty()) {
+            return;
+        }
+
+        setText(getTextAt(RESOURCE_BUNDLE, "menu.location.text"));
+
+        add(new SendToLocationMenu(campaign, frame, items,
+              destination -> campaign.getCampaignLocationManager().queueTravel(items, destination)));
+
+        if (campaign.isGM()) {
+            add(new SendToLocationMenu(campaign, frame, items,
+                  destination -> campaign.getCampaignLocationManager().gmTeleport(campaign, items, destination),
+                  "menu.teleportTo.text"));
+
+            JMenuItem completeTravel = new JMenuItem(getTextAt(RESOURCE_BUNDLE, "menuItem.completeTravel.text"));
+            completeTravel.setEnabled(anyTravelingOrQueued(campaign, items));
+            completeTravel.addActionListener(e -> campaign.getCampaignLocationManager().gmCompleteTravel(campaign, items));
+            add(completeTravel);
+        }
+    }
+
+    private static boolean anyTravelingOrQueued(Campaign campaign, List<? extends ILocation> items) {
+        return items.stream().anyMatch(item -> LocationUtils.isInTransit(item)
+              || campaign.getCampaignLocationManager().isQueuedForTravel(item));
+    }
+}

--- a/MekHQ/src/mekhq/gui/menus/LocationMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/LocationMenu.java
@@ -32,6 +32,7 @@
  */
 package mekhq.gui.menus;
 
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import java.util.List;
@@ -86,11 +87,24 @@ public class LocationMenu extends JScrollableMenu {
                   destination -> campaign.getCampaignLocationManager().gmTeleport(campaign, items, destination),
                   "menu.teleportTo.text"));
 
-            JMenuItem completeTravel = new JMenuItem(getTextAt(RESOURCE_BUNDLE, "menuItem.completeTravel.text"));
+            JMenuItem completeTravel = new JMenuItem(completeTravelLabel(campaign, items));
             completeTravel.setEnabled(anyTravelingOrQueued(campaign, items));
             completeTravel.addActionListener(e -> campaign.getCampaignLocationManager().gmCompleteTravel(campaign, items));
             add(completeTravel);
         }
+    }
+
+    /**
+     * Builds the "Complete Travel" label, appending a "(+ n others)" hint when collapsing the selection's shared travel
+     * node(s) would also arrive co-travelers that are not part of the selection.
+     */
+    private static String completeTravelLabel(Campaign campaign, List<? extends ILocation> items) {
+        String label = getTextAt(RESOURCE_BUNDLE, "menuItem.completeTravel.text");
+        int others = campaign.getCampaignLocationManager().countUnselectedCoTravelers(items);
+        if (others > 0) {
+            label += " " + getFormattedTextAt(RESOURCE_BUNDLE, "menuItem.completeTravel.others.text", others);
+        }
+        return label;
     }
 
     private static boolean anyTravelingOrQueued(Campaign campaign, List<? extends ILocation> items) {

--- a/MekHQ/src/mekhq/gui/menus/SendToLocationMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/SendToLocationMenu.java
@@ -81,18 +81,35 @@ public class SendToLocationMenu extends JScrollableMenu {
     public SendToLocationMenu(Campaign campaign, JFrame frame,
           List<? extends ILocation> items,
           Consumer<ILocation> dispatcher) {
+        this(campaign, frame, items, dispatcher, "menu.sendTo.text");
+    }
+
+    /**
+     * @param campaign    the active campaign
+     * @param frame       parent frame for any dialogs
+     * @param items       the {@link ILocation} objects to dispatch (persons, units, or parts)
+     * @param dispatcher  callback invoked with the chosen destination when the user clicks an entry
+     * @param menuTextKey resource-bundle key for this menu's label (e.g. "menu.sendTo.text" or
+     *                    "menu.teleportTo.text"), letting the same destination picker be reused under
+     *                    different top-level labels
+     */
+    public SendToLocationMenu(Campaign campaign, JFrame frame,
+          List<? extends ILocation> items,
+          Consumer<ILocation> dispatcher,
+          String menuTextKey) {
         super("SendToLocationMenu");
-        initialize(campaign, frame, items, dispatcher);
+        initialize(campaign, frame, items, dispatcher, menuTextKey);
     }
 
     private void initialize(Campaign campaign, JFrame frame,
           List<? extends ILocation> items,
-          Consumer<ILocation> dispatcher) {
+          Consumer<ILocation> dispatcher,
+          String menuTextKey) {
         if (items.isEmpty()) {
             return;
         }
 
-        setText(getTextAt(RESOURCE_BUNDLE, "menu.sendTo.text"));
+        setText(getTextAt(RESOURCE_BUNDLE, menuTextKey));
 
         // Determine the ILocation parent all selected items share (if any), to exclude it.
         // ILocation subtypes like Personnel extend LinkedHashMap, so Objects.equals() would

--- a/MekHQ/unittests/mekhq/campaign/CampaignLocationManagerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/CampaignLocationManagerTest.java
@@ -32,17 +32,21 @@
  */
 package mekhq.campaign;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import mekhq.MekHQ;
+import mekhq.campaign.events.units.UnitChangedEvent;
 import mekhq.campaign.location.LocationDispatch;
 import mekhq.campaign.unit.Unit;
 import org.junit.jupiter.api.Test;
@@ -166,5 +170,50 @@ class CampaignLocationManagerTest {
         verify(travelNode).setTransitTime(0);
         verify(travelNode).setJumpPath(null);
         verify(campaign).processArrivals(campaign);
+    }
+
+    @Test
+    void gmCompleteTravel_refreshesUnselectedCoTravelers() {
+        CampaignLocationManager manager = new CampaignLocationManager();
+        Campaign campaign = mock(Campaign.class);
+        Unit selectedUnit = mock(Unit.class);
+        Unit coTraveler = mock(Unit.class);
+        CurrentLocation travelNode = mock(CurrentLocation.class);
+        when(selectedUnit.getCurrentLocation()).thenReturn(travelNode);
+        when(travelNode.hasArrived()).thenReturn(false);
+        when(travelNode.fetchPersonnelAtLocation()).thenReturn(Set.of());
+        when(travelNode.fetchUnitsAtLocation()).thenReturn(Set.of(selectedUnit, coTraveler));
+        when(travelNode.fetchPartsAtLocation()).thenReturn(Set.of());
+
+        try (MockedStatic<MekHQ> mekhq = mockStatic(MekHQ.class)) {
+            manager.gmCompleteTravel(campaign, List.of(selectedUnit));
+
+            // The co-traveler, though not selected, arrives with the node and must get a refresh event too.
+            mekhq.verify(() -> MekHQ.triggerEvent(argThat(
+                  event -> event instanceof UnitChangedEvent changed && changed.getUnit() == coTraveler)));
+        }
+    }
+
+    @Test
+    void countUnselectedCoTravelers_countsOnlyItemsNotInSelection() {
+        CampaignLocationManager manager = new CampaignLocationManager();
+        Unit selectedUnit = mock(Unit.class);
+        Unit coTraveler = mock(Unit.class);
+        CurrentLocation travelNode = mock(CurrentLocation.class);
+        when(selectedUnit.getCurrentLocation()).thenReturn(travelNode);
+        when(travelNode.hasArrived()).thenReturn(false);
+        when(travelNode.fetchPersonnelAtLocation()).thenReturn(Set.of());
+        when(travelNode.fetchUnitsAtLocation()).thenReturn(Set.of(selectedUnit, coTraveler));
+        when(travelNode.fetchPartsAtLocation()).thenReturn(Set.of());
+
+        assertEquals(1, manager.countUnselectedCoTravelers(List.of(selectedUnit)));
+    }
+
+    @Test
+    void countUnselectedCoTravelers_zeroWhenNotTraveling() {
+        CampaignLocationManager manager = new CampaignLocationManager();
+        Unit unit = mock(Unit.class);
+
+        assertEquals(0, manager.countUnselectedCoTravelers(List.of(unit)));
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/CampaignLocationManagerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/CampaignLocationManagerTest.java
@@ -36,11 +36,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.UUID;
 
+import mekhq.MekHQ;
 import mekhq.campaign.location.LocationDispatch;
 import mekhq.campaign.unit.Unit;
 import org.junit.jupiter.api.Test;
@@ -103,5 +105,66 @@ class CampaignLocationManagerTest {
             dispatch.verify(() -> LocationDispatch.dispatchTravelers(List.of(unit), campaign, campaign));
         }
         assertFalse(manager.isQueuedForTravel(unit));
+    }
+
+    @Test
+    void gmTeleport_dispatchesThenProcessesArrivals() {
+        CampaignLocationManager manager = new CampaignLocationManager();
+        Campaign campaign = mock(Campaign.class);
+        Unit unit = mock(Unit.class);
+
+        try (MockedStatic<LocationDispatch> dispatch = mockStatic(LocationDispatch.class)) {
+            manager.gmTeleport(campaign, List.of(unit), campaign);
+            dispatch.verify(() -> LocationDispatch.dispatchTravelers(List.of(unit), campaign, campaign));
+        }
+        verify(campaign).processArrivals(campaign);
+    }
+
+    @Test
+    void gmCompleteTravel_startsQueuedItemToItsDestination() {
+        CampaignLocationManager manager = new CampaignLocationManager();
+        Campaign campaign = mock(Campaign.class);
+        Unit unit = mock(Unit.class);
+
+        // Queue the unit to travel to the campaign (used here as the destination ILocation).
+        manager.queueTravel(List.of(unit), campaign);
+
+        try (MockedStatic<LocationDispatch> dispatch = mockStatic(LocationDispatch.class)) {
+            manager.gmCompleteTravel(campaign, List.of(unit));
+            dispatch.verify(() -> LocationDispatch.dispatchTravelers(List.of(unit), campaign, campaign));
+        }
+        assertFalse(manager.isQueuedForTravel(unit));
+        verify(campaign).processArrivals(campaign);
+    }
+
+    @Test
+    void gmCompleteTravel_noopWhenNothingTravelingOrQueued() {
+        CampaignLocationManager manager = new CampaignLocationManager();
+        Campaign campaign = mock(Campaign.class);
+        Unit unit = mock(Unit.class);
+
+        try (MockedStatic<LocationDispatch> dispatch = mockStatic(LocationDispatch.class)) {
+            manager.gmCompleteTravel(campaign, List.of(unit));
+            dispatch.verifyNoInteractions();
+        }
+        verify(campaign).processArrivals(campaign);
+    }
+
+    @Test
+    void gmCompleteTravel_forcesInTransitNodeToArrive() {
+        CampaignLocationManager manager = new CampaignLocationManager();
+        Campaign campaign = mock(Campaign.class);
+        Unit unit = mock(Unit.class);
+        CurrentLocation travelNode = mock(CurrentLocation.class);
+        when(unit.getCurrentLocation()).thenReturn(travelNode);
+        when(travelNode.hasArrived()).thenReturn(false);
+
+        try (MockedStatic<MekHQ> ignored = mockStatic(MekHQ.class)) {
+            manager.gmCompleteTravel(campaign, List.of(unit));
+        }
+
+        verify(travelNode).setTransitTime(0);
+        verify(travelNode).setJumpPath(null);
+        verify(campaign).processArrivals(campaign);
     }
 }


### PR DESCRIPTION
Fixes #9447 
Adds proper options to Users, Persons, and Parts to GM teleport to location and GM complete travel. 

I then updated the GM Complete Education to use the GM Complete Travel if the education phases is traveling.