### PR TITLE
Close #9630: Added the Ability to Remove Individual Parts Without Flipping Unit to Strip in Repair Tab

### DIFF
--- a/MekHQ/resources/mekhq/resources/TaskTableMouseAdapter.properties
+++ b/MekHQ/resources/mekhq/resources/TaskTableMouseAdapter.properties
@@ -31,3 +31,8 @@
 TaskTableMouseAdapter.FIX_GM_ACQUIRE=Complete Task (GM Acquire Part)
 TaskTableMouseAdapter.FIX_GM_ACQUIRE.report=GM Repair, {0} {1}
 TaskTableMouseAdapter.scrap=Cannot Scrap
+TaskTableMouseAdapter.strip=Strip Part (TN {0}, {1} min)
+TaskTableMouseAdapter.strip.disabled=Strip Part
+TaskTableMouseAdapter.strip.noTech.tooltip=Select a technician to strip this part.
+TaskTableMouseAdapter.strip.impossible.tooltip=The selected technician cannot strip this part.
+TaskTableMouseAdapter.strip.mekLocation.tooltip=Locations can't be stripped directly. Remove the armor and any equipment on this location first, then use Scrap component to salvage the location itself.

--- a/MekHQ/src/mekhq/gui/RepairTab.java
+++ b/MekHQ/src/mekhq/gui/RepairTab.java
@@ -425,7 +425,7 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
         sortKeys = new ArrayList<>();
         sortKeys.add(new RowSorter.SortKey(0, SortOrder.ASCENDING));
         taskSorter.setSortKeys(sortKeys);
-        TaskTableMouseAdapter.connect(getCampaignGui(), taskTable, taskModel);
+        TaskTableMouseAdapter.connect(getCampaignGui(), taskTable, taskModel, this);
         JScrollPane scrollTaskTable = new FastJScrollPane(taskTable);
         scrollTaskTable.setMinimumSize(new Dimension(200, 200));
         scrollTaskTable.setPreferredSize(new Dimension(300, 300));

--- a/MekHQ/src/mekhq/gui/adapter/TaskTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TaskTableMouseAdapter.java
@@ -51,18 +51,21 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.events.AcquisitionEvent;
 import mekhq.campaign.events.parts.PartChangedEvent;
 import mekhq.campaign.events.parts.PartModeChangedEvent;
+import mekhq.campaign.events.parts.PartWorkEvent;
 import mekhq.campaign.events.units.UnitChangedEvent;
 import mekhq.campaign.parts.Armor;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.equipment.AmmoBin;
 import mekhq.campaign.parts.meks.MekLocation;
 import mekhq.campaign.parts.missing.MissingPart;
+import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.work.IAcquisitionWork;
 import mekhq.campaign.work.IPartWork;
 import mekhq.campaign.work.WorkTime;
 import mekhq.gui.CampaignGUI;
+import mekhq.gui.ITechWorkPanel;
 import mekhq.gui.dialog.QuickStripDialog;
 import mekhq.gui.model.TaskTableModel;
 import mekhq.service.mrms.MRMSService;
