### PR TITLE
PR: Make auto-restock per-base/campaign instead of campaign wide

### DIFF
--- a/MekHQ/resources/mekhq/resources/PartsReportDialog.properties
+++ b/MekHQ/resources/mekhq/resources/PartsReportDialog.properties
@@ -36,6 +36,7 @@ topUpBtn.text=Order Parts to Minimum Stock Levels
 topUpGMBtn.text=(GM) Add Parts to Minimum Stock Levels
 resetRequestedStockBtn.text=Reset Minimum Stock Levels to Default
 lblIgnoreSparesUnderQuality.text=Ignore Spare Parts Under Quality
+lblLocation.text=Location:
 lblPartsGroup.text=Filter:
 lblPartsGroup.all=All Parts
 lblPartsGroup.armor=Armor

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -177,6 +177,7 @@ import mekhq.campaign.log.LogEntry;
 import mekhq.campaign.log.ServiceLogger;
 import mekhq.campaign.market.PartsStore;
 import mekhq.campaign.market.PersonnelMarket;
+import mekhq.campaign.market.RequestedStockLevels;
 import mekhq.campaign.market.ShoppingList;
 import mekhq.campaign.market.contractMarket.AbstractContractMarket;
 import mekhq.campaign.market.personnelMarket.markets.NewPersonnelMarket;
@@ -307,10 +308,9 @@ public class Campaign implements ITechManager, IPlace {
     private final TreeMap<Integer, Scenario> scenarios = new TreeMap<>();
     private final Map<UUID, List<Kill>> kills = new HashMap<>();
 
-    // This maps PartInUse ToString() results to doubles, representing a mapping
-    // of parts in use to their requested stock percentages to make these values
-    // persistent
-    private Map<String, Double> partsInUseRequestedStockMap = new LinkedHashMap<>();
+    // The main force's per-part requested stock percentages. Each player base owns its own instance; see
+    // IPlace.getRequestedStockLevels().
+    private final RequestedStockLevels requestedStockLevels = new RequestedStockLevels();
 
     private transient final UnitNameTracker unitNameTracker = new UnitNameTracker();
 
@@ -8757,13 +8757,20 @@ public class Campaign implements ITechManager, IPlace {
         this.processProcurement = processProcurement;
     }
 
+    @Override
+    public RequestedStockLevels getRequestedStockLevels() {
+        return requestedStockLevels;
+    }
+
     // Simple getters and setters for our stock map
     public Map<String, Double> getPartsInUseRequestedStockMap() {
-        return partsInUseRequestedStockMap;
+        return requestedStockLevels.getStockMap();
     }
 
     public void setPartsInUseRequestedStockMap(Map<String, Double> partsInUseRequestedStockMap) {
-        this.partsInUseRequestedStockMap = partsInUseRequestedStockMap;
+        Map<String, Double> stockMap = requestedStockLevels.getStockMap();
+        stockMap.clear();
+        stockMap.putAll(partsInUseRequestedStockMap);
     }
 
     public boolean getIgnoreMothballed() {
@@ -8794,25 +8801,14 @@ public class Campaign implements ITechManager, IPlace {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "ignoreMothBalled", ignoreMothballed);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "topUpWeekly", topUpWeekly);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "ignoreSparesUnderQuality", ignoreSparesUnderQuality.name());
-        MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "partInUseMap");
-        writePartInUseMapToXML(pw, indent);
-        MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "partInUseMap");
-    }
-
-    public void writePartInUseMapToXML(final PrintWriter pw, int indent) {
-        for (String key : partsInUseRequestedStockMap.keySet()) {
-            MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "partInUseMapEntry");
-            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "partInUseMapKey", key);
-            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "partInUseMapVal", partsInUseRequestedStockMap.get(key));
-            MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "partInUseMapEntry");
-        }
+        requestedStockLevels.writeToXML(pw, indent);
     }
 
     /**
      * Wipes the Parts in use map for the purpose of resetting all values to their default
      */
     public void wipePartsInUseMap() {
-        this.partsInUseRequestedStockMap.clear();
+        this.requestedStockLevels.clear();
     }
 
     /** Discriminator identifying the main campaign as a serialized {@link ILocation} reference. */

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -121,6 +121,7 @@ import mekhq.campaign.finances.Finances;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.enums.TransactionType;
 import mekhq.campaign.force.Formation;
+import mekhq.campaign.location.IPlace;
 import mekhq.campaign.location.LocationNewDayUtil;
 import mekhq.campaign.market.PartsInUseManager;
 import mekhq.campaign.mission.AtBContract;
@@ -577,11 +578,19 @@ public class CampaignNewDayManager {
         }
 
         if (campaign.getTopUpWeekly() && isMonday) {
-            PartsInUseManager partsInUseManager = new PartsInUseManager(campaign);
-            Set<PartInUse> actualPartsInUse = partsInUseManager.getPartsInUse(campaign.getIgnoreMothballed(),
-                  false,
-                  campaign.getIgnoreSparesUnderQuality());
-            int bought = partsInUseManager.stockUpPartsInUse(actualPartsInUse);
+            // Each location keeps its own stock levels, so top up the main force and every base independently.
+            List<IPlace> places = new ArrayList<>();
+            places.add(campaign);
+            places.addAll(campaign.getCampaignLocationManager().getPlayerBases());
+
+            int bought = 0;
+            for (IPlace place : places) {
+                PartsInUseManager partsInUseManager = new PartsInUseManager(campaign, place);
+                Set<PartInUse> actualPartsInUse = partsInUseManager.getPartsInUse(campaign.getIgnoreMothballed(),
+                      false,
+                      campaign.getIgnoreSparesUnderQuality());
+                bought += partsInUseManager.stockUpPartsInUse(actualPartsInUse);
+            }
             campaign.addReport(ACQUISITIONS, String.format(resources.getString("weeklyStockCheck.text"), bought));
         }
 

