### PR TITLE
Fix #9574: Do not remove travel node upon arrival if the node is still in use.

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1813,6 +1813,12 @@ public class Campaign implements ITechManager, IPlace {
         getForceLocationManager().processArrivals(campaign);
     }
 
+    /** The campaign is always in use, so any location node with the campaign below it must never be pruned. */
+    @Override
+    public boolean isInUse() {
+        return true;
+    }
+
     public boolean isOnContractAndPlanetside() {
         boolean isOnContract = !getActiveMissions(false).isEmpty();
         boolean isPlanetside = isOnPlanet();

--- a/MekHQ/src/mekhq/campaign/CampaignLocationManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignLocationManager.java
@@ -444,11 +444,16 @@ public class CampaignLocationManager {
      * died or were removed before arriving, and {@link FixedLocation}/{@link AcademyCampusLocation} pairs that were
      * never cleaned up after the last student graduated.</p>
      *
+     * <p>A location whose subtree still holds a queued pending-travel destination is retained even when otherwise
+     * empty: dispatching that queued travel later would dereference the destination, so removing it here would leave
+     * {@link #dispatchPendingTravel} with a detached node.</p>
+     *
      * <p>Call this once per day after all personnel processing has completed.</p>
      */
     public void pruneEmptyLocations() {
+        Set<ILocation> pendingDestinations = collectPendingDestinations();
         locations.removeIf(location -> {
-            if (location.isInUse()) {
+            if (location.isInUse() || subtreeHoldsPendingDestination(location, pendingDestinations)) {
                 return false;
             }
             if (location instanceof AbstractMobileLocation) {
@@ -462,6 +467,45 @@ public class CampaignLocationManager {
             }
             return true;
         });
+    }
+
+    /**
+     * Returns {@code true} if {@code location} or any node in its subtree is queued as a pending-travel destination, so
+     * that a caller about to remove {@code location} from the tree can spare it — dispatching that queued travel later
+     * would otherwise dereference a detached destination.
+     */
+    public boolean holdsPendingTravelDestination(ILocation location) {
+        return subtreeHoldsPendingDestination(location, collectPendingDestinations());
+    }
+
+    /** Collects the destinations of all queued pending travel into an identity set. */
+    private Set<ILocation> collectPendingDestinations() {
+        Set<ILocation> destinations = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (TravelRoute route : pendingTravel.keySet()) {
+            if (route.destination() != null) {
+                destinations.add(route.destination());
+            }
+        }
+        return destinations;
+    }
+
+    /**
+     * Returns {@code true} if {@code location} or any node in its subtree is one of {@code pendingDestinations}. Used to
+     * spare an otherwise-empty node that queued travel is still bound for.
+     */
+    private static boolean subtreeHoldsPendingDestination(ILocation location, Set<ILocation> pendingDestinations) {
+        if (pendingDestinations.isEmpty()) {
+            return false;
+        }
+        if (pendingDestinations.contains(location)) {
+            return true;
+        }
+        for (ILocation child : location.getChildLocations()) {
+            if (subtreeHoldsPendingDestination(child, pendingDestinations)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/CampaignLocationManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignLocationManager.java
@@ -436,8 +436,9 @@ public class CampaignLocationManager {
     }
 
     /**
-     * Removes any {@link AbstractLocation} entries that have no personnel, parts, or units at any depth in their
-     * subtree, excluding the campaign's own current location.
+     * Removes any tracked top-level {@link AbstractLocation} that is no longer {@link ILocation#isInUse() in use} —
+     * one with no {@link Campaign}, {@link mekhq.campaign.base.AbstractBase}, person, unit, or part anywhere in its
+     * subtree. The main force's current location is retained automatically because the campaign node sits below it.
      *
      * <p>This handles two leak paths: {@link CurrentLocation} travel nodes whose passengers all
      * died or were removed before arriving, and {@link FixedLocation}/{@link AcademyCampusLocation} pairs that were
@@ -445,15 +446,9 @@ public class CampaignLocationManager {
      *
      * <p>Call this once per day after all personnel processing has completed.</p>
      */
-    public void pruneEmptyLocations(Campaign campaign) {
-        AbstractLocation mainLocation = campaign.getCurrentLocation();
+    public void pruneEmptyLocations() {
         locations.removeIf(location -> {
-            if (location == mainLocation) {
-                return false;
-            }
-            if (!location.fetchPersonnelAtLocation().isEmpty()
-                      || !location.fetchPartsAtLocation().isEmpty()
-                      || !location.fetchUnitsAtLocation().isEmpty()) {
+            if (location.isInUse()) {
                 return false;
             }
             if (location instanceof AbstractMobileLocation) {

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -480,7 +480,7 @@ public class CampaignNewDayManager {
 
         processAllArrivals();
 
-        campaign.getCampaignLocationManager().pruneEmptyLocations(campaign);
+        campaign.getCampaignLocationManager().pruneEmptyLocations();
 
         if (campaignOptions.isUseRandomDiseases() && campaignOptions.isUseAlternativeAdvancedMedical()) {
             PlanetarySystem currentSystem = updatedLocation.getCurrentSystem();

--- a/MekHQ/src/mekhq/campaign/base/AbstractBase.java
+++ b/MekHQ/src/mekhq/campaign/base/AbstractBase.java
@@ -102,6 +102,12 @@ public abstract class AbstractBase implements IPlace {
         return locationNode;
     }
 
+    /** A base is always in use, so any location node with a base below it must never be pruned. */
+    @Override
+    public boolean isInUse() {
+        return true;
+    }
+
     /** Returns the {@link Personnel} node that holds persons who have arrived at this base. */
     public Personnel getBasePersonnel() {
         return basePersonnel;

--- a/MekHQ/src/mekhq/campaign/location/ILocatable.java
+++ b/MekHQ/src/mekhq/campaign/location/ILocatable.java
@@ -68,4 +68,13 @@ public interface ILocatable extends ILocation {
     default boolean isQueuedForTravel(CampaignLocationManager locationManager) {
         return locationManager.isQueuedForTravel(this);
     }
+
+    /**
+     * A {@link Unit}, {@link Person}, or {@link Part} is a real occupant, so a location node hosting one is always in
+     * use and must not be pruned.
+     */
+    @Override
+    default boolean isInUse() {
+        return true;
+    }
 }

--- a/MekHQ/src/mekhq/campaign/location/ILocation.java
+++ b/MekHQ/src/mekhq/campaign/location/ILocation.java
@@ -461,6 +461,23 @@ public interface ILocation {
     }
 
     /**
+     * Returns {@code true} if this node — or anything in the tree below it — is a real occupant that must not be
+     * pruned: a {@link Campaign}, {@link mekhq.campaign.base.AbstractBase}, {@link Person}, {@link Unit}, or
+     * {@link Part}. A top-level {@link AbstractLocation} for which this returns {@code false} is dead structure safe to
+     * remove from the tree.
+     *
+     * <p>The default recurses into child locations; occupant types override it to return {@code true} directly.</p>
+     */
+    default boolean isInUse() {
+        for (ILocation child : getChildLocations()) {
+            if (child.isInUse()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Processes arriving travel nodes parented to this location.
      *
      * <p>For each completed {@link mekhq.campaign.CurrentLocation} child (one whose jump path has

--- a/MekHQ/src/mekhq/campaign/location/LocationDispatch.java
+++ b/MekHQ/src/mekhq/campaign/location/LocationDispatch.java
@@ -81,17 +81,20 @@ public final class LocationDispatch {
      * Removes a spent travel node from the campaign: detaches it from the location tree and de-registers it from the
      * campaign's location list.
      *
-     * <p>No-op when {@code travelNode} is {@code null} or still {@link ILocation#isInUse() in use} — i.e. it still has
-     * a {@link mekhq.campaign.Campaign}, {@link mekhq.campaign.base.AbstractBase}, person, unit, or part below it.
-     * This guards against removing a node that is not really a spent travel node, most notably the main force's own
-     * {@link mekhq.campaign.CurrentLocation} (which carries the whole campaign) when it is reached during education
-     * arrival.</p>
+     * <p>No-op when {@code travelNode} is {@code null}, still {@link ILocation#isInUse() in use} — i.e. it still has a
+     * {@link mekhq.campaign.Campaign}, {@link mekhq.campaign.base.AbstractBase}, person, unit, or part below it — or its
+     * subtree is still a queued {@link CampaignLocationManager#holdsPendingTravelDestination pending-travel
+     * destination}. This guards against removing a node that is not really a spent travel node, most notably the main
+     * force's own {@link mekhq.campaign.CurrentLocation} (which carries the whole campaign) when it is reached during
+     * education arrival.</p>
      *
      * @param travelNode      the node to remove, or {@code null}
      * @param locationManager the campaign's location registry; must not be {@code null}
      */
     public static void removeTravelNode(@Nullable AbstractMobileLocation travelNode, CampaignLocationManager locationManager) {
-        if (travelNode == null || travelNode.isInUse()) {
+        if (travelNode == null
+                  || travelNode.isInUse()
+                  || locationManager.holdsPendingTravelDestination(travelNode)) {
             return;
         }
         travelNode.setParent(null);

--- a/MekHQ/src/mekhq/campaign/location/LocationDispatch.java
+++ b/MekHQ/src/mekhq/campaign/location/LocationDispatch.java
@@ -78,16 +78,20 @@ public final class LocationDispatch {
     private LocationDispatch() {}
 
     /**
-     * Removes a completed travel node from the campaign: detaches it from the location tree and
-     * de-registers it from the campaign's location list.
+     * Removes a spent travel node from the campaign: detaches it from the location tree and de-registers it from the
+     * campaign's location list.
      *
-     * <p>Safe to call with a {@code null} argument (no-op).</p>
+     * <p>No-op when {@code travelNode} is {@code null} or still {@link ILocation#isInUse() in use} — i.e. it still has
+     * a {@link mekhq.campaign.Campaign}, {@link mekhq.campaign.base.AbstractBase}, person, unit, or part below it.
+     * This guards against removing a node that is not really a spent travel node, most notably the main force's own
+     * {@link mekhq.campaign.CurrentLocation} (which carries the whole campaign) when it is reached during education
+     * arrival.</p>
      *
      * @param travelNode      the node to remove, or {@code null}
      * @param locationManager the campaign's location registry; must not be {@code null}
      */
     public static void removeTravelNode(@Nullable AbstractMobileLocation travelNode, CampaignLocationManager locationManager) {
-        if (travelNode == null) {
+        if (travelNode == null || travelNode.isInUse()) {
             return;
         }
         travelNode.setParent(null);


### PR DESCRIPTION
Fixes #9574 

When a travel node reached its destination, it was being blindly deleted. We now have common logic for checking if there's anything important in an ILocation tree (`isInUse()`) which is utilized in this manual removal and in the automatic daily one that closes orphaned nodes.

The `CurrentLocation` used by `Campaign` was getting cleaned up so the new day processing was not occurring for anything at the campaign's location.