### PR TITLE
Updated StratCon Ocean Hexes to Actually Generate Ocean Scenarios; Updated StratCon to Bar Scenarios and Facilities from Spawning in Ocean Hexes; Disallowed Players From Deploying to Ocean Hexes; Added Limiter on How Much of the AO Can be Ocean Hexes

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratCon/StratConBiomeManifest.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConBiomeManifest.java
@@ -76,7 +76,7 @@ public class StratConBiomeManifest {
      * @return {@code true} if the given terrain type is open water (ocean)
      */
     public static boolean isOceanTerrain(String terrainType) {
-        return OCEAN_TERRAIN_TYPES.contains(terrainType);
+        return terrainType != null && OCEAN_TERRAIN_TYPES.contains(terrainType);
     }
 
     // these constants will eventually be driven by planetary or track data

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConBiomeManifest.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConBiomeManifest.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import javax.xml.transform.Source;
 
@@ -62,6 +63,21 @@ public class StratConBiomeManifest {
     public static final String FACILITY_ALLIED = "FacilityAllied";
     public static final String FORCE_FRIENDLY = "ForceFriendly";
     public static final String FORCE_HOSTILE = "ForceHostile";
+
+    /**
+     * The terrain types that represent open water. Ocean hexes are always revealed, are barred from hosting scenarios
+     * or facilities, and are capped so that a sector is always at least partly dry land.
+     */
+    public static final Set<String> OCEAN_TERRAIN_TYPES = Set.of("Sea", "ColdSea", "HotSea", "FrozenSea");
+
+    /**
+     * @param terrainType a StratCon terrain type name (as returned by {@link StratConTrackState#getTerrainTile})
+     *
+     * @return {@code true} if the given terrain type is open water (ocean)
+     */
+    public static boolean isOceanTerrain(String terrainType) {
+        return OCEAN_TERRAIN_TYPES.contains(terrainType);
+    }
 
     // these constants will eventually be driven by planetary or track data
     /**

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConContractInitializer.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConContractInitializer.java
@@ -649,6 +649,11 @@ public class StratConContractInitializer {
         for (int y = 0; y < trackHeight; y++) {
             for (int x = 0; x < trackWidth; x++) {
                 StratConCoords coords = new StratConCoords(x, y);
+                // Ocean hexes never host scenarios or facilities.
+                if (StratConBiomeManifest.isOceanTerrain(trackState.getTerrainTile(coords))) {
+                    continue;
+                }
+
                 if (trackState.getScenario(coords) != null) {
                     continue;
                 }

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -1191,6 +1191,11 @@ public class StratConRulesManager {
      */
     public static void deployForceToCoords(StratConCoords coords, int forceID, Campaign campaign, AtBContract contract,
           StratConTrackState track, boolean sticky) {
+        // Ocean hexes are barred entirely - a force cannot deploy there, so no scenario can spawn there.
+        if (StratConBiomeManifest.isOceanTerrain(track.getTerrainTile(coords))) {
+            return;
+        }
+
         CombatTeam combatTeam = campaign.getCombatTeamsAsMap().get(forceID);
 
         // This shouldn't be possible, but never hurts to have a little insurance
@@ -1358,6 +1363,11 @@ public class StratConRulesManager {
         List<StratConCoords> suitableCoords = new ArrayList<>();
         for (int direction : ALL_DIRECTIONS) {
             StratConCoords newCoords = originCoords.translate(direction);
+
+            // Ocean hexes never host scenarios.
+            if (StratConBiomeManifest.isOceanTerrain(trackState.getTerrainTile(newCoords))) {
+                continue;
+            }
 
             if (trackState.getScenario(newCoords) != null) {
                 continue;
@@ -3508,8 +3518,13 @@ public class StratConRulesManager {
     /**
      * Can any force be manually deployed to the given coordinates on the given track for the given contract?
      */
-    public static boolean canManuallyDeployAnyForce(StratConCoords coords, StratConTrackState track,
-          AtBContract contract) {
+    public static boolean canManuallyDeployAnyForce(StratConCoords coords, StratConTrackState track) {
+        // Ocean hexes are barred entirely - forces can never be deployed onto open water.
+        // TODO if we ever add ocean battles to the scenario generator we should consider retiring this conditional
+        if (StratConBiomeManifest.isOceanTerrain(track.getTerrainTile(coords))) {
+            return false;
+        }
+
         // Rules: can't manually deploy if there's already a force deployed there
         // exception: on allied facilities
         // can't manually deploy if there's a non-cloaked scenario

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConTerrainPlacer.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConTerrainPlacer.java
@@ -32,6 +32,9 @@
  */
 package mekhq.campaign.stratCon;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import megamek.common.board.Coords;
 import megamek.common.compute.Compute;
 
@@ -62,11 +65,23 @@ public class StratConTerrainPlacer {
         }
         StratConBiome biome = biomeEntry.getValue();
 
-        int baseTerrainIndex = Compute.randomInt(biome.allowedTerrainTypes.size());
+        // Base terrain is always dry land; ocean is only ever added as "stripes" and is capped below,
+        // so a sector is never dominated by water.
+        List<String> baseCandidates = new ArrayList<>();
+        for (String terrainType : biome.allowedTerrainTypes) {
+            if (!StratConBiomeManifest.isOceanTerrain(terrainType)) {
+                baseCandidates.add(terrainType);
+            }
+        }
+        // Fallback for the (data-error) case where a biome offers only water.
+        if (baseCandidates.isEmpty()) {
+            baseCandidates = biome.allowedTerrainTypes;
+        }
+        String baseTerrain = baseCandidates.get(Compute.randomInt(baseCandidates.size()));
 
         for (int x = 0; x < track.getWidth(); x++) {
             for (int y = 0; y < track.getHeight(); y++) {
-                track.setTerrainTile(new StratConCoords(x, y), biome.allowedTerrainTypes.get(baseTerrainIndex));
+                track.setTerrainTile(new StratConCoords(x, y), baseTerrain);
             }
         }
 
@@ -92,9 +107,60 @@ public class StratConTerrainPlacer {
          * }
          */
 
-        for (int x = 0; x < biome.allowedTerrainTypes.size(); x++) {
-            if (x != baseTerrainIndex) {
-                DrawStripe(track, biome.allowedTerrainTypes.get(x));
+        for (String terrainType : biome.allowedTerrainTypes) {
+            if (!terrainType.equals(baseTerrain)) {
+                DrawStripe(track, terrainType);
+            }
+        }
+
+        // A sector must be at least 25% dry land; convert any excess ocean back to the base terrain.
+        enforceLandMinimum(track, baseTerrain);
+
+        // Ocean hexes are always revealed - open water holds no fog of war.
+        revealOceanHexes(track);
+    }
+
+    /**
+     * Ensures at least 25% of the given track is non-ocean by converting randomly selected excess ocean hexes into the
+     * supplied dry-land base terrain.
+     *
+     * @param track       the track to adjust
+     * @param baseTerrain the dry-land terrain type to convert excess ocean hexes into
+     */
+    private static void enforceLandMinimum(StratConTrackState track, String baseTerrain) {
+        int totalHexes = track.getWidth() * track.getHeight();
+        int minimumLand = (int) Math.ceil(totalHexes * 0.25);
+
+        List<StratConCoords> oceanCoords = new ArrayList<>();
+        for (int x = 0; x < track.getWidth(); x++) {
+            for (int y = 0; y < track.getHeight(); y++) {
+                StratConCoords coords = new StratConCoords(x, y);
+                if (StratConBiomeManifest.isOceanTerrain(track.getTerrainTile(coords))) {
+                    oceanCoords.add(coords);
+                }
+            }
+        }
+
+        int landHexes = totalHexes - oceanCoords.size();
+        while ((landHexes < minimumLand) && !oceanCoords.isEmpty()) {
+            StratConCoords coords = oceanCoords.remove(Compute.randomInt(oceanCoords.size()));
+            track.setTerrainTile(coords, baseTerrain);
+            landHexes++;
+        }
+    }
+
+    /**
+     * Adds every ocean hex on the given track to its revealed-coordinates set, so open water is always visible.
+     *
+     * @param track the track whose ocean hexes should be revealed
+     */
+    private static void revealOceanHexes(StratConTrackState track) {
+        for (int x = 0; x < track.getWidth(); x++) {
+            for (int y = 0; y < track.getHeight(); y++) {
+                StratConCoords coords = new StratConCoords(x, y);
+                if (StratConBiomeManifest.isOceanTerrain(track.getTerrainTile(coords))) {
+                    track.getRevealedCoords().add(coords);
+                }
             }
         }
     }

--- a/MekHQ/src/mekhq/gui/StratConPanel.java
+++ b/MekHQ/src/mekhq/gui/StratConPanel.java
@@ -202,7 +202,7 @@ public class StratConPanel extends JPanel implements ActionListener {
 
         // display "Manage Force Assignment" if there is not a force already on the hex
         // except if there is already a non-cloaked scenario here.
-        if (StratConRulesManager.canManuallyDeployAnyForce(coords, currentTrack, campaignState.getContract())) {
+        if (StratConRulesManager.canManuallyDeployAnyForce(coords, currentTrack)) {
             JMenuItem menuItemManageForceAssignments = new JMenuItem();
             menuItemManageForceAssignments.setText("Manage Deployment");
             menuItemManageForceAssignments.setActionCommand(RIGHT_CLICK_COMMAND_MANAGE_FORCES);


### PR DESCRIPTION
# Requires https://github.com/MegaMek/mm-data/pull/456

I've never really liked StratCon's way of handling ocean hexes. Generally what would happen is a player would spawn into an AO with a lot of water and rather than reducing the operational area it just meant the player could look forward to scenario after scenario in Shrek's swamp. It wasn't fun, it wasn't interesting, and it wasn't immersive.

This PR does the following:

# Ocean Means Ocean
Ocean hexes now spawn scenario maps in oceans. Coastal scenario maps have been moved to other hex types.

# Facilities Don't Float
Facilities and random scenarios cannot spawn on ocean hexes.

# Meks Don't Float
Players cannot deploy forces to ocean hexes.

# It's Ocean, What Can it Hide?
To ensure players don't feel compelled to try and deploy to ocean hexes, oceans start automatically scouted.

# Waterworld Was a Box Office Flop
To ensure each sector has a playable area I've added a limitation to how much of the sector can be ocean (75%).

# Future Plans
I am increasingly tempted to wrap scenario generation into the Contract Overhaul, in which case I will be allowing ocean scenarios to spawn with ocean-going OpFors.