### PR TITLE
Fix #9380: Show linked person/unit even if not at active location

### DIFF
--- a/MekHQ/src/mekhq/gui/HangarTab.java
+++ b/MekHQ/src/mekhq/gui/HangarTab.java
@@ -125,6 +125,12 @@ public final class HangarTab extends CampaignGuiTab {
     private JButton btnAssignTechs;
     private JScrollPane scrollUnitView;
 
+    /**
+     * A unit shown in the detail panel while not present in the grid, e.g. when a link targets a unit outside the
+     * active location scope. Kept so table refreshes that clear the grid selection do not blank the detail panel.
+     */
+    private Unit pinnedUnit;
+
     private UnitTableModel unitModel;
     private TableRowSorter<UnitTableModel> unitSorter;
 
@@ -715,15 +721,30 @@ public final class HangarTab extends CampaignGuiTab {
         if (row != -1) {
             unitTable.setRowSelectionInterval(row, row);
             unitTable.scrollRectToVisible(unitTable.getCellRect(row, 0, true));
+            return;
+        }
+        // The unit is outside the active location scope, so the grid does not contain it. Pin it to the detail panel
+        // so it shows without forcing it onto the grid, surviving later table refreshes.
+        Unit unit = getCampaign().getUnit(id);
+        if (unit != null) {
+            pinnedUnit = unit;
+            unitTable.clearSelection();
+            refreshUnitView();
         }
     }
 
     public void refreshUnitView() {
         int row = unitTable.getSelectedRow();
         if (row < 0) {
-            scrollUnitView.setViewportView(null);
+            if (pinnedUnit != null) {
+                scrollUnitView.setViewportView(new UnitViewPanel(pinnedUnit, getCampaign()));
+                SwingUtilities.invokeLater(() -> scrollUnitView.getVerticalScrollBar().setValue(0));
+            } else {
+                scrollUnitView.setViewportView(null);
+            }
             return;
         }
+        pinnedUnit = null;
         Unit selectedUnit = unitModel.getUnit(unitTable.convertRowIndexToModel(row));
         scrollUnitView.setViewportView(new UnitViewPanel(selectedUnit, getCampaign()));
         // This odd code is to make sure that the scrollbar stays at the top

--- a/MekHQ/src/mekhq/gui/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/PersonnelTab.java
@@ -113,6 +113,12 @@ public final class PersonnelTab extends CampaignGuiTab {
     private JScrollPane scrollPersonnelView;
     private JCheckBox chkGroupByUnit;
 
+    /**
+     * A person shown in the detail panel while not present in the grid, e.g. when a link targets someone outside the
+     * active location scope. Kept so table refreshes that clear the grid selection do not blank the detail panel.
+     */
+    private Person pinnedPerson;
+
     private final IPreferenceChangeListener scalingChangeListener = e -> changePersonnelView();
 
     // region Constructors
@@ -502,6 +508,15 @@ public final class PersonnelTab extends CampaignGuiTab {
         if (row != -1) {
             personnelTable.setRowSelectionInterval(row, row);
             personnelTable.scrollRectToVisible(personnelTable.getCellRect(row, 0, true));
+            return;
+        }
+        // The person is outside the active location scope, so the grid does not contain them. Pin them to the detail
+        // panel so it shows them without forcing them onto the grid, surviving later table refreshes.
+        Person person = getCampaign().getPerson(id);
+        if (person != null) {
+            pinnedPerson = person;
+            personnelTable.clearSelection();
+            refreshPersonnelView();
         }
     }
 
@@ -542,9 +557,15 @@ public final class PersonnelTab extends CampaignGuiTab {
     public void refreshPersonnelView() {
         int row = personnelTable.getSelectedRow();
         if (row < 0) {
-            scrollPersonnelView.setViewportView(null);
+            if (pinnedPerson != null) {
+                scrollPersonnelView.setViewportView(new PersonViewPanel(pinnedPerson, getCampaign(), getCampaignGui()));
+                SwingUtilities.invokeLater(() -> scrollPersonnelView.getVerticalScrollBar().setValue(0));
+            } else {
+                scrollPersonnelView.setViewportView(null);
+            }
             return;
         }
+        pinnedPerson = null;
         Person selectedPerson = getPersonnelTableModel().getRow(personnelTable.convertRowIndexToModel(row));
         scrollPersonnelView.setViewportView(new PersonViewPanel(selectedPerson, getCampaign(), getCampaignGui()));
         // This odd code is to make sure that the scrollbar stays at the top


### PR DESCRIPTION
Fixes #9380

<img width="1676" height="304" alt="image" src="https://github.com/user-attachments/assets/f04fdb50-e052-41aa-8a86-bed82136a732" />
(Screenshot of a person gotten to via clicking their name in a report. I have the active location set as a base with no people present.)