@@ -72,21 +75,25 @@ public class TaskTableMouseAdapter extends JPopupMenuAdapter {
     private final CampaignGUI gui;
     private final JTable taskTable;
     private final TaskTableModel taskModel;
+    private final ITechWorkPanel techWorkPanel;
 
 
     private static final String RESOURCE_BUNDLE = "mekhq.resources.TaskTableMouseAdapter";
     //endregion Variable Declaration
 
     //region Constructors
-    protected TaskTableMouseAdapter(CampaignGUI gui, JTable taskTable, TaskTableModel taskModel) {
+    protected TaskTableMouseAdapter(CampaignGUI gui, JTable taskTable, TaskTableModel taskModel,
+          ITechWorkPanel techWorkPanel) {
         this.gui = gui;
         this.taskTable = taskTable;
         this.taskModel = taskModel;
+        this.techWorkPanel = techWorkPanel;
     }
     //endregion Constructors
 
-    public static void connect(CampaignGUI gui, JTable taskTable, TaskTableModel taskModel) {
-        new TaskTableMouseAdapter(gui, taskTable, taskModel).connect(taskTable);
+    public static void connect(CampaignGUI gui, JTable taskTable, TaskTableModel taskModel,
+          ITechWorkPanel techWorkPanel) {
+        new TaskTableMouseAdapter(gui, taskTable, taskModel, techWorkPanel).connect(taskTable);
     }
 
     @Override
@@ -132,6 +139,16 @@ public class TaskTableMouseAdapter extends JPopupMenuAdapter {
                     campaign.removeUnit(u.getId());
                 }
                 MekHQ.triggerEvent(new UnitChangedEvent(u));
+            }
+        } else if (command.equalsIgnoreCase("STRIP")) {
+            Person tech = techWorkPanel.getSelectedTech();
+            if (tech == null) {
+                return;
+            }
+            for (IPartWork work : parts) {
+                if (work instanceof Part part) {
+                    stripPart(campaign, part, tech);
+                }
             }
         } else if (command.contains("CHANGE_MODE")) {
             String sel = command.split(":")[1];
@@ -195,6 +212,116 @@ public class TaskTableMouseAdapter extends JPopupMenuAdapter {
         }
     }
 
+    /**
+     * Determines whether a "Strip Part" entry should be shown for the given task.
+     *
+     * <p>The entry is offered for any installed component on a unit that is set to repair. Mek locations are included
+     * even though they cannot actually be stripped from here: they are surfaced (disabled, with an explanation) so the
+     * player understands why, rather than silently omitting the option. Replacement tasks (missing parts) and spare
+     * parts are excluded outright, as are units already in salvage mode (where removal is already the default
+     * task).</p>
+     *
+     * @param part the task to test
+     *
+     * @return {@code true} if a "Strip Part" entry should be shown for this task
+     */
+    private static boolean isStripCandidate(Part part) {
+        Unit unit = part.getUnit();
+        if ((unit == null) || unit.isSalvage() || (part instanceof MissingPart)) {
+            return false;
+        }
+        // Mek locations are shown so we can explain why they can't be stripped; everything else must be scrappable.
+        return (part instanceof MekLocation) || !part.canNeverScrap();
+    }
+
+    /**
+     * Computes the salvage-removal target roll for a part as if its unit were in salvage mode, without permanently
+     * changing the unit's salvage state. This lets the repair task list surface the removal target number even though
+     * the unit is set to repair.
+     *
+     * @param part the part to be stripped
+     * @param tech the technician who would perform the removal
+     *
+     * @return the target roll for removing the part, or {@code null} if it cannot be computed
+     */
+    private TargetRoll getStripTarget(Part part, Person tech) {
+        Unit unit = part.getUnit();
+        if ((unit == null) || (tech == null)) {
+            return null;
+        }
+
+        boolean wasSalvage = unit.isSalvage();
+        boolean techWasNull = part.getTech() == null;
+        unit.setSalvage(true);
+        // Temporarily set the tech (mirrors RepairTab#updateTechTarget) so the Clan-tech flag resolves correctly.
+        if (techWasNull) {
+            part.setTech(tech);
+        }
+        try {
+            return gui.getCampaign().getTargetFor(part, tech);
+        } finally {
+            if (techWasNull) {
+                part.setTech(null);
+            }
+            unit.setSalvage(wasSalvage);
+        }
+    }
+
+    /**
+     * Computes how many minutes a salvage-removal of the part would take, evaluated as if the unit were in salvage
+     * mode, without permanently changing the unit's salvage state.
+     *
+     * @param part the part to be stripped
+     *
+     * @return the time (in minutes) left to remove the part
+     */
+    private int getStripTime(Part part) {
+        Unit unit = part.getUnit();
+        if (unit == null) {
+            return 0;
+        }
+
+        boolean wasSalvage = unit.isSalvage();
+        unit.setSalvage(true);
+        try {
+            return part.getTimeLeft();
+        } finally {
+            unit.setSalvage(wasSalvage);
+        }
+    }
+
+    /**
+     * Performs a salvage-removal ("strip") of a part using the supplied tech, consuming the tech's time and rolling
+     * against the salvage target number exactly as the normal Do Task action would. The part's unit is temporarily
+     * flipped into salvage mode so the work is resolved as a removal rather than a repair; the flag is restored
+     * afterward (a multi-day task keeps salvaging because {@code fixPart} captures the salvage state when it assigns
+     * the tech).
+     *
+     * @param campaign the current campaign
+     * @param part     the part to strip
+     * @param tech     the technician performing the removal
+     */
+    private void stripPart(Campaign campaign, Part part, Person tech) {
+        Unit unit = part.getUnit();
+        if (unit == null) {
+            return;
+        }
+
+        boolean wasSalvage = unit.isSalvage();
+        unit.setSalvage(true);
+        try {
+            campaign.fixPart(part, tech);
+        } finally {
+            unit.setSalvage(wasSalvage);
+        }
+
+        if (!unit.isRepairable() && !unit.hasSalvageableParts()) {
+            campaign.removeUnit(unit.getId());
+        }
+        unit.refreshPodSpace();
+        MekHQ.triggerEvent(new PartWorkEvent(tech, part));
+    }
+
     @Override
     protected Optional<JPopupMenu> createPopupMenu() {
         int row = taskTable.getSelectedRow();
@@ -256,6 +383,41 @@ public class TaskTableMouseAdapter extends JPopupMenuAdapter {
             menuItem.addActionListener(this);
             menuItem.setEnabled(!isBeingWorked);
             popup.add(menuItem);
+        }
+
+        // Strip part: one-click salvage removal using the currently selected tech, even though the unit is set to
+        // repair. Only offered for a single installed, damaged component so the target number and time can be shown.
+        if ((rows.length == 1) && (partWork instanceof Part stripCandidate) && isStripCandidate(stripCandidate)) {
+            if (stripCandidate instanceof MekLocation) {
+                // Locations can't be stripped from here (armor and equipment must come off first, in order); show a
+                // disabled entry that explains why and points the player at Scrap.
+                menuItem = new JMenuItem(getTextAt(RESOURCE_BUNDLE, "TaskTableMouseAdapter.strip.disabled"));
+                menuItem.setToolTipText(getTextAt(RESOURCE_BUNDLE, "TaskTableMouseAdapter.strip.mekLocation.tooltip"));
+                menuItem.setEnabled(false);
+                popup.add(menuItem);
+            } else {
+                Person tech = techWorkPanel.getSelectedTech();
+                TargetRoll target = getStripTarget(stripCandidate, tech);
+                boolean canPerformStrip = !isBeingWorked
+                                                && (tech != null)
+                                                && (target != null)
+                                                && (target.getValue() != TargetRoll.IMPOSSIBLE);
+
+                if (canPerformStrip) {
+                    menuItem = new JMenuItem(getFormattedTextAt(RESOURCE_BUNDLE, "TaskTableMouseAdapter.strip",
+                          target.getValueAsString(), String.valueOf(getStripTime(stripCandidate))));
+                    menuItem.setToolTipText(target.getDesc());
+                } else {
+                    menuItem = new JMenuItem(getTextAt(RESOURCE_BUNDLE, "TaskTableMouseAdapter.strip.disabled"));
+                    menuItem.setToolTipText(getTextAt(RESOURCE_BUNDLE,
+                          (tech == null) ? "TaskTableMouseAdapter.strip.noTech.tooltip"
+                                : "TaskTableMouseAdapter.strip.impossible.tooltip"));
+                }
+                menuItem.setActionCommand("STRIP");
+                menuItem.addActionListener(this);
+                menuItem.setEnabled(canPerformStrip);
+                popup.add(menuItem);
+            }
         }
 
         if (gui.getCampaign().isGM()) {

--- a/MekHQ/src/mekhq/gui/adapter/TaskTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TaskTableMouseAdapter.java
@@ -387,7 +387,8 @@ public class TaskTableMouseAdapter extends JPopupMenuAdapter {
 
         // Strip part: one-click salvage removal using the currently selected tech, even though the unit is set to
         // repair. Only offered for a single installed, damaged component so the target number and time can be shown.
-        if ((rows.length == 1) && (partWork instanceof Part stripCandidate) && isStripCandidate(stripCandidate)) {
+        if (!isBeingWorked && (rows.length == 1) && (partWork instanceof Part stripCandidate)
+              && isStripCandidate(stripCandidate)) {
             if (stripCandidate instanceof MekLocation) {
                 // Locations can't be stripped from here (armor and equipment must come off first, in order); show a
                 // disabled entry that explains why and points the player at Scrap.

--- a/MekHQ/src/mekhq/gui/adapter/TaskTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TaskTableMouseAdapter.java
@@ -225,7 +225,7 @@ public class TaskTableMouseAdapter extends JPopupMenuAdapter {
      *
      * @return {@code true} if a "Strip Part" entry should be shown for this task
      */
-    private static boolean isStripCandidate(Part part) {
+    static boolean isStripCandidate(Part part) {
         Unit unit = part.getUnit();
         if ((unit == null) || unit.isSalvage() || (part instanceof MissingPart)) {
             return false;
@@ -244,7 +244,7 @@ public class TaskTableMouseAdapter extends JPopupMenuAdapter {
      *
      * @return the target roll for removing the part, or {@code null} if it cannot be computed
      */
-    private TargetRoll getStripTarget(Part part, Person tech) {
+    TargetRoll getStripTarget(Part part, Person tech) {
         Unit unit = part.getUnit();
         if ((unit == null) || (tech == null)) {
             return null;
@@ -275,7 +275,7 @@ public class TaskTableMouseAdapter extends JPopupMenuAdapter {
      *
      * @return the time (in minutes) left to remove the part
      */
-    private int getStripTime(Part part) {
+    int getStripTime(Part part) {
         Unit unit = part.getUnit();
         if (unit == null) {
             return 0;
@@ -301,7 +301,7 @@ public class TaskTableMouseAdapter extends JPopupMenuAdapter {
      * @param part     the part to strip
      * @param tech     the technician performing the removal
      */
-    private void stripPart(Campaign campaign, Part part, Person tech) {
+    void stripPart(Campaign campaign, Part part, Person tech) {
         Unit unit = part.getUnit();
         if (unit == null) {
             return;

--- a/MekHQ/unittests/mekhq/gui/adapter/TaskTableMouseAdapterTest.java
+++ b/MekHQ/unittests/mekhq/gui/adapter/TaskTableMouseAdapterTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.adapter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.swing.JTable;
+
+import megamek.common.rolls.TargetRoll;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.parts.Part;
+import mekhq.campaign.parts.meks.MekLocation;
+import mekhq.campaign.parts.missing.MissingPart;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.unit.Unit;
+import mekhq.gui.CampaignGUI;
+import mekhq.gui.ITechWorkPanel;
+import mekhq.gui.model.TaskTableModel;
+import org.junit.jupiter.api.Test;
+
+class TaskTableMouseAdapterTest {
+
+    private TaskTableMouseAdapter newAdapter(CampaignGUI gui) {
+        return new TaskTableMouseAdapter(gui, mock(JTable.class), mock(TaskTableModel.class),
+              mock(ITechWorkPanel.class));
+    }
+
+    /**
+     * Returns a mock {@link Unit} whose salvage flag is backed by the supplied {@link AtomicBoolean}, so that
+     * {@code setSalvage}/{@code isSalvage} behave like the real (mutable) field. This lets tests observe the temporary
+     * salvage toggle the strip helpers perform.
+     */
+    private Unit salvageTrackingUnit(AtomicBoolean salvage) {
+        Unit unit = mock(Unit.class);
+        when(unit.isSalvage()).thenAnswer(inv -> salvage.get());
+        doAnswer(inv -> {
+            salvage.set(inv.getArgument(0));
+            return null;
+        }).when(unit).setSalvage(anyBoolean());
+        return unit;
+    }
+
+    // region isStripCandidate
+
+    @Test
+    void isStripCandidate_installedScrappableComponent_true() {
+        Unit unit = mock(Unit.class);
+        when(unit.isSalvage()).thenReturn(false);
+        Part part = mock(Part.class);
+        when(part.getUnit()).thenReturn(unit);
+        when(part.canNeverScrap()).thenReturn(false);
+
+        assertTrue(TaskTableMouseAdapter.isStripCandidate(part));
+    }
+
+    @Test
+    void isStripCandidate_sparePartWithoutUnit_false() {
+        Part part = mock(Part.class);
+        when(part.getUnit()).thenReturn(null);
+
+        assertFalse(TaskTableMouseAdapter.isStripCandidate(part));
+    }
+
+    @Test
+    void isStripCandidate_unitInSalvageMode_false() {
+        Unit unit = mock(Unit.class);
+        when(unit.isSalvage()).thenReturn(true);
+        Part part = mock(Part.class);
+        when(part.getUnit()).thenReturn(unit);
+
+        assertFalse(TaskTableMouseAdapter.isStripCandidate(part));
+    }
+
+    @Test
+    void isStripCandidate_missingPart_false() {
+        Unit unit = mock(Unit.class);
+        when(unit.isSalvage()).thenReturn(false);
+        MissingPart part = mock(MissingPart.class);
+        when(part.getUnit()).thenReturn(unit);
+
+        assertFalse(TaskTableMouseAdapter.isStripCandidate(part));
+    }
+
+    @Test
+    void isStripCandidate_partThatCanNeverScrap_false() {
+        Unit unit = mock(Unit.class);
+        when(unit.isSalvage()).thenReturn(false);
+        Part part = mock(Part.class);
+        when(part.getUnit()).thenReturn(unit);
+        when(part.canNeverScrap()).thenReturn(true);
+
+        assertFalse(TaskTableMouseAdapter.isStripCandidate(part));
+    }
+
+    @Test
+    void isStripCandidate_mekLocationShownEvenWhenNotScrappable_true() {
+        // Mek locations are surfaced (so the menu can explain, disabled, why they can't be stripped) even if they
+        // report that they can never be scrapped.
+        Unit unit = mock(Unit.class);
+        when(unit.isSalvage()).thenReturn(false);
+        MekLocation part = mock(MekLocation.class);
+        when(part.getUnit()).thenReturn(unit);
+        when(part.canNeverScrap()).thenReturn(true);
+
+        assertTrue(TaskTableMouseAdapter.isStripCandidate(part));
+    }
+
+    // endregion isStripCandidate
+
+    // region getStripTarget / getStripTime
+
+    @Test
+    void getStripTarget_evaluatesWithSalvageForcedThenRestoresFlag() {
+        AtomicBoolean salvage = new AtomicBoolean(false);
+        Unit unit = salvageTrackingUnit(salvage);
+        Part part = mock(Part.class);
+        when(part.getUnit()).thenReturn(unit);
+        when(part.getTech()).thenReturn(null);
+        Person tech = mock(Person.class);
+
+        Campaign campaign = mock(Campaign.class);
+        CampaignGUI gui = mock(CampaignGUI.class);
+        when(gui.getCampaign()).thenReturn(campaign);
+
+        TargetRoll expected = new TargetRoll(5, "salvage");
+        AtomicBoolean salvageDuringCall = new AtomicBoolean(false);
+        when(campaign.getTargetFor(part, tech)).thenAnswer(inv -> {
+            salvageDuringCall.set(salvage.get());
+            return expected;
+        });
+
+        TargetRoll result = newAdapter(gui).getStripTarget(part, tech);
+
+        assertSame(expected, result);
+        assertTrue(salvageDuringCall.get(), "salvage must be forced on while the target number is computed");
+        assertFalse(salvage.get(), "salvage flag must be restored afterwards");
+        // The tech is set temporarily (for the Clan-tech flag) and cleared again.
+        verify(part).setTech(tech);
+        verify(part).setTech(null);
+    }
+
+    @Test
+    void getStripTarget_sparePart_returnsNull() {
+        Part part = mock(Part.class);
+        when(part.getUnit()).thenReturn(null);
+
+        assertSame(null, newAdapter(mock(CampaignGUI.class)).getStripTarget(part, mock(Person.class)));
+    }
+
+    @Test
+    void getStripTime_evaluatesWithSalvageForcedThenRestoresFlag() {
+        AtomicBoolean salvage = new AtomicBoolean(false);
+        Unit unit = salvageTrackingUnit(salvage);
+        Part part = mock(Part.class);
+        when(part.getUnit()).thenReturn(unit);
+
+        AtomicBoolean salvageDuringCall = new AtomicBoolean(false);
+        when(part.getTimeLeft()).thenAnswer(inv -> {
+            salvageDuringCall.set(salvage.get());
+            return 180;
+        });
+
+        int minutes = newAdapter(mock(CampaignGUI.class)).getStripTime(part);
+
+        assertEquals(180, minutes);
+        assertTrue(salvageDuringCall.get(), "salvage must be forced on while the time is computed");
+        assertFalse(salvage.get(), "salvage flag must be restored afterwards");
+    }
+
+    @Test
+    void getStripTime_sparePart_returnsZero() {
+        Part part = mock(Part.class);
+        when(part.getUnit()).thenReturn(null);
+
+        assertEquals(0, newAdapter(mock(CampaignGUI.class)).getStripTime(part));
+    }
+
+    // endregion getStripTarget / getStripTime
+
+    // region stripPart
+
+    @Test
+    void stripPart_forcesSalvageDuringFixPartAndRestoresAfterwards() {
+        AtomicBoolean salvage = new AtomicBoolean(false);
+        Unit unit = salvageTrackingUnit(salvage);
+        when(unit.isRepairable()).thenReturn(true);
+        Part part = mock(Part.class);
+        when(part.getUnit()).thenReturn(unit);
+        Person tech = mock(Person.class);
+
+        Campaign campaign = mock(Campaign.class);
+        AtomicBoolean salvageDuringCall = new AtomicBoolean(false);
+        when(campaign.fixPart(part, tech)).thenAnswer(inv -> {
+            salvageDuringCall.set(salvage.get());
+            return "done";
+        });
+
+        newAdapter(mock(CampaignGUI.class)).stripPart(campaign, part, tech);
+
+        assertTrue(salvageDuringCall.get(), "salvage must be forced on while the work is resolved");
+        assertFalse(salvage.get(), "salvage flag must be restored afterwards");
+        verify(campaign).fixPart(part, tech);
+        verify(campaign, never()).removeUnit(any());
+        verify(unit).refreshPodSpace();
+    }
+
+    @Test
+    void stripPart_removesUnitWhenNoLongerRepairableOrSalvageable() {
+        AtomicBoolean salvage = new AtomicBoolean(false);
+        Unit unit = salvageTrackingUnit(salvage);
+        UUID unitId = UUID.randomUUID();
+        when(unit.getId()).thenReturn(unitId);
+        when(unit.isRepairable()).thenReturn(false);
+        when(unit.hasSalvageableParts()).thenReturn(false);
+        Part part = mock(Part.class);
+        when(part.getUnit()).thenReturn(unit);
+        Person tech = mock(Person.class);
+
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.fixPart(part, tech)).thenReturn("done");
+
+        newAdapter(mock(CampaignGUI.class)).stripPart(campaign, part, tech);
+
+        verify(campaign).removeUnit(unitId);
+    }
+
+    @Test
+    void stripPart_sparePart_doesNothing() {
+        Part part = mock(Part.class);
+        when(part.getUnit()).thenReturn(null);
+        Campaign campaign = mock(Campaign.class);
+
+        newAdapter(mock(CampaignGUI.class)).stripPart(campaign, part, mock(Person.class));
+
+        verify(campaign, never()).fixPart(any(), any());
+    }
+
+    // endregion stripPart
+}


### PR DESCRIPTION
Close #9630

Process temporarily flips the individual part to 'salvage' and then performs to strip task. This helps streamline the process of manually repairing components.

Contains AI tests