### PR TITLE
Close #4276: Scenario Generation Now Accounts for Being Ambushed & Bungling Scouting Patrols

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -41,6 +41,7 @@ Clan.text=Clan
 Close.text=Close
 Confirm.text=Confirm
 Understood.text=Understood
+Unfortunate.button=Unfortunate
 Day.text=Day
 Days.text=Days
 Edit.text=Edit

--- a/MekHQ/resources/mekhq/resources/StratConAmbushedDialog.properties
+++ b/MekHQ/resources/mekhq/resources/StratConAmbushedDialog.properties
@@ -1,0 +1,37 @@
+# Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+#
+# This file is part of MekHQ.
+#
+# MekHQ is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (GPL),
+# version 3 or (at your option) any later version,
+# as published by the Free Software Foundation.
+#
+# MekHQ is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# A copy of the GPL should have been included with this project;
+# if not, see <https://www.gnu.org/licenses/>.
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+# suppress inspection "UnusedProperty" for the whole file
+StratConAmbushedDialog.ooc=Deploying to an unexplored hex is dangerous and should be avoided where possible.
+StratConAmbushedDialog.ic.bungle={0}, the patrol has made unintended contact. Enemy strength and intent are still \
+  being assessed. We are breaking clear and reorganizing to respond. Will report as the situation develops.
+StratConAmbushedDialog.ic.ambush={0}, the force has been engaged unexpectedly and is now committed to action. Enemy \
+  strength and intent are still being assessed. We are consolidating and responding as the situation develops. Will \
+  report as the engagement clarifies.

--- a/MekHQ/src/mekhq/campaign/force/Formation.java
+++ b/MekHQ/src/mekhq/campaign/force/Formation.java
@@ -638,6 +638,10 @@ public class Formation {
         return formationCommanderID;
     }
 
