### PR TITLE
PR: Disable "Send To..." under certain circumstances

### DIFF
--- a/MekHQ/src/mekhq/campaign/location/ILocatable.java
+++ b/MekHQ/src/mekhq/campaign/location/ILocatable.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.location;
+
+import mekhq.campaign.parts.Part;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.unit.Unit;
+
+/**
+ * An {@link ILocation} that the player can pick up and move around the location tree — a concrete thing that lives
+ * somewhere, as opposed to a place that hosts other locations. Implemented by {@link Unit}, {@link Person}, and
+ * {@link Part}.
+ */
+public interface ILocatable extends ILocation {
+
+    /**
+     * Whether the player may manually dispatch this item to a new location (via the "Send To..." context menu).
+     *
+     * <p>Each implementation forbids dispatch while the item is committed elsewhere — e.g. deployed to a scenario,
+     * enrolled as a student, reserved for work, or still in transit from a purchase.</p>
+     *
+     * @return {@code true} if the item is free to be dispatched, otherwise {@code false}
+     */
+    boolean canBeManuallyDispatched();
+}

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -69,6 +69,7 @@ import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.Warehouse;
 import mekhq.campaign.finances.Money;
+import mekhq.campaign.location.ILocatable;
 import mekhq.campaign.location.ILocation;
 import mekhq.campaign.location.IPlace;
 import mekhq.campaign.location.LocationNode;
@@ -111,7 +112,7 @@ import org.w3c.dom.NodeList;
  *
  * @author Jay Lawson (jaylawson39 at yahoo.com)
  */
