### PR TITLE
Fix #8739: Markdown AARs, editable resolved scenarios, and pre-date deployment prep

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/Scenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/Scenario.java
@@ -968,6 +968,23 @@ public class Scenario implements IPlayerSettings {
     }
 
     public boolean canStartScenario(Campaign c) {
+        return canPrepareScenario(c);
+    }
+
+    /**
+     * Determines whether this scenario is ready for deployment preparation: it is current, has a deployed force, and
+     * meets its required personnel and unit constraints.
+     *
+     * <p>Unlike {@link #canStartScenario(Campaign)}, this check does not consider whether the scenario may be launched
+     * on the current date. It is therefore suitable for gating preparation actions (adjusting the deployment,
+     * exporting or printing the assigned force) that players should be able to perform ahead of the scenario's
+     * date.</p>
+     *
+     * @param c the campaign this scenario belongs to
+     *
+     * @return {@code true} if the scenario is current and its deployment requirements are met
+     */
+    public boolean canPrepareScenario(Campaign c) {
 
         if (!getStatus().isCurrent()) {
             return false;

--- a/MekHQ/src/mekhq/campaign/mission/Scenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/Scenario.java
@@ -967,6 +967,15 @@ public class Scenario implements IPlayerSettings {
 
     }
 
+    /**
+     * Determines whether this scenario can be started now. The base implementation applies only the readiness checks in
+     * {@link #canPrepareScenario(Campaign)}; subclasses may override it to impose additional restrictions, such as
+     * requiring the current date to match the scenario's scheduled date (see {@link AtBScenario}).
+     *
+     * @param c the campaign this scenario belongs to
+     *
+     * @return {@code true} if the scenario can be started
+     */
     public boolean canStartScenario(Campaign c) {
         return canPrepareScenario(c);
     }
@@ -975,10 +984,12 @@ public class Scenario implements IPlayerSettings {
      * Determines whether this scenario is ready for deployment preparation: it is current, has a deployed force, and
      * meets its required personnel and unit constraints.
      *
-     * <p>Unlike {@link #canStartScenario(Campaign)}, this check does not consider whether the scenario may be launched
-     * on the current date. It is therefore suitable for gating preparation actions (adjusting the deployment,
-     * exporting or printing the assigned force) that players should be able to perform ahead of the scenario's
-     * date.</p>
+     * <p>This readiness check intentionally excludes any date-based restriction. In the base {@link Scenario}
+     * implementation {@link #canStartScenario(Campaign)} simply delegates to this method, but subclasses such as
+     * {@link AtBScenario} may override {@code canStartScenario} to additionally require that the scenario be launched on
+     * its scheduled date. Because {@code canPrepareScenario} never applies such a restriction, it is suitable for gating
+     * preparation actions (adjusting the deployment, exporting or printing the assigned force) that players should be
+     * able to perform ahead of the scenario's date.</p>
      *
      * @param c the campaign this scenario belongs to
      *

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -507,9 +507,6 @@ public final class BriefingTab extends CampaignGuiTab {
 
     private void styleSecondaryButton(AbstractButton button) {
         styleBriefingButton(button);
-        // Reset to the default button background (rather than null, which renders flat) so these buttons match the
-        // standard look of every other button - including the danger buttons - and so a button that was previously
-        // emphasized as primary reverts correctly.
         button.setBackground(UIManager.getColor("Button.background"));
         button.setForeground(null);
         button.setFont(button.getFont().deriveFont(Font.PLAIN));

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -2495,24 +2495,28 @@ public final class BriefingTab extends CampaignGuiTab {
             return;
         }
 
-        final boolean canStartGame = ((!getCampaign().checkLinkedScenario(scenario.getId())) &&
-                                            (scenario.canStartScenario(getCampaign())));
+        final boolean linkedScenario = getCampaign().checkLinkedScenario(scenario.getId());
+        final boolean canStartGame = !linkedScenario && scenario.canStartScenario(getCampaign());
+        // Preparation actions (adjusting the deployment, exporting or printing the assigned force) do not require the
+        // scenario's date to have arrived - they only need the scenario to be current with a valid deployed force - so
+        // they are gated on the date-free readiness check instead.
+        final boolean canPrepare = !linkedScenario && scenario.canPrepareScenario(getCampaign());
 
         btnStartGame.setEnabled(canStartGame);
         btnJoinGame.setEnabled(canStartGame);
         btnLoadGame.setEnabled(canStartGame);
-        btnGetMul.setEnabled(canStartGame);
+        btnGetMul.setEnabled(canPrepare);
 
         final boolean hasTrack = scenario.getHasTrack();
         if (hasTrack) {
-            btnClearAssignedUnits.setEnabled(canStartGame && getCampaign().isGM());
+            btnClearAssignedUnits.setEnabled(canPrepare && getCampaign().isGM());
         } else {
-            btnClearAssignedUnits.setEnabled(canStartGame);
+            btnClearAssignedUnits.setEnabled(canPrepare);
         }
 
         btnResolveScenario.setEnabled(canStartGame);
         btnAutoResolveScenario.setEnabled(canStartGame);
-        btnPrintRS.setEnabled(canStartGame);
+        btnPrintRS.setEnabled(canPrepare);
         refreshScenarioActionButtonEmphasis();
     }
 

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -507,29 +507,38 @@ public final class BriefingTab extends CampaignGuiTab {
 
     private void styleSecondaryButton(AbstractButton button) {
         styleBriefingButton(button);
-        button.setBackground(null);
+        // Reset to the default button background (rather than null, which renders flat) so these buttons match the
+        // standard look of every other button - including the danger buttons - and so a button that was previously
+        // emphasized as primary reverts correctly.
+        button.setBackground(UIManager.getColor("Button.background"));
         button.setForeground(null);
         button.setFont(button.getFont().deriveFont(Font.PLAIN));
     }
 
     private void stylePrimaryButton(AbstractButton button) {
-        styleBriefingButton(button);
-        button.setFont(button.getFont().deriveFont(Font.BOLD));
-
-        Color background = getUIColor("Button.default.background", "Actions.Blue");
-        if (background != null) {
-            button.setBackground(background);
-        }
-
-        Color foreground = getUIColor("Button.default.foreground", "Button.foreground");
-        if (foreground != null) {
-            button.setForeground(foreground);
-        }
+        styleFilledButton(button,
+              getUIColor("Button.default.background", "Actions.Blue"),
+              getUIColor("Button.default.foreground", "Button.foreground"));
     }
 
     private void styleDangerButton(AbstractButton button) {
+        // Actions.Red is the muted sibling of the Actions.Blue used for primary buttons; a filled red communicates a
+        // destructive action more strongly than red text alone.
+        styleFilledButton(button,
+              getUIColor("Actions.Red"),
+              getUIColor("Button.default.foreground", "Button.foreground"));
+    }
+
+    // Shared emphasized (filled) treatment for primary and danger buttons; they differ only in the colors supplied.
+    private void styleFilledButton(AbstractButton button, Color background, Color foreground) {
         styleBriefingButton(button);
-        button.setForeground(MekHQ.getMHQOptions().getBelowContractMinimumForeground());
+        button.setFont(button.getFont().deriveFont(Font.BOLD));
+        if (background != null) {
+            button.setBackground(background);
+        }
+        if (foreground != null) {
+            button.setForeground(foreground);
+        }
     }
 
     private void styleBriefingButton(AbstractButton button) {

--- a/MekHQ/src/mekhq/gui/adapter/ScenarioTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/ScenarioTableMouseAdapter.java
@@ -77,16 +77,20 @@ public class ScenarioTableMouseAdapter extends JPopupMenuAdapter {
         }
 
         Scenario scenario = scenarioModel.getScenario(scenarioTable.convertRowIndexToModel(row));
-        if ((scenario == null) || !scenario.getStatus().isCurrent()) {
+        if (scenario == null) {
             return Optional.empty();
         }
+
+        // Resolved scenarios can still be edited (e.g. to add an After-Action Report), but actions that only make
+        // sense for an active scenario, such as deploying to it, are only offered while the scenario is current.
+        final boolean isCurrent = scenario.getStatus().isCurrent();
 
         JPopupMenu popup = new JPopupMenu();
         JMenuItem menuItem;
         JMenu menu;
 
         // let's fill the pop-up menu
-        if (gui.getStratConTab().isPresent() && scenario instanceof AtBDynamicScenario) {
+        if (isCurrent && gui.getStratConTab().isPresent() && scenario instanceof AtBDynamicScenario) {
             menuItem = new JMenuItem("Deploy...");
             menuItem.addActionListener(
                   event -> gui.getStratConTab().ifPresent(

--- a/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
@@ -85,6 +85,7 @@ import mekhq.campaign.mission.ScenarioForceTemplate;
 import mekhq.campaign.mission.ScenarioObjective;
 import mekhq.gui.baseComponents.JScrollablePanel;
 import mekhq.gui.utilities.BriefingStyle;
+import mekhq.gui.utilities.MarkdownRenderer;
 
 /**
  * @author Neoancient
@@ -145,7 +146,7 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
 
     private JTree playerForceTree;
 
-    private JTextArea txtDesc;
+    private JTextPane txtDesc;
 
     private final StubTreeModel playerForceModel;
 
@@ -180,7 +181,7 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
 
         JPanel statsSection = BriefingStyle.createSectionPanel(scenario.getName());
         panStats = new JPanel();
-        txtDesc = new JTextArea();
+        txtDesc = new JTextPane();
         playerForceTree = new JTree() {
             @Override
             public Dimension getMinimumSize() {
@@ -210,12 +211,11 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
 
         if ((scenario.getReport() != null) && !scenario.getReport().isBlank()) {
             JPanel reportSection = BriefingStyle.createSectionPanel("After-Action Report");
-            JTextArea txtReport = new JTextArea();
+            JTextPane txtReport = new JTextPane();
             txtReport.setName("txtReport");
-            txtReport.setText(scenario.getReport());
             txtReport.setEditable(false);
-            txtReport.setLineWrap(true);
-            txtReport.setWrapStyleWord(true);
+            txtReport.setContentType("text/html");
+            txtReport.setText(MarkdownRenderer.getRenderedHtml(scenario.getReport()));
             txtReport.setBorder(BorderFactory.createEmptyBorder());
             reportSection.add(txtReport, BorderLayout.CENTER);
             gridBagConstraints = new GridBagConstraints();
@@ -350,10 +350,9 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
         }
 
         txtDesc.setName("txtDesc");
-        txtDesc.setText(scenario.getDescription());
         txtDesc.setEditable(false);
-        txtDesc.setLineWrap(true);
-        txtDesc.setWrapStyleWord(true);
+        txtDesc.setContentType("text/html");
+        txtDesc.setText(MarkdownRenderer.getRenderedHtml(scenario.getDescription()));
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = y++;
         gridBagConstraints.gridwidth = 3;


### PR DESCRIPTION
## Summary

Fixes the regressions reported in #8739 for the reworked briefing window, all specific to AtB/StratCon scenarios (which render through `AtBScenarioViewPanel`). Also includes some briefing-button styling cleanup that came up while working in the area.

## Fixes (#8739)

1. **Markdown now renders in the After-Action Report and description.**
   `AtBScenarioViewPanel` was showing the raw markdown because the AAR and description used a plain `JTextArea`. They now use a `JTextPane` with `text/html` + `MarkdownRenderer`, matching the non-AtB `ScenarioViewPanel`.

2. **Resolved scenarios can be edited again.**
   The scenario right-click menu returned an empty popup for non-current scenarios, so "Edit…" was unreachable — which is the intended path for adding an AAR (the `CustomizeScenarioDialog` only exposes the AAR editor for resolved scenarios). The menu is now available for resolved scenarios; "Deploy…" remains limited to current ones.

3. **Deployment prep no longer requires the scenario's exact date.**
   All scenario action buttons were gated on `canStartScenario`, which for AtB scenarios requires the campaign date to equal the scenario date. Readiness is now split from timing via a new date-free `Scenario.canPrepareScenario(...)`, so **Reset Deployment**, **Export MUL File**, and **Print Sheets** are usable ahead of the scenario date, while **Start/Join/Load/Resolve/Auto-Resolve** stay date-gated.

## Additional polish (briefing buttons)

- Secondary buttons now use the standard button background instead of `null` (which rendered flat), so every briefing button looks consistent — including the top mission strip and the scenario-action strip.
- Danger buttons (Delete Mission, Reset Deployment) use a filled, muted red (`Actions.Red`) with light text, mirroring the filled primary buttons, to signal destructive actions more clearly.
- `stylePrimaryButton` and `styleDangerButton` now share a small `styleFilledButton` helper and differ only by their color keys.

## Testing

- `./gradlew :MekHQ:compileJava :MekHQ:checkstyleMain` — clean.
- Manual, StratCon campaign:
  - Added a `##`/`**bold**` AAR to a resolved scenario → renders formatted.
  - Right-click a resolved scenario → **Edit…** available; AAR editor present.
  - Future-dated scenario with forces assigned → Reset Deployment / Export MUL File / Print Sheets enabled; Start/Resolve disabled until the scenario date.
  - Verified button styling in the mission and scenario-action strips.

Closes #8739