+    public @Nullable Person getFormationCommander(Campaign campaign) {
+        return formationCommanderID == null ? null : campaign.getPerson(formationCommanderID);
+    }
+
     /**
      * Sets the formation commander ID to the provided UUID. You probably want to use
      * setOverrideFormationCommanderID(UUID) followed by updateCommander(campaign).

--- a/MekHQ/src/mekhq/campaign/mission/ScenarioTemplate.java
+++ b/MekHQ/src/mekhq/campaign/mission/ScenarioTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2018-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/campaign/mission/ScenarioTemplate.java
+++ b/MekHQ/src/mekhq/campaign/mission/ScenarioTemplate.java
@@ -82,6 +82,9 @@ public class ScenarioTemplate implements Cloneable {
     public boolean isHostileFacility;
     public boolean isAlliedFacility;
 
+    public boolean isSuitedForAmbushes = false;
+    public boolean isSuitedForBungledPatrols = false;
+
     @XmlElement(name = "battlefieldControl")
     @XmlJavaTypeAdapter(value = BattlefieldControlTypeAdapter.class)
     public BattlefieldControlType battlefieldControl = BattlefieldControlType.VICTOR;
@@ -127,6 +130,8 @@ public class ScenarioTemplate implements Cloneable {
         template.stratConScenarioType = this.stratConScenarioType;
         template.shortBriefing = this.shortBriefing;
         template.detailedBriefing = this.detailedBriefing;
+        template.isSuitedForAmbushes = this.isSuitedForAmbushes;
+        template.isSuitedForBungledPatrols = this.isSuitedForBungledPatrols;
         template.isHostileFacility = this.isHostileFacility;
         template.isAlliedFacility = this.isAlliedFacility;
         template.battlefieldControl = this.battlefieldControl;
@@ -194,6 +199,14 @@ public class ScenarioTemplate implements Cloneable {
 
     public boolean isFacilityScenario() {
         return isHostileFacility || isAlliedFacility;
+    }
+
+    public boolean isSuitedForAmbushes() {
+        return isSuitedForAmbushes;
+    }
+
+    public boolean isSuitedForBungledPatrols() {
+        return isSuitedForBungledPatrols;
     }
 
     public BattlefieldControlType getBattlefieldControl() {

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -2463,27 +2463,38 @@ public class StratConRulesManager {
      * @param contract          the {@link AtBContract} governing the StratCon campaign
      * @param track             the {@link StratConTrackState} where the scenario is placed
      * @param forceID           the ID of the force for which the scenario is generated
-     * @param coords            the {@link StratConCoords} specifying where the scenario will be generated
+     * @param scenarioCoords    the {@link StratConCoords} specifying where the scenario will be generated
      * @param daysTilDeployment the number of days until the scenario is deployed; if {@code null}, deployment dates are
      *                          determined dynamically
      *
      * @return the generated {@link StratConScenario}, or {@code null} if scenario generation fails
      */
     private static @Nullable StratConScenario generateScenario(Campaign campaign, AtBContract contract,
-          StratConTrackState track, @Nullable Integer forceID, StratConCoords coords,
+          StratConTrackState track, @Nullable Integer forceID, StratConCoords scenarioCoords,
           @Nullable Integer daysTilDeployment) {
         int unitType = MEK;
 
         if (forceID != null) {
-            unitType = campaign.getFormation(forceID).getPrimaryUnitType(campaign);
+            Formation formation = campaign.getFormation(forceID);
+            if (formation != null) {
+                unitType = formation.getPrimaryUnitType(campaign);
+            }
         }
 
-        ScenarioTemplate template = StratConScenarioFactory.getRandomScenario(unitType);
+        CombatTeam combatTeam = campaign.getCombatTeamsAsMap().get(forceID);
+        boolean isPatrol = combatTeam != null && combatTeam.getRole().isPatrol();
+
+        StratConCoords deployedCoords = track.getAssignedForceCoords().get(forceID);
+        boolean isAmbushed = deployedCoords != null && deployedCoords.equals(scenarioCoords);
+
+        boolean isBungledPatrol = isPatrol && isAmbushed;
+
+        ScenarioTemplate template = StratConScenarioFactory.getRandomScenario(unitType, isAmbushed, isBungledPatrol);
         // useful for debugging specific scenario types
         // template = StratConScenarioFactory.getSpecificScenario("Defend Grounded
         // Dropship.xml");
 
-        return generateScenario(campaign, contract, track, forceID, coords, template, daysTilDeployment);
+        return generateScenario(campaign, contract, track, forceID, scenarioCoords, template, daysTilDeployment);
     }
 
     /**
@@ -2535,7 +2546,7 @@ public class StratConRulesManager {
                 // This just means the player has no units
             }
 
-            template = StratConScenarioFactory.getRandomScenario(unitType);
+            template = StratConScenarioFactory.getRandomScenario(unitType, false, false);
         }
 
         if (template == null) {

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -127,6 +127,7 @@ import mekhq.campaign.stratCon.StratConContractDefinition.StrategicObjectiveType
 import mekhq.campaign.stratCon.StratConScenario.ScenarioState;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Planet;
+import mekhq.gui.dialog.StratConAmbushedDialog;
 import mekhq.gui.dialog.nagDialogs.CombatChallengeNagDialog;
 import mekhq.utilities.ReportingUtilities;
 import org.apache.commons.math3.util.Pair;
@@ -1202,6 +1203,12 @@ public class StratConRulesManager {
         boolean isPatrol = combatRole.isPatrol();
         boolean isTraining = combatRole.isTraining();
 
+        // A force that deploys into an unexplored hex is walking in blind. If that deployment trips a scenario, the
+        // force is caught off-guard: the scenario is pinned to the deployed hex (bypassing the patrol adjacent-shift)
+        // and counts as an ambush - or a bungled patrol, if the force was on patrol. This must be captured *before*
+        // processForceDeployment, which reveals the hex.
+        boolean deployedToUnexploredHex = !track.getRevealedCoords().contains(coords);
+
         // the following things should happen:
         // 1. call to "process force deployment", which reveals fog of war in or around the coords,
         // depending on force role
@@ -1236,8 +1243,14 @@ public class StratConRulesManager {
         if (isNonAlliedFacility || spawnScenario) {
             StratConScenario scenario;
 
-            // If we're not deploying on top of an enemy facility, migrate the scenario
-            if (!isNonAlliedFacility && isPatrol) {
+            // A blind deployment into an unexplored, empty hex is an ambush (a bungled patrol, if the force was
+            // patrolling). Facility scenarios are never ambushes.
+            boolean isAmbushed = spawnScenario && deployedToUnexploredHex;
+            boolean isBungledPatrol = isAmbushed && isPatrol;
+
+            // If we're not deploying on top of an enemy facility, migrate the scenario. An ambush/bungled patrol
+            // pins the scenario to the deployed hex, so it is not migrated.
+            if (!isNonAlliedFacility && isPatrol && !isAmbushed) {
                 StratConCoords newCoords = getUnoccupiedAdjacentCoords(coords, track);
 
                 if (newCoords != null) {
@@ -1245,8 +1258,21 @@ public class StratConRulesManager {
                 }
             }
 
-            // Patrols only get autoAssigned to the scenario if they're dropped on top of a non-allied facility
-            boolean autoAssignLances = !isPatrol || isNonAlliedFacility;
+            // Patrols only get autoAssigned to the scenario if they're dropped on top of a non-allied facility, or
+            // if they bungled a patrol into an ambush.
+            boolean autoAssignLances = !isPatrol || isNonAlliedFacility || isAmbushed;
+
+            // An ambush restricts the scenario to templates flagged as suitable for that context; the deploying force
+            // is always pinned to (and present at) the deployed hex, so template selection uses its unit type.
+            ScenarioTemplate ambushTemplate = null;
+            if (isAmbushed) {
+                int unitType = MEK;
+                Formation formation = campaign.getFormation(forceID);
+                if (formation != null) {
+                    unitType = formation.getPrimaryUnitType(campaign);
+                }
+                ambushTemplate = StratConScenarioFactory.getRandomScenario(unitType, true, isBungledPatrol);
+            }
 
             // Do we already have forces deployed to the target coordinates?
             // If so, assign them to the scenario.
@@ -1257,7 +1283,9 @@ public class StratConRulesManager {
                       track.getAssignedCoordForces().get(coords),
                       contract,
                       campaign,
-                      track);
+                      track,
+                      ambushTemplate,
+                      null);
                 // Otherwise, pick a random force from those available
             } else {
                 List<Integer> availableForceIDs = getAvailableForceIDs(campaign, contract, false);
@@ -1280,7 +1308,18 @@ public class StratConRulesManager {
                 scenario = setupScenario(coords, forceID, campaign, contract, track);
             }
 
-            finalizeBackingScenario(campaign, contract, track, autoAssignLances, scenario);
+            if (scenario != null) {
+                finalizeBackingScenario(campaign, contract, track, autoAssignLances, scenario);
+
+                if (isAmbushed) {
+                    // Ambushes are always Crisis scenarios, this stop
+                    scenario.getBackingScenario().setIsCrisis(true);
+                    scenario.setTurningPoint(false);
+
+                    new StratConAmbushedDialog(campaign, forceID, isBungledPatrol);
+                }
+            }
+
             return;
         }
 
@@ -2481,15 +2520,10 @@ public class StratConRulesManager {
             }
         }
 
-        CombatTeam combatTeam = campaign.getCombatTeamsAsMap().get(forceID);
-        boolean isPatrol = combatTeam != null && combatTeam.getRole().isPatrol();
-
-        StratConCoords deployedCoords = track.getAssignedForceCoords().get(forceID);
-        boolean isAmbushed = deployedCoords != null && deployedCoords.equals(scenarioCoords);
-
-        boolean isBungledPatrol = isPatrol && isAmbushed;
-
-        ScenarioTemplate template = StratConScenarioFactory.getRandomScenario(unitType, isAmbushed, isBungledPatrol);
+        // Ambush and bungled-patrol scenarios are determined and pre-selected up-front in deployForceToCoords, where
+        // the pre-deployment fog-of-war state is still known. Scenarios reaching this random-selection path (auto
+        // generation, deployments into already-explored hexes) are never ambushes.
+        ScenarioTemplate template = StratConScenarioFactory.getRandomScenario(unitType, false, false);
         // useful for debugging specific scenario types
         // template = StratConScenarioFactory.getSpecificScenario("Defend Grounded
         // Dropship.xml");

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConScenarioFactory.java
@@ -196,7 +196,7 @@ public class StratConScenarioFactory {
 
         // We don't want facilities spawning mid-contract; this stops facility count getting out of control
         jointList.removeIf(ScenarioTemplate::isFacilityScenario);
-        
+
         if (jointList.isEmpty()) {
             logger.warn("No scenarios configured for unit type {}, ({}) and ambushed status {}", unitType,
                   generalUnitType, isAmbushed);
@@ -206,6 +206,15 @@ public class StratConScenarioFactory {
         return ObjectUtility.getRandomItem(jointList).clone();
     }
 
+    /**
+     * Filters and collects viable scenario templates based on the specified unit type and additional parameters, such
+     * as ambush or bungled patrol conditions, and adds them to the provided set of scenario templates.
+     *
+     * @param unitType        The specific unit type that the scenarios should be associated with.
+     * @param isAmbushed      A boolean flag indicating whether the scenarios should be suitable for ambushes.
+     * @param isBungledPatrol A boolean flag indicating whether the scenarios should be suitable for bungled patrols.
+     * @param jointList       A set to which viable scenario templates will be added.
+     */
     private static void getViableScenarioTemplates(int unitType, boolean isAmbushed, boolean isBungledPatrol,
           Set<ScenarioTemplate> jointList) {
         if (!isAmbushed && !isBungledPatrol) {

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConScenarioFactory.java
@@ -35,8 +35,10 @@ package mekhq.campaign.stratCon;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import megamek.codeUtilities.ObjectUtility;
 import megamek.common.annotations.Nullable;
@@ -158,14 +160,20 @@ public class StratConScenarioFactory {
     }
 
     /**
-     * Retrieves a random scenario template appropriate for the given unit type. This includes the more general ATB_MIX
-     * and ATB_AERO_MIX where appropriate
+     * Retrieves a random scenario template based on the given unit type and additional parameters.
      *
-     * @param unitType The desired unit type, as per megamek.common.units.UnitType
+     * <p>Filters applicable scenarios and randomly selects a viable option, ensuring that facility scenarios
+     * are excluded to prevent facility overpopulation.</p>
      *
-     * @return Random scenario template.
+     * @param unitType        The specific unit type that the scenario should be associated with.
+     * @param isAmbushed      A boolean flag indicating whether the unit is ambushed.
+     * @param isBungledPatrol A boolean flag indicating whether the scenario involves a bungled patrol.
+     *
+     * @return A randomly selected {@code ScenarioTemplate} that fits the specified criteria, or {@code null} if no
+     *       suitable scenarios are configured for the unit type.
      */
-    public static ScenarioTemplate getRandomScenario(int unitType) {
+    public static @Nullable ScenarioTemplate getRandomScenario(int unitType, boolean isAmbushed,
+          boolean isBungledPatrol) {
         int generalUnitType = convertSpecificUnitTypeToGeneral(unitType);
 
         // if the specific unit type doesn't have any scenario templates for it
@@ -176,20 +184,45 @@ public class StratConScenarioFactory {
             return null;
         }
 
-        List<ScenarioTemplate> jointList = new ArrayList<>();
+        Set<ScenarioTemplate> jointList = new HashSet<>();
 
         if (dynamicScenarioUnitTypeMap.containsKey(unitType)) {
-            jointList.addAll(dynamicScenarioUnitTypeMap.get(unitType));
+            getViableScenarioTemplates(unitType, isAmbushed, isBungledPatrol, jointList);
         }
 
         if (dynamicScenarioUnitTypeMap.containsKey(generalUnitType)) {
-            jointList.addAll(dynamicScenarioUnitTypeMap.get(generalUnitType));
+            getViableScenarioTemplates(generalUnitType, isAmbushed, isBungledPatrol, jointList);
         }
 
         // We don't want facilities spawning mid-contract; this stops facility count getting out of control
         jointList.removeIf(ScenarioTemplate::isFacilityScenario);
+        
+        if (jointList.isEmpty()) {
+            logger.warn("No scenarios configured for unit type {}, ({}) and ambushed status {}", unitType,
+                  generalUnitType, isAmbushed);
+            return null;
+        }
 
         return ObjectUtility.getRandomItem(jointList).clone();
+    }
+
+    private static void getViableScenarioTemplates(int unitType, boolean isAmbushed, boolean isBungledPatrol,
+          Set<ScenarioTemplate> jointList) {
+        if (!isAmbushed && !isBungledPatrol) {
+            jointList.addAll(dynamicScenarioUnitTypeMap.get(unitType));
+        }
+
+        for (ScenarioTemplate template : dynamicScenarioUnitTypeMap.get(unitType)) {
+            // If bungled patrol is true, so is isAmbushed so we need to parse isBungledPatrol first
+            if (template.isSuitedForBungledPatrols() && isBungledPatrol) {
+                jointList.add(template);
+                continue;
+            }
+
+            if (template.isSuitedForAmbushes() && isAmbushed) {
+                jointList.add(template);
+            }
+        }
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogSimple.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogSimple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -142,6 +142,37 @@ public class ImmersiveDialogSimple extends ImmersiveDialogCore {
               useVerticalLayout,
               null,
               imageIcon,
+              true);
+    }
+
+    /**
+     * Constructs an {@code ImmersiveDialogSimple} with the specified campaign, message details, and optional speaker
+     * and button configuration. This dialog represents an immersive interaction with optional elements like a speaker
+     * and out-of-character information.
+     *
+     * @param campaign              The current game state, providing relevant campaign data.
+     * @param leftSpeaker           The {@link Person} appearing as the left speaker, or {@code null} if no speaker is
+     *                              displayed on the left side.
+     * @param centerMessage         The primary message to be displayed in the center of the dialog. This typically
+     *                              conveys the main information or narrative of the dialog.
+     * @param buttonLabels          A {@link List} of custom button labels to display in the dialog. If the list is
+     *                              {@code null}, a default "Understood" button is displayed.
+     * @param outOfCharacterMessage An optional out-of-character (OOC) message, or {@code null} if not applicable. This
+     *                              message is displayed outside the dialog's in-character context, usually to provide
+     *                              additional explanation or game-related information to the player.
+     */
+    public ImmersiveDialogSimple(Campaign campaign, @Nullable Person leftSpeaker, String centerMessage,
+          @Nullable List<String> buttonLabels, @Nullable String outOfCharacterMessage) {
+        super(campaign,
+              leftSpeaker,
+              null,
+              centerMessage,
+              createButtons(buttonLabels),
+              outOfCharacterMessage,
+              null,
+              false,
+              null,
+              null,
               true);
     }
 

--- a/MekHQ/src/mekhq/gui/dialog/StratConAmbushedDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/StratConAmbushedDialog.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.dialog;
+
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.MHQInternationalization.getText;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
+
+import java.util.List;
+
+import mekhq.campaign.Campaign;
+import mekhq.campaign.force.Formation;
+import mekhq.campaign.personnel.Person;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
+import org.jspecify.annotations.NonNull;
+
+public class StratConAmbushedDialog {
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.StratConAmbushedDialog";
+
+    public StratConAmbushedDialog(Campaign campaign, int formationId, boolean isBungledPatrol) {
+        new ImmersiveDialogSimple(campaign,
+              getFormationCommander(campaign, formationId),
+              getInCharacterMessage(isBungledPatrol, campaign.getCommanderAddress()),
+              getResponseText(),
+              getOutOfCharacterMessage());
+    }
+
+    private static Person getFormationCommander(Campaign campaign, int formationId) {
+        Formation formation = campaign.getFormation(formationId);
+
+        return formation == null ? null : formation.getFormationCommander(campaign);
+    }
+
+    private static String getInCharacterMessage(boolean isBungledPatrol, String commanderAddress) {
+        String resourceKey = "StratConAmbushedDialog.ic." + (isBungledPatrol ? "bungle" : "ambush");
+        return getFormattedTextAt(RESOURCE_BUNDLE, resourceKey, commanderAddress);
+    }
+
+    private static @NonNull List<String> getResponseText() {
+        return List.of(getText("Unfortunate.button"));
+    }
+
+    private static @NonNull String getOutOfCharacterMessage() {
+        return getTextAt(RESOURCE_BUNDLE, "StratConAmbushedDialog.ooc");
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/stratCon/StratConRulesManagerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/stratCon/StratConRulesManagerTest.java
@@ -45,6 +45,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -84,12 +85,14 @@ import mekhq.campaign.stratCon.StratConContractDefinition.StrategicObjectiveType
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Atmosphere;
 import mekhq.campaign.universe.Planet;
+import mekhq.gui.dialog.StratConAmbushedDialog;
 import mekhq.utilities.EntityUtilities;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 
 /**
@@ -259,8 +262,8 @@ class StratConRulesManagerTest {
     }
 
     /**
-     * Creates the common mock infrastructure needed for deployForceToCoords tests.
-     * processForceDeployment -> scanNeighboringCoords touches many objects.
+     * Creates the common mock infrastructure needed for deployForceToCoords tests. processForceDeployment ->
+     * scanNeighboringCoords touches many objects.
      */
     private void setupProcessForceDeploymentMocks(Campaign campaign, CampaignOptions options,
           StratConTrackState track, int forceID) {
@@ -345,8 +348,8 @@ class StratConRulesManagerTest {
     }
 
     /**
-     * Verifies that when a force deploys to coordinates containing a non-challenge scenario
-     * (e.g., a fixed objective), the force IS auto-assigned as before.
+     * Verifies that when a force deploys to coordinates containing a non-challenge scenario (e.g., a fixed objective),
+     * the force IS auto-assigned as before.
      */
     @Test
     void deployForceToCoords_nonChallengeScenario_autoAssignsForce() {
@@ -387,6 +390,153 @@ class StratConRulesManagerTest {
 
         // Assert: force SHOULD be added to the regular scenario
         verify(regularScenario).addPrimaryForce(forceID);
+    }
+
+    /**
+     * Bundles the mocks a {@link StratConRulesManager#deployForceToCoords} ambush test needs.
+     */
+    private record AmbushFixture(Campaign campaign, AtBContract contract, StratConTrackState track,
+          StratConCoords coords, int forceID) {}
+
+    /**
+     * Builds the mock infrastructure for a deployment that trips a randomly-spawned scenario on an empty hex.
+     *
+     * @param isPatrol whether the deploying force is on a patrol role
+     * @param explored whether the target hex has already been revealed (an explored hex is never an ambush)
+     */
+    private AmbushFixture buildAmbushFixture(boolean isPatrol, boolean explored) {
+        Campaign campaign = mock(Campaign.class);
+        CampaignOptions options = mock(CampaignOptions.class);
+        when(campaign.getCampaignOptions()).thenReturn(options);
+
+        AtBContract contract = mock(AtBContract.class);
+        StratConTrackState track = mock(StratConTrackState.class);
+        StratConCoords coords = new StratConCoords(2, 3);
+        int forceID = 1;
+
+        CombatTeam combatTeam = mock(CombatTeam.class);
+        CombatRole combatRole = mock(CombatRole.class);
+        when(combatRole.isPatrol()).thenReturn(isPatrol);
+        when(combatRole.isTraining()).thenReturn(false);
+        when(combatTeam.getRole()).thenReturn(combatRole);
+        var combatTeamsMap = new Hashtable<Integer, CombatTeam>();
+        combatTeamsMap.put(forceID, combatTeam);
+        when(campaign.getCombatTeamsAsMap()).thenReturn(combatTeamsMap);
+
+        setupProcessForceDeploymentMocks(campaign, options, track, forceID);
+
+        // No fixed scenario or facility at the target hex, so a random scenario may spawn there.
+        when(track.getScenario(coords)).thenReturn(null);
+        when(track.getFacility(coords)).thenReturn(null);
+
+        // Revealed state decides whether the deployment is "blind" (into an unexplored hex).
+        Set<StratConCoords> revealed = new HashSet<>();
+        if (explored) {
+            revealed.add(coords);
+        }
+        when(track.getRevealedCoords()).thenReturn(revealed);
+        when(track.getAssignedForceCoords()).thenReturn(new HashMap<>());
+
+        // The deploying force is present at the hex it deployed into, so the "existing forces" branch is taken.
+        Map<StratConCoords, Set<Integer>> assignedCoordForces = new HashMap<>();
+        assignedCoordForces.put(coords, new HashSet<>(Set.of(forceID)));
+        when(track.getAssignedCoordForces()).thenReturn(assignedCoordForces);
+
+        return new AmbushFixture(campaign, contract, track, coords, forceID);
+    }
+
+    /**
+     * Stubs the scenario-generation collaborators so {@code deployForceToCoords} runs to completion: a scenario always
+     * spawns ({@code calculateScenarioOdds} returns 100), and template selection, existing-force generation, and
+     * finalization are neutralized so only the ambush decision logic is exercised.
+     */
+    private void stubScenarioGeneration(MockedStatic<StratConScenarioFactory> scenarioFactory,
+          MockedStatic<StratConRulesManager> rulesManager) {
+        scenarioFactory.when(() -> StratConScenarioFactory.getRandomScenario(anyInt(), anyBoolean(), anyBoolean()))
+              .thenReturn(mock(ScenarioTemplate.class));
+        rulesManager.when(() -> StratConRulesManager.calculateScenarioOdds(any(), any(), anyBoolean()))
+              .thenReturn(100);
+        rulesManager.when(() -> StratConRulesManager.generateScenarioForExistingForces(any(), any(), any(), any(),
+              any(), any(), any())).thenReturn(mock(StratConScenario.class));
+        rulesManager.when(() -> StratConRulesManager.finalizeBackingScenario(any(), any(), any(), anyBoolean(),
+              any())).thenAnswer(invocation -> null);
+    }
+
+    /**
+     * A non-patrol force that deploys blind into an unexplored hex and trips a scenario is ambushed: the scenario is
+     * restricted to ambush-suited templates and the player is notified. It is not a bungled patrol.
+     */
+    @Test
+    void deployForceToCoords_blindDeployment_isAmbush() {
+        AmbushFixture fixture = buildAmbushFixture(false, false);
+        List<Boolean> dialogBungledArgs = new ArrayList<>();
+
+        try (MockedConstruction<StratConAmbushedDialog> dialogs = mockConstruction(StratConAmbushedDialog.class,
+              (dialog, context) -> dialogBungledArgs.add((Boolean) context.arguments().get(2)));
+              MockedStatic<StratConScenarioFactory> scenarioFactory = mockStatic(StratConScenarioFactory.class);
+              MockedStatic<StratConRulesManager> rulesManager = mockStatic(StratConRulesManager.class,
+                    CALLS_REAL_METHODS)) {
+            stubScenarioGeneration(scenarioFactory, rulesManager);
+
+            StratConRulesManager.deployForceToCoords(fixture.coords(), fixture.forceID(), fixture.campaign(),
+                  fixture.contract(), fixture.track(), false);
+
+            scenarioFactory.verify(() -> StratConScenarioFactory.getRandomScenario(anyInt(), eq(true), eq(false)));
+            assertEquals(List.of(false), dialogBungledArgs);
+        }
+    }
+
+    /**
+     * A patrol force that deploys blind into an unexplored hex bungles the patrol: the scenario is restricted to
+     * bungled-patrol templates, is pinned to the deployed hex (not migrated to an adjacent hex), and the player is
+     * notified that it was a bungled patrol.
+     */
+    @Test
+    void deployForceToCoords_blindPatrolDeployment_isBungledPatrolPinnedToHex() {
+        AmbushFixture fixture = buildAmbushFixture(true, false);
+        List<Boolean> dialogBungledArgs = new ArrayList<>();
+
+        try (MockedConstruction<StratConAmbushedDialog> dialogs = mockConstruction(StratConAmbushedDialog.class,
+              (dialog, context) -> dialogBungledArgs.add((Boolean) context.arguments().get(2)));
+              MockedStatic<StratConScenarioFactory> scenarioFactory = mockStatic(StratConScenarioFactory.class);
+              MockedStatic<StratConRulesManager> rulesManager = mockStatic(StratConRulesManager.class,
+                    CALLS_REAL_METHODS)) {
+            stubScenarioGeneration(scenarioFactory, rulesManager);
+
+            StratConRulesManager.deployForceToCoords(fixture.coords(), fixture.forceID(), fixture.campaign(),
+                  fixture.contract(), fixture.track(), false);
+
+            scenarioFactory.verify(() -> StratConScenarioFactory.getRandomScenario(anyInt(), eq(true), eq(true)));
+            assertEquals(List.of(true), dialogBungledArgs);
+            // Pinned to the deployed hex: the scenario is built for the force already there, not migrated away.
+            rulesManager.verify(() -> StratConRulesManager.generateScenarioForExistingForces(eq(fixture.coords()),
+                  any(), any(), any(), any(), any(), any()));
+        }
+    }
+
+    /**
+     * A patrol force deploying into an already-explored hex is never ambushed or bungled: no ambush template is
+     * requested and the player is not notified.
+     */
+    @Test
+    void deployForceToCoords_deploymentIntoExploredHex_isNotAmbush() {
+        AmbushFixture fixture = buildAmbushFixture(true, true);
+        List<Boolean> dialogBungledArgs = new ArrayList<>();
+
+        try (MockedConstruction<StratConAmbushedDialog> dialogs = mockConstruction(StratConAmbushedDialog.class,
+              (dialog, context) -> dialogBungledArgs.add((Boolean) context.arguments().get(2)));
+              MockedStatic<StratConScenarioFactory> scenarioFactory = mockStatic(StratConScenarioFactory.class);
+              MockedStatic<StratConRulesManager> rulesManager = mockStatic(StratConRulesManager.class,
+                    CALLS_REAL_METHODS)) {
+            stubScenarioGeneration(scenarioFactory, rulesManager);
+
+            StratConRulesManager.deployForceToCoords(fixture.coords(), fixture.forceID(), fixture.campaign(),
+                  fixture.contract(), fixture.track(), false);
+
+            scenarioFactory.verify(() -> StratConScenarioFactory.getRandomScenario(anyInt(), eq(true), anyBoolean()),
+                  never());
+            assertTrue(dialogBungledArgs.isEmpty());
+        }
     }
 
     /**
@@ -431,12 +581,11 @@ class StratConRulesManagerTest {
     }
 
     /**
-     * Verifies that when an Official Challenge scenario spawns on a hex that already has a deployed
-     * force (the {@code generateScenarioForExistingForces} path), the scenario does NOT override
-     * force auto-assignment. This means {@code finalizeBackingScenario} (called with
-     * {@code autoAssignLances=false} in {@code generateDailyScenariosForTrack}) will remove the
-     * forces from the backing scenario and set the scenario to UNRESOLVED, preventing
-     * auto-assignment.
+     * Verifies that when an Official Challenge scenario spawns on a hex that already has a deployed force (the
+     * {@code generateScenarioForExistingForces} path), the scenario does NOT override force auto-assignment. This means
+     * {@code finalizeBackingScenario} (called with {@code autoAssignLances=false} in
+     * {@code generateDailyScenariosForTrack}) will remove the forces from the backing scenario and set the scenario to
+     * UNRESOLVED, preventing auto-assignment.
      *
      * <p>Regression test for
      * <a href="https://github.com/MegaMek/mekhq/issues/8612">issue #8612</a>
@@ -481,8 +630,8 @@ class StratConRulesManagerTest {
     }
 
     /**
-     * Verifies that when a non-challenge scenario spawns on a hex with an existing force,
-     * the scenario DOES override force auto-assignment (so forces are committed as usual).
+     * Verifies that when a non-challenge scenario spawns on a hex with an existing force, the scenario DOES override
+     * force auto-assignment (so forces are committed as usual).
      */
     @Test
     void generateScenarioForExistingForces_nonChallenge_overridesAutoAssignment() {
@@ -526,11 +675,11 @@ class StratConRulesManagerTest {
     /**
      * Creates common mock infrastructure for isValidUnitForScenario tests.
      *
-     * @param unitType the unit type to return from the entity
+     * @param unitType              the unit type to return from the entity
      * @param hasUnstreamlinedQuirk whether the entity has the unstreamlined quirk
-     * @param atmosphere the planet's atmosphere (null to simulate missing planet data)
-     * @param isUseDropShips whether campaign options allow player dropships
-     * @param allowedUnitType the allowed unit type on the scenario force template (-2 for ATB_MIX)
+     * @param atmosphere            the planet's atmosphere (null to simulate missing planet data)
+     * @param isUseDropShips        whether campaign options allow player dropships
+     * @param allowedUnitType       the allowed unit type on the scenario force template (-2 for ATB_MIX)
      *
      * @return an Object array: [Unit, ScenarioForceTemplate, Campaign]
      */
@@ -703,7 +852,7 @@ class StratConRulesManagerTest {
         }
 
         @ParameterizedTest
-        @CsvSource({ "false, false, 0", "true, false, -1",  "false, true, 0",  "true, true, 0" })
+        @CsvSource({ "false, false, 0", "true, false, -1", "false, true, 0", "true, true, 0" })
         void testGetScoutComplementarySPAModifier(boolean hasEagleEyes, boolean hasSensorEquipment,
               int expectedModifier) {
             TargetRollModifier modifier =
@@ -935,7 +1084,8 @@ class StratConRulesManagerTest {
                     scenarioFactory.when(() -> AtBDynamicScenarioFactory.calculateAtBSpeed(entity)).thenReturn(5);
                     entityUtils.when(() -> EntityUtilities.hasImprovedSensors(entity)).thenReturn(hasImprovedSensors);
                     entityUtils.when(() -> EntityUtilities.hasActiveProbe(entity)).thenReturn(hasActiveProbe);
-                    scoutingSkills.when(() -> ScoutingSkills.getBestScoutingSkill(crew)).thenReturn(S_SENSOR_OPERATIONS);
+                    scoutingSkills.when(() -> ScoutingSkills.getBestScoutingSkill(crew))
+                          .thenReturn(S_SENSOR_OPERATIONS);
                     return unit;
                 }).toList();
                 when(formation.getAllUnitsAsUnits(hangar, false)).thenReturn(units);

--- a/MekHQ/unittests/mekhq/campaign/stratCon/StratConRulesManagerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/stratCon/StratConRulesManagerTest.java
@@ -456,8 +456,11 @@ class StratConRulesManagerTest {
               .thenReturn(mock(ScenarioTemplate.class));
         rulesManager.when(() -> StratConRulesManager.calculateScenarioOdds(any(), any(), anyBoolean()))
               .thenReturn(100);
+        // The ambush branch marks the generated scenario as a crisis via its backing scenario, so it must be present.
+        StratConScenario generatedScenario = mock(StratConScenario.class);
+        when(generatedScenario.getBackingScenario()).thenReturn(mock(AtBDynamicScenario.class));
         rulesManager.when(() -> StratConRulesManager.generateScenarioForExistingForces(any(), any(), any(), any(),
-              any(), any(), any())).thenReturn(mock(StratConScenario.class));
+              any(), any(), any())).thenReturn(generatedScenario);
         rulesManager.when(() -> StratConRulesManager.finalizeBackingScenario(any(), any(), any(), anyBoolean(),
               any())).thenAnswer(invocation -> null);
     }


### PR DESCRIPTION
# Requires https://github.com/MegaMek/mm-data/pull/458

Close #4276

An ambush occurs when a player deploys 'blindly' to an unexplored StratCon hex. If that deployment generates a scenario, the scenario will automatically pull the force in, even if it's a Patrol.

Ambush scenarios use a smaller pool of scenario types all curated to make sense for an ambush scenario. The curation differentiates between a normal ambush and a bungled scouting attempt.

# Important
Essential scenarios are pre-placed. In the event an essential scenario is landed on via a force deploying blind it will not be rerolled as an ambush scenario. The player will just have to make do.