-public abstract class Part implements IPartWork, ITechnology, ILocation {
+public abstract class Part implements IPartWork, ITechnology, ILocatable {
     private static final MMLogger LOGGER = MMLogger.create(Part.class);
     private static final String RESOURCE_BUNDLE = "mekhq.resources.Parts";
 
@@ -1445,6 +1446,12 @@ public abstract class Part implements IPartWork, ITechnology, ILocation {
      */
     public boolean isPresent() {
         return daysToArrival == 0;
+    }
+
+    @Override
+    public boolean canBeManuallyDispatched() {
+        // A part still in transit from a purchase hasn't arrived yet, and a reserved part is committed to work.
+        return isPresent() && !isReservedForRefit() && !isReservedForReplacement();
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -116,6 +116,7 @@ import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.enums.TransactionType;
 import mekhq.campaign.force.Formation;
 import mekhq.campaign.location.AcademyCampusLocation;
+import mekhq.campaign.location.ILocatable;
 import mekhq.campaign.location.ILocation;
 import mekhq.campaign.location.LocationNode;
 import mekhq.campaign.log.LogEntry;
@@ -176,7 +177,7 @@ import org.w3c.dom.NodeList;
  * @author Jay Lawson (jaylawson39 at yahoo.com)
  * @author Justin "Windchild" Bowen
  */
-public class Person implements ILocation {
+public class Person implements ILocatable {
     // region Variable Declarations
     public static final Map<Integer, Money> MEKWARRIOR_AERO_RANSOM_VALUES;
     public static final Map<Integer, Money> OTHER_RANSOM_VALUES;
@@ -2716,6 +2717,12 @@ public class Person implements ILocation {
 
     public boolean isDeployed() {
         return (getUnit() != null) && (getUnit().getScenarioId() != -1);
+    }
+
+    @Override
+    public boolean canBeManuallyDispatched() {
+        // A deployed person is committed to a scenario, and a student is tied to their academy campus.
+        return !isDeployed() && !getStatus().isStudent();
     }
 
     public String getBiography() {
@@ -9457,7 +9464,7 @@ public class Person implements ILocation {
     @Override
     public boolean setParent(ILocation parent) {
         ILocation oldParent = getParentLocation();
-        if (ILocation.super.setParent(parent)) {
+        if (ILocatable.super.setParent(parent)) {
             if (oldParent instanceof Personnel personnel) {
                 personnel.remove(getId());
             }

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -116,7 +116,7 @@ import mekhq.campaign.events.units.UnitChangedEvent;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.force.Formation;
 import mekhq.campaign.force.FormationType;
-import mekhq.campaign.location.ILocation;
+import mekhq.campaign.location.ILocatable;
 import mekhq.campaign.location.LocationNode;
 import mekhq.campaign.location.LocationUtils;
 import mekhq.campaign.log.AssignmentLogger;
@@ -169,7 +169,7 @@ import org.w3c.dom.NodeList;
  *
  * @author Jay Lawson (jaylawson39 at yahoo.com)
  */
-public class Unit implements ITechnology, ILocation {
+public class Unit implements ITechnology, ILocatable {
     private static final String RESOURCE_BUNDLE = "mekhq.resources.Unit";
     private static final MMLogger LOGGER = MMLogger.create(Unit.class);
 
@@ -1203,6 +1203,12 @@ public class Unit implements ITechnology, ILocation {
 
     public boolean isDeployed() {
         return scenarioId != -1;
+    }
+
+    @Override
+    public boolean canBeManuallyDispatched() {
+        // A deployed unit is committed to a scenario, and a unit still in transit from a purchase hasn't arrived yet.
+        return isPresent() && !isDeployed();
     }
 
     public void undeploy() {

--- a/MekHQ/src/mekhq/gui/menus/LocationMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/LocationMenu.java
@@ -40,6 +40,7 @@ import javax.swing.JFrame;
 import javax.swing.JMenuItem;
 
 import mekhq.campaign.Campaign;
+import mekhq.campaign.location.ILocatable;
 import mekhq.campaign.location.ILocation;
 import mekhq.campaign.location.LocationUtils;
 import mekhq.gui.baseComponents.JScrollableMenu;
@@ -65,33 +66,49 @@ public class LocationMenu extends JScrollableMenu {
     /**
      * @param campaign the active campaign
      * @param frame    parent frame for any dialogs
-     * @param items    the {@link ILocation} objects to act on (persons, units, or parts)
+     * @param items    the {@link ILocatable} objects to act on (persons, units, or parts)
      */
-    public LocationMenu(Campaign campaign, JFrame frame, List<? extends ILocation> items) {
+    public LocationMenu(Campaign campaign, JFrame frame, List<? extends ILocatable> items) {
         super("LocationMenu");
         initialize(campaign, frame, items);
     }
 
-    private void initialize(Campaign campaign, JFrame frame, List<? extends ILocation> items) {
+    private void initialize(Campaign campaign, JFrame frame, List<? extends ILocatable> items) {
         if (items.isEmpty()) {
             return;
         }
 
         setText(getTextAt(RESOURCE_BUNDLE, "menu.location.text"));
 
-        add(new SendToLocationMenu(campaign, frame, items,
-              destination -> campaign.getCampaignLocationManager().queueTravel(items, destination)));
+        // Disable dispatch unless every selected item is free to move — a deployed unit/person, a student,
+        // a reserved part, or an item still in transit from a purchase cannot be manually dispatched.
+        boolean canDispatch = items.stream().allMatch(ILocatable::canBeManuallyDispatched);
+
+        SendToLocationMenu sendTo = new SendToLocationMenu(campaign, frame, items,
+              destination -> campaign.getCampaignLocationManager().queueTravel(items, destination));
+        sendTo.setEnabled(canDispatch);
+        add(sendTo);
+
+        // Track whether any child entry is actionable; if none are, the whole Location menu is disabled below.
+        boolean anyEnabled = canDispatch;
 
         if (campaign.isGM()) {
-            add(new SendToLocationMenu(campaign, frame, items,
+            SendToLocationMenu teleportTo = new SendToLocationMenu(campaign, frame, items,
                   destination -> campaign.getCampaignLocationManager().gmTeleport(campaign, items, destination),
-                  "menu.teleportTo.text"));
+                  "menu.teleportTo.text");
+            teleportTo.setEnabled(canDispatch);
+            add(teleportTo);
 
+            boolean canCompleteTravel = anyTravelingOrQueued(campaign, items);
             JMenuItem completeTravel = new JMenuItem(completeTravelLabel(campaign, items));
-            completeTravel.setEnabled(anyTravelingOrQueued(campaign, items));
+            completeTravel.setEnabled(canCompleteTravel);
             completeTravel.addActionListener(e -> campaign.getCampaignLocationManager().gmCompleteTravel(campaign, items));
             add(completeTravel);
+
+            anyEnabled |= canCompleteTravel;
         }
+
+        setEnabled(anyEnabled);
     }
 
     /**

--- a/MekHQ/unittests/mekhq/campaign/parts/PartTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/PartTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -313,6 +313,48 @@ public class PartTest {
 
         assertEquals(0, part.getDaysToArrival());
         assertTrue(part.isPresent());
+    }
+
+    @Test
+    public void canBeManuallyDispatchedWhenPresentAndUnreserved() {
+        Part part = new MekSensor();
+        part.setDaysToArrival(0);
+
+        assertTrue(part.canBeManuallyDispatched());
+    }
+
+    @Test
+    public void cannotBeManuallyDispatchedWhenNotPresent() {
+        Part part = new MekSensor();
+        part.setDaysToArrival(5);
+
+        assertFalse(part.canBeManuallyDispatched());
+    }
+
+    @Test
+    public void cannotBeManuallyDispatchedWhenReservedForRefit() {
+        Unit mockUnit = mock(Unit.class);
+        when(mockUnit.getId()).thenReturn(UUID.randomUUID());
+
+        Part part = new MekSensor();
+        part.setDaysToArrival(0);
+        part.setRefitUnit(mockUnit);
+
+        assertTrue(part.isReservedForRefit());
+        assertFalse(part.canBeManuallyDispatched());
+    }
+
+    @Test
+    public void cannotBeManuallyDispatchedWhenReservedForReplacement() {
+        Person mockTech = mock(Person.class);
+        when(mockTech.getId()).thenReturn(UUID.randomUUID());
+
+        Part part = new MekSensor();
+        part.setDaysToArrival(0);
+        part.setReservedBy(mockTech);
+
+        assertTrue(part.isReservedForReplacement());
+        assertFalse(part.canBeManuallyDispatched());
     }
 
     @Test

--- a/MekHQ/unittests/mekhq/campaign/personnel/PersonTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/PersonTest.java
@@ -312,6 +312,38 @@ public class PersonTest {
     }
 
     @Test
+    public void canBeManuallyDispatchedWhenNotDeployedAndNotStudent() {
+        initPerson();
+
+        assertFalse(mockPerson.isDeployed());
+        assertFalse(mockPerson.getStatus().isStudent());
+        assertTrue(mockPerson.canBeManuallyDispatched());
+    }
+
+    @Test
+    public void cannotBeManuallyDispatchedWhenDeployed() {
+        initPerson();
+
+        Unit unit0 = mock(Unit.class);
+        when(unit0.getId()).thenReturn(UUID.randomUUID());
+        when(unit0.getScenarioId()).thenReturn(1);
+        mockPerson.setUnit(unit0);
+
+        assertTrue(mockPerson.isDeployed());
+        assertFalse(mockPerson.canBeManuallyDispatched());
+    }
+
+    @Test
+    public void cannotBeManuallyDispatchedWhenStudent() {
+        initPerson();
+        mockPerson.setStatus(PersonnelStatus.STUDENT);
+
+        assertFalse(mockPerson.isDeployed());
+        assertTrue(mockPerson.getStatus().isStudent());
+        assertFalse(mockPerson.canBeManuallyDispatched());
+    }
+
+    @Test
     public void testAddInjuriesResetsUnitStatus() {
         initPerson();
 

--- a/MekHQ/unittests/mekhq/campaign/unit/UnitLocationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/UnitLocationTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.unit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class UnitLocationTest {
+    @Test
+    public void canBeManuallyDispatchedWhenPresentAndNotDeployed() {
+        Unit unit = new Unit();
+        unit.setDaysToArrival(0);
+        unit.undeploy();
+
+        assertTrue(unit.isPresent());
+        assertFalse(unit.isDeployed());
+        assertTrue(unit.canBeManuallyDispatched());
+    }
+
+    @Test
+    public void cannotBeManuallyDispatchedWhenNotPresent() {
+        Unit unit = new Unit();
+        unit.setDaysToArrival(5);
+        unit.undeploy();
+
+        assertFalse(unit.isPresent());
+        assertFalse(unit.canBeManuallyDispatched());
+    }
+
+    @Test
+    public void cannotBeManuallyDispatchedWhenDeployed() {
+        Unit unit = new Unit();
+        unit.setDaysToArrival(0);
+        unit.setScenarioId(1);
+
+        assertTrue(unit.isDeployed());
+        assertFalse(unit.canBeManuallyDispatched());
+    }
+}


### PR DESCRIPTION
Disables send to / teleport to under certain circumstances:
1. Person cannot manually  be dispatched if they're currently in education or deployed.
2. Unit cannot be manually  dispatched if they're currently deployed or still in transit after purchase.
3. Parts cannot be manually dispatched if they're still in transit after purchase or reserved for a refit/repair.