--- a/MekHQ/src/mekhq/campaign/Quartermaster.java
+++ b/MekHQ/src/mekhq/campaign/Quartermaster.java
@@ -121,6 +121,15 @@ public record Quartermaster(Campaign campaign) {
     }
 
     /**
+     * Returns the warehouse a part physically lives in — its own (a base warehouse for a base spare, resolved through
+     * the location tree), falling back to the campaign warehouse.
+     */
+    private Warehouse warehouseFor(Part part) {
+        Warehouse partWarehouse = part.getWarehouse();
+        return (partWarehouse != null) ? partWarehouse : getWarehouse();
+    }
+
+    /**
      * Adds a part to the campaign's warehouse, specifying the number of transit days for its arrival and whether the
      * part is considered brand new. The method validates the input and decides whether to skip the addition based on
      * specific conditions, such as test units, spare ammo bins, or missing parts without associated units.
@@ -137,6 +146,22 @@ public record Quartermaster(Campaign campaign) {
      * @throws NullPointerException If {@code part} is {@code null}.
      */
     public void addPart(Part part, int transitDays, boolean isBrandNew) {
+        addPart(part, transitDays, isBrandNew, null);
+    }
+
+    /**
+     * Adds a part to a warehouse, specifying the number of transit days for its arrival and whether the part is
+     * considered brand new. Behaves like {@link #addPart(Part, int, boolean)} but allows the caller to direct the part
+     * to a specific {@code target} warehouse (e.g. a base's warehouse for a location-scoped purchase or GM add).
+     *
+     * @param part        The part to add. Cannot be {@code null}.
+     * @param transitDays The number of days until the part arrives; negative values are treated as zero.
+     * @param isBrandNew  {@code true} if the part is brand new.
+     * @param target      The warehouse to add the part to, or {@code null} to use the warehouse the part resolves to
+     *                    through its own location (a base warehouse for a base spare), falling back to the campaign
+     *                    warehouse.
+     */
+    public void addPart(Part part, int transitDays, boolean isBrandNew, @Nullable Warehouse target) {
         Objects.requireNonNull(part);
 
         // Refit kits are special, if this is for a refit kit use that method
@@ -167,12 +192,9 @@ public record Quartermaster(Campaign campaign) {
         // be careful in using this next line
         part.postProcessCampaignAddition();
 
-        // Add the part to the warehouse local to its unit (e.g. a base warehouse for a unit
-        // stationed at a base) and merge it with any existing part if possible
-        Unit unit = part.getUnit();
-        Warehouse warehouse = ((unit != null) && (unit.getWarehouse() != null))
-              ? unit.getWarehouse()
-              : getWarehouse();
+        // Add the part to the requested target warehouse, or the warehouse local to the part (e.g. a base warehouse for
+        // a unit or spare at a base), and merge it with any existing part if possible
+        Warehouse warehouse = (target != null) ? target : warehouseFor(part);
         warehouse.addPart(part, true);
     }
 
@@ -735,7 +757,7 @@ public record Quartermaster(Campaign campaign) {
         campaign().getFinances().credit(TransactionType.EQUIPMENT_SALE, campaign().getLocalDate(),
               cost, "Sale of " + quantity + " " + part.getName() + plural);
 
-        getWarehouse().removePart(part, quantity);
+        warehouseFor(part).removePart(part, quantity);
     }
 
     /**
@@ -776,7 +798,7 @@ public record Quartermaster(Campaign campaign) {
         campaign().getFinances().credit(TransactionType.EQUIPMENT_SALE, campaign().getLocalDate(),
               cost, "Sale of " + shots + " " + ammo.getName());
 
-        getWarehouse().removeAmmo(ammo, shots);
+        warehouseFor(ammo).removeAmmo(ammo, shots);
     }
 
     /**
@@ -817,7 +839,7 @@ public record Quartermaster(Campaign campaign) {
         campaign().getFinances().credit(TransactionType.EQUIPMENT_SALE, campaign().getLocalDate(),
               cost, "Sale of " + points + " " + armor.getName());
 
-        getWarehouse().removeArmor(armor, points);
+        warehouseFor(armor).removeArmor(armor, points);
     }
 
     /**
@@ -915,19 +937,34 @@ public record Quartermaster(Campaign campaign) {
      * @return True if the part was purchased, otherwise false.
      */
     public boolean buyPart(Part part, double costMultiplier, int transitDays) {
+        return buyPart(part, costMultiplier, transitDays, null);
+    }
+
+    /**
+     * Tries to buy a part with a cost multiplier, arriving in a given number of days, delivered to a specific
+     * warehouse.
+     *
+     * @param part           The part to buy.
+     * @param costMultiplier The cost multiplier for the purchase.
+     * @param transitDays    The number of days until the new part arrives.
+     * @param target         The warehouse to deliver to, or {@code null} to use the part's own location.
+     *
+     * @return True if the part was purchased, otherwise false.
+     */
+    public boolean buyPart(Part part, double costMultiplier, int transitDays, @Nullable Warehouse target) {
         Objects.requireNonNull(part);
 
         if (getCampaignOptions().isPayForParts()) {
             Money cost = part.getActualValue().multipliedBy(costMultiplier);
             if (campaign().getFinances().debit(TransactionType.EQUIPMENT_PURCHASE,
                   campaign().getLocalDate(), cost, "Purchase of " + part.getName())) {
-                addPart(part, transitDays, true);
+                addPart(part, transitDays, true, target);
                 return true;
             } else {
                 return false;
             }
         } else {
-            addPart(part, transitDays, true);
+            addPart(part, transitDays, true, target);
             return true;
         }
     }

--- a/MekHQ/src/mekhq/campaign/base/AbstractBase.java
+++ b/MekHQ/src/mekhq/campaign/base/AbstractBase.java
@@ -46,6 +46,7 @@ import mekhq.campaign.Warehouse;
 import mekhq.campaign.location.ILocation;
 import mekhq.campaign.location.IPlace;
 import mekhq.campaign.location.LocationNode;
+import mekhq.campaign.market.RequestedStockLevels;
 import mekhq.utilities.MHQXMLUtility;
 import org.w3c.dom.Node;
 
@@ -67,6 +68,7 @@ public abstract class AbstractBase implements IPlace {
     private final Personnel basePersonnel = new Personnel();
     private final Warehouse baseWarehouse = new Warehouse();
     private final Hangar baseHangar = new Hangar();
+    private final RequestedStockLevels baseRequestedStockLevels = new RequestedStockLevels();
 
     /**
      * Creates a new base anchored under {@code parentLocation}.
@@ -130,6 +132,11 @@ public abstract class AbstractBase implements IPlace {
         return basePersonnel;
     }
 
+    @Override
+    public RequestedStockLevels getRequestedStockLevels() {
+        return baseRequestedStockLevels;
+    }
+
     public UUID getId() {
         return id;
     }
@@ -178,6 +185,9 @@ public abstract class AbstractBase implements IPlace {
         if (planetId != null) {
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "planetId", planetId);
         }
+        if (!baseRequestedStockLevels.isEmpty()) {
+            baseRequestedStockLevels.writeToXML(pw, indent);
+        }
     }
 
     /**
@@ -207,6 +217,11 @@ public abstract class AbstractBase implements IPlace {
             }
             case "planetid" -> {
                 base.planetId = wn2.getTextContent().trim();
+                return true;
+            }
+            case "partinusemap" -> {
+                base.baseRequestedStockLevels.getStockMap()
+                      .putAll(RequestedStockLevels.generateInstanceFromXML(wn2).getStockMap());
                 return true;
             }
             default -> {

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -58,7 +58,6 @@ import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Hashtable;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -106,6 +105,7 @@ import mekhq.campaign.location.AcademyCampusLocation;
 import mekhq.campaign.location.ILocation;
 import mekhq.campaign.location.LocationNode;
 import mekhq.campaign.market.PersonnelMarket;
+import mekhq.campaign.market.RequestedStockLevels;
 import mekhq.campaign.market.ShoppingList;
 import mekhq.campaign.market.contractMarket.AbstractContractMarket;
 import mekhq.campaign.market.contractMarket.AtbMonthlyContractMarket;
@@ -2880,59 +2880,12 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                 retVal.setIgnoreSparesUnderQuality(ignoreQuality);
             } else if (wn2.getNodeName().equalsIgnoreCase("partInUseMap")) {
                 if (version.isHigherThan(new Version("0.50.07"))) { // <50.10 compatibility handler
-                    processPartsInUseRequestedStockMap(retVal, wn2);
+                    retVal.setPartsInUseRequestedStockMap(
+                          RequestedStockLevels.generateInstanceFromXML(wn2).getStockMap());
                 }
             } else {
                 LOGGER.error("Unknown node type not loaded in PartInUse nodes: {}", wn2.getNodeName());
             }
-        }
-    }
-
-    private static void processPartsInUseRequestedStockMap(Campaign retVal, Node wn) {
-        NodeList wList = wn.getChildNodes();
-
-        Map<String, Double> partInUseStockMap = new LinkedHashMap<>();
-
-        for (int i = 0; i < wList.getLength(); i++) {
-            Node wn2 = wList.item(i);
-
-            if (wn2.getNodeType() != Node.ELEMENT_NODE) {
-                continue;
-            }
-
-            if (!wn2.getNodeName().equalsIgnoreCase("partInUseMapEntry")) {
-                LOGGER.error("Unknown node type not loaded in PartInUseStockMap nodes: {}", wn2.getNodeName());
-            }
-
-            processPartsInUseRequestedStockMapVal(retVal, wn2, partInUseStockMap);
-
-        }
-
-        retVal.setPartsInUseRequestedStockMap(partInUseStockMap);
-    }
-
-    private static void processPartsInUseRequestedStockMapVal(Campaign retVal, Node wn,
-          Map<String, Double> partsInUseRequestedStockMap) {
-        NodeList wList = wn.getChildNodes();
-
-        String key = null;
-        double val = 0;
-
-        for (int i = 0; i < wList.getLength(); i++) {
-            Node wn2 = wList.item(i);
-
-            if (wn2.getNodeType() != Node.ELEMENT_NODE) {
-                continue;
-            }
-
-            if (wn2.getNodeName().equalsIgnoreCase("partInUseMapKey")) {
-                key = wn2.getTextContent();
-            } else if (wn2.getNodeName().equalsIgnoreCase("partInUseMapVal")) {
-                val = Double.parseDouble(wn2.getTextContent());
-            }
-        }
-        if (key != null) {
-            partsInUseRequestedStockMap.put(key, val);
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/location/IPlace.java
+++ b/MekHQ/src/mekhq/campaign/location/IPlace.java
@@ -43,6 +43,7 @@ import mekhq.campaign.Hangar;
 import mekhq.campaign.Personnel;
 import mekhq.campaign.Warehouse;
 import mekhq.campaign.campaignOptions.CampaignOptions;
+import mekhq.campaign.market.RequestedStockLevels;
 import mekhq.campaign.parts.AmmoStorage;
 import mekhq.campaign.parts.Armor;
 import mekhq.campaign.parts.Part;
@@ -99,6 +100,17 @@ public interface IPlace extends ILocation {
     @Nullable
     default Personnel getPersonnel() {
         return null;
+    }
+
+    /**
+     * Returns the per-part "requested stock percent" targets this place maintains for its warehouse.
+     *
+     * <p>Only {@link mekhq.campaign.Campaign} (main force) and {@link mekhq.campaign.base.AbstractBase} own real stock
+     * levels; every other place inherits the empty {@link RequestedStockLevels#NO_RESTOCK}, so its parts fall through to
+     * default stock percentages.</p>
+     */
+    default RequestedStockLevels getRequestedStockLevels() {
+        return RequestedStockLevels.NO_RESTOCK;
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/location/LocationDispatch.java
+++ b/MekHQ/src/mekhq/campaign/location/LocationDispatch.java
@@ -271,13 +271,19 @@ public final class LocationDispatch {
         dispatch(units, destination, campaign, LOG_DISPATCH_UNITS, arrivalHangar, group -> {
             for (Unit unit : group) {
                 Hangar sourceHangar = unit.getHangar();
+                // Capture the unit's current warehouse BEFORE moving it: Hangar.addUnit reparents the unit's node, after
+                // which each installed part's getWarehouse() (resolved through the unit) would already read the arrival
+                // warehouse and the move below would be skipped.
+                Warehouse sourceWarehouse = unit.getWarehouse();
+                if (sourceWarehouse == null) {
+                    sourceWarehouse = campaign.getWarehouse();
+                }
                 (sourceHangar != null ? sourceHangar : campaign.getHangar()).removeUnit(unit.getId());
                 arrivalHangar.addUnit(unit);
                 // Installed parts live in the warehouse local to their unit; move them along.
-                for (Part part : unit.getParts()) {
-                    Warehouse sourceWarehouse = part.getWarehouse();
-                    if (sourceWarehouse != arrivalWarehouse) {
-                        (sourceWarehouse != null ? sourceWarehouse : campaign.getWarehouse()).removePart(part);
+                if (sourceWarehouse != arrivalWarehouse) {
+                    for (Part part : unit.getParts()) {
+                        sourceWarehouse.removePart(part);
                         arrivalWarehouse.addPart(part);
                     }
                 }

--- a/MekHQ/src/mekhq/campaign/market/PartsInUseManager.java
+++ b/MekHQ/src/mekhq/campaign/market/PartsInUseManager.java
@@ -37,6 +37,7 @@ import static mekhq.campaign.mission.resupplyAndCaches.Resupply.isProhibitedUnit
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import megamek.common.equipment.EquipmentType;
@@ -47,7 +48,9 @@ import megamek.common.units.Mek;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.Quartermaster;
 import mekhq.campaign.Warehouse;
+import mekhq.campaign.base.PlayerBase;
 import mekhq.campaign.campaignOptions.CampaignOptions;
+import mekhq.campaign.location.IPlace;
 import mekhq.campaign.parts.AmmoStorage;
 import mekhq.campaign.parts.Armor;
 import mekhq.campaign.parts.EnginePart;
@@ -93,6 +96,7 @@ import mekhq.campaign.work.IAcquisitionWork;
  */
 public class PartsInUseManager {
     private final Campaign campaign;
+    private final IPlace place;
     private final CampaignOptions campaignOptions;
     private final Warehouse warehouse;
     private final ShoppingList shoppingList;
@@ -100,17 +104,58 @@ public class PartsInUseManager {
     private final Map<String, Double> partsInUseRequestedStockMap;
 
     /**
-     * Creates a new {@link PartsInUseManager} manager for the specified campaign.
+     * Creates a new {@link PartsInUseManager} for the campaign's main force.
      *
      * @param campaign the {@link Campaign} to manage parts for
      */
     public PartsInUseManager(Campaign campaign) {
+        this(campaign, campaign);
+    }
+
+    /**
+     * Creates a new {@link PartsInUseManager} scoped to a specific location.
+     *
+     * <p>The parts, spares, and requested stock levels are all drawn from {@code place}: the campaign for the main
+     * force, or a base for that base's warehouse. The shopping list and quartermaster remain campaign-level.</p>
+     *
+     * @param campaign the owning {@link Campaign}
+     * @param place    the {@link IPlace} whose warehouse and stock levels this manager operates on
+     */
+    public PartsInUseManager(Campaign campaign, IPlace place) {
         this.campaign = campaign;
+        this.place = place;
         this.campaignOptions = campaign.getCampaignOptions();
-        this.warehouse = campaign.getWarehouse();
+        Warehouse placeWarehouse = place.getWarehouse();
+        this.warehouse = (placeWarehouse != null) ? placeWarehouse : campaign.getWarehouse();
         this.shoppingList = campaign.getShoppingList();
         this.quartermaster = campaign.getQuartermaster();
-        this.partsInUseRequestedStockMap = campaign.getPartsInUseRequestedStockMap();
+        this.partsInUseRequestedStockMap = place.getRequestedStockLevels().getStockMap();
+    }
+
+    /** The place a part is located at — its unit's location for installed parts, its warehouse for spares. */
+    private IPlace placeOf(Part part) {
+        IPlace partPlace = part.getPlace();
+        return (partPlace != null) ? partPlace : campaign;
+    }
+
+    /**
+     * Applies {@code consumer} to every part, across the main-force and all base warehouses, whose location resolves to
+     * this manager's {@code place}. Attributing each part by {@link Part#getPlace()} scopes the report to the selected
+     * location regardless of which warehouse map physically holds the part (installed parts follow their unit's base).
+     */
+    private void forEachPartAtPlace(Consumer<Part> consumer) {
+        campaign.getWarehouse().forEachPart(part -> {
+            if (placeOf(part) == place) {
+                consumer.accept(part);
+            }
+        });
+        for (PlayerBase base : campaign.getCampaignLocationManager().getPlayerBases()) {
+            base.getBaseWarehouse().forEachPart(part -> {
+                if (placeOf(part) == place) {
+                    consumer.accept(part);
+                }
+            });
+        }
     }
 
     /**
@@ -296,13 +341,16 @@ public class PartsInUseManager {
         partInUse.setStoreCount(0);
         partInUse.setTransferCount(0);
         partInUse.setPlannedCount(0);
-        warehouse.forEachPart(incomingPart -> {
+        forEachPartAtPlace(incomingPart -> {
             PartInUse newPartInUse = getPartInUse(incomingPart);
             if (partInUse.equals(newPartInUse)) {
                 updatePartInUseData(partInUse, incomingPart, ignoreMothballedUnits, ignoreSparesUnderQuality);
             }
         });
         for (IAcquisitionWork maybePart : shoppingList.getPartList()) {
+            if (placeOf((Part) maybePart) != place) {
+                continue;
+            }
             PartInUse newPartInUse = getPartInUse((Part) maybePart);
             if (partInUse.equals(newPartInUse)) {
                 Part newPart = (maybePart instanceof MissingPart)
@@ -347,7 +395,7 @@ public class PartsInUseManager {
         // java.util.Set doesn't supply a get(Object) method, so we have to use a
         // java.util.Map
         Map<PartInUse, PartInUse> inUse = new HashMap<>();
-        warehouse.forEachPart(incomingPart -> {
+        forEachPartAtPlace(incomingPart -> {
             if (isResupply) {
                 Unit unit = incomingPart.getUnit();
 
@@ -385,6 +433,9 @@ public class PartsInUseManager {
 
         for (IAcquisitionWork maybePart : shoppingList.getPartList()) {
             if (!(maybePart instanceof Part)) {
+                continue;
+            }
+            if (placeOf((Part) maybePart) != place) {
                 continue;
             }
             PartInUse partInUse = getPartInUse((Part) maybePart);
@@ -436,7 +487,7 @@ public class PartsInUseManager {
             int toBuy = findStockUpAmount(partInUse);
             if (toBuy > 0) {
                 IAcquisitionWork partToBuy = partInUse.getPartToBuy();
-                shoppingList.addShoppingItem(partToBuy, toBuy, campaign);
+                shoppingList.addShoppingItem(partToBuy, toBuy, campaign, place);
                 bought += 1;
             }
         }
@@ -459,7 +510,7 @@ public class PartsInUseManager {
             int toBuy = findStockUpAmount(partInUse);
             while (toBuy > 0) {
                 IAcquisitionWork partToBuy = partInUse.getPartToBuy();
-                quartermaster.addPart((Part) partToBuy.getNewEquipment(), 0, true);
+                quartermaster.addPart((Part) partToBuy.getNewEquipment(), 0, true, warehouse);
                 --toBuy;
             }
         }

--- a/MekHQ/src/mekhq/campaign/market/RequestedStockLevels.java
+++ b/MekHQ/src/mekhq/campaign/market/RequestedStockLevels.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.market;
+
+import java.io.PrintWriter;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import megamek.logging.MMLogger;
+import mekhq.utilities.MHQXMLUtility;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * The per-part "requested stock percent" targets that a single {@link mekhq.campaign.location.IPlace} maintains for its
+ * warehouse.
+ *
+ * <p>Each value maps a stock key (produced by {@link PartsInUseManager#getStockKey}) to the target percentage of the
+ * in-use count that should be kept as spares. A place that has no explicit entry for a part falls through to the
+ * campaign-option default. Both the campaign's main force and every player base own their own instance, so stock targets
+ * are tracked independently per location.</p>
+ */
+public final class RequestedStockLevels {
+    private static final MMLogger LOGGER = MMLogger.create(RequestedStockLevels.class);
+
+    /**
+     * A shared, empty, do-nothing instance returned by any {@link mekhq.campaign.location.IPlace} that does not own real
+     * stock levels, so callers never have to deal with {@code null}. Its map is empty and unmodifiable, and mutating
+     * operations are no-ops, so every part falls through to its default stock percentage.
+     */
+    public static final RequestedStockLevels NO_RESTOCK = new RequestedStockLevels(true);
+
+    private final Map<String, Double> stockMap;
+    private final boolean readOnly;
+
+    public RequestedStockLevels() {
+        this(false);
+    }
+
+    private RequestedStockLevels(boolean readOnly) {
+        this.readOnly = readOnly;
+        this.stockMap = readOnly ? Collections.emptyMap() : new LinkedHashMap<>();
+    }
+
+    /**
+     * Returns the live stock-key to requested-percent map. Callers may mutate it directly (except for
+     * {@link #NO_RESTOCK}, whose map is unmodifiable).
+     */
+    public Map<String, Double> getStockMap() {
+        return stockMap;
+    }
+
+    public boolean isEmpty() {
+        return stockMap.isEmpty();
+    }
+
+    public void clear() {
+        if (!readOnly) {
+            stockMap.clear();
+        }
+    }
+
+    /**
+     * Writes this place's stock levels as a {@code <partInUseMap>} element. Reused by both the campaign and each player
+     * base so the save format is identical everywhere.
+     */
+    public void writeToXML(final PrintWriter pw, int indent) {
+        MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "partInUseMap");
+        for (Map.Entry<String, Double> entry : stockMap.entrySet()) {
+            MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "partInUseMapEntry");
+            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "partInUseMapKey", entry.getKey());
+            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "partInUseMapVal", entry.getValue());
+            MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "partInUseMapEntry");
+        }
+        MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "partInUseMap");
+    }
+
+    /**
+     * Parses a {@code <partInUseMap>} element into a new {@code RequestedStockLevels}.
+     *
+     * @param wn the {@code <partInUseMap>} node
+     *
+     * @return a populated instance (never {@code null})
+     */
+    public static RequestedStockLevels generateInstanceFromXML(final Node wn) {
+        RequestedStockLevels result = new RequestedStockLevels();
+        NodeList entries = wn.getChildNodes();
+        for (int i = 0; i < entries.getLength(); i++) {
+            Node entry = entries.item(i);
+            if (entry.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+            if (!entry.getNodeName().equalsIgnoreCase("partInUseMapEntry")) {
+                LOGGER.error("Unknown node type not loaded in partInUseMap nodes: {}", entry.getNodeName());
+                continue;
+            }
+            readEntry(result.stockMap, entry);
+        }
+        return result;
+    }
+
+    private static void readEntry(final Map<String, Double> stockMap, final Node wn) {
+        NodeList fields = wn.getChildNodes();
+        String key = null;
+        double val = 0;
+        for (int i = 0; i < fields.getLength(); i++) {
+            Node field = fields.item(i);
+            if (field.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+            if (field.getNodeName().equalsIgnoreCase("partInUseMapKey")) {
+                key = field.getTextContent();
+            } else if (field.getNodeName().equalsIgnoreCase("partInUseMapVal")) {
+                val = Double.parseDouble(field.getTextContent());
+            }
+        }
+        if (key != null) {
+            stockMap.put(key, val);
+        }
+    }
+}

--- a/MekHQ/src/mekhq/campaign/market/RequestedStockLevels.java
+++ b/MekHQ/src/mekhq/campaign/market/RequestedStockLevels.java
@@ -142,7 +142,11 @@ public final class RequestedStockLevels {
             if (field.getNodeName().equalsIgnoreCase("partInUseMapKey")) {
                 key = field.getTextContent();
             } else if (field.getNodeName().equalsIgnoreCase("partInUseMapVal")) {
-                value = Double.parseDouble(field.getTextContent());
+                try {
+                    value = Double.parseDouble(field.getTextContent());
+                } catch (NumberFormatException e) {
+                    LOGGER.error("Invalid partInUseMapVal '{}', defaulting to 0", field.getTextContent());
+                }
             }
         }
         if (key != null) {

--- a/MekHQ/src/mekhq/campaign/market/RequestedStockLevels.java
+++ b/MekHQ/src/mekhq/campaign/market/RequestedStockLevels.java
@@ -109,13 +109,13 @@ public final class RequestedStockLevels {
     /**
      * Parses a {@code <partInUseMap>} element into a new {@code RequestedStockLevels}.
      *
-     * @param wn the {@code <partInUseMap>} node
+     * @param mapNode the {@code <partInUseMap>} node
      *
      * @return a populated instance (never {@code null})
      */
-    public static RequestedStockLevels generateInstanceFromXML(final Node wn) {
+    public static RequestedStockLevels generateInstanceFromXML(final Node mapNode) {
         RequestedStockLevels result = new RequestedStockLevels();
-        NodeList entries = wn.getChildNodes();
+        NodeList entries = mapNode.getChildNodes();
         for (int i = 0; i < entries.getLength(); i++) {
             Node entry = entries.item(i);
             if (entry.getNodeType() != Node.ELEMENT_NODE) {
@@ -130,10 +130,10 @@ public final class RequestedStockLevels {
         return result;
     }
 
-    private static void readEntry(final Map<String, Double> stockMap, final Node wn) {
-        NodeList fields = wn.getChildNodes();
+    private static void readEntry(final Map<String, Double> stockMap, final Node entryNode) {
+        NodeList fields = entryNode.getChildNodes();
         String key = null;
-        double val = 0;
+        double value = 0;
         for (int i = 0; i < fields.getLength(); i++) {
             Node field = fields.item(i);
             if (field.getNodeType() != Node.ELEMENT_NODE) {
@@ -142,11 +142,11 @@ public final class RequestedStockLevels {
             if (field.getNodeName().equalsIgnoreCase("partInUseMapKey")) {
                 key = field.getTextContent();
             } else if (field.getNodeName().equalsIgnoreCase("partInUseMapVal")) {
-                val = Double.parseDouble(field.getTextContent());
+                value = Double.parseDouble(field.getTextContent());
             }
         }
         if (key != null) {
-            stockMap.put(key, val);
+            stockMap.put(key, value);
         }
     }
 }

--- a/MekHQ/src/mekhq/campaign/market/RequestedStockLevels.java
+++ b/MekHQ/src/mekhq/campaign/market/RequestedStockLevels.java
@@ -56,8 +56,8 @@ public final class RequestedStockLevels {
 
     /**
      * A shared, empty, do-nothing instance returned by any {@link mekhq.campaign.location.IPlace} that does not own real
-     * stock levels, so callers never have to deal with {@code null}. Its map is empty and unmodifiable, and mutating
-     * operations are no-ops, so every part falls through to its default stock percentage.
+     * stock levels, so callers never have to deal with {@code null}. Its map is empty and unmodifiable; mutating
+     * methods are no-ops, so every part falls through to its default stock percentage.
      */
     public static final RequestedStockLevels NO_RESTOCK = new RequestedStockLevels(true);
 

--- a/MekHQ/src/mekhq/campaign/market/ShoppingList.java
+++ b/MekHQ/src/mekhq/campaign/market/ShoppingList.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2009 Jay Lawson (jaylawson39 at yahoo.com). All rights reserved.
- * Copyright (C) 2013-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2013-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/campaign/market/ShoppingList.java
+++ b/MekHQ/src/mekhq/campaign/market/ShoppingList.java
@@ -47,7 +47,6 @@ import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.events.ProcurementEvent;
 import mekhq.campaign.finances.Money;
-import mekhq.campaign.location.ILocation;
 import mekhq.campaign.location.IPlace;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.Refit;
@@ -184,8 +183,8 @@ public class ShoppingList {
         // The main force leaves orders unanchored (their part resolves to the campaign warehouse); a base anchors the
         // order at that base so it resolves to the base warehouse.
         IPlace destination = (place instanceof Campaign) ? null : place;
-        if (destination != null && newWork instanceof ILocation location) {
-            location.setParent(destination);
+        if (destination != null) {
+            newWork.setParent(destination);
         }
 
         // check to see if this is already on the shopping list for the same destination. If so, then add

--- a/MekHQ/src/mekhq/campaign/market/ShoppingList.java
+++ b/MekHQ/src/mekhq/campaign/market/ShoppingList.java
@@ -47,6 +47,8 @@ import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.events.ProcurementEvent;
 import mekhq.campaign.finances.Money;
+import mekhq.campaign.location.ILocation;
+import mekhq.campaign.location.IPlace;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.Refit;
 import mekhq.campaign.parts.equipment.MissingEquipmentPart;
@@ -161,11 +163,37 @@ public class ShoppingList {
     }
 
     public void addShoppingItem(IAcquisitionWork newWork, int quantity, Campaign campaign) {
-        // check to see if this is already on the shopping list. If so, then add
+        addShoppingItem(newWork, quantity, campaign, null);
+    }
+
+    /** The place an existing order resolves to (a base for a base order), or {@code null} for the main force. */
+    private static @Nullable IPlace orderPlace(IAcquisitionWork shoppingItem) {
+        return (shoppingItem instanceof Part part) ? part.getPlace() : null;
+    }
+
+    /**
+     * Adds an item to the shopping list, destined for a specific {@link IPlace}.
+     *
+     * <p>A non-main-force {@code place} anchors the order's location node to that place, so it (and the part
+     * eventually delivered from it) resolves to that base's warehouse. Orders bound for different places are kept as
+     * separate line items even when they are the same equipment.</p>
+     *
+     * @param place the destination; {@code null} or the campaign itself means the main force
+     */
+    public void addShoppingItem(IAcquisitionWork newWork, int quantity, Campaign campaign, @Nullable IPlace place) {
+        // The main force leaves orders unanchored (their part resolves to the campaign warehouse); a base anchors the
+        // order at that base so it resolves to the base warehouse.
+        IPlace destination = (place instanceof Campaign) ? null : place;
+        if (destination != null && newWork instanceof ILocation location) {
+            location.setParent(destination);
+        }
+
+        // check to see if this is already on the shopping list for the same destination. If so, then add
         // quantity to the list
         // and return
         for (IAcquisitionWork shoppingItem : getShoppingList()) {
-            if (isSameEquipment(shoppingItem.getNewEquipment(), newWork.getNewEquipment())) {
+            if (isSameEquipment(shoppingItem.getNewEquipment(), newWork.getNewEquipment())
+                      && orderPlace(shoppingItem) == destination) {
                 campaign.addReport(ACQUISITIONS, newWork.getShoppingListReport(quantity));
                 while (quantity > 0) {
                     shoppingItem.incrementQuantity();

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
@@ -59,6 +59,7 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.force.CombatTeam;
 import mekhq.campaign.force.Formation;
+import mekhq.campaign.location.IPlace;
 import mekhq.campaign.market.PartsInUseManager;
 import mekhq.campaign.market.procurement.Procurement;
 import mekhq.campaign.mission.AtBContract;
@@ -553,8 +554,7 @@ public class Resupply {
      */
 
     private Map<Part, PartDetails> collectParts() {
-        PartsInUseManager partsInUseManager = new PartsInUseManager(campaign);
-        Set<PartInUse> partsInUse = partsInUseManager.getPartsInUse(true, true, PartQuality.QUALITY_A);
+        Set<PartInUse> partsInUse = collectPartsInUseAcrossLocations();
 
         Faction campaignFaction = campaign.getFaction();
         LocalDate today = campaign.getLocalDate();
@@ -576,6 +576,41 @@ public class Resupply {
         partsInUse.removeAll(partsToRemove);
 
         return applyWarehouseWeightModifiers(partsInUse);
+    }
+
+    /**
+     * Gathers the parts in use from the main force and every base into a single set, accumulating the per-location
+     * counts for parts that appear in more than one location.
+     */
+    private Set<PartInUse> collectPartsInUseAcrossLocations() {
+        List<IPlace> places = new ArrayList<>();
+        places.add(campaign);
+        places.addAll(campaign.getCampaignLocationManager().getPlayerBases());
+
+        Map<PartInUse, PartInUse> merged = new HashMap<>();
+        for (IPlace place : places) {
+            PartsInUseManager partsInUseManager = new PartsInUseManager(campaign, place);
+            for (PartInUse partInUse : partsInUseManager.getPartsInUse(true, true, PartQuality.QUALITY_A)) {
+                mergePartInUse(merged, partInUse);
+            }
+        }
+        return new HashSet<>(merged.values());
+    }
+
+    /**
+     * Adds {@code incoming} to {@code merged}, or accumulates its per-location counts onto the existing entry for the
+     * same part. Planned count comes from the campaign-wide shopping list and is identical for every location, so it is
+     * not summed.
+     */
+    private static void mergePartInUse(Map<PartInUse, PartInUse> merged, PartInUse incoming) {
+        PartInUse existing = merged.get(incoming);
+        if (existing == null) {
+            merged.put(incoming, incoming);
+            return;
+        }
+        existing.setUseCount(existing.getUseCount() + incoming.getUseCount());
+        existing.setStoreCount(existing.getStoreCount() + incoming.getStoreCount());
+        existing.setTransferCount(existing.getTransferCount() + incoming.getTransferCount());
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -294,7 +294,8 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
     public String find(int transitDays, double valueMultiplier) {
         AmmoStorage newPart = getNewPart();
         newPart.setBrandNew(true);
-        if (campaign.getQuartermaster().buyPart(newPart, valueMultiplier, transitDays)) {
+        // Deliver to this order's own warehouse (a base warehouse for a base order, else the campaign warehouse).
+        if (campaign.getQuartermaster().buyPart(newPart, valueMultiplier, transitDays, getWarehouse())) {
             return "<font color='" + ReportingUtilities.getPositiveColor()
                          + "'><b> part found</b>.</font> It will be delivered in " + transitDays + " days.";
         } else {

--- a/MekHQ/src/mekhq/campaign/parts/Armor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Armor.java
@@ -376,7 +376,9 @@ public class Armor extends Part implements IAcquisitionWork {
         Part newPart = getNewPart();
         newPart.setBrandNew(true);
         newPart.setDaysToArrival(transitDays);
-        if (campaign.getQuartermaster().buyPart(newPart, valueMultiplier, transitDays)) {
+        // Deliver to this order's own warehouse — a base warehouse for a base order, or the campaign warehouse for the
+        // main force.
+        if (campaign.getQuartermaster().buyPart(newPart, valueMultiplier, transitDays, getWarehouse())) {
             return "<font color='" +
                          ReportingUtilities.getPositiveColor() +
                          "'><b> part found</b>.</font> It will be delivered in " +

--- a/MekHQ/src/mekhq/campaign/parts/missing/MissingPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/missing/MissingPart.java
@@ -393,8 +393,9 @@ public abstract class MissingPart extends Part implements IAcquisitionWork {
         Part newPart = getNewPart();
         newPart.setBrandNew(true);
         newPart.setDaysToArrival(transitDays);
+        // Deliver to this order's own warehouse (a base warehouse for a base order, else the campaign warehouse).
         StringBuilder toReturn = new StringBuilder();
-        if (campaign.getQuartermaster().buyPart(newPart, valueMultiplier, transitDays)) {
+        if (campaign.getQuartermaster().buyPart(newPart, valueMultiplier, transitDays, getWarehouse())) {
             toReturn.append(messageSurroundedBySpanWithColor(
                         ReportingUtilities.getPositiveColor(), "<b> part found</b>"))
                   .append(". It will be delivered in ")

--- a/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
@@ -42,7 +42,6 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -62,6 +61,8 @@ import megamek.common.ui.FastJScrollPane;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.Quartermaster;
+import mekhq.campaign.base.PlayerBase;
+import mekhq.campaign.location.IPlace;
 import mekhq.campaign.market.PartsInUseManager;
 import mekhq.campaign.parts.AmmoStorage;
 import mekhq.campaign.parts.Armor;
@@ -80,6 +81,7 @@ import mekhq.campaign.work.IAcquisitionWork;
 import mekhq.gui.CampaignGUI;
 import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
 import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
+import mekhq.gui.model.LocationFilterItem;
 import mekhq.gui.model.PartsInUseTableModel;
 import mekhq.gui.sorter.FormattedNumberSorter;
 import mekhq.gui.sorter.TwoNumbersSorter;
@@ -97,10 +99,13 @@ public class PartsReportDialog extends JDialog {
     private PartsInUseTableModel overviewPartsModel;
     private JTextField txtPartsSearch;
     private JComboBox<String> partsGroupFilterCB;
+    private JComboBox<LocationFilterItem> choiceLocation;
     private TableRowSorter<PartsInUseTableModel> partsInUseSorter;
 
     private final Campaign campaign;
-    private final PartsInUseManager partsInUseManager;
+    private PartsInUseManager partsInUseManager;
+    /** The location whose parts are currently shown in the table and whose stock edits are being saved. */
+    private IPlace activePlace;
     private final CampaignGUI gui;
 
     private static final int SG_ALL = 0;
@@ -125,8 +130,12 @@ public class PartsReportDialog extends JDialog {
         super(gui.getFrame(), modal);
         this.gui = gui;
         this.campaign = gui.getCampaign();
-        this.partsInUseManager = new PartsInUseManager(campaign);
+        this.activePlace = campaign;
+        this.partsInUseManager = new PartsInUseManager(campaign, campaign);
         initComponents();
+        // initComponents() selects the dropdown to match the main GUI's active location; sync the scoped manager to it.
+        activePlace = getSelectedPlace();
+        partsInUseManager = new PartsInUseManager(campaign, activePlace);
         updateOverviewPartsInUse();
         pack();
         setLocationRelativeTo(gui.getFrame());
@@ -195,7 +204,7 @@ public class PartsReportDialog extends JDialog {
                 int row = Integer.parseInt(e.getActionCommand());
                 PartInUse partInUse = overviewPartsModel.getPartInUse(row);
                 IAcquisitionWork partToBuy = partInUse.getPartToBuy();
-                campaign.getShoppingList().addShoppingItem(partToBuy, 1, campaign);
+                campaign.getShoppingList().addShoppingItem(partToBuy, 1, campaign, getSelectedPlace());
                 refreshOverviewSpecificPart(row, partInUse, partToBuy);
             }
         };
@@ -215,7 +224,7 @@ public class PartsReportDialog extends JDialog {
                     return;
                 }
                 IAcquisitionWork partToBuy = partInUse.getPartToBuy();
-                campaign.getShoppingList().addShoppingItem(partToBuy, quantity, campaign);
+                campaign.getShoppingList().addShoppingItem(partToBuy, quantity, campaign, getSelectedPlace());
                 refreshOverviewSpecificPart(row, partInUse, partToBuy);
             }
         };
@@ -281,7 +290,8 @@ public class PartsReportDialog extends JDialog {
                 int row = Integer.parseInt(e.getActionCommand());
                 PartInUse partInUse = overviewPartsModel.getPartInUse(row);
                 IAcquisitionWork partToBuy = partInUse.getPartToBuy();
-                campaign.getQuartermaster().addPart((Part) partToBuy.getNewEquipment(), 0, false);
+                campaign.getQuartermaster()
+                      .addPart((Part) partToBuy.getNewEquipment(), 0, false, getSelectedPlace().getWarehouse());
                 refreshOverviewSpecificPart(row, partInUse, partToBuy);
             }
         };
@@ -298,7 +308,8 @@ public class PartsReportDialog extends JDialog {
                 quantity = pcd.getValue();
                 IAcquisitionWork partToBuy = partInUse.getPartToBuy();
                 while (quantity > 0) {
-                    campaign.getQuartermaster().addPart((Part) partToBuy.getNewEquipment(), 0, false);
+                    campaign.getQuartermaster()
+                          .addPart((Part) partToBuy.getNewEquipment(), 0, false, getSelectedPlace().getWarehouse());
                     --quantity;
                 }
                 refreshOverviewSpecificPart(row, partInUse, partToBuy);
@@ -336,6 +347,14 @@ public class PartsReportDialog extends JDialog {
         partsGroupFilterCB = new JComboBox<>(groupNames);
         partsGroupFilterCB.setMaximumSize(partsGroupFilterCB.getPreferredSize());
         partsGroupFilterCB.addActionListener(evt -> applyFilter());
+
+        JLabel lblLocation = new JLabel(getTextAt(RESOURCE_BUNDLE, "lblLocation.text"));
+        choiceLocation = new JComboBox<>(buildLocationModel());
+        // Open at the same location as the main GUI's active-location filter (ALL collapses to Main Force here). Select
+        // before attaching the listener so this doesn't fire onLocationChanged() before the rest of the UI is built.
+        choiceLocation.setSelectedItem(initialLocationItem());
+        choiceLocation.setMaximumSize(choiceLocation.getPreferredSize());
+        choiceLocation.addActionListener(evt -> onLocationChanged());
 
         JLabel lblSearch = new JLabel(getTextAt(RESOURCE_BUNDLE, "lblPartsSearch.text"));
 
@@ -414,6 +433,9 @@ public class PartsReportDialog extends JDialog {
         layout.setHorizontalGroup(
               layout.createParallelGroup()
                     .addGroup(layout.createSequentialGroup()
+                                    .addComponent(lblLocation)
+                                    .addComponent(choiceLocation)
+                                    .addGap(20)
                                     .addComponent(lblGroup)
                                     .addComponent(partsGroupFilterCB)
                                     .addGap(20)
@@ -455,6 +477,8 @@ public class PartsReportDialog extends JDialog {
         layout.setVerticalGroup(
               layout.createSequentialGroup()
                     .addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                    .addComponent(lblLocation)
+                                    .addComponent(choiceLocation)
                                     .addComponent(lblGroup)
                                     .addComponent(partsGroupFilterCB)
                                     .addComponent(lblSearch)
@@ -599,6 +623,51 @@ public class PartsReportDialog extends JDialog {
         updateOverviewPartsInUse();
     }
 
+    private DefaultComboBoxModel<LocationFilterItem> buildLocationModel() {
+        DefaultComboBoxModel<LocationFilterItem> model = new DefaultComboBoxModel<>();
+        model.addElement(LocationFilterItem.MAIN_FORCE);
+        for (PlayerBase base : campaign.getCampaignLocationManager().getPlayerBases()) {
+            model.addElement(LocationFilterItem.forBase(base));
+        }
+        return model;
+    }
+
+    /**
+     * The dropdown item to open on, matching the main GUI's active-location filter. "All" has no equivalent here, so it
+     * (and Main Force) map to Main Force; a base maps to this dialog's own item wrapping that same base.
+     */
+    private LocationFilterItem initialLocationItem() {
+        LocationFilterItem active = gui.getActiveLocation();
+        if (active == null || active.isAll() || active.isMainForce()) {
+            return LocationFilterItem.MAIN_FORCE;
+        }
+        ComboBoxModel<LocationFilterItem> model = choiceLocation.getModel();
+        for (int i = 0; i < model.getSize(); i++) {
+            LocationFilterItem item = model.getElementAt(i);
+            if (!item.isMainForce() && item.getBase() == active.getBase()) {
+                return item;
+            }
+        }
+        return LocationFilterItem.MAIN_FORCE;
+    }
+
+    /** The place currently selected in the location dropdown; the campaign (main force) or a specific base. */
+    private IPlace getSelectedPlace() {
+        LocationFilterItem item = (LocationFilterItem) choiceLocation.getSelectedItem();
+        if (item == null || item.isMainForce()) {
+            return campaign;
+        }
+        return item.getBase();
+    }
+
+    private void onLocationChanged() {
+        // Persist edits made while the previous location was active before switching the table over.
+        storePartInUseRequestedStockMap();
+        activePlace = getSelectedPlace();
+        partsInUseManager = new PartsInUseManager(campaign, activePlace);
+        updateOverviewPartsInUse();
+    }
+
     public void storePartInUseRequestedStockMap() {
         if (overviewPartsInUseTable.isEditing()) {
             overviewPartsInUseTable.getCellEditor().stopCellEditing();
@@ -615,13 +684,8 @@ public class PartsReportDialog extends JDialog {
             }
         }
 
-        Map<String, Double> stockMap = campaign.getPartsInUseRequestedStockMap();
-        if (stockMap == null) {
-            stockMap = new LinkedHashMap<>();
-            campaign.setPartsInUseRequestedStockMap(stockMap);
-        } else {
-            stockMap.clear();
-        }
+        Map<String, Double> stockMap = activePlace.getRequestedStockLevels().getStockMap();
+        stockMap.clear();
 
         for (int row = 0; row < overviewPartsModel.getRowCount(); row++) {
             PartInUse partInUse = overviewPartsModel.getPartInUse(row);
@@ -630,7 +694,7 @@ public class PartsReportDialog extends JDialog {
     }
 
     private void storePartInUseRequestedStock(PartInUse partInUse) {
-        Map<String, Double> stockMap = campaign.getPartsInUseRequestedStockMap();
+        Map<String, Double> stockMap = activePlace.getRequestedStockLevels().getStockMap();
         stockMap.put(PartsInUseManager.getStockKey(partInUse), partInUse.getRequestedStock());
     }
 
@@ -638,7 +702,7 @@ public class PartsReportDialog extends JDialog {
      * Wipes the requested stock numbers back to their defaults
      */
     private void resetRequestedStock() {
-        campaign.wipePartsInUseMap();
+        activePlace.getRequestedStockLevels().clear();
         updateOverviewPartsInUse();
     }
 

--- a/MekHQ/unittests/mekhq/campaign/market/RequestedStockLevelsTest.java
+++ b/MekHQ/unittests/mekhq/campaign/market/RequestedStockLevelsTest.java
@@ -39,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.ByteArrayInputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Map;
 
@@ -57,7 +58,7 @@ class RequestedStockLevelsTest {
         String xml = sw.toString();
 
         Document document = MHQXMLUtility.newSafeDocumentBuilder()
-                                  .parse(new ByteArrayInputStream(xml.getBytes()));
+                                  .parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
         Element root = document.getDocumentElement();
         assertEquals("partInUseMap", root.getNodeName());
         return RequestedStockLevels.generateInstanceFromXML(root);

--- a/MekHQ/unittests/mekhq/campaign/market/RequestedStockLevelsTest.java
+++ b/MekHQ/unittests/mekhq/campaign/market/RequestedStockLevelsTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.market;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Map;
+
+import mekhq.utilities.MHQXMLUtility;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+class RequestedStockLevelsTest {
+
+    private static RequestedStockLevels roundTrip(RequestedStockLevels source) throws Exception {
+        StringWriter sw = new StringWriter();
+        try (PrintWriter pw = new PrintWriter(sw)) {
+            source.writeToXML(pw, 0);
+        }
+        String xml = sw.toString();
+
+        Document document = MHQXMLUtility.newSafeDocumentBuilder()
+                                  .parse(new ByteArrayInputStream(xml.getBytes()));
+        Element root = document.getDocumentElement();
+        assertEquals("partInUseMap", root.getNodeName());
+        return RequestedStockLevels.generateInstanceFromXML(root);
+    }
+
+    @Test
+    void xmlRoundTripPreservesEntriesAndOrder() throws Exception {
+        RequestedStockLevels original = new RequestedStockLevels();
+        original.getStockMap().put("Large LaserIS", 50.0);
+        original.getStockMap().put("Medium LaserClan", 125.0);
+        original.getStockMap().put("SRM 6IS", 0.0);
+
+        RequestedStockLevels restored = roundTrip(original);
+
+        assertEquals(original.getStockMap(), restored.getStockMap());
+        // LinkedHashMap ordering must survive the round trip.
+        assertEquals(new ArrayList<>(original.getStockMap().keySet()),
+              new ArrayList<>(restored.getStockMap().keySet()));
+    }
+
+    @Test
+    void emptyLevelsRoundTripToEmpty() throws Exception {
+        RequestedStockLevels restored = roundTrip(new RequestedStockLevels());
+        assertTrue(restored.isEmpty());
+    }
+
+    @Test
+    void noRestockMapIsUnmodifiable() {
+        Map<String, Double> map = RequestedStockLevels.NO_RESTOCK.getStockMap();
+        assertThrows(UnsupportedOperationException.class, () -> map.put("Anything", 100.0));
+        assertTrue(RequestedStockLevels.NO_RESTOCK.isEmpty());
+    }
+}


### PR DESCRIPTION
Adds a location dropdown to the parts in use. Defaults to the Active Location set in the main gui. Only shows parts for that location (because it gets real weird showing everything on this report, especially in regards to auto-restock). Auto restock is now per-location.