### PR TITLE
Reflow Campaign Options widths on runtime GUI-scale change

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsUtilities.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsUtilities.java
@@ -84,13 +84,25 @@ import mekhq.gui.baseComponents.MHQCollapsiblePanel;
 public class CampaignOptionsUtilities {
     private static final String RESOURCE_BUNDLE = "mekhq.resources.CampaignOptionsDialog";
     final static String IMAGE_DIRECTORY = "data/images/universe/factions/";
-    public final static int CAMPAIGN_OPTIONS_PANEL_WIDTH = scaleForGUI(950);
+
     /**
-     * Fixed content width for page-shell section bodies (tables, ability panels). Kept narrower than
-     * {@link #CAMPAIGN_OPTIONS_PANEL_WIDTH} so that, once the collapsible section's padding and insets are added, the
-     * content never reports a preferred width wider than the page can display (which would break the section layout).
+     * Shared page-width cap for the Campaign Options dialog, at the current GUI scale. Resolved on each call (rather
+     * than cached in a {@code static final}) so the dialog reflows when the GUI scale changes at runtime instead of
+     * staying frozen at the scale in effect when the class first loaded.
      */
-    public final static int CAMPAIGN_OPTIONS_PAGE_CONTENT_WIDTH = scaleForGUI(860);
+    public static int campaignOptionsPanelWidth() {
+        return scaleForGUI(950);
+    }
+
+    /**
+     * Content width for page-shell section bodies (tables, ability panels), at the current GUI scale. Kept narrower
+     * than {@link #campaignOptionsPanelWidth()} so that, once the collapsible section's padding and insets are added,
+     * the content never reports a preferred width wider than the page can display (which would break the section
+     * layout). Resolved on each call so it tracks a runtime GUI-scale change.
+     */
+    public static int campaignOptionsPageContentWidth() {
+        return scaleForGUI(860);
+    }
     private static final int QUOTE_TOP_PADDING = scaleForGUI(12);
     private static final int QUOTE_BOTTOM_PADDING = scaleForGUI(8);
     // Ambient sink for contextual help text. Campaign Options is a single-instance modal dialog, and this sink is
@@ -229,7 +241,7 @@ public class CampaignOptionsUtilities {
             return content;
         }
 
-        int quoteWidth = Math.max(1, Math.min(getQuoteReferenceWidth(content), CAMPAIGN_OPTIONS_PANEL_WIDTH));
+        int quoteWidth = Math.max(1, Math.min(getQuoteReferenceWidth(content), campaignOptionsPanelWidth()));
 
         JPanel quotePanel = new JPanel(new GridBagLayout());
         quotePanel.setBorder(BorderFactory.createEmptyBorder(QUOTE_TOP_PADDING, 0, QUOTE_BOTTOM_PADDING, 0));
@@ -297,7 +309,7 @@ public class CampaignOptionsUtilities {
         @Override
         public Dimension getPreferredSize() {
             Dimension preferredSize = content.getPreferredSize();
-            return new Dimension(Math.min(preferredSize.width, CAMPAIGN_OPTIONS_PANEL_WIDTH), preferredSize.height);
+            return new Dimension(Math.min(preferredSize.width, campaignOptionsPanelWidth()), preferredSize.height);
         }
 
         @Override
@@ -308,7 +320,7 @@ public class CampaignOptionsUtilities {
         @Override
         public void doLayout() {
             Dimension preferredSize = content.getPreferredSize();
-            int contentWidth = Math.min(preferredSize.width, CAMPAIGN_OPTIONS_PANEL_WIDTH);
+            int contentWidth = Math.min(preferredSize.width, campaignOptionsPanelWidth());
             contentWidth = Math.min(contentWidth, getWidth());
             int x = Math.max(0, (getWidth() - contentWidth) / 2);
             content.setBounds(x, 0, contentWidth, preferredSize.height);

--- a/MekHQ/src/mekhq/gui/campaignOptions/components/CampaignOptionsIntroPanel.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/components/CampaignOptionsIntroPanel.java
@@ -33,7 +33,7 @@
 package mekhq.gui.campaignOptions.components;
 
 import static megamek.client.ui.util.FlatLafStyleBuilder.setFontScaling;
-import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.CAMPAIGN_OPTIONS_PANEL_WIDTH;
+import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.campaignOptionsPanelWidth;
 
 import java.awt.Dimension;
 import java.awt.FlowLayout;
@@ -77,7 +77,7 @@ public class CampaignOptionsIntroPanel extends JPanel {
     }
 
     private static int getTextWidth(int textWidth) {
-        return Math.max(1, Math.min(textWidth, CAMPAIGN_OPTIONS_PANEL_WIDTH));
+        return Math.max(1, Math.min(textWidth, campaignOptionsPanelWidth()));
     }
 
     private static Dimension getWrappedTextSize(JEditorPane textPane, int textWidth) {

--- a/MekHQ/src/mekhq/gui/campaignOptions/components/CampaignOptionsPagePanel.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/components/CampaignOptionsPagePanel.java
@@ -34,7 +34,7 @@ package mekhq.gui.campaignOptions.components;
 
 import static megamek.client.ui.util.FlatLafStyleBuilder.setFontScaling;
 import static megamek.client.ui.util.FontHandler.symbolIcon;
-import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.CAMPAIGN_OPTIONS_PANEL_WIDTH;
+import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.campaignOptionsPanelWidth;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.formatBadges;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.getCampaignOptionsResourceBundle;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.setSmallSizeVariant;
@@ -72,7 +72,7 @@ import mekhq.gui.campaignOptions.CampaignOptionsMetadata;
  * expand/collapse-all controls), and an optional
  * quote footer. Arbitrary components can also be interleaved with the sections.
  * Every sectioned page is floored to a
- * shared width ({@link #UNIFORM_SECTION_STACK_WIDTH}) so the dialog's pages
+ * shared width ({@link #uniformSectionStackWidth()}) so the dialog's pages
  * render at a consistent width, while pages
  * whose content is naturally wider keep their size up to the page-width cap.
  * </p>
@@ -89,14 +89,14 @@ public class CampaignOptionsPagePanel extends JPanel {
     private static final int QUOTE_BOTTOM_PADDING = UIUtil.scaleForGUI(8);
     private static final int QUOTE_HORIZONTAL_PADDING = UIUtil.scaleForGUI(24);
     private static final int DEFAULT_HEADER_IMAGE_SIZE = 80;
-    // Shared minimum width every sectioned page is floored to, so form pages render
-    // at a consistent width across the
-    // dialog instead of each page shrinking to its own widest section. Comfortably
-    // covers a two-column form section
-    // (label column plus a long right-column control or checkbox) and stays well
-    // under the page width cap, so wider
-    // table pages and the 950 cap are unaffected.
-    private static final int UNIFORM_SECTION_STACK_WIDTH = UIUtil.scaleForGUI(640);
+    private static int uniformSectionStackWidth() {
+        // Shared minimum width every sectioned page is floored to, so form pages render at a consistent width across
+        // the dialog instead of each page shrinking to its own widest section. Comfortably covers a two-column form
+        // section (label column plus a long right-column control or checkbox) and stays well under the page width cap,
+        // so wider table pages and the 950 cap are unaffected. Resolved on each call (not cached in a static final) so
+        // the pages reflow when the GUI scale changes at runtime.
+        return UIUtil.scaleForGUI(640);
+    }
 
     private final JPanel pageBody;
     private final boolean showDetailsPanel;
@@ -142,7 +142,7 @@ public class CampaignOptionsPagePanel extends JPanel {
         if (sectionStackWidth == 0 && builder.standardContentWidth) {
             // A section-less page (such as a category landing page) would otherwise collapse its intro and quote to
             // the header width; floor it to the shared page width so it matches the dialog's sectioned pages.
-            sectionStackWidth = UNIFORM_SECTION_STACK_WIDTH;
+            sectionStackWidth = uniformSectionStackWidth();
         }
 
         JPanel contentPanel = createContentPanel(builder, renderItems, sections, sectionControls, sectionStackWidth);
@@ -240,7 +240,7 @@ public class CampaignOptionsPagePanel extends JPanel {
     @Override
     public @Nonnull Dimension getPreferredSize() {
         Dimension preferredSize = pageBody.getPreferredSize();
-        return new Dimension(Math.min(preferredSize.width, CAMPAIGN_OPTIONS_PANEL_WIDTH), preferredSize.height);
+        return new Dimension(Math.min(preferredSize.width, campaignOptionsPanelWidth()), preferredSize.height);
     }
 
     @Override
@@ -424,8 +424,8 @@ public class CampaignOptionsPagePanel extends JPanel {
         // is naturally wider than the
         // floor (e.g. table-based pages) keep their larger width; this only grows
         // narrower pages up to the floor, so it
-        // never clips. Tune UNIFORM_SECTION_STACK_WIDTH to adjust the shared width.
-        return Math.max(contentWidth, UNIFORM_SECTION_STACK_WIDTH);
+        // never clips. Tune uniformSectionStackWidth() to adjust the shared width.
+        return Math.max(contentWidth, uniformSectionStackWidth());
     }
 
     private JPanel createSectionControls(List<MHQCollapsiblePanel> sections) {
@@ -464,7 +464,7 @@ public class CampaignOptionsPagePanel extends JPanel {
             return null;
         }
 
-        int quotePanelWidth = Math.max(1, Math.min(contentWidth, CAMPAIGN_OPTIONS_PANEL_WIDTH));
+        int quotePanelWidth = Math.max(1, Math.min(contentWidth, campaignOptionsPanelWidth()));
         int quoteHorizontalPadding = getQuoteHorizontalPadding(quotePanelWidth);
         int quoteTextWidth = quotePanelWidth - (quoteHorizontalPadding * 2);
         JPanel quotePanel = new JPanel(new GridBagLayout());

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/AbilitiesPages.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/AbilitiesPages.java
@@ -35,7 +35,7 @@ package mekhq.gui.campaignOptions.contents;
 import static mekhq.campaign.personnel.SkillPrerequisite.DISPLAY_GROUP_CLOSE;
 import static mekhq.campaign.personnel.SkillPrerequisite.DISPLAY_GROUP_OPEN;
 import static mekhq.campaign.personnel.SkillPrerequisite.DISPLAY_OR_SEPARATOR;
-import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.CAMPAIGN_OPTIONS_PAGE_CONTENT_WIDTH;
+import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.campaignOptionsPageContentWidth;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.getCampaignOptionsResourceBundle;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.getImageDirectory;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
@@ -576,13 +576,13 @@ public class AbilitiesPages {
         @Override
         public Dimension getPreferredSize() {
             Dimension preferredSize = super.getPreferredSize();
-            return new Dimension(CAMPAIGN_OPTIONS_PAGE_CONTENT_WIDTH, preferredSize.height);
+            return new Dimension(campaignOptionsPageContentWidth(), preferredSize.height);
         }
 
         @Override
         public Dimension getMaximumSize() {
             Dimension maximumSize = super.getMaximumSize();
-            return new Dimension(CAMPAIGN_OPTIONS_PAGE_CONTENT_WIDTH, maximumSize.height);
+            return new Dimension(campaignOptionsPageContentWidth(), maximumSize.height);
         }
 
         private static JPanel newColumnPanel() {

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/SkillsPages.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/SkillsPages.java
@@ -33,7 +33,7 @@
 package mekhq.gui.campaignOptions.contents;
 
 import static mekhq.campaign.personnel.skills.enums.SkillSubType.*;
-import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.CAMPAIGN_OPTIONS_PAGE_CONTENT_WIDTH;
+import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.campaignOptionsPageContentWidth;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.getCampaignOptionsResourceBundle;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.getImageDirectory;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.getMetadata;
@@ -401,7 +401,7 @@ public class SkillsPages {
         int rowCount = Math.max(1, table.getRowCount());
         int bodyHeight = table.getRowHeight() * rowCount;
         int headerHeight = table.getTableHeader().getPreferredSize().height;
-        int width = Math.max(CAMPAIGN_OPTIONS_PAGE_CONTENT_WIDTH, table.getPreferredSize().width);
+        int width = Math.max(campaignOptionsPageContentWidth(), table.getPreferredSize().width);
         Dimension viewportSize = new Dimension(width, bodyHeight);
         Dimension scrollPaneSize = new Dimension(width, bodyHeight + headerHeight + UIUtil.scaleForGUI(4));
 


### PR DESCRIPTION
## Problem
`CAMPAIGN_OPTIONS_PANEL_WIDTH`, `CAMPAIGN_OPTIONS_PAGE_CONTENT_WIDTH`, and `UNIFORM_SECTION_STACK_WIDTH` were `static final scaleForGUI(...)` values captured once at class load. After a runtime GUI-scale change (e.g. 160% → 100%), the look-and-feel rescales fonts but these fixed widths stay frozen, so a reopened
Campaign Options dialog is wider than its viewport, which with the as-needed horizontal scrollbar, shows a scrollbar and pushes the section expand/collapse controls off the right edge.

## Fix
Convert the three width constants to accessor methods (`campaignOptionsPanelWidth()`, `campaignOptionsPageContentWidth()`, `uniformSectionStackWidth()`) that resolve `scaleForGUI` at call time, so pages
reflow to the current scale on rebuild. Form-column widths were already computed dynamically at build.

## Testing
- Start at 160%, reduce to 100%, reopen Campaign Options → content fits, no horizontal scrollbar or off-screen controls (no restart needed).
- Reverse (100% → 160%) still reaches all content.
- `:MekHQ:compileJava`, `:MekHQ:compileTestJava`, `:MekHQ:checkstyleMain` green.