### PR TITLE
PR: Extract Force and Detachment from Campaign

### DIFF
--- a/MekHQ/src/mekhq/campaign/AbstractLocation.java
+++ b/MekHQ/src/mekhq/campaign/AbstractLocation.java
@@ -210,7 +210,7 @@ public abstract class AbstractLocation implements IPlace {
               isSilentProcessing);
     }
 
-    void checkForDiseaseOrBioweaponOutbreaks(Campaign campaign, LocalDate today) {
+    public void checkForDiseaseOrBioweaponOutbreaks(Campaign campaign, LocalDate today) {
         Set<InjuryType> availableCures = getAllSystemSpecificDiseasesWithCures(currentSystem.getId(), today, true);
 
         Set<InjuryType> activeBioweapons = getAllActiveBioweapons(currentSystem.getId(), today, true);
@@ -249,7 +249,7 @@ public abstract class AbstractLocation implements IPlace {
      *
      * @param campaign The {@link Campaign} instance.
      */
-    void testForEarlyArrival(Campaign campaign) {
+    public void testForEarlyArrival(Campaign campaign) {
         for (Contract contract : campaign.getFutureContracts()) {
             if (Objects.equals(currentSystem, contract.getSystem())) {
                 int daysTillStart = campaign.getLocalDate().until(contract.getStartDate()).getDays();

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -387,7 +387,7 @@ public class Campaign implements ITechManager, IPlace {
     private Systems systemsInstance;
     private final Map<String, PlanetarySystem> planetarySystemOverrides = new LinkedHashMap<>();
     private final CampaignLocationManager locationManager = new CampaignLocationManager();
-    private final ForceLocationManager forceLocationManager = new ForceLocationManager(this);
+    private final ForceLocationManager forceLocationManager = new ForceLocationManager(getPlayerForce());
     private boolean isAvoidingEmptySystems;
     private boolean isOverridingCommandCircuitRequirements;
 
@@ -1719,7 +1719,7 @@ public class Campaign implements ITechManager, IPlace {
 
     @Nonnull
     public ForceLocationManager getForceLocationManager() {
-        return forceLocationManager;
+        return getPlayerForce().getForceLocationManager();
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -51,8 +51,6 @@ import static mekhq.campaign.force.Formation.FORMATION_NONE;
 import static mekhq.campaign.force.Formation.FORMATION_ORIGIN;
 import static mekhq.campaign.force.Formation.NO_ASSIGNED_SCENARIO;
 import static mekhq.campaign.force.FormationType.STANDARD;
-import static mekhq.campaign.market.contractMarket.ContractAutomation.performAutomatedActivation;
-import static mekhq.campaign.mission.RandomFactionCamouflage.pickRandomCamouflage;
 import static mekhq.campaign.parts.enums.PartQuality.QUALITY_A;
 import static mekhq.campaign.personnel.PersonnelOptions.ADMIN_INTERSTELLAR_NEGOTIATOR;
 import static mekhq.campaign.personnel.PersonnelOptions.ADMIN_LOGISTICIAN;
@@ -166,8 +164,8 @@ import mekhq.campaign.finances.enums.TransactionType;
 import mekhq.campaign.force.CombatTeam;
 import mekhq.campaign.force.Formation;
 import mekhq.campaign.force.FormationType;
+import mekhq.campaign.force.PlayerForce;
 import mekhq.campaign.icons.StandardFormationIcon;
-import mekhq.campaign.icons.UnitIcon;
 import mekhq.campaign.location.ILocation;
 import mekhq.campaign.location.IPlace;
 import mekhq.campaign.location.LocationNode;
@@ -224,7 +222,6 @@ import mekhq.campaign.personnel.medical.MASHCapacity;
 import mekhq.campaign.personnel.procreation.AbstractProcreation;
 import mekhq.campaign.personnel.ranks.AutoAssignRankForCompanyGenerator;
 import mekhq.campaign.personnel.ranks.RankSystem;
-import mekhq.campaign.personnel.ranks.RankValidator;
 import mekhq.campaign.personnel.skills.ActionCheckResult;
 import mekhq.campaign.personnel.skills.Appraisal;
 import mekhq.campaign.personnel.skills.Attributes;
@@ -246,7 +243,6 @@ import mekhq.campaign.unit.HangarStatistics;
 import mekhq.campaign.unit.TestUnit;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.UnitOrder;
-import mekhq.campaign.unit.UnitTechProgression;
 import mekhq.campaign.unit.enums.TransporterType;
 import mekhq.campaign.universe.*;
 import mekhq.campaign.universe.enums.HiringHallLevel;
@@ -297,20 +293,17 @@ public class Campaign implements ITechManager, IPlace {
     // OK now we have more, parts, personnel, forces, missions, and scenarios.
     // and more still - we're tracking DropShips and WarShips in a separate set so
     // that we can assign units to transports
-    private final Hangar units = new Hangar();
+    /** The player's active force: faction identity, finances, reputation, and the owned hangar/warehouse/personnel. */
+    @Nonnull
+    private final PlayerForce playerForce;
     CampaignTransporterMap shipTransporters = new CampaignTransporterMap(this, CampaignTransportType.SHIP_TRANSPORT);
     CampaignTransporterMap tacticalTransporters = new CampaignTransporterMap(this,
           CampaignTransportType.TACTICAL_TRANSPORT);
     CampaignTransporterMap towTransporters = new CampaignTransporterMap(this, CampaignTransportType.TOW_TRANSPORT);
-    private Warehouse parts = new Warehouse();
     private final TreeMap<Integer, Formation> formationIds = new TreeMap<>();
     private final TreeMap<Integer, Mission> missions = new TreeMap<>();
     private final TreeMap<Integer, Scenario> scenarios = new TreeMap<>();
     private final Map<UUID, List<Kill>> kills = new HashMap<>();
-
-    // The main force's per-part requested stock percentages. Each player base owns its own instance; see
-    // IPlace.getRequestedStockLevels().
-    private final RequestedStockLevels requestedStockLevels = new RequestedStockLevels();
 
     private transient final UnitNameTracker unitNameTracker = new UnitNameTracker();
 
@@ -326,7 +319,6 @@ public class Campaign implements ITechManager, IPlace {
 
     private GameOptions gameOptions;
 
-    private String name;
     private LocalDate currentDay;
     private LocalDate campaignStartDate;
 
@@ -336,11 +328,6 @@ public class Campaign implements ITechManager, IPlace {
     private Formation formations;
     private Hashtable<Integer, CombatTeam> combatTeams; // AtB
 
-    private Faction faction;
-    private megamek.common.enums.Faction techFaction;
-    private String retainerEmployerCode; // AtB
-    private LocalDate retainerStartDate; // AtB
-    private RankSystem rankSystem;
 
     private final ArrayList<String> currentReport;
     private transient String currentReportHTML;
@@ -396,17 +383,11 @@ public class Campaign implements ITechManager, IPlace {
     private boolean gmMode;
     private transient boolean overviewLoadingValue = true;
 
-    private Camouflage camouflage = pickRandomCamouflage(3025, "Root");
-    private PlayerColour colour = PlayerColour.BLUE;
-    private StandardFormationIcon unitIcon = new UnitIcon(null, null);
-
-    private Finances finances;
 
     private Systems systemsInstance;
     private final Map<String, PlanetarySystem> planetarySystemOverrides = new LinkedHashMap<>();
     private final CampaignLocationManager locationManager = new CampaignLocationManager();
     private final ForceLocationManager forceLocationManager = new ForceLocationManager(this);
-    private final Personnel mainForcePersonnel = new Personnel();
     private boolean isAvoidingEmptySystems;
     private boolean isOverridingCommandCircuitRequirements;
 
@@ -420,8 +401,6 @@ public class Campaign implements ITechManager, IPlace {
     private RandomSkillPreferences randomSkillPreferences = new RandomSkillPreferences();
     private CampaignGUI gui;
 
-    private ShoppingList shoppingList;
-
     private AbstractContractMarket contractMarket;
     private AbstractUnitMarket unitMarket;
 
@@ -432,13 +411,6 @@ public class Campaign implements ITechManager, IPlace {
     private IUnitGenerator unitGenerator; // deprecated
     @Deprecated(since = "0.50.10", forRemoval = true)
     private IUnitRating unitRating; // deprecated
-    private ReputationController reputation;
-    private int crimeRating;
-    private int crimePirateModifier;
-    private LocalDate dateOfLastCrime;
-    private FactionStandings factionStandings;
-    private int initiativeBonus;
-    private int initiativeMaxBonus;
     private CampaignSummary campaignSummary;
     private final Quartermaster quartermaster;
     private StoryArc storyArc;
@@ -487,8 +459,6 @@ public class Campaign implements ITechManager, IPlace {
     private static final String RESOURCE_BUNDLE = "mekhq.resources.Campaign";
     private static final String ACTION_CHECK_BUNDLE = "mekhq.resources.ActionCheck";
     private static final String TERRA_ID = "Terra";
-
-    private HumanResources humanResources = new HumanResources();
 
     /**
      * This is used to determine if the player has an active AtB Contract, and is recalculated on load
@@ -554,32 +524,29 @@ public class Campaign implements ITechManager, IPlace {
         this.game = game;
         this.player = player;
         this.game.addPlayer(0, this.player);
-        this.name = name;
         currentDay = date;
         campaignOptions = campaignOpts;
         this.gameOptions = gameOptions;
         game.setOptions(gameOptions);
-        this.techFaction = techFaction;
         this.systemsInstance = systemsInstance;
+
+        // The player force owns faction identity, finances, reputation, and the hangar/warehouse/personnel. It is the
+        // IPlace anchored into the location tree, so it must exist before we set the campaign's location.
+        playerForce = new PlayerForce(faction, techFaction, rankSystem, finances, reputationController,
+              factionStandings, campaignOpts);
+        playerForce.setName(name);
+
         setLocation(startLocation);
         this.setParent(startLocation);
-        if (startLocation != null) {
-            mainForcePersonnel.setParent(this);
-            units.setParent(this);
-            parts.setParent(this);
-        }
-        reputation = reputationController;
-        this.factionStandings = factionStandings;
         formations = formation;
         formationIds.put(0, formations);
-        this.finances = finances;
         randomEventLibraries = randomEvents;
         factionStandingUltimatumsLibrary = ultimatums;
-        humanResources.setRetirementDefectionTracker(retDefTracker);
+        getHumanResources().setRetirementDefectionTracker(retDefTracker);
         autosaveService = autosave;
         autoResolveBehaviorSettings = behaviorSettings;
         this.partsStore = partsStore;
-        humanResources.setNewPersonnelMarket(newPersonnelMarket);
+        getHumanResources().setNewPersonnelMarket(newPersonnelMarket);
         this.randomDeath = randomDeath;
         this.campaignSummary = campaignSummary;
 
@@ -598,18 +565,10 @@ public class Campaign implements ITechManager, IPlace {
 
         // Starting config / default values
         campaignStartDate = null;
-        shoppingList = new ShoppingList();
         isAvoidingEmptySystems = true;
         isOverridingCommandCircuitRequirements = false;
         overtime = false;
         gmMode = false;
-        retainerEmployerCode = null;
-        retainerStartDate = null;
-        crimeRating = 0;
-        crimePirateModifier = 0;
-        dateOfLastCrime = null;
-        initiativeBonus = 0;
-        initiativeMaxBonus = 1;
         combatTeams = new Hashtable<>();
         customs = new ArrayList<>();
         turnoverRetirementInformation = new ArrayList<>();
@@ -673,7 +632,7 @@ public class Campaign implements ITechManager, IPlace {
         // These classes require a Campaign reference to operate/initialize
         currencyManager.setCampaign(this);
         this.partsStore.stock(this);
-        humanResources.getNewPersonnelMarket().setCampaign(this);
+        getHumanResources().getNewPersonnelMarket().setCampaign(this);
         this.randomDeath.setCampaign(this);
         this.campaignSummary.setCampaign(this);
     }
@@ -697,7 +656,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return the human resources subsystem
      */
     public HumanResources getHumanResources() {
-        return humanResources;
+        return playerForce.getHumanResources();
     }
 
     /**
@@ -706,7 +665,7 @@ public class Campaign implements ITechManager, IPlace {
      * @param humanResources the new human resources subsystem
      */
     public void setHumanResources(HumanResources humanResources) {
-        this.humanResources = humanResources;
+        playerForce.setHumanResources(humanResources);
     }
 
     public void setGUI(CampaignGUI gui) {
@@ -760,11 +719,11 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     public String getName() {
-        return name;
+        return playerForce.getName();
     }
 
     public void setName(String s) {
-        this.name = s;
+        playerForce.setName(s);
     }
 
     public Era getEra() {
@@ -863,7 +822,7 @@ public class Campaign implements ITechManager, IPlace {
             return FactionStandingUtilities.isUseCommandCircuit(
                   isOverridingCommandCircuitRequirements, gmMode,
                   campaignOptions.isUseFactionStandingCommandCircuitSafe(),
-                  factionStandings, List.of(atBContract));
+                  getFactionStandings(), List.of(atBContract));
         } else {
             return false;
         }
@@ -887,7 +846,7 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     public Money getFunds() {
-        return finances.getBalance();
+        return playerForce.getFunds();
     }
 
     public void setFormations(Formation f) {
@@ -1000,20 +959,20 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     public void setShoppingList(ShoppingList sl) {
-        shoppingList = sl;
+        getPlayerForce().setShoppingList(sl);
     }
 
     public ShoppingList getShoppingList() {
-        return shoppingList;
+        return getPlayerForce().getShoppingList();
     }
 
     // region Markets
     public PersonnelMarket getPersonnelMarket() {
-        return humanResources.getPersonnelMarket();
+        return getHumanResources().getPersonnelMarket();
     }
 
     public void setPersonnelMarket(final PersonnelMarket personnelMarket) {
-        humanResources.setPersonnelMarket(personnelMarket);
+        getHumanResources().setPersonnelMarket(personnelMarket);
     }
 
     public AbstractContractMarket getContractMarket() {
@@ -1033,12 +992,12 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     public NewPersonnelMarket getNewPersonnelMarket() {
-        return humanResources.getNewPersonnelMarket();
+        return getHumanResources().getNewPersonnelMarket();
     }
 
     public void setNewPersonnelMarket(final NewPersonnelMarket newPersonnelMarket) {
-        humanResources.setNewPersonnelMarket(newPersonnelMarket);
-        humanResources.getNewPersonnelMarket().setCampaign(this);
+        getHumanResources().setNewPersonnelMarket(newPersonnelMarket);
+        getHumanResources().getNewPersonnelMarket().setCampaign(this);
     }
     // endregion Markets
 
@@ -1057,36 +1016,36 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     public AbstractDivorce getDivorce() {
-        return humanResources.getDivorce();
+        return getHumanResources().getDivorce();
     }
 
     public void setDivorce(final AbstractDivorce divorce) {
-        humanResources.setDivorce(divorce);
+        getHumanResources().setDivorce(divorce);
     }
 
     public AbstractMarriage getMarriage() {
-        return humanResources.getMarriage();
+        return getHumanResources().getMarriage();
     }
 
     public void setMarriage(final AbstractMarriage marriage) {
-        humanResources.setMarriage(marriage);
+        getHumanResources().setMarriage(marriage);
     }
 
     public AbstractProcreation getProcreation() {
-        return humanResources.getProcreation();
+        return getHumanResources().getProcreation();
     }
 
     public void setProcreation(final AbstractProcreation procreation) {
-        humanResources.setProcreation(procreation);
+        getHumanResources().setProcreation(procreation);
     }
     // endregion Personnel Modules
 
     public void setRetirementDefectionTracker(RetirementDefectionTracker rdt) {
-        humanResources.setRetirementDefectionTracker(rdt);
+        getHumanResources().setRetirementDefectionTracker(rdt);
     }
 
     public RetirementDefectionTracker getRetirementDefectionTracker() {
-        return humanResources.getRetirementDefectionTracker();
+        return getHumanResources().getRetirementDefectionTracker();
     }
 
     /**
@@ -1096,7 +1055,7 @@ public class Campaign implements ITechManager, IPlace {
      *                                 XP.
      */
     public void setPersonnelWhoAdvancedInXP(List<Person> personnelWhoAdvancedInXP) {
-        humanResources.setPersonnelWhoAdvancedInXP(personnelWhoAdvancedInXP);
+        getHumanResources().setPersonnelWhoAdvancedInXP(personnelWhoAdvancedInXP);
     }
 
     /**
@@ -1105,7 +1064,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return a {@link List} of {@link Person} objects representing personnel who have gained XP.
      */
     public List<Person> getPersonnelWhoAdvancedInXP() {
-        return humanResources.getPersonnelWhoAdvancedInXP();
+        return getHumanResources().getPersonnelWhoAdvancedInXP();
     }
 
     /**
@@ -1763,8 +1722,17 @@ public class Campaign implements ITechManager, IPlace {
         return forceLocationManager;
     }
 
+    /**
+     * Returns the player's active force — the {@link PlayerForce} this campaign is played through, which owns the
+     * faction identity, finances, reputation, and the hangar/warehouse/personnel.
+     */
+    @Nonnull
+    public PlayerForce getPlayerForce() {
+        return playerForce;
+    }
+
     public Personnel getMainForcePersonnel() {
-        return mainForcePersonnel;
+        return playerForce.getPersonnel();
     }
 
     public void moveToPlanetarySystem(PlanetarySystem planetarySystem) {
@@ -1779,33 +1747,8 @@ public class Campaign implements ITechManager, IPlace {
 
     @Override
     public void onArrival(Campaign campaign, boolean isSilentProcessing) {
-        // We are intentionally using the passed in Campaign. When Campaign is split into Force and Campaign, Force
-        // will be an IPlace, so this method will move to Force, but we'll still need Campaign for some information.
-
-        // This should be before inoculations so that we can correctly read the TO&E
-        if (!campaign.getAutomatedMothballUnits().isEmpty()) {
-            performAutomatedActivation(campaign);
-        }
-
-        CampaignOptions campaignOptions = campaign.getCampaignOptions();
-        if (campaignOptions.isUseRandomDiseases() && campaignOptions.isUseAlternativeAdvancedMedical()) {
-            if (getParentLocation() instanceof AbstractLocation loc) {
-                loc.checkForDiseaseOrBioweaponOutbreaks(campaign, campaign.getLocalDate());
-            }
-        }
-
-        // Inoculations (generic IPlace behavior)
-        IPlace.super.onArrival(campaign, isSilentProcessing);
-
-        if (getParentLocation() instanceof AbstractLocation loc) {
-            loc.testForEarlyArrival(campaign);
-        }
-
-        // We've just stopped traveling, so we should see if there are any local applicants.
-        if (!HumanResources.isUsingLegacyPersonnelMarket(campaign.getCampaignOptions())) {
-            campaign.refreshApplicants(true);
-            CampaignNewDayManager.showRarePersonnelDialog(campaign, false);
-        }
+        // The main force is the IPlace that arrives; this is a pass-through to it.
+        playerForce.onArrival(campaign, isSilentProcessing);
     }
 
     @Override
@@ -2068,7 +2011,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return the current hangar containing the player's units.
      */
     public Hangar getHangar() {
-        return units;
+        return playerForce.getHangar();
     }
 
     /**
@@ -2076,7 +2019,7 @@ public class Campaign implements ITechManager, IPlace {
      *                                                                                                             TODO: This won't work once we support multiple hangars. Method separated from getHangar() for future refactor
      */
     public Hangar getAllHangar() {
-        return units;
+        return playerForce.getHangar();
     }
 
     /**
@@ -2147,7 +2090,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return Return a {@link Person} object representing the new dependent.
      */
     public Person newDependent(Gender gender) {
-        return humanResources.newDependent(this, gender);
+        return getHumanResources().newDependent(this, gender);
     }
 
     /**
@@ -2160,7 +2103,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return Return a {@link Person} object representing the new dependent.
      */
     public Person newDependent(Gender gender, @Nullable Faction originFaction, @Nullable Planet originPlanet) {
-        return humanResources.newDependent(this, gender, originFaction, originPlanet);
+        return getHumanResources().newDependent(this, gender, originFaction, originPlanet);
     }
 
     /**
@@ -2172,7 +2115,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return A new {@link Person}.
      */
     public Person newPerson(final PersonnelRole role) {
-        return humanResources.newPerson(this, role);
+        return getHumanResources().newPerson(this, role);
     }
 
     /**
@@ -2185,7 +2128,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return A new {@link Person}.
      */
     public Person newPerson(final PersonnelRole primaryRole, final PersonnelRole secondaryRole) {
-        return humanResources.newPerson(this, primaryRole, secondaryRole);
+        return getHumanResources().newPerson(this, primaryRole, secondaryRole);
     }
 
     /**
@@ -2199,7 +2142,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return A new {@link Person}.
      */
     public Person newPerson(final PersonnelRole primaryRole, final String factionCode, final Gender gender) {
-        return humanResources.newPerson(this, primaryRole, factionCode, gender);
+        return getHumanResources().newPerson(this, primaryRole, factionCode, gender);
     }
 
     /**
@@ -2217,7 +2160,7 @@ public class Campaign implements ITechManager, IPlace {
     public Person newPerson(final PersonnelRole primaryRole, final PersonnelRole secondaryRole,
           final AbstractFactionSelector factionSelector, final AbstractPlanetSelector planetSelector,
           final Gender gender) {
-        return humanResources.newPerson(this, primaryRole, secondaryRole, factionSelector, planetSelector, gender);
+        return getHumanResources().newPerson(this, primaryRole, secondaryRole, factionSelector, planetSelector, gender);
     }
 
     /**
@@ -2229,7 +2172,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return A new {@link Person} configured using {@code personnelGenerator}.
      */
     public Person newPerson(final PersonnelRole primaryRole, final AbstractPersonnelGenerator personnelGenerator) {
-        return humanResources.newPerson(this, primaryRole, personnelGenerator);
+        return getHumanResources().newPerson(this, primaryRole, personnelGenerator);
     }
 
     /**
@@ -2244,7 +2187,7 @@ public class Campaign implements ITechManager, IPlace {
      */
     public Person newPerson(final PersonnelRole primaryRole, final PersonnelRole secondaryRole,
           final AbstractPersonnelGenerator personnelGenerator, final Gender gender) {
-        return humanResources.newPerson(this, primaryRole, secondaryRole, personnelGenerator, gender);
+        return getHumanResources().newPerson(this, primaryRole, secondaryRole, personnelGenerator, gender);
     }
 
     public boolean getFieldKitchenWithinCapacity() {
@@ -2260,7 +2203,7 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     public int calculateMASHTheaterCapacity() {
-        List<Unit> unitsInTOE = getFormation(FORMATION_ORIGIN).getAllUnitsAsUnits(units, false);
+        List<Unit> unitsInTOE = getFormation(FORMATION_ORIGIN).getAllUnitsAsUnits(getHangar(), false);
         int baseCapacity = MASHCapacity.checkMASHCapacity(unitsInTOE, campaignOptions.getMASHTheatreCapacity());
         int rentedCapacity = FacilityRentals.getCapacityIncreaseFromRentals(getActiveContracts(),
               ContractRentalType.HOSPITAL_BEDS);
@@ -2308,7 +2251,7 @@ public class Campaign implements ITechManager, IPlace {
      * @see #importPerson(Person)
      */
     public boolean recruitPerson(Person person) {
-        return humanResources.recruitPerson(this, person);
+        return getHumanResources().recruitPerson(this, person);
     }
 
     /**
@@ -2316,7 +2259,7 @@ public class Campaign implements ITechManager, IPlace {
      */
     @Deprecated(since = "0.50.06", forRemoval = true)
     public boolean recruitPerson(Person person, boolean gmAdd) {
-        return humanResources.recruitPerson(this, person, gmAdd, true);
+        return getHumanResources().recruitPerson(this, person, gmAdd, true);
     }
 
     /**
@@ -2340,7 +2283,7 @@ public class Campaign implements ITechManager, IPlace {
      * @see #importPerson(Person)
      */
     public boolean recruitPerson(Person person, boolean gmAdd, boolean employ) {
-        return humanResources.recruitPerson(this, person, gmAdd, employ);
+        return getHumanResources().recruitPerson(this, person, gmAdd, employ);
     }
 
     /**
@@ -2348,7 +2291,7 @@ public class Campaign implements ITechManager, IPlace {
      */
     @Deprecated(since = "0.50.06", forRemoval = true)
     public boolean recruitPerson(Person person, PrisonerStatus prisonerStatus) {
-        return humanResources.recruitPerson(this, person, prisonerStatus, true);
+        return getHumanResources().recruitPerson(this, person, prisonerStatus, true);
     }
 
     /**
@@ -2371,7 +2314,7 @@ public class Campaign implements ITechManager, IPlace {
      * @see #importPerson(Person)
      */
     public boolean recruitPerson(Person person, PrisonerStatus prisonerStatus, boolean employ) {
-        return humanResources.recruitPerson(this, person, prisonerStatus, employ);
+        return getHumanResources().recruitPerson(this, person, prisonerStatus, employ);
     }
 
     /**
@@ -2398,7 +2341,7 @@ public class Campaign implements ITechManager, IPlace {
      */
     public boolean recruitPerson(Person person, PrisonerStatus prisonerStatus, boolean gmAdd, boolean log,
           boolean employ) {
-        return humanResources.recruitPerson(this, person, prisonerStatus, gmAdd, log, employ);
+        return getHumanResources().recruitPerson(this, person, prisonerStatus, gmAdd, log, employ);
     }
 
     /**
@@ -2406,7 +2349,7 @@ public class Campaign implements ITechManager, IPlace {
      */
     @Deprecated(since = "0.50.06", forRemoval = true)
     public boolean recruitPerson(Person person, PrisonerStatus prisonerStatus, boolean gmAdd, boolean log) {
-        return humanResources.recruitPerson(this, person, prisonerStatus, gmAdd, log, true);
+        return getHumanResources().recruitPerson(this, person, prisonerStatus, gmAdd, log, true);
     }
 
     /**
@@ -2431,7 +2374,7 @@ public class Campaign implements ITechManager, IPlace {
      */
     public boolean recruitPerson(Person person, PrisonerStatus prisonerStatus, boolean gmAdd, boolean log,
           boolean employ, boolean bypassSimulateRelationships) {
-        return humanResources.recruitPerson(this, person, prisonerStatus, gmAdd, log, employ,
+        return getHumanResources().recruitPerson(this, person, prisonerStatus, gmAdd, log, employ,
               bypassSimulateRelationships);
     }
 
@@ -2441,7 +2384,7 @@ public class Campaign implements ITechManager, IPlace {
      * @param person the {@code Person} being employed; may be {@code null}
      */
     public void employCampFollower(Person person) {
-        humanResources.employCampFollower(this, person);
+        getHumanResources().employCampFollower(this, person);
     }
     // endregion Personnel Recruitment
 
@@ -2456,7 +2399,7 @@ public class Campaign implements ITechManager, IPlace {
      * @param ignoreDice If true, skips the random roll and assigns a Bloodname automatically
      */
     public void checkBloodnameAdd(Person person, boolean ignoreDice) {
-        humanResources.checkBloodnameAdd(this, person, ignoreDice);
+        getHumanResources().checkBloodnameAdd(this, person, ignoreDice);
     }
 
     // endregion Bloodnames
@@ -2475,24 +2418,24 @@ public class Campaign implements ITechManager, IPlace {
      * @see #recruitPerson(Person)
      */
     public void importPerson(Person person) {
-        humanResources.importPerson(person);
-        person.setParent(mainForcePersonnel);
+        getHumanResources().importPerson(person);
+        person.setParent(getMainForcePersonnel());
     }
 
     public @Nullable Person getPerson(final UUID id) {
-        return humanResources.getPerson(id);
+        return getHumanResources().getPerson(id);
     }
 
     @Override
     public Personnel getPersonnel() {
-        return mainForcePersonnel;
+        return playerForce.getPersonnel();
     }
 
     /**
      * @return all personnel across all locations associated with this campaign.
      */
     public Collection<Person> getAllPersonnel() {
-        return humanResources.getPersonnel();
+        return getHumanResources().getPersonnel();
     }
 
     /**
@@ -2501,7 +2444,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return a {@code List} of {@link Person} objects who have not left the unit
      */
     public List<Person> getPersonnelFilteringOutDeparted() {
-        return humanResources.getPersonnelFilteringOutDeparted();
+        return getHumanResources().getPersonnelFilteringOutDeparted();
     }
 
     /**
@@ -2511,7 +2454,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return a {@code List} of {@link Person} objects who have not left the unit
      */
     public List<Person> getPersonnelFilteringOutDepartedAndAbsent() {
-        return humanResources.getPersonnelFilteringOutDepartedAndAbsent();
+        return getHumanResources().getPersonnelFilteringOutDepartedAndAbsent();
     }
 
     /**
@@ -2519,7 +2462,7 @@ public class Campaign implements ITechManager, IPlace {
      */
     @Deprecated(since = "0.50.07", forRemoval = true)
     public List<Person> getActivePersonnel(boolean includePrisoners) {
-        return humanResources.getActivePersonnel(includePrisoners, false);
+        return getHumanResources().getActivePersonnel(includePrisoners, false);
     }
 
     /**
@@ -2531,14 +2474,14 @@ public class Campaign implements ITechManager, IPlace {
      * @return a {@link List} of {@link Person} objects matching the criteria
      */
     public List<Person> getActivePersonnel(boolean includePrisoners, boolean includeCampFollowers) {
-        return humanResources.getActivePersonnel(includePrisoners, includeCampFollowers);
+        return getHumanResources().getActivePersonnel(includePrisoners, includeCampFollowers);
     }
 
     /**
      * Clears the {@code activePersonnelCache} so it's recalculated next time we getActivePersonnel
      */
     public void invalidateActivePersonnelCache() {
-        humanResources.invalidateActivePersonnelCache();
+        getHumanResources().invalidateActivePersonnelCache();
     }
 
     /**
@@ -2548,7 +2491,7 @@ public class Campaign implements ITechManager, IPlace {
      * @since 0.50.06
      */
     public List<Person> getSalaryEligiblePersonnel() {
-        return humanResources.getSalaryEligiblePersonnel();
+        return getHumanResources().getSalaryEligiblePersonnel();
     }
 
     /**
@@ -2558,7 +2501,7 @@ public class Campaign implements ITechManager, IPlace {
      */
     @Deprecated(since = "0.51.0", forRemoval = true)
     public List<Person> getActiveCombatPersonnel() {
-        return HumanResources.getActiveCombatPersonnel(humanResources.getActivePersonnel(false, false));
+        return HumanResources.getActiveCombatPersonnel(getHumanResources().getActivePersonnel(false, false));
     }
 
     /**
@@ -2567,7 +2510,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return a {@link Person} <code>List</code> containing all active personnel
      */
     public List<Person> getActiveDependents() {
-        return humanResources.getActiveDependents();
+        return getHumanResources().getActiveDependents();
     }
 
     /**
@@ -2576,7 +2519,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return a {@link Person} <code>List</code> containing all active personnel
      */
     public List<Person> getCurrentPrisoners() {
-        return humanResources.getCurrentPrisoners();
+        return getHumanResources().getCurrentPrisoners();
     }
 
     /**
@@ -2585,7 +2528,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return a {@link Person} <code>List</code> containing all active personnel
      */
     public List<Person> getPrisonerDefectors() {
-        return humanResources.getPrisonerDefectors();
+        return getHumanResources().getPrisonerDefectors();
     }
 
     /**
@@ -2594,7 +2537,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return a {@link Person} <code>List</code> containing all active personnel
      */
     public List<Person> getFriendlyPrisoners() {
-        return humanResources.getFriendlyPrisoners();
+        return getHumanResources().getFriendlyPrisoners();
     }
 
     /**
@@ -2603,7 +2546,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return a {@link Person} <code>List</code> containing all active personnel
      */
     public List<Person> getStudents() {
-        return humanResources.getStudents();
+        return getHumanResources().getStudents();
     }
     // endregion Other Personnel Methods
 
@@ -2615,7 +2558,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return An {@link AbstractFactionSelector} to use when selecting a {@link Faction}.
      */
     public AbstractFactionSelector getFactionSelector() {
-        return humanResources.getFactionSelector(getCampaignOptions());
+        return getHumanResources().getFactionSelector(getCampaignOptions());
     }
 
     /**
@@ -2626,7 +2569,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return An {@link AbstractFactionSelector} to use when selecting a {@link Faction}.
      */
     public AbstractFactionSelector getFactionSelector(final RandomOriginOptions options) {
-        return humanResources.getFactionSelector(options);
+        return getHumanResources().getFactionSelector(options);
     }
 
     /**
@@ -2635,7 +2578,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return An {@link AbstractPlanetSelector} to use when selecting a {@link Planet}.
      */
     public AbstractPlanetSelector getPlanetSelector() {
-        return humanResources.getPlanetSelector(getCampaignOptions());
+        return getHumanResources().getPlanetSelector(getCampaignOptions());
     }
 
     /**
@@ -2646,7 +2589,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return An {@link AbstractPlanetSelector} to use when selecting a {@link Planet}.
      */
     public AbstractPlanetSelector getPlanetSelector(final RandomOriginOptions options) {
-        return humanResources.getPlanetSelector(options);
+        return getHumanResources().getPlanetSelector(options);
     }
 
     /**
@@ -2659,21 +2602,21 @@ public class Campaign implements ITechManager, IPlace {
      */
     public AbstractPersonnelGenerator getPersonnelGenerator(final AbstractFactionSelector factionSelector,
           final AbstractPlanetSelector planetSelector) {
-        return humanResources.getPersonnelGenerator(getCampaignOptions(), factionSelector, planetSelector);
+        return getHumanResources().getPersonnelGenerator(getCampaignOptions(), factionSelector, planetSelector);
     }
     // endregion Personnel Selectors and Generators
     // endregion Personnel
 
     public List<Person> getPatients() {
-        return humanResources.getPatients();
+        return getHumanResources().getPatients();
     }
 
     public List<Person> getPatientsAssignedToDoctors() {
-        return humanResources.getPatientsAssignedToDoctors();
+        return getHumanResources().getPatientsAssignedToDoctors();
     }
 
     public List<Person> getPatientsWithNonPermanentInjuries() {
-        return humanResources.getPatientsWithNonPermanentInjuries();
+        return getHumanResources().getPatientsWithNonPermanentInjuries();
     }
 
     /**
@@ -2708,7 +2651,7 @@ public class Campaign implements ITechManager, IPlace {
 
             // Add the part to the campaign, but do not
             // merge it with any existing parts
-            parts.addPart(p, false);
+            getWarehouse().addPart(p, false);
         }
     }
 
@@ -2716,7 +2659,7 @@ public class Campaign implements ITechManager, IPlace {
      * Gets the Warehouse which stores parts.
      */
     public Warehouse getWarehouse() {
-        return parts;
+        return playerForce.getWarehouse();
     }
 
     /**
@@ -2724,7 +2667,7 @@ public class Campaign implements ITechManager, IPlace {
      *                                                                                                             TODO: This won't work once we support multiple warehouse. Method separated from getWarehouse() for future
      */
     public Warehouse getAllWarehouse() {
-        return parts;
+        return playerForce.getWarehouse();
     }
 
     /**
@@ -2733,7 +2676,7 @@ public class Campaign implements ITechManager, IPlace {
      * @param warehouse The warehouse in which to store parts.
      */
     public void setWarehouse(Warehouse warehouse) {
-        parts = Objects.requireNonNull(warehouse);
+        playerForce.setWarehouse(warehouse);
     }
 
     public Quartermaster getQuartermaster() {
@@ -2744,11 +2687,11 @@ public class Campaign implements ITechManager, IPlace {
      * @return A collection of parts in the Warehouse.
      */
     public Collection<Part> getParts() {
-        return parts.getParts();
+        return getWarehouse().getParts();
     }
 
     public Part getPart(int id) {
-        return parts.getPart(id);
+        return getWarehouse().getPart(id);
     }
 
     /**
@@ -3040,7 +2983,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return The person in the designated role with the most experience.
      */
     public Person findBestInRole(PersonnelRole role, String primary, @Nullable String secondary) {
-        return humanResources.findBestInRole(role,
+        return getHumanResources().findBestInRole(role,
               primary,
               secondary,
               getCampaignOptions(),
@@ -3049,7 +2992,7 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     public Person findBestInRole(PersonnelRole role, String skill) {
-        return humanResources.findBestInRole(role, skill, getCampaignOptions(), isClanCampaign(), getLocalDate());
+        return getHumanResources().findBestInRole(role, skill, getCampaignOptions(), isClanCampaign(), getLocalDate());
     }
 
     /**
@@ -3061,18 +3004,21 @@ public class Campaign implements ITechManager, IPlace {
      *       if no qualifying person is found
      */
     public @Nullable Person findBestAtSkill(String skillName) {
-        return humanResources.findBestAtSkill(skillName, getCampaignOptions(), isClanCampaign(), getLocalDate());
+        return getHumanResources().findBestAtSkill(skillName, getCampaignOptions(), isClanCampaign(), getLocalDate());
     }
 
     /**
      * @return The list of all active {@link Person}s who qualify as technicians ({@link Person#isTech()});
      */
     public List<Person> getTechs() {
-        return humanResources.getTechs(getHangar().getUnits(), getCampaignOptions(), isClanCampaign(), getLocalDate());
+        return getHumanResources().getTechs(getHangar().getUnits(),
+              getCampaignOptions(),
+              isClanCampaign(),
+              getLocalDate());
     }
 
     public List<Person> getTechs(final boolean noZeroMinute) {
-        return humanResources.getTechs(getHangar().getUnits(),
+        return getHumanResources().getTechs(getHangar().getUnits(),
               getCampaignOptions(),
               isClanCampaign(),
               getLocalDate(),
@@ -3080,14 +3026,14 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     public List<Person> getTechsExpanded() {
-        return humanResources.getTechsExpanded(getHangar().getUnits(),
+        return getHumanResources().getTechsExpanded(getHangar().getUnits(),
               getCampaignOptions(),
               isClanCampaign(),
               getLocalDate());
     }
 
     public List<Person> getTechs(final boolean noZeroMinute, final boolean eliteFirst) {
-        return humanResources.getTechs(getHangar().getUnits(),
+        return getHumanResources().getTechs(getHangar().getUnits(),
               getCampaignOptions(),
               isClanCampaign(),
               getLocalDate(),
@@ -3105,7 +3051,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return A list of active technicians sorted appropriately.
      */
     public List<Person> getTechsExpanded(final boolean noZeroMinute, final boolean eliteFirst, final boolean expanded) {
-        return humanResources.getTechsExpanded(getHangar().getUnits(),
+        return getHumanResources().getTechsExpanded(getHangar().getUnits(),
               getCampaignOptions(),
               isClanCampaign(),
               getLocalDate(),
@@ -3115,19 +3061,19 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     public List<Person> getAdmins() {
-        return humanResources.getAdmins();
+        return getHumanResources().getAdmins();
     }
 
     public boolean isWorkingOnRefit(Person person) {
-        return humanResources.isWorkingOnRefit(getHangar(), person);
+        return getHumanResources().isWorkingOnRefit(getHangar(), person);
     }
 
     public List<Person> getDoctors() {
-        return humanResources.getDoctors();
+        return getHumanResources().getDoctors();
     }
 
     public int getPatientsFor(Person doctor) {
-        return humanResources.getPatientsFor(doctor);
+        return getHumanResources().getPatientsFor(doctor);
     }
 
     /**
@@ -3154,7 +3100,7 @@ public class Campaign implements ITechManager, IPlace {
      *       found.
      */
     public @Nullable Person getLogisticsPerson() {
-        return humanResources.getLogisticsPerson(getCampaignOptions(), isClanCampaign(), getLocalDate());
+        return getHumanResources().getLogisticsPerson(getCampaignOptions(), isClanCampaign(), getLocalDate());
     }
 
     /**
@@ -3207,15 +3153,15 @@ public class Campaign implements ITechManager, IPlace {
      * @throws IllegalStateException if {@code type} is null or an unsupported value.
      */
     public @Nullable Person getSeniorAdminPerson(AdministratorSpecialization type) {
-        return humanResources.getSeniorAdminPerson(type, getCampaignOptions(), isClanCampaign(), getLocalDate());
+        return getHumanResources().getSeniorAdminPerson(type, getCampaignOptions(), isClanCampaign(), getLocalDate());
     }
 
     public @Nullable Person getSeniorMedicalPerson() {
-        return humanResources.getSeniorMedicalPerson(getCampaignOptions(), isClanCampaign(), getLocalDate());
+        return getHumanResources().getSeniorMedicalPerson(getCampaignOptions(), isClanCampaign(), getLocalDate());
     }
 
     public @Nullable Person getSeniorTechPerson() {
-        return humanResources.getSeniorTechPerson(getCampaignOptions(), isClanCampaign(), getLocalDate());
+        return getHumanResources().getSeniorTechPerson(getCampaignOptions(), isClanCampaign(), getLocalDate());
     }
 
     /**
@@ -3224,7 +3170,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return the {@link Person} who is the commander, or {@code null} if there are no suitable candidates.
      */
     public @Nullable Person getCommander() {
-        return humanResources.getCommander(getCampaignOptions(), isClanCampaign(), getLocalDate());
+        return getHumanResources().getCommander(getCampaignOptions(), isClanCampaign(), getLocalDate());
     }
 
     /**
@@ -3234,7 +3180,7 @@ public class Campaign implements ITechManager, IPlace {
      *       candidates.
      */
     public @Nullable Person getSecondInCommand() {
-        return humanResources.getSecondInCommand(getCampaignOptions(), isClanCampaign(), getLocalDate());
+        return getHumanResources().getSecondInCommand(getCampaignOptions(), isClanCampaign(), getLocalDate());
     }
 
     /**
@@ -3267,7 +3213,7 @@ public class Campaign implements ITechManager, IPlace {
      *       empty list if acquisitions automatically succeed.
      */
     public List<Person> getLogisticsPersonnel() {
-        return humanResources.getLogisticsPersonnel(getCampaignOptions(), isClanCampaign(), getLocalDate());
+        return getHumanResources().getLogisticsPersonnel(getCampaignOptions(), isClanCampaign(), getLocalDate());
     }
 
     /***
@@ -3810,7 +3756,7 @@ public class Campaign implements ITechManager, IPlace {
             int minutes = Math.min(tech.getMinutesLeft(), unit.getMothballTime());
 
             // check AsTech time
-            if (!unit.isSelfCrewed() && humanResources.getAsTechPoolMinutes() < minutes * 6) {
+            if (!unit.isSelfCrewed() && getHumanResources().getAsTechPoolMinutes() < minutes * 6) {
                 // uh-oh
                 addReport(TECHNICAL, String.format(resources.getString("notEnoughAstechTime.mothballing"),
                       unit.getHyperlinkedName()));
@@ -3821,7 +3767,7 @@ public class Campaign implements ITechManager, IPlace {
 
             tech.setMinutesLeft(tech.getMinutesLeft() - minutes);
             if (!unit.isSelfCrewed()) {
-                humanResources.setAsTechPoolMinutes(humanResources.getAsTechPoolMinutes() - 6 * minutes);
+                getHumanResources().setAsTechPoolMinutes(getHumanResources().getAsTechPoolMinutes() - 6 * minutes);
             }
 
             report = String.format(resources.getString("timeSpent.mothballing.tech"),
@@ -3896,7 +3842,7 @@ public class Campaign implements ITechManager, IPlace {
             int minutes = Math.min(tech.getMinutesLeft(), unit.getMothballTime());
 
             // check AsTech time
-            if (!unit.isSelfCrewed() && humanResources.getAsTechPoolMinutes() < minutes * 6) {
+            if (!unit.isSelfCrewed() && getHumanResources().getAsTechPoolMinutes() < minutes * 6) {
                 // uh-oh
                 addReport(TECHNICAL, String.format(resources.getString("notEnoughAstechTime.activation"),
                       unit.getHyperlinkedName()));
@@ -3907,7 +3853,7 @@ public class Campaign implements ITechManager, IPlace {
 
             tech.setMinutesLeft(tech.getMinutesLeft() - minutes);
             if (!unit.isSelfCrewed()) {
-                humanResources.setAsTechPoolMinutes(humanResources.getAsTechPoolMinutes() - 6 * minutes);
+                getHumanResources().setAsTechPoolMinutes(getHumanResources().getAsTechPoolMinutes() - 6 * minutes);
             }
 
             report = String.format(resources.getString("timeSpent.activation.tech"),
@@ -4173,12 +4119,12 @@ public class Campaign implements ITechManager, IPlace {
             tech.setMinutesLeft(tech.getMinutesLeft() - minutes);
         }
         int asTechMinutesUsed = minutesUsed * getAvailableAsTechs(minutesUsed, usedOvertime);
-        if (humanResources.getAsTechPoolMinutes() < asTechMinutesUsed) {
-            asTechMinutesUsed -= humanResources.getAsTechPoolMinutes();
-            humanResources.setAsTechPoolMinutes(0);
-            humanResources.setAsTechPoolOvertime(humanResources.getAsTechPoolOvertime() - asTechMinutesUsed);
+        if (getHumanResources().getAsTechPoolMinutes() < asTechMinutesUsed) {
+            asTechMinutesUsed -= getHumanResources().getAsTechPoolMinutes();
+            getHumanResources().setAsTechPoolMinutes(0);
+            getHumanResources().setAsTechPoolOvertime(getHumanResources().getAsTechPoolOvertime() - asTechMinutesUsed);
         } else {
-            humanResources.setAsTechPoolMinutes(humanResources.getAsTechPoolMinutes() - asTechMinutesUsed);
+            getHumanResources().setAsTechPoolMinutes(getHumanResources().getAsTechPoolMinutes() - asTechMinutesUsed);
         }
         // check for the type
         int roll;
@@ -4226,7 +4172,10 @@ public class Campaign implements ITechManager, IPlace {
             if (getCampaignOptions().isPayForRepairs() && action.equals(" fix ") && !(partWork instanceof Armor)) {
                 Money cost = partWork.getUndamagedValue().multipliedBy(0.2);
                 report += "<br>Repairs cost " + cost.toAmountAndSymbolString() + " worth of parts.";
-                finances.debit(TransactionType.REPAIRS, getLocalDate(), cost, "Repair of " + partWork.getPartName());
+                getFinances().debit(TransactionType.REPAIRS,
+                      getLocalDate(),
+                      cost,
+                      "Repair of " + partWork.getPartName());
             }
             if ((roll == 12) && (target.getValue() != TargetRoll.AUTOMATIC_SUCCESS)) {
                 xpGained += getCampaignOptions().getSuccessXP();
@@ -4499,45 +4448,31 @@ public class Campaign implements ITechManager, IPlace {
      * @since 0.50.06
      */
     public void refreshApplicants(boolean bypassDateRestrictions) {
-        humanResources.refreshApplicants(this, bypassDateRestrictions);
+        getHumanResources().refreshApplicants(this, bypassDateRestrictions);
     }
 
     public int getInitiativeBonus() {
-        return initiativeBonus;
+        return playerForce.getInitiativeBonus();
     }
 
     public void setInitiativeBonus(int bonus) {
-        initiativeBonus = bonus;
+        playerForce.setInitiativeBonus(bonus);
     }
 
     public void applyInitiativeBonus(int bonus) {
-        if (bonus > initiativeMaxBonus) {
-            initiativeMaxBonus = bonus;
-        }
-        if ((bonus + initiativeBonus) > initiativeMaxBonus) {
-            initiativeBonus = initiativeMaxBonus;
-        } else {
-            initiativeBonus += bonus;
-        }
+        playerForce.applyInitiativeBonus(bonus);
     }
 
     public void initiativeBonusIncrement(boolean change) {
-        if (change) {
-            setInitiativeBonus(++initiativeBonus);
-        } else {
-            setInitiativeBonus(--initiativeBonus);
-        }
-        if (initiativeBonus > initiativeMaxBonus) {
-            initiativeBonus = initiativeMaxBonus;
-        }
+        playerForce.initiativeBonusIncrement(change);
     }
 
     public int getInitiativeMaxBonus() {
-        return initiativeMaxBonus;
+        return playerForce.getInitiativeMaxBonus();
     }
 
     public void setInitiativeMaxBonus(int bonus) {
-        initiativeMaxBonus = bonus;
+        playerForce.setInitiativeMaxBonus(bonus);
     }
 
 
@@ -4641,15 +4576,15 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     public void removePerson(final @Nullable Person person) {
-        humanResources.removePerson(this, person);
+        getHumanResources().removePerson(this, person);
     }
 
     public void removePerson(final @Nullable Person person, final boolean log) {
-        humanResources.removePerson(this, person, log);
+        getHumanResources().removePerson(this, person, log);
     }
 
     public void removeAllPatientsFor(Person doctor) {
-        humanResources.removeAllPatientsFor(doctor, getCampaignOptions());
+        getHumanResources().removeAllPatientsFor(doctor, getCampaignOptions());
     }
 
     public void removeScenario(final Scenario scenario) {
@@ -4856,7 +4791,7 @@ public class Campaign implements ITechManager, IPlace {
             u.runDiagnostic(false);
         }
 
-        shoppingList.restore();
+        getShoppingList().restore();
 
         if (getCampaignOptions().isUseStratCon()) {
             RandomFactionGenerator.getInstance().startup(this);
@@ -4939,7 +4874,7 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     public Faction getFaction() {
-        return faction;
+        return playerForce.getFaction();
     }
 
     /**
@@ -4954,7 +4889,7 @@ public class Campaign implements ITechManager, IPlace {
      * @since 0.50.05
      */
     public boolean isClanCampaign() {
-        return faction.isClan();
+        return getFaction().isClan();
     }
 
     /**
@@ -4969,7 +4904,7 @@ public class Campaign implements ITechManager, IPlace {
      * @since 0.50.07
      */
     public boolean isPirateCampaign() {
-        return faction.getShortName().equals(PIRATE_FACTION_CODE);
+        return getFaction().getShortName().equals(PIRATE_FACTION_CODE);
     }
 
     /**
@@ -4984,40 +4919,39 @@ public class Campaign implements ITechManager, IPlace {
      * @since 0.50.07
      */
     public boolean isMercenaryCampaign() {
-        return faction.getShortName().equals(MERCENARY_FACTION_CODE);
+        return getFaction().getShortName().equals(MERCENARY_FACTION_CODE);
     }
 
     public void setFaction(final Faction faction) {
-        setFactionDirect(faction);
-        updateTechFactionCode();
+        playerForce.setFaction(faction);
     }
 
     public void setFactionDirect(final Faction faction) {
-        this.faction = faction;
+        playerForce.setFactionDirect(faction);
     }
 
     public String getRetainerEmployerCode() {
-        return retainerEmployerCode;
+        return playerForce.getRetainerEmployerCode();
     }
 
     public void setRetainerEmployerCode(String code) {
-        retainerEmployerCode = code;
+        playerForce.setRetainerEmployerCode(code);
     }
 
     public LocalDate getRetainerStartDate() {
-        return retainerStartDate;
+        return playerForce.getRetainerStartDate();
     }
 
     public void setRetainerStartDate(LocalDate retainerStartDate) {
-        this.retainerStartDate = retainerStartDate;
+        playerForce.setRetainerStartDate(retainerStartDate);
     }
 
     public int getRawCrimeRating() {
-        return crimeRating;
+        return playerForce.getRawCrimeRating();
     }
 
     public void setCrimeRating(int crimeRating) {
-        this.crimeRating = crimeRating;
+        playerForce.setCrimeRating(crimeRating);
     }
 
     /**
@@ -5027,15 +4961,15 @@ public class Campaign implements ITechManager, IPlace {
      * @param change the change to be applied to the crime rating
      */
     public void changeCrimeRating(int change) {
-        this.crimeRating = Math.min(0, crimeRating + change);
+        playerForce.changeCrimeRating(change);
     }
 
     public int getCrimePirateModifier() {
-        return crimePirateModifier;
+        return playerForce.getCrimePirateModifier();
     }
 
     public void setCrimePirateModifier(int crimePirateModifier) {
-        this.crimePirateModifier = crimePirateModifier;
+        playerForce.setCrimePirateModifier(crimePirateModifier);
     }
 
     /**
@@ -5045,7 +4979,7 @@ public class Campaign implements ITechManager, IPlace {
      * @param change the change to be applied to the crime modifier
      */
     public void changeCrimePirateModifier(int change) {
-        this.crimePirateModifier = Math.min(0, crimePirateModifier + change);
+        playerForce.changeCrimePirateModifier(change);
     }
 
     /**
@@ -5054,31 +4988,31 @@ public class Campaign implements ITechManager, IPlace {
      * @return The adjusted crime rating.
      */
     public int getAdjustedCrimeRating() {
-        return crimeRating + crimePirateModifier;
+        return playerForce.getAdjustedCrimeRating();
     }
 
     public @Nullable LocalDate getDateOfLastCrime() {
-        return dateOfLastCrime;
+        return playerForce.getDateOfLastCrime();
     }
 
     public void setDateOfLastCrime(LocalDate dateOfLastCrime) {
-        this.dateOfLastCrime = dateOfLastCrime;
+        playerForce.setDateOfLastCrime(dateOfLastCrime);
     }
 
     public ReputationController getReputation() {
-        return reputation;
+        return playerForce.getReputation();
     }
 
     public void setReputation(ReputationController reputation) {
-        this.reputation = reputation;
+        playerForce.setReputation(reputation);
     }
 
     public FactionStandings getFactionStandings() {
-        return factionStandings;
+        return playerForce.getFactionStandings();
     }
 
     public void setFactionStandings(FactionStandings factionStandings) {
-        this.factionStandings = factionStandings;
+        playerForce.setFactionStandings(factionStandings);
     }
 
     private void addInMemoryLogHistory(LogEntry le) {
@@ -5265,47 +5199,43 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     public Camouflage getCamouflage() {
-        return camouflage;
+        return playerForce.getCamouflage();
     }
 
     public void setCamouflage(final Camouflage camouflage) {
-        this.camouflage = camouflage;
+        playerForce.setCamouflage(camouflage);
     }
 
     public PlayerColour getColour() {
-        return colour;
+        return playerForce.getColour();
     }
 
     public void setColour(final PlayerColour colour) {
-        this.colour = Objects.requireNonNull(colour, "Colour cannot be set to null");
+        playerForce.setColour(colour);
     }
 
     public StandardFormationIcon getUnitIcon() {
-        return unitIcon;
+        return playerForce.getUnitIcon();
     }
 
     public void setUnitIcon(final StandardFormationIcon unitIcon) {
-        this.unitIcon = unitIcon;
+        playerForce.setUnitIcon(unitIcon);
     }
 
     public void addFunds(final TransactionType type, final Money quantity, @Nullable String description) {
         if ((description == null) || description.isEmpty()) {
             description = "Rich Uncle";
         }
-
-        finances.credit(type, getLocalDate(), quantity, description);
-        String quantityString = quantity.toAmountAndSymbolString();
-        addReport(FINANCES, "Funds added : " + quantityString + " (" + description + ')');
+        playerForce.addFunds(type, getLocalDate(), quantity, description);
+        addReport(FINANCES, "Funds added : " + quantity.toAmountAndSymbolString() + " (" + description + ')');
     }
 
     public void removeFunds(final TransactionType type, final Money quantity, @Nullable String description) {
         if ((description == null) || description.isEmpty()) {
             description = "Rich Uncle";
         }
-
-        finances.debit(type, getLocalDate(), quantity, description);
-        String quantityString = quantity.toAmountAndSymbolString();
-        addReport(FINANCES, "Funds removed : " + quantityString + " (" + description + ')');
+        playerForce.removeFunds(type, getLocalDate(), quantity, description);
+        addReport(FINANCES, "Funds removed : " + quantity.toAmountAndSymbolString() + " (" + description + ')');
     }
 
     /**
@@ -5347,6 +5277,8 @@ public class Campaign implements ITechManager, IPlace {
         boolean vesselCrewWasEnabled = campaignOptions.isUseBlobVesselCrew();
 
         campaignOptions = options;
+        // Keep the player force's ForceOptions pass-through pointed at the current campaign options.
+        playerForce.getForceOptions().setCampaignOptions(options);
 
         // If blob crew was disabled for a specific role, clear only that role's blob crew
         if (infantryWasEnabled && !options.isUseBlobInfantry()) {
@@ -5482,21 +5414,21 @@ public class Campaign implements ITechManager, IPlace {
 
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "id", id.toString());
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "calendar", getLocalDate());
-        MHQXMLUtility.writeSimpleXMLTag(writer, indent, "name", name);
+        MHQXMLUtility.writeSimpleXMLTag(writer, indent, "name", getName());
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "faction", getFaction().getShortName());
-        if (retainerEmployerCode != null) {
-            MHQXMLUtility.writeSimpleXMLTag(writer, indent, "retainerEmployerCode", retainerEmployerCode);
-            MHQXMLUtility.writeSimpleXMLTag(writer, indent, "retainerStartDate", retainerStartDate);
+        if (getRetainerEmployerCode() != null) {
+            MHQXMLUtility.writeSimpleXMLTag(writer, indent, "retainerEmployerCode", getRetainerEmployerCode());
+            MHQXMLUtility.writeSimpleXMLTag(writer, indent, "retainerStartDate", getRetainerStartDate());
         }
-        MHQXMLUtility.writeSimpleXMLTag(writer, indent, "crimeRating", crimeRating);
-        MHQXMLUtility.writeSimpleXMLTag(writer, indent, "crimePirateModifier", crimePirateModifier);
+        MHQXMLUtility.writeSimpleXMLTag(writer, indent, "crimeRating", getRawCrimeRating());
+        MHQXMLUtility.writeSimpleXMLTag(writer, indent, "crimePirateModifier", getCrimePirateModifier());
 
-        if (dateOfLastCrime != null) {
-            MHQXMLUtility.writeSimpleXMLTag(writer, indent, "dateOfLastCrime", dateOfLastCrime);
+        if (getDateOfLastCrime() != null) {
+            MHQXMLUtility.writeSimpleXMLTag(writer, indent, "dateOfLastCrime", getDateOfLastCrime());
         }
 
         MHQXMLUtility.writeSimpleXMLOpenTag(writer, indent++, "reputation");
-        reputation.writeReputationToXML(writer, indent);
+        getReputation().writeReputationToXML(writer, indent);
         MHQXMLUtility.writeSimpleXMLCloseTag(writer, --indent, "reputation");
         if (getNewPersonnelMarket() != null) {
             MHQXMLUtility.writeSimpleXMLOpenTag(writer, indent++, "newPersonnelMarket");
@@ -5505,7 +5437,7 @@ public class Campaign implements ITechManager, IPlace {
         }
 
         MHQXMLUtility.writeSimpleXMLOpenTag(writer, indent++, "factionStandings");
-        factionStandings.writeFactionStandingsToXML(writer, indent);
+        getFactionStandings().writeFactionStandingsToXML(writer, indent);
         MHQXMLUtility.writeSimpleXMLCloseTag(writer, --indent, "factionStandings");
 
         // this handles campaigns that predate 49.20
@@ -5527,8 +5459,8 @@ public class Campaign implements ITechManager, IPlace {
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "lastFormationId", lastFormationId);
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "lastMissionId", lastMissionId);
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "lastScenarioId", lastScenarioId);
-        MHQXMLUtility.writeSimpleXMLTag(writer, indent, "initiativeBonus", initiativeBonus);
-        MHQXMLUtility.writeSimpleXMLTag(writer, indent, "initiativeMaxBonus", initiativeMaxBonus);
+        MHQXMLUtility.writeSimpleXMLTag(writer, indent, "initiativeBonus", getInitiativeBonus());
+        MHQXMLUtility.writeSimpleXMLTag(writer, indent, "initiativeMaxBonus", getInitiativeMaxBonus());
         MHQXMLUtility.writeSimpleXMLOpenTag(writer, indent++, "nameGen");
         MHQXMLUtility.writeSimpleXMLTag(writer,
               indent,
@@ -5631,9 +5563,9 @@ public class Campaign implements ITechManager, IPlace {
         PlanetarySystemCampaignXmlIO.writeToXML(writer, indent, getPlanetarySystemOverrides());
 
         // Lists of objects:
-        units.writeToXML(writer, indent, "units"); // Units
+        getHangar().writeToXML(writer, indent, "units"); // Units
 
-        humanResources.writeToXML(writer, indent, this);
+        getHumanResources().writeToXML(writer, indent, this);
 
         MHQXMLUtility.writeSimpleXMLOpenTag(writer, indent++, "missions");
         for (final Mission mission : getMissions()) {
@@ -5646,7 +5578,7 @@ public class Campaign implements ITechManager, IPlace {
         MHQXMLUtility.writeSimpleXMLOpenTag(writer, indent++, "formations");
         formations.writeToXML(writer, indent);
         MHQXMLUtility.writeSimpleXMLCloseTag(writer, --indent, "formations");
-        finances.writeToXML(writer, indent);
+        getFinances().writeToXML(writer, indent);
         forceLocationManager.writeToXML(writer, indent);
         locationManager.writeToXML(this, writer, indent);
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "isAvoidingEmptySystems", isAvoidingEmptySystems);
@@ -5654,7 +5586,7 @@ public class Campaign implements ITechManager, IPlace {
               indent,
               "isOverridingCommandCircuitRequirements",
               isOverridingCommandCircuitRequirements);
-        shoppingList.writeToXML(writer, indent);
+        getShoppingList().writeToXML(writer, indent);
         MHQXMLUtility.writeSimpleXMLOpenTag(writer, indent++, "kills");
         for (List<Kill> kills : kills.values()) {
             for (Kill k : kills) {
@@ -5678,7 +5610,7 @@ public class Campaign implements ITechManager, IPlace {
         randomSkillPreferences.writeToXML(writer, indent);
 
         // parts is the biggest so it goes last
-        parts.writeToXML(writer, indent, "parts"); // Parts
+        getWarehouse().writeToXML(writer, indent, "parts"); // Parts
 
         // current story arc
         if (null != storyArc) {
@@ -5779,7 +5711,7 @@ public class Campaign implements ITechManager, IPlace {
           boolean shouldSaveAllCustoms) {
         Set<String> customUnits = new HashSet<>();
         if (shouldSaveAllUnits) {
-            for (Unit unit : units.getUnits()) {
+            for (Unit unit : getHangar().getUnits()) {
                 Entity entity = unit.getEntity();
                 if (entity != null) {
                     String shortName = entity.getShortNameRaw();
@@ -5921,47 +5853,24 @@ public class Campaign implements ITechManager, IPlace {
 
     // region Ranks
     public RankSystem getRankSystem() {
-        return rankSystem;
+        return playerForce.getRankSystem();
     }
 
     public void setRankSystem(final @Nullable RankSystem rankSystem) {
-        // If they are the same object, there hasn't been a change and thus don't need
-        // to process further
-        if (Objects.equals(getRankSystem(), rankSystem)) {
-            return;
-        }
-
-        // Then, we need to validate the rank system. Null isn't valid to be set but may
-        // be the
-        // result of a cancelled load. However, validation will prevent that
-        final RankValidator rankValidator = new RankValidator();
-        if (!rankValidator.validate(rankSystem, false)) {
-            return;
-        }
-
-        // We need to know the old campaign rank system for personnel processing
-        final RankSystem oldRankSystem = getRankSystem();
-
-        // And with that, we can set the rank system
-        setRankSystemDirect(rankSystem);
-
-        // Finally, we fix all personnel ranks and ensure they are properly set
-        getPersonnel().values().stream()
-              .filter(person -> person.getRankSystem().equals(oldRankSystem))
-              .forEach(person -> person.setRankSystem(rankValidator, rankSystem));
+        playerForce.setRankSystem(rankSystem);
     }
 
     public void setRankSystemDirect(final RankSystem rankSystem) {
-        this.rankSystem = rankSystem;
+        playerForce.setRankSystemDirect(rankSystem);
     }
     // endregion Ranks
 
     public void setFinances(Finances f) {
-        finances = f;
+        playerForce.setFinances(f);
     }
 
     public Finances getFinances() {
-        return finances;
+        return playerForce.getFinances();
     }
 
     public Accountant getAccountant() {
@@ -6038,7 +5947,7 @@ public class Campaign implements ITechManager, IPlace {
 
         FactionHints factionHints = FactionHints.getInstance();
         if (!skipAccessCheck && campaignOptions.isUseFactionStandingOutlawedSafe()) {
-            boolean canAccessSystem = FactionStandingUtilities.canEnterTargetSystem(faction, factionStandings,
+            boolean canAccessSystem = FactionStandingUtilities.canEnterTargetSystem(getFaction(), getFactionStandings(),
                   start, end, currentDay, activeAtBContracts, factionHints);
             if (!canAccessSystem) {
                 new ImmersiveDialogSimple(this, getSeniorAdminPerson(AdministratorSpecialization.TRANSPORT), null,
@@ -6075,7 +5984,8 @@ public class Campaign implements ITechManager, IPlace {
         // We need this additional check as later we're going to be comparing neighbors, rather than start point.
         // Which means that if we're passing through more than one Outlawed system en route to our escape our
         // progress will be blocked.
-        boolean isEscapingOutlawing = !FactionStandingUtilities.canEnterTargetSystem(faction, factionStandings,
+        boolean isEscapingOutlawing = !FactionStandingUtilities.canEnterTargetSystem(getFaction(),
+              getFactionStandings(),
               null, start, currentDay, activeAtBContracts, factionHints);
 
         // A* search
@@ -6086,8 +5996,7 @@ public class Campaign implements ITechManager, IPlace {
             boolean isUseCommandCircuits =
                   FactionStandingUtilities.isUseCommandCircuit(isOverridingCommandCircuitRequirements, gmMode,
                         campaignOptions.isUseFactionStandingCommandCircuitSafe(),
-                        factionStandings,
-                        getFutureAtBContracts());
+                        getFactionStandings(), getFutureAtBContracts());
 
             // Get current node's information
             double currentG = scoreG.get(current) + currentSystem.getRechargeTime(getLocalDate(), isUseCommandCircuits);
@@ -6108,7 +6017,8 @@ public class Campaign implements ITechManager, IPlace {
                 if (!skipAccessCheck &&
                           !isEscapingOutlawing &&
                           campaignOptions.isUseFactionStandingOutlawedSafe()) {
-                    boolean canAccessSystem = FactionStandingUtilities.canEnterTargetSystem(faction, factionStandings,
+                    boolean canAccessSystem = FactionStandingUtilities.canEnterTargetSystem(getFaction(),
+                          getFactionStandings(),
                           currentSystem, neighborSystem, currentDay, activeAtBContracts, factionHints);
                     if (!canAccessSystem) {
                         return;
@@ -6544,7 +6454,7 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     public void personUpdated(Person person) {
-        humanResources.personUpdated(this, person);
+        getHumanResources().personUpdated(this, person);
     }
 
     /**
@@ -6666,7 +6576,7 @@ public class Campaign implements ITechManager, IPlace {
             final int helpers = getAvailableAsTechs(minutes, isOvertime);
             helpMod = getShorthandedMod(helpers, false);
             // we may have just gone overtime with our helpers
-            if (!isOvertime && (humanResources.getAsTechPoolMinutes() < (minutes * helpers))) {
+            if (!isOvertime && (getHumanResources().getAsTechPoolMinutes() < (minutes * helpers))) {
                 target.addModifier(3, "overtime astechs");
             }
         }
@@ -6881,59 +6791,59 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     public void resetAsTechMinutes() {
-        humanResources.resetAsTechMinutes(getCampaignOptions());
+        getHumanResources().resetAsTechMinutes(getCampaignOptions());
     }
 
     public void setAsTechPoolMinutes(int minutes) {
-        humanResources.setAsTechPoolMinutes(minutes);
+        getHumanResources().setAsTechPoolMinutes(minutes);
     }
 
     public int getAsTechPoolMinutes() {
-        return humanResources.getAsTechPoolMinutes();
+        return getHumanResources().getAsTechPoolMinutes();
     }
 
     public void setAsTechPoolOvertime(int overtime) {
-        humanResources.setAsTechPoolOvertime(overtime);
+        getHumanResources().setAsTechPoolOvertime(overtime);
     }
 
     public int getAsTechPoolOvertime() {
-        return humanResources.getAsTechPoolOvertime();
+        return getHumanResources().getAsTechPoolOvertime();
     }
 
     public int getPossibleAsTechPoolMinutes() {
-        return humanResources.getPossibleAsTechPoolMinutes(getCampaignOptions());
+        return getHumanResources().getPossibleAsTechPoolMinutes(getCampaignOptions());
     }
 
     public int getPossibleAsTechPoolOvertime() {
-        return humanResources.getPossibleAsTechPoolOvertime(getCampaignOptions());
+        return getHumanResources().getPossibleAsTechPoolOvertime(getCampaignOptions());
     }
 
     public void setAsTechPool(int size) {
-        humanResources.setAsTechPool(size);
+        getHumanResources().setAsTechPool(size);
     }
 
     /** @deprecated no longer in use **/
     @Deprecated(since = "0.50.07", forRemoval = true)
     public int getAsTechPool() {
-        return humanResources.getTemporaryAsTechPool();
+        return getHumanResources().getTemporaryAsTechPool();
     }
 
     public int getTemporaryAsTechPool() {
-        return humanResources.getTemporaryAsTechPool();
+        return getHumanResources().getTemporaryAsTechPool();
     }
 
     public void setMedicPool(int size) {
-        humanResources.setMedicPool(size);
+        getHumanResources().setMedicPool(size);
     }
 
     /** @deprecated no longer in use **/
     @Deprecated(since = "0.50.07", forRemoval = true)
     public int getMedicPool() {
-        return humanResources.getTemporaryMedicPool();
+        return getHumanResources().getTemporaryMedicPool();
     }
 
     public int getTemporaryMedicPool() {
-        return humanResources.getTemporaryMedicPool();
+        return getHumanResources().getTemporaryMedicPool();
     }
 
     /**
@@ -6944,11 +6854,11 @@ public class Campaign implements ITechManager, IPlace {
      * @return the total number of temp crew in the pool for this role
      */
     public int getTempCrewPool(PersonnelRole role) {
-        return humanResources.getTempCrewPool(role);
+        return getHumanResources().getTempCrewPool(role);
     }
 
     public Set<PersonnelRole> getTempCrewRoleKeys() {
-        return humanResources.getTempCrewRoleKeys();
+        return getHumanResources().getTempCrewRoleKeys();
     }
 
     /**
@@ -6958,7 +6868,7 @@ public class Campaign implements ITechManager, IPlace {
      * @param size the total number of temp crew in the pool
      */
     public void setTempCrewPool(PersonnelRole role, int size) {
-        humanResources.setTempCrewPool(this, role, size);
+        getHumanResources().setTempCrewPool(this, role, size);
     }
 
     /**
@@ -6969,7 +6879,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return true if this blob crew type is enabled
      */
     public boolean isBlobCrewEnabled(PersonnelRole role) {
-        return humanResources.isBlobCrewEnabled(role, getCampaignOptions());
+        return getHumanResources().isBlobCrewEnabled(role, getCampaignOptions());
     }
 
     /**
@@ -6980,7 +6890,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return the number of temp crew in use
      */
     public int getTempCrewInUse(PersonnelRole role) {
-        return humanResources.getTempCrewInUse(this, role);
+        return getHumanResources().getTempCrewInUse(this, role);
     }
 
     /**
@@ -6991,19 +6901,19 @@ public class Campaign implements ITechManager, IPlace {
      * @return total pool minus crew currently in use
      */
     public int getAvailableTempCrewPool(PersonnelRole role) {
-        return humanResources.getAvailableTempCrewPool(this, role);
+        return getHumanResources().getAvailableTempCrewPool(this, role);
     }
 
     public boolean requiresAdditionalAsTechs() {
-        return humanResources.requiresAdditionalAsTechs(campaignOptions);
+        return getHumanResources().requiresAdditionalAsTechs(campaignOptions);
     }
 
     public int getAsTechNeed() {
-        return humanResources.getAsTechNeed(campaignOptions);
+        return getHumanResources().getAsTechNeed(campaignOptions);
     }
 
     public void increaseAsTechPool(int i) {
-        humanResources.increaseAsTechPool(this, i);
+        getHumanResources().increaseAsTechPool(this, i);
     }
 
     public void resetAsTechPool() {
@@ -7024,7 +6934,7 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     public void decreaseAsTechPool(int i) {
-        humanResources.decreaseAsTechPool(this, i);
+        getHumanResources().decreaseAsTechPool(this, i);
     }
 
     public int getNumberAsTechs() {
@@ -7104,7 +7014,10 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     public int getAvailableAsTechs(final int minutes, final boolean alreadyOvertime) {
-        return humanResources.getAvailableAsTechs(minutes, alreadyOvertime, isOvertimeAllowed(), getCampaignOptions());
+        return getHumanResources().getAvailableAsTechs(minutes,
+              alreadyOvertime,
+              isOvertimeAllowed(),
+              getCampaignOptions());
     }
 
     public int getShorthandedMod(int availableHelp, boolean medicalStaff) {
@@ -7212,15 +7125,15 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     public boolean requiresAdditionalMedics() {
-        return humanResources.requiresAdditionalMedics();
+        return getHumanResources().requiresAdditionalMedics();
     }
 
     public int getMedicsNeed() {
-        return humanResources.getMedicsNeed();
+        return getHumanResources().getMedicsNeed();
     }
 
     public void increaseMedicPool(int i) {
-        humanResources.increaseMedicPool(this, i);
+        getHumanResources().increaseMedicPool(this, i);
     }
 
     public void resetMedicPool() {
@@ -7241,7 +7154,7 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     public void decreaseMedicPool(int i) {
-        humanResources.decreaseMedicPool(this, i);
+        getHumanResources().decreaseMedicPool(this, i);
     }
 
     /**
@@ -7302,7 +7215,7 @@ public class Campaign implements ITechManager, IPlace {
      * @param role the personnel role to fill
      */
     public void fillTempCrewPoolForRole(PersonnelRole role) {
-        humanResources.fillTempCrewPoolForRole(this, getCampaignOptions(), role);
+        getHumanResources().fillTempCrewPoolForRole(this, getCampaignOptions(), role);
     }
 
     /**
@@ -7321,7 +7234,7 @@ public class Campaign implements ITechManager, IPlace {
      * needed, no change is made.
      */
     public void releaseSurplusAsTechPool() {
-        humanResources.releaseSurplusAsTechPool(this);
+        getHumanResources().releaseSurplusAsTechPool(this);
     }
 
     /**
@@ -7329,7 +7242,7 @@ public class Campaign implements ITechManager, IPlace {
      * needed, no change is made.
      */
     public void releaseSurplusMedicPool() {
-        humanResources.releaseSurplusMedicPool(this);
+        getHumanResources().releaseSurplusMedicPool(this);
     }
 
     /**
@@ -7341,7 +7254,7 @@ public class Campaign implements ITechManager, IPlace {
      * @param role the personnel role to trim
      */
     public void releaseSurplusBlobCrewForRole(PersonnelRole role) {
-        humanResources.releaseSurplusBlobCrewForRole(this, role);
+        getHumanResources().releaseSurplusBlobCrewForRole(this, role);
     }
 
     /**
@@ -7351,7 +7264,7 @@ public class Campaign implements ITechManager, IPlace {
      * @param role the personnel role to clear
      */
     public void clearBlobCrewForRole(PersonnelRole role) {
-        humanResources.clearBlobCrewForRole(this, role);
+        getHumanResources().clearBlobCrewForRole(this, role);
     }
 
     /**
@@ -7373,7 +7286,7 @@ public class Campaign implements ITechManager, IPlace {
      * @param role the personnel role to distribute
      */
     public void distributeTempCrewPoolToUnits(PersonnelRole role) {
-        humanResources.distributeTempCrewPoolToUnits(this, getCampaignOptions(), role);
+        getHumanResources().distributeTempCrewPoolToUnits(this, getCampaignOptions(), role);
     }
 
 
@@ -7496,7 +7409,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return The text representation of the unit rating
      */
     public String getUnitRatingText() {
-        return String.valueOf(reputation.getReputationRating());
+        return String.valueOf(getReputation().getReputationRating());
     }
 
     /**
@@ -7505,7 +7418,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return The unit rating modifier based on the campaign options.
      */
     public int getAtBUnitRatingMod() {
-        return reputation.getAtbModifier();
+        return getReputation().getAtbModifier();
     }
 
     /**
@@ -7565,7 +7478,7 @@ public class Campaign implements ITechManager, IPlace {
      * @param person The {@link Person} who should receive a randomized portrait.
      */
     public void assignRandomPortraitFor(final Person person) {
-        humanResources.assignRandomPortraitFor(getCampaignOptions(), person);
+        getHumanResources().assignRandomPortraitFor(getCampaignOptions(), person);
     }
 
     /**
@@ -7574,7 +7487,7 @@ public class Campaign implements ITechManager, IPlace {
      * @param person The {@link Person} who should receive a randomized origin.
      */
     public void assignRandomOriginFor(final Person person) {
-        humanResources.assignRandomOriginFor(this, getCampaignOptions(), person);
+        getHumanResources().assignRandomOriginFor(this, getCampaignOptions(), person);
     }
 
     /**
@@ -8244,16 +8157,16 @@ public class Campaign implements ITechManager, IPlace {
                                   ". Your account has been credited " +
                                   loan.getPrincipal().toAmountAndSymbolString() +
                                   " for the principal amount.");
-        finances.addLoan(loan);
+        getFinances().addLoan(loan);
         MekHQ.triggerEvent(new LoanNewEvent(loan));
-        finances.credit(TransactionType.LOAN_PRINCIPAL,
+        getFinances().credit(TransactionType.LOAN_PRINCIPAL,
               getLocalDate(),
               loan.getPrincipal(),
               "Loan principal for " + loan);
     }
 
     public void payOffLoan(Loan loan) {
-        if (finances.debit(TransactionType.LOAN_PAYMENT,
+        if (getFinances().debit(TransactionType.LOAN_PAYMENT,
               getLocalDate(),
               loan.determineRemainingValue(),
               "Loan payoff for " + loan)) {
@@ -8261,7 +8174,7 @@ public class Campaign implements ITechManager, IPlace {
                                       loan.determineRemainingValue().toAmountAndSymbolString() +
                                       " on " +
                                       loan);
-            finances.removeLoan(loan);
+            getFinances().removeLoan(loan);
             MekHQ.triggerEvent(new LoanPaidEvent(loan));
         } else {
             addReport(FINANCES, "<font color='" +
@@ -8623,35 +8536,11 @@ public class Campaign implements ITechManager, IPlace {
 
     @Override
     public megamek.common.enums.Faction getTechFaction() {
-        return techFaction;
+        return playerForce.getTechFaction();
     }
 
     public void updateTechFactionCode() {
-        if (campaignOptions.isFactionIntroDate()) {
-            for (megamek.common.enums.Faction f : megamek.common.enums.Faction.values()) {
-                if (f.equals(megamek.common.enums.Faction.NONE)) {
-                    continue;
-                }
-                if (f.getCodeMM().equals(getFaction().getShortName())) {
-                    techFaction = f;
-                    UnitTechProgression.loadFaction(techFaction);
-                    return;
-                }
-            }
-            // If the tech progression data does not include the current faction,
-            // use a generic.
-            if (getFaction().isClan()) {
-                techFaction = megamek.common.enums.Faction.CLAN;
-            } else if (getFaction().isPeriphery()) {
-                techFaction = megamek.common.enums.Faction.PER;
-            } else {
-                techFaction = megamek.common.enums.Faction.IS;
-            }
-        } else {
-            techFaction = megamek.common.enums.Faction.NONE;
-        }
-        // Unit tech level will be calculated if the code has changed.
-        UnitTechProgression.loadFaction(techFaction);
+        playerForce.updateTechFactionCode();
     }
 
     @Override
@@ -8767,16 +8656,16 @@ public class Campaign implements ITechManager, IPlace {
 
     @Override
     public RequestedStockLevels getRequestedStockLevels() {
-        return requestedStockLevels;
+        return playerForce.getRequestedStockLevels();
     }
 
     // Simple getters and setters for our stock map
     public Map<String, Double> getPartsInUseRequestedStockMap() {
-        return requestedStockLevels.getStockMap();
+        return getRequestedStockLevels().getStockMap();
     }
 
     public void setPartsInUseRequestedStockMap(Map<String, Double> partsInUseRequestedStockMap) {
-        Map<String, Double> stockMap = requestedStockLevels.getStockMap();
+        Map<String, Double> stockMap = getRequestedStockLevels().getStockMap();
         stockMap.clear();
         stockMap.putAll(partsInUseRequestedStockMap);
     }
@@ -8809,23 +8698,24 @@ public class Campaign implements ITechManager, IPlace {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "ignoreMothBalled", ignoreMothballed);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "topUpWeekly", topUpWeekly);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "ignoreSparesUnderQuality", ignoreSparesUnderQuality.name());
-        requestedStockLevels.writeToXML(pw, indent);
+        getRequestedStockLevels().writeToXML(pw, indent);
     }
 
     /**
      * Wipes the Parts in use map for the purpose of resetting all values to their default
      */
     public void wipePartsInUseMap() {
-        this.requestedStockLevels.clear();
+        getRequestedStockLevels().clear();
     }
 
-    /** Discriminator identifying the main campaign as a serialized {@link ILocation} reference. */
+    /**
+     * Legacy discriminator for the main force in older saves. The referable main-force node is now the
+     * {@link mekhq.campaign.force.PlayerForce}; this constant is retained only as a read alias in
+     * {@link ILocation#REFERENCE_RESOLVERS} so pre-split saves still resolve. The campaign itself is no longer written
+     * as a location reference, so it inherits {@link ILocation#locationReferenceType()}'s {@code null} default (not
+     * referable).
+     */
     public static final String LOCATION_REFERENCE_TYPE = "campaign";
-
-    @Override
-    public String locationReferenceType() {
-        return LOCATION_REFERENCE_TYPE;
-    }
 
     /**
      * Retrieves the campaign faction icon for the specified {@link Campaign}. If a custom icon is defined in the
@@ -8915,7 +8805,7 @@ public class Campaign implements ITechManager, IPlace {
         // All other campaigns begin with their own faction; the player only chooses capital vs. hiring hall
         boolean useFactionCapital = choice.useFactionCapital();
 
-        Faction startingFaction = faction;
+        Faction startingFaction = getFaction();
         Planet startingPlanet = resolveStartingPlanetForFaction(startingFaction, useFactionCapital);
 
         // Fallback if the faction has no usable starting location

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -387,7 +387,6 @@ public class Campaign implements ITechManager, IPlace {
     private Systems systemsInstance;
     private final Map<String, PlanetarySystem> planetarySystemOverrides = new LinkedHashMap<>();
     private final CampaignLocationManager locationManager = new CampaignLocationManager();
-    private final ForceLocationManager forceLocationManager = new ForceLocationManager(getPlayerForce());
     private boolean isAvoidingEmptySystems;
     private boolean isOverridingCommandCircuitRequirements;
 
@@ -5579,7 +5578,7 @@ public class Campaign implements ITechManager, IPlace {
         formations.writeToXML(writer, indent);
         MHQXMLUtility.writeSimpleXMLCloseTag(writer, --indent, "formations");
         getFinances().writeToXML(writer, indent);
-        forceLocationManager.writeToXML(writer, indent);
+        getForceLocationManager().writeToXML(writer, indent);
         locationManager.writeToXML(this, writer, indent);
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "isAvoidingEmptySystems", isAvoidingEmptySystems);
         MHQXMLUtility.writeSimpleXMLTag(writer,

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -46,12 +46,6 @@ import static mekhq.campaign.enums.DailyReportType.FINANCES;
 import static mekhq.campaign.enums.DailyReportType.GENERAL;
 import static mekhq.campaign.enums.DailyReportType.PERSONNEL;
 import static mekhq.campaign.enums.DailyReportType.TECHNICAL;
-import static mekhq.campaign.force.CombatTeam.recalculateCombatTeams;
-import static mekhq.campaign.force.Formation.FORMATION_NONE;
-import static mekhq.campaign.force.Formation.FORMATION_ORIGIN;
-import static mekhq.campaign.force.Formation.NO_ASSIGNED_SCENARIO;
-import static mekhq.campaign.force.FormationType.STANDARD;
-import static mekhq.campaign.parts.enums.PartQuality.QUALITY_A;
 import static mekhq.campaign.personnel.PersonnelOptions.ADMIN_INTERSTELLAR_NEGOTIATOR;
 import static mekhq.campaign.personnel.PersonnelOptions.ADMIN_LOGISTICIAN;
 import static mekhq.campaign.personnel.PersonnelOptions.EDGE_ADMIN_APPRAISAL_FAIL;
@@ -65,8 +59,6 @@ import static mekhq.campaign.personnel.skills.SkillType.S_TECH_MECHANIC;
 import static mekhq.campaign.personnel.skills.SkillType.getType;
 import static mekhq.campaign.personnel.turnoverAndRetention.RetirementDefectionTracker.Payout.isBreakingContract;
 import static mekhq.campaign.randomEvents.other.GrayMonday.isGrayMonday;
-import static mekhq.campaign.randomEvents.prisoners.PrisonerEventManager.DEFAULT_TEMPORARY_CAPACITY;
-import static mekhq.campaign.randomEvents.prisoners.PrisonerEventManager.MINIMUM_TEMPORARY_CAPACITY;
 import static mekhq.campaign.unit.Unit.TECH_WORK_DAY;
 import static mekhq.campaign.universe.Faction.MERCENARY_FACTION_CODE;
 import static mekhq.campaign.universe.Faction.PIRATE_FACTION_CODE;
@@ -167,7 +159,6 @@ import mekhq.campaign.force.FormationType;
 import mekhq.campaign.force.PlayerForce;
 import mekhq.campaign.icons.StandardFormationIcon;
 import mekhq.campaign.location.ILocation;
-import mekhq.campaign.location.IPlace;
 import mekhq.campaign.location.LocationNode;
 import mekhq.campaign.location.LocationUtils;
 import mekhq.campaign.log.HistoricalLogEntry;
@@ -218,7 +209,6 @@ import mekhq.campaign.personnel.enums.PersonnelStatus;
 import mekhq.campaign.personnel.enums.SplittingSurnameStyle;
 import mekhq.campaign.personnel.generator.AbstractPersonnelGenerator;
 import mekhq.campaign.personnel.marriage.AbstractMarriage;
-import mekhq.campaign.personnel.medical.MASHCapacity;
 import mekhq.campaign.personnel.procreation.AbstractProcreation;
 import mekhq.campaign.personnel.ranks.AutoAssignRankForCompanyGenerator;
 import mekhq.campaign.personnel.ranks.RankSystem;
@@ -236,7 +226,6 @@ import mekhq.campaign.randomEvents.randomEventsSystem.RandomEventLibraries;
 import mekhq.campaign.storyArc.StoryArc;
 import mekhq.campaign.stratCon.StratConContractInitializer;
 import mekhq.campaign.stratCon.StratConRulesManager;
-import mekhq.campaign.stratCon.StratConTrackState;
 import mekhq.campaign.unit.CargoStatistics;
 import mekhq.campaign.unit.CrewType;
 import mekhq.campaign.unit.HangarStatistics;
@@ -273,7 +262,7 @@ import mekhq.utilities.ReportingUtilities;
  *
  * @author Taharqa
  */
-public class Campaign implements ITechManager, IPlace {
+public class Campaign implements ITechManager {
     private static final MMLogger LOGGER = MMLogger.create(Campaign.class);
 
     public static final String REPORT_LINEBREAK = "<br/><br/>";
@@ -296,18 +285,18 @@ public class Campaign implements ITechManager, IPlace {
     /** The player's active force: faction identity, finances, reputation, and the owned hangar/warehouse/personnel. */
     @Nonnull
     private final PlayerForce playerForce;
-    CampaignTransporterMap shipTransporters = new CampaignTransporterMap(this, CampaignTransportType.SHIP_TRANSPORT);
+    // TODO (campaign split): Quartermaster holds a Campaign back-reference. Remove that coupling so it can
+    //   move onto the force (AbstractForce/PlayerForce) alongside the other owned state.
+    private final Quartermaster quartermaster;
     CampaignTransporterMap tacticalTransporters = new CampaignTransporterMap(this,
           CampaignTransportType.TACTICAL_TRANSPORT);
     CampaignTransporterMap towTransporters = new CampaignTransporterMap(this, CampaignTransportType.TOW_TRANSPORT);
-    private final TreeMap<Integer, Formation> formationIds = new TreeMap<>();
     private final TreeMap<Integer, Mission> missions = new TreeMap<>();
     private final TreeMap<Integer, Scenario> scenarios = new TreeMap<>();
     private final Map<UUID, List<Kill>> kills = new HashMap<>();
 
     private transient final UnitNameTracker unitNameTracker = new UnitNameTracker();
 
-    private int lastFormationId;
     private int lastMissionId;
     private int lastScenarioId;
 
@@ -323,11 +312,6 @@ public class Campaign implements ITechManager, IPlace {
     private LocalDate campaignStartDate;
 
     private transient CampaignNewDayManager newDayManager = null;
-
-    // hierarchically structured Formation object to define TO&E
-    private Formation formations;
-    private Hashtable<Integer, CombatTeam> combatTeams; // AtB
-
 
     private final ArrayList<String> currentReport;
     private transient String currentReportHTML;
@@ -369,10 +353,6 @@ public class Campaign implements ITechManager, IPlace {
     private transient String aggregateReportHTML;
     private transient List<String> newAggregateReports;
 
-    private boolean fieldKitchenWithinCapacity;
-    private int mashTheatreCapacity;
-    private int repairBaysRented;
-
     private Person genericAcquisitionPerson;
 
     // this is updated and used per gaming session, it is enabled/disabled via the Campaign options we're re-using
@@ -387,8 +367,6 @@ public class Campaign implements ITechManager, IPlace {
     private Systems systemsInstance;
     private final Map<String, PlanetarySystem> planetarySystemOverrides = new LinkedHashMap<>();
     private final CampaignLocationManager locationManager = new CampaignLocationManager();
-    private boolean isAvoidingEmptySystems;
-    private boolean isOverridingCommandCircuitRequirements;
 
     private final News news;
 
@@ -411,17 +389,12 @@ public class Campaign implements ITechManager, IPlace {
     @Deprecated(since = "0.50.10", forRemoval = true)
     private IUnitRating unitRating; // deprecated
     private CampaignSummary campaignSummary;
-    private final Quartermaster quartermaster;
+    // TODO (campaign split): the transporter maps hold a Campaign back-reference. Remove that coupling so they
+    //   can move onto the force (AbstractForce/PlayerForce) alongside the other owned state.
+    CampaignTransporterMap shipTransporters = new CampaignTransporterMap(this, CampaignTransportType.SHIP_TRANSPORT);
     private StoryArc storyArc;
     private BehaviorSettings autoResolveBehaviorSettings;
-    private List<UUID> automatedMothballUnits;
-    private int temporaryPrisonerCapacity;
     private boolean processProcurement;
-
-    // options relating to parts in use and restock
-    private boolean ignoreMothballed;
-    private boolean topUpWeekly;
-    private PartQuality ignoreSparesUnderQuality;
 
     // Libraries
     // We deliberately don't write this data to the save file as we want it rebuilt
@@ -536,9 +509,9 @@ public class Campaign implements ITechManager, IPlace {
         playerForce.setName(name);
 
         setLocation(startLocation);
-        this.setParent(startLocation);
-        formations = formation;
-        formationIds.put(0, formations);
+        playerForce.getForceDetachment().setParent(startLocation);
+        playerForce.setFormations(formation);
+        playerForce.getFormationIds().put(0, formation);
         randomEventLibraries = randomEvents;
         factionStandingUltimatumsLibrary = ultimatums;
         getHumanResources().setRetirementDefectionTracker(retDefTracker);
@@ -564,24 +537,16 @@ public class Campaign implements ITechManager, IPlace {
 
         // Starting config / default values
         campaignStartDate = null;
-        isAvoidingEmptySystems = true;
-        isOverridingCommandCircuitRequirements = false;
         overtime = false;
         gmMode = false;
-        combatTeams = new Hashtable<>();
         customs = new ArrayList<>();
         turnoverRetirementInformation = new ArrayList<>();
         atbConfig = null;
         hasActiveContract = false;
-        fieldKitchenWithinCapacity = false;
-        mashTheatreCapacity = 0;
-        repairBaysRented = 0;
-        automatedMothballUnits = new ArrayList<>();
-        temporaryPrisonerCapacity = DEFAULT_TEMPORARY_CAPACITY;
         processProcurement = true;
-        topUpWeekly = mekhqOptions.getNewDayAutoLogistics();
-        ignoreMothballed = true;
-        ignoreSparesUnderQuality = QUALITY_A;
+        // The force initializes the migrated settings/capacities to their static defaults; only the
+        // MHQ-options-derived one is asserted here where those options are available.
+        playerForce.setTopUpWeekly(mekhqOptions.getNewDayAutoLogistics());
 
         // Reports
         currentReport = new ArrayList<>();
@@ -794,32 +759,31 @@ public class Campaign implements ITechManager, IPlace {
         this.campaignStartDate = campaignStartDate;
     }
 
-    @Override
     public PlanetarySystem getCurrentSystem() {
         AbstractLocation location = getCurrentLocation();
         return location != null ? location.getCurrentSystem() : null;
     }
 
     public boolean isAvoidingEmptySystems() {
-        return isAvoidingEmptySystems;
+        return playerForce.isAvoidingEmptySystems();
     }
 
     public void setIsAvoidingEmptySystems(boolean isAvoidingEmptySystems) {
-        this.isAvoidingEmptySystems = isAvoidingEmptySystems;
+        playerForce.setIsAvoidingEmptySystems(isAvoidingEmptySystems);
     }
 
     public boolean isOverridingCommandCircuitRequirements() {
-        return isOverridingCommandCircuitRequirements;
+        return playerForce.isOverridingCommandCircuitRequirements();
     }
 
     public void setIsOverridingCommandCircuitRequirements(boolean isOverridingCommandCircuitRequirements) {
-        this.isOverridingCommandCircuitRequirements = isOverridingCommandCircuitRequirements;
+        playerForce.setIsOverridingCommandCircuitRequirements(isOverridingCommandCircuitRequirements);
     }
 
     public boolean isUseCommandCircuitForContract(AbstractMissionTransition abstractMission) {
         if (abstractMission instanceof AtBContract atBContract) {
             return FactionStandingUtilities.isUseCommandCircuit(
-                  isOverridingCommandCircuitRequirements, gmMode,
+                  isOverridingCommandCircuitRequirements(), gmMode,
                   campaignOptions.isUseFactionStandingCommandCircuitSafe(),
                   getFactionStandings(), List.of(atBContract));
         } else {
@@ -848,20 +812,20 @@ public class Campaign implements ITechManager, IPlace {
         return playerForce.getFunds();
     }
 
-    public void setFormations(Formation f) {
-        formations = f;
+    public Formation getFormations() {
+        return playerForce.getFormations();
     }
 
-    public Formation getFormations() {
-        return formations;
+    public void setFormations(Formation f) {
+        playerForce.setFormations(f);
     }
 
     public List<Formation> getAllFormations() {
-        return new ArrayList<>(formationIds.values());
+        return playerForce.getAllFormations();
     }
 
     public TreeMap<Integer, Formation> getFormationIds() {
-        return formationIds;
+        return playerForce.getFormationIds();
     }
 
     /**
@@ -879,7 +843,7 @@ public class Campaign implements ITechManager, IPlace {
      * @since 0.50.05
      */
     public List<UUID> getAllUnitsInTheTOE(boolean standardFormationsOnly) {
-        return formations.getAllUnits(standardFormationsOnly);
+        return playerForce.getAllUnitsInTheTOE(standardFormationsOnly);
     }
 
     /**
@@ -888,7 +852,7 @@ public class Campaign implements ITechManager, IPlace {
      * @param combatTeam the {@link CombatTeam} to be added to the {@link Hashtable}
      */
     public void addCombatTeam(CombatTeam combatTeam) {
-        combatTeams.put(combatTeam.getFormationId(), combatTeam);
+        playerForce.addCombatTeam(combatTeam);
     }
 
     /**
@@ -898,7 +862,7 @@ public class Campaign implements ITechManager, IPlace {
      * @param formationId the key of the {@link CombatTeam} to be removed from the {@link Hashtable}
      */
     public void removeCombatTeam(final int formationId) {
-        this.combatTeams.remove(formationId);
+        playerForce.removeCombatTeam(formationId);
     }
 
     /**
@@ -909,34 +873,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return the sanitized {@link Hashtable} of {@link CombatTeam} objects stored in the current campaign.
      */
     public Hashtable<Integer, CombatTeam> getCombatTeamsAsMap() {
-        // Here we sanitize the list, ensuring ineligible formations have been removed
-        // before
-        // returning the hashtable. In theory, this shouldn't be necessary, however,
-        // having this
-        // sanitizing step should remove the need for isEligible() checks whenever we
-        // fetch the
-        // hashtable.
-        for (Formation formation : getAllFormations()) {
-            int formationId = formation.getId();
-            if (combatTeams.containsKey(formationId)) {
-                CombatTeam combatTeam = combatTeams.get(formationId);
-
-                if (combatTeam.isEligible(this)) {
-                    continue;
-                }
-            } else {
-                CombatTeam combatTeam = new CombatTeam(formationId, this);
-
-                if (combatTeam.isEligible(this)) {
-                    combatTeams.put(formationId, combatTeam);
-                    continue;
-                }
-            }
-
-            combatTeams.remove(formationId);
-        }
-
-        return combatTeams;
+        return playerForce.getCombatTeamsAsMap(this);
     }
 
     /**
@@ -947,14 +884,7 @@ public class Campaign implements ITechManager, IPlace {
      * @return an {@link ArrayList} of all the {@link CombatTeam} objects in the {@code combatTeams} {@link Hashtable}
      */
     public ArrayList<CombatTeam> getCombatTeamsAsList() {
-        // This call allows us to utilize the self-sanitizing feature of getCombatTeamsTable(), without needing to
-        // directly include the code here, too.
-        combatTeams = getCombatTeamsAsMap();
-
-        return combatTeams.values()
-                     .stream()
-                     .filter(l -> formationIds.containsKey(l.getFormationId()))
-                     .collect(Collectors.toCollection(ArrayList::new));
+        return playerForce.getCombatTeamsAsList(this);
     }
 
     public void setShoppingList(ShoppingList sl) {
@@ -1265,50 +1195,11 @@ public class Campaign implements ITechManager, IPlace {
      * @param superFormation - the superformation to add the new formation to
      */
     public void addFormation(Formation formation, Formation superFormation) {
-        int id = lastFormationId + 1;
-        formation.setId(id);
-        superFormation.addSubFormation(formation, true);
-        formation.setScenarioId(superFormation.getScenarioId(), this);
-        formationIds.put(id, formation);
-        lastFormationId = id;
-
-        formation.updateCommander(this);
-
-        if (campaignOptions.isUseStratCon()) {
-            recalculateCombatTeams(this);
-        }
+        playerForce.addFormation(formation, superFormation, this);
     }
 
     public void moveFormation(Formation formation, Formation superFormation) {
-        // Can't move a null formation under a subformation and can't move a formation under itself.
-        if (formation == null || formation.equals(superFormation)) {
-            return;
-        }
-        Formation parentFormation = formation.getParentFormation();
-
-        if (null != parentFormation) {
-            parentFormation.removeSubFormation(formation.getId());
-        }
-
-        superFormation.addSubFormation(formation, true);
-        formation.setScenarioId(superFormation.getScenarioId(), this);
-
-        FormationType formationType = formation.getFormationType();
-
-        if (formationType.shouldStandardizeParents()) {
-            for (Formation individualParentFormation : formation.getAllParents()) {
-                individualParentFormation.setFormationType(STANDARD, false);
-            }
-        }
-
-        if (formationType.shouldChildrenInherit()) {
-            for (Formation childFormation : formation.getAllSubFormations()) {
-                childFormation.setFormationType(formationType, false);
-            }
-        }
-
-        // repopulate formation levels across the TO&E
-        Formation.populateFormationLevelsFromOrigin(this);
+        playerForce.moveFormation(formation, superFormation, this);
     }
 
     /**
@@ -1317,8 +1208,7 @@ public class Campaign implements ITechManager, IPlace {
      * @param formation Formation to add
      */
     public void importFormation(Formation formation) {
-        lastFormationId = max(lastFormationId, formation.getId());
-        formationIds.put(formation.getId(), formation);
+        playerForce.importFormation(formation);
     }
 
     /**
@@ -1332,7 +1222,7 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     public void addUnitToFormation(final @Nullable Unit unit, final Formation formation) {
-        addUnitToFormation(unit, formation.getId());
+        playerForce.addUnitToFormation(unit, formation, this);
     }
 
     /**
@@ -1342,72 +1232,7 @@ public class Campaign implements ITechManager, IPlace {
      * @param id   Formation ID to add unit to
      */
     public void addUnitToFormation(@Nullable Unit unit, int id) {
-        if (unit == null) {
-            return;
-        }
-
-        if (id == FORMATION_NONE) {
-            Formation currentFormation = getFormation(unit.getFormationId());
-            unit.setFormationId(FORMATION_NONE);
-            unit.setScenarioId(NO_ASSIGNED_SCENARIO);
-            MekHQ.triggerEvent(new OrganizationChangedEvent(this, currentFormation, unit));
-            return;
-        }
-
-        Formation formation = formationIds.get(id);
-        Formation prevFormation = formationIds.get(unit.getFormationId());
-        boolean useTransfers = false;
-        boolean transferLog = !getCampaignOptions().isUseTransfers();
-
-        if (null != prevFormation) {
-            if (null != prevFormation.getTechID()) {
-                unit.removeTech();
-            }
-            // We log removal if we don't use transfers or if it can't be assigned to a new
-            // formation
-            prevFormation.removeUnit(this, unit.getId(), transferLog || (formation == null));
-            useTransfers = !transferLog;
-            MekHQ.triggerEvent(new OrganizationChangedEvent(this, prevFormation, unit));
-        }
-
-        if (null != formation) {
-            unit.setFormationId(id);
-            unit.setScenarioId(formation.getScenarioId());
-            if (null != formation.getTechID()) {
-                Person formationTech = getPerson(formation.getTechID());
-                if (formationTech.canTech(unit.getEntity())) {
-                    if (null != unit.getTech()) {
-                        unit.removeTech();
-                    }
-
-                    unit.setTech(formationTech);
-                } else {
-                    String cantTech = formationTech.getFullName() +
-                                            " cannot maintain " +
-                                            unit.getName() +
-                                            '\n' +
-                                            "You will need to assign a tech manually.";
-                    JOptionPane.showMessageDialog(null, cantTech, "Warning", JOptionPane.WARNING_MESSAGE);
-                }
-            }
-            formation.addUnit(this, unit.getId(), useTransfers, prevFormation);
-            MekHQ.triggerEvent(new OrganizationChangedEvent(this, formation, unit));
-        }
-
-        if (campaignOptions.isUseStratCon()) {
-            recalculateCombatTeams(this);
-        }
-    }
-
-    /**
-     * Adds formation and all its sub-formations to the Combat Teams table
-     */
-    private void addAllCombatTeams(Formation formation) {
-        recalculateCombatTeams(this);
-
-        for (Formation subFormation : formation.getSubFormations()) {
-            addAllCombatTeams(subFormation);
-        }
+        playerForce.addUnitToFormation(unit, id, this);
     }
 
     // region Missions/Contracts
@@ -1708,7 +1533,7 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     public void setLocation(AbstractLocation location) {
-        getForceLocationManager().setLocation(getCampaignLocationManager(), location);
+        getDetachmentLocationManager().setLocation(getCampaignLocationManager(), location);
     }
 
     @Nonnull
@@ -1717,8 +1542,8 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     @Nonnull
-    public ForceLocationManager getForceLocationManager() {
-        return getPlayerForce().getForceLocationManager();
+    public DetachmentLocationManager getDetachmentLocationManager() {
+        return getPlayerForce().getDetachmentLocationManager();
     }
 
     /**
@@ -1735,24 +1560,35 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     public void moveToPlanetarySystem(PlanetarySystem planetarySystem) {
-        getForceLocationManager().moveToPlanetarySystem(this, planetarySystem);
+        getDetachmentLocationManager().moveToPlanetarySystem(this, planetarySystem);
     }
 
-    @Override
     @Nonnull
     public LocationNode getLocationNode() {
-        return getForceLocationManager().getLocationNode();
+        return getDetachmentLocationManager().getLocationNode();
     }
 
-    @Override
-    public void onArrival(Campaign campaign, boolean isSilentProcessing) {
-        // The main force is the IPlace that arrives; this is a pass-through to it.
-        playerForce.onArrival(campaign, isSilentProcessing);
-    }
-
-    @Override
     public void processArrivals(Campaign campaign) {
-        getForceLocationManager().processArrivals(campaign);
+        getDetachmentLocationManager().processArrivals(campaign);
+    }
+
+    // The campaign is no longer an ILocation/IPlace itself; the main force (PlayerForce) is the location node.
+    // These convenience accessors delegate to it so callers can still ask the campaign about its position.
+
+    public @Nullable AbstractLocation getCurrentLocation() {
+        return playerForce.getForceDetachment().getCurrentLocation();
+    }
+
+    public boolean isOnPlanet() {
+        return playerForce.getForceDetachment().isOnPlanet();
+    }
+
+    public @Nullable Planet getPlanet() {
+        return playerForce.getForceDetachment().getPlanet();
+    }
+
+    public Set<ILocation> getChildLocations() {
+        return playerForce.getForceDetachment().getChildLocations();
     }
 
     public boolean isOnContractAndPlanetside() {
@@ -2190,46 +2026,42 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     public boolean getFieldKitchenWithinCapacity() {
-        return fieldKitchenWithinCapacity;
+        return playerForce.getFieldKitchenWithinCapacity();
     }
 
     public void setFieldKitchenWithinCapacity(boolean fieldKitchenWithinCapacity) {
-        this.fieldKitchenWithinCapacity = fieldKitchenWithinCapacity;
+        playerForce.setFieldKitchenWithinCapacity(fieldKitchenWithinCapacity);
     }
 
     public boolean getMashTheatresWithinCapacity() {
-        return !isOnContractAndPlanetside() || calculateMASHTheaterCapacity() >= getPatientsAssignedToDoctors().size();
+        return playerForce.getMashTheatresWithinCapacity(this);
     }
 
     public int calculateMASHTheaterCapacity() {
-        List<Unit> unitsInTOE = getFormation(FORMATION_ORIGIN).getAllUnitsAsUnits(getHangar(), false);
-        int baseCapacity = MASHCapacity.checkMASHCapacity(unitsInTOE, campaignOptions.getMASHTheatreCapacity());
-        int rentedCapacity = FacilityRentals.getCapacityIncreaseFromRentals(getActiveContracts(),
-              ContractRentalType.HOSPITAL_BEDS);
-        return baseCapacity + rentedCapacity;
+        return playerForce.calculateMASHTheaterCapacity(this);
     }
 
     @Deprecated(since = "0.51.0", forRemoval = true)
     public int getCachedMashTheaterCapacity() {
-        return mashTheatreCapacity;
+        return playerForce.getCachedMashTheaterCapacity();
     }
 
     public void setMashTheatreCapacity(int mashTheatreCapacity) {
-        this.mashTheatreCapacity = mashTheatreCapacity;
+        playerForce.setMashTheatreCapacity(mashTheatreCapacity);
     }
 
     @Deprecated(since = "0.51.0", forRemoval = true)
     public int getRepairBaysRented() {
-        return repairBaysRented;
+        return playerForce.getRepairBaysRented();
     }
 
     public void setRepairBaysRented(int repairBaysRented) {
-        this.repairBaysRented = repairBaysRented;
+        playerForce.setRepairBaysRented(repairBaysRented);
     }
 
     @Deprecated(since = "0.51.0", forRemoval = true)
     public void changeRepairBaysRented(int delta) {
-        repairBaysRented = max(0, repairBaysRented + delta);
+        playerForce.changeRepairBaysRented(delta);
     }
     // endregion Person Creation
 
@@ -2425,7 +2257,6 @@ public class Campaign implements ITechManager, IPlace {
         return getHumanResources().getPerson(id);
     }
 
-    @Override
     public Personnel getPersonnel() {
         return playerForce.getPersonnel();
     }
@@ -2707,7 +2538,7 @@ public class Campaign implements ITechManager, IPlace {
 
     @Nullable
     public Formation getFormation(int id) {
-        return formationIds.get(id);
+        return playerForce.getFormation(id);
     }
 
     public List<String> getCurrentReport() {
@@ -4287,7 +4118,7 @@ public class Campaign implements ITechManager, IPlace {
         int role = -max(1, contract.getRequiredCombatElements() / 2);
 
         final CombatRole requiredLanceRole = contract.getContractType().getRequiredCombatRole();
-        for (CombatTeam combatTeam : combatTeams.values()) {
+        for (CombatTeam combatTeam : playerForce.getCombatTeamsMap().values()) {
             CombatRole combatRole = combatTeam.getRole();
 
             if (!combatRole.isReserve() && !combatRole.isAuxiliary()) {
@@ -4564,7 +4395,7 @@ public class Campaign implements ITechManager, IPlace {
         }
 
         // remove from automatic mothballing
-        automatedMothballUnits.remove(unit.getId());
+        getAutomatedMothballUnits().remove(unit.getId());
 
         // finally, remove the unit
         getHangar().removeUnit(unit.getId());
@@ -4639,104 +4470,19 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     public void removeFormation(Formation formation) {
-        int fid = formation.getId();
-        formationIds.remove(fid);
-        // clear formationIds of all personnel with this formation
-        for (UUID uid : formation.getUnits()) {
-            Unit u = getHangar().getUnit(uid);
-            if (null == u) {
-                continue;
-            }
-            if (u.getFormationId() == fid) {
-                u.setFormationId(FORMATION_NONE);
-                if (formation.isDeployed()) {
-                    u.setScenarioId(NO_ASSIGNED_SCENARIO);
-                }
-            }
-        }
-
-        // also remove this formation's id from any scenarios
-        if (formation.isDeployed()) {
-            Scenario s = getScenario(formation.getScenarioId());
-            s.removeFormation(fid);
-        }
-
-        if (null != formation.getParentFormation()) {
-            formation.getParentFormation().removeSubFormation(fid);
-        }
-
-        // clear out StratCon formation assignments
-        for (AtBContract contract : getActiveAtBContracts()) {
-            if (contract.getStratConCampaignState() != null) {
-                for (StratConTrackState track : contract.getStratConCampaignState().getTracks()) {
-                    track.unassignFormation(fid);
-                }
-            }
-        }
-
-        if (campaignOptions.isUseStratCon()) {
-            recalculateCombatTeams(this);
-        }
+        playerForce.removeFormation(formation, this);
     }
 
     public void removeUnitFromFormation(Unit u) {
-        Formation formation = getFormation(u.getFormationId());
-        if (null != formation) {
-            formation.removeUnit(this, u.getId(), true);
-            u.setFormationId(FORMATION_NONE);
-            u.setScenarioId(NO_ASSIGNED_SCENARIO);
-            if (u.getEntity().hasNavalC3() && u.getEntity().calculateFreeC3Nodes() < 5) {
-                Vector<Unit> removedUnits = new Vector<>();
-                removedUnits.add(u);
-                removeUnitsFromNetwork(removedUnits);
-                u.getEntity().setC3MasterIsUUIDAsString(null);
-                u.getEntity().setC3Master(null, true);
-                refreshNetworks();
-            } else if (u.getEntity().hasC3i() && u.getEntity().calculateFreeC3Nodes() < 5) {
-                Vector<Unit> removedUnits = new Vector<>();
-                removedUnits.add(u);
-                removeUnitsFromNetwork(removedUnits);
-                u.getEntity().setC3MasterIsUUIDAsString(null);
-                u.getEntity().setC3Master(null, true);
-                refreshNetworks();
-            } else if (u.getEntity().hasNovaCEWS() && u.getEntity().calculateFreeC3Nodes() < 2) {
-                // Nova CEWS max is 3 nodes, so < 2 free means unit is networked
-                Vector<Unit> removedUnits = new Vector<>();
-                removedUnits.add(u);
-                removeUnitsFromNetwork(removedUnits);
-                u.getEntity().setC3MasterIsUUIDAsString(null);
-                u.getEntity().setC3Master(null, true);
-                refreshNetworks();
-            }
-            if (u.getEntity().hasC3M()) {
-                removeUnitsFromC3Master(u);
-                u.getEntity().setC3MasterIsUUIDAsString(null);
-                u.getEntity().setC3Master(null, true);
-            }
-
-            if (campaignOptions.isUseStratCon() && formation.getUnits().isEmpty()) {
-                combatTeams.remove(formation.getId());
-            }
-        }
+        playerForce.removeUnitFromFormation(u, this);
     }
 
     public @Nullable Formation getFormationFor(final @Nullable Unit unit) {
-        return (unit == null) ? null : getFormation(unit.getFormationId());
+        return playerForce.getFormationFor(unit);
     }
 
     public @Nullable Formation getFormationFor(final Person person) {
-        final Unit unit = person.getUnit();
-        if (unit != null) {
-            return getFormationFor(unit);
-        } else if (person.isTech()) {
-            return formationIds.values()
-                         .stream()
-                         .filter(formation -> person.getId().equals(formation.getTechID()))
-                         .findFirst()
-                         .orElse(null);
-        }
-
-        return null;
+        return playerForce.getFormationFor(person);
     }
 
     public void restore() {
@@ -4824,7 +4570,7 @@ public class Campaign implements ITechManager, IPlace {
         }
 
         // clean up non-existent unit references in formation unit lists
-        for (Formation formation : formationIds.values()) {
+        for (Formation formation : getFormationIds().values()) {
             List<UUID> orphanFormationUnitIDs = new ArrayList<>();
 
             for (UUID unitID : formation.getUnits()) {
@@ -5348,7 +5094,7 @@ public class Campaign implements ITechManager, IPlace {
      *       no units are configured.
      */
     public List<UUID> getAutomatedMothballUnits() {
-        return automatedMothballUnits;
+        return playerForce.getAutomatedMothballUnits();
     }
 
     /**
@@ -5361,15 +5107,15 @@ public class Campaign implements ITechManager, IPlace {
      * @param automatedMothballUnits A {@link List} of {@link UUID} objects to configure for automated mothballing.
      */
     public void setAutomatedMothballUnits(List<UUID> automatedMothballUnits) {
-        this.automatedMothballUnits = automatedMothballUnits;
+        playerForce.setAutomatedMothballUnits(automatedMothballUnits);
     }
 
     public int getTemporaryPrisonerCapacity() {
-        return temporaryPrisonerCapacity;
+        return playerForce.getTemporaryPrisonerCapacity();
     }
 
     public void setTemporaryPrisonerCapacity(int temporaryPrisonerCapacity) {
-        this.temporaryPrisonerCapacity = max(MINIMUM_TEMPORARY_CAPACITY, temporaryPrisonerCapacity);
+        playerForce.setTemporaryPrisonerCapacity(temporaryPrisonerCapacity);
     }
 
     /**
@@ -5382,8 +5128,7 @@ public class Campaign implements ITechManager, IPlace {
      *              capacity, while a negative value decreases it.
      */
     public void changeTemporaryPrisonerCapacity(int delta) {
-        int newCapacity = temporaryPrisonerCapacity + delta;
-        temporaryPrisonerCapacity = max(MINIMUM_TEMPORARY_CAPACITY, newCapacity);
+        playerForce.changeTemporaryPrisonerCapacity(delta);
     }
 
     public RandomEventLibraries getRandomEventLibraries() {
@@ -5449,13 +5194,13 @@ public class Campaign implements ITechManager, IPlace {
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "overtime", overtime);
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "gmMode", gmMode);
 
-        MHQXMLUtility.writeSimpleXMLTag(writer, indent, "fieldKitchenWithinCapacity", fieldKitchenWithinCapacity);
-        MHQXMLUtility.writeSimpleXMLTag(writer, indent, "mashTheatreCapacity", mashTheatreCapacity);
-        MHQXMLUtility.writeSimpleXMLTag(writer, indent, "repairBaysRented", repairBaysRented);
+        MHQXMLUtility.writeSimpleXMLTag(writer, indent, "fieldKitchenWithinCapacity", getFieldKitchenWithinCapacity());
+        MHQXMLUtility.writeSimpleXMLTag(writer, indent, "mashTheatreCapacity", getCachedMashTheaterCapacity());
+        MHQXMLUtility.writeSimpleXMLTag(writer, indent, "repairBaysRented", getRepairBaysRented());
         getCamouflage().writeToXML(writer, indent);
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "colour", getColour().name());
         getUnitIcon().writeToXML(writer, indent);
-        MHQXMLUtility.writeSimpleXMLTag(writer, indent, "lastFormationId", lastFormationId);
+        MHQXMLUtility.writeSimpleXMLTag(writer, indent, "lastFormationId", playerForce.getLastFormationId());
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "lastMissionId", lastMissionId);
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "lastScenarioId", lastScenarioId);
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "initiativeBonus", getInitiativeBonus());
@@ -5575,16 +5320,16 @@ public class Campaign implements ITechManager, IPlace {
         // the formations structure is hierarchical, but that should be handled
         // internally from with writeToXML function for Formation
         MHQXMLUtility.writeSimpleXMLOpenTag(writer, indent++, "formations");
-        formations.writeToXML(writer, indent);
+        getFormations().writeToXML(writer, indent);
         MHQXMLUtility.writeSimpleXMLCloseTag(writer, --indent, "formations");
         getFinances().writeToXML(writer, indent);
-        getForceLocationManager().writeToXML(writer, indent);
+        getDetachmentLocationManager().writeToXML(writer, indent);
         locationManager.writeToXML(this, writer, indent);
-        MHQXMLUtility.writeSimpleXMLTag(writer, indent, "isAvoidingEmptySystems", isAvoidingEmptySystems);
+        MHQXMLUtility.writeSimpleXMLTag(writer, indent, "isAvoidingEmptySystems", isAvoidingEmptySystems());
         MHQXMLUtility.writeSimpleXMLTag(writer,
               indent,
               "isOverridingCommandCircuitRequirements",
-              isOverridingCommandCircuitRequirements);
+              isOverridingCommandCircuitRequirements());
         getShoppingList().writeToXML(writer, indent);
         MHQXMLUtility.writeSimpleXMLOpenTag(writer, indent++, "kills");
         for (List<Kill> kills : kills.values()) {
@@ -5636,10 +5381,10 @@ public class Campaign implements ITechManager, IPlace {
             // CAW: implicit DEPENDS-ON to the <missions> node, do not move this above it
             contractMarket.writeToXML(this, writer, indent);
 
-            if (!combatTeams.isEmpty()) {
+            if (!playerForce.getCombatTeamsMap().isEmpty()) {
                 MHQXMLUtility.writeSimpleXMLOpenTag(writer, indent++, "combatTeams");
-                for (CombatTeam combatTeam : combatTeams.values()) {
-                    if (formationIds.containsKey(combatTeam.getFormationId())) {
+                for (CombatTeam combatTeam : playerForce.getCombatTeamsMap().values()) {
+                    if (getFormationIds().containsKey(combatTeam.getFormationId())) {
                         combatTeam.writeToXML(writer, indent);
                     }
                 }
@@ -5652,11 +5397,11 @@ public class Campaign implements ITechManager, IPlace {
         }
 
         MHQXMLUtility.writeSimpleXMLOpenTag(writer, indent++, "automatedMothballUnits");
-        for (UUID unitId : automatedMothballUnits) {
+        for (UUID unitId : getAutomatedMothballUnits()) {
             MHQXMLUtility.writeSimpleXMLTag(writer, indent, "mothballedUnit", unitId);
         }
         MHQXMLUtility.writeSimpleXMLCloseTag(writer, --indent, "automatedMothballUnits");
-        MHQXMLUtility.writeSimpleXMLTag(writer, indent, "temporaryPrisonerCapacity", temporaryPrisonerCapacity);
+        MHQXMLUtility.writeSimpleXMLTag(writer, indent, "temporaryPrisonerCapacity", getTemporaryPrisonerCapacity());
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "processProcurement", processProcurement);
 
         MHQXMLUtility.writeSimpleXMLOpenTag(writer, ++indent, "partsInUse");
@@ -5933,7 +5678,7 @@ public class Campaign implements ITechManager, IPlace {
 
         // Shortcuts to ensure we're not processing a lot of data when we're unable to reach the target system
         if (!skipEmptySystemCheck
-                  && isAvoidingEmptySystems
+                  && isAvoidingEmptySystems()
                   && end.getPopulation(currentDay) == 0) {
             new ImmersiveDialogSimple(this, getSeniorAdminPerson(AdministratorSpecialization.TRANSPORT), null,
                   String.format(resources.getString("unableToEnterSystem.abandoned.ic"), getCommanderAddress()),
@@ -5993,7 +5738,7 @@ public class Campaign implements ITechManager, IPlace {
             PlanetarySystem currentSystem = systemsInstance.getSystemById(current);
 
             boolean isUseCommandCircuits =
-                  FactionStandingUtilities.isUseCommandCircuit(isOverridingCommandCircuitRequirements, gmMode,
+                  FactionStandingUtilities.isUseCommandCircuit(isOverridingCommandCircuitRequirements(), gmMode,
                         campaignOptions.isUseFactionStandingCommandCircuitSafe(),
                         getFactionStandings(), getFutureAtBContracts());
 
@@ -6007,7 +5752,7 @@ public class Campaign implements ITechManager, IPlace {
 
                 // Skip systems without population if avoiding empty systems
                 if (!skipEmptySystemCheck
-                          && isAvoidingEmptySystems
+                          && isAvoidingEmptySystems()
                           && neighborSystem.getPopulation(currentDay) == 0) {
                     return;
                 }
@@ -7592,331 +7337,43 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     public void refreshNetworks() {
-        for (Unit unit : getUnits()) {
-            // we are going to rebuild the c3, nc3 and c3i networks based on
-            // the c3UUIDs
-            // TODO: can we do this more efficiently?
-            // this code is cribbed from megamek.server#receiveEntityAdd
-            Entity entity = unit.getEntity();
-            if (null != entity && (entity.hasC3() || entity.hasC3i() || entity.hasNavalC3())) {
-                boolean C3iSet = false;
-                boolean NC3Set = false;
-
-                for (Entity e : game.getEntitiesVector()) {
-                    // C3 Checks
-                    if (entity.hasC3()) {
-                        if ((entity.getC3MasterIsUUIDAsString() != null) &&
-                                  entity.getC3MasterIsUUIDAsString().equals(e.getC3UUIDAsString())) {
-                            entity.setC3Master(e, false);
-                            break;
-                        }
-                    }
-                    // Naval C3 checks
-                    if (entity.hasNavalC3() && !NC3Set) {
-                        entity.setC3NetIdSelf();
-                        int pos = 0;
-                        // Well, they're the same value of 6...
-                        while (pos < Entity.MAX_C3i_NODES) {
-                            // We've found a network, join it.
-                            if ((entity.getNC3NextUUIDAsString(pos) != null) &&
-                                      (e.getC3UUIDAsString() != null) &&
-                                      entity.getNC3NextUUIDAsString(pos).equals(e.getC3UUIDAsString())) {
-                                entity.setC3NetId(e);
-                                NC3Set = true;
-                                break;
-                            }
-
-                            pos++;
-                        }
-                    }
-                    // C3i Checks
-                    if (entity.hasC3i() && !C3iSet) {
-                        entity.setC3NetIdSelf();
-                        int pos = 0;
-                        while (pos < Entity.MAX_C3i_NODES) {
-                            // We've found a network, join it.
-                            if ((entity.getC3iNextUUIDAsString(pos) != null) &&
-                                      (e.getC3UUIDAsString() != null) &&
-                                      entity.getC3iNextUUIDAsString(pos).equals(e.getC3UUIDAsString())) {
-                                entity.setC3NetId(e);
-                                C3iSet = true;
-                                break;
-                            }
-
-                            pos++;
-                        }
-                    }
-                }
-            }
-        }
+        playerForce.refreshNetworks(game);
     }
 
     public void disbandNetworkOf(Unit u) {
-        // collect all the other units on this network to rebuild the uuids
-        Vector<Unit> networkedUnits = new Vector<>();
-        for (Unit unit : getUnits()) {
-            if (null != unit.getEntity().getC3NetId() &&
-                      unit.getEntity().getC3NetId().equals(u.getEntity().getC3NetId())) {
-                networkedUnits.add(unit);
-            }
-        }
-        for (int pos = 0; pos < Entity.MAX_C3i_NODES; pos++) {
-            for (Unit nUnit : networkedUnits) {
-                if (nUnit.getEntity().hasNavalC3()) {
-                    nUnit.getEntity().setNC3NextUUIDAsString(pos, null);
-                } else {
-                    nUnit.getEntity().setC3iNextUUIDAsString(pos, null);
-                }
-            }
-        }
-        refreshNetworks();
-        MekHQ.triggerEvent(new NetworkChangedEvent(networkedUnits));
+        playerForce.disbandNetworkOf(u, game);
     }
 
     public void removeUnitsFromNetwork(Vector<Unit> removedUnits) {
-        // collect all the other units on this network to rebuild the uuids
-        Vector<String> uuids = new Vector<>();
-        Vector<Unit> networkedUnits = new Vector<>();
-        String network = removedUnits.getFirst().getEntity().getC3NetId();
-        for (Unit unit : getUnits()) {
-            if (removedUnits.contains(unit)) {
-                continue;
-            }
-            if (null != unit.getEntity().getC3NetId() && unit.getEntity().getC3NetId().equals(network)) {
-                networkedUnits.add(unit);
-                uuids.add(unit.getEntity().getC3UUIDAsString());
-            }
-        }
-        for (int pos = 0; pos < Entity.MAX_C3i_NODES; pos++) {
-            for (Unit u : removedUnits) {
-                if (u.getEntity().hasNavalC3()) {
-                    u.getEntity().setNC3NextUUIDAsString(pos, null);
-                } else {
-                    u.getEntity().setC3iNextUUIDAsString(pos, null);
-                }
-            }
-            for (Unit nUnit : networkedUnits) {
-                if (pos < uuids.size()) {
-                    if (nUnit.getEntity().hasNavalC3()) {
-                        nUnit.getEntity().setNC3NextUUIDAsString(pos, uuids.get(pos));
-                    } else {
-                        nUnit.getEntity().setC3iNextUUIDAsString(pos, uuids.get(pos));
-                    }
-                } else {
-                    if (nUnit.getEntity().hasNavalC3()) {
-                        nUnit.getEntity().setNC3NextUUIDAsString(pos, null);
-                    } else {
-                        nUnit.getEntity().setC3iNextUUIDAsString(pos, null);
-                    }
-                }
-            }
-        }
-        refreshNetworks();
+        playerForce.removeUnitsFromNetwork(removedUnits, game);
     }
 
     public void addUnitsToNetwork(Vector<Unit> addedUnits, String networkID) {
-        // collect all the other units on this network to rebuild the uuids
-        Vector<String> uuids = new Vector<>();
-        Vector<Unit> networkedUnits = new Vector<>();
-        for (Unit u : addedUnits) {
-            uuids.add(u.getEntity().getC3UUIDAsString());
-            networkedUnits.add(u);
-        }
-        for (Unit unit : getUnits()) {
-            if (addedUnits.contains(unit)) {
-                continue;
-            }
-            if (null != unit.getEntity().getC3NetId() && unit.getEntity().getC3NetId().equals(networkID)) {
-                networkedUnits.add(unit);
-                uuids.add(unit.getEntity().getC3UUIDAsString());
-            }
-        }
-        for (int pos = 0; pos < Entity.MAX_C3i_NODES; pos++) {
-            for (Unit nUnit : networkedUnits) {
-                if (pos < uuids.size()) {
-                    if (nUnit.getEntity().hasNavalC3()) {
-                        nUnit.getEntity().setNC3NextUUIDAsString(pos, uuids.get(pos));
-                    } else {
-                        nUnit.getEntity().setC3iNextUUIDAsString(pos, uuids.get(pos));
-                    }
-                } else {
-                    if (nUnit.getEntity().hasNavalC3()) {
-                        nUnit.getEntity().setNC3NextUUIDAsString(pos, null);
-                    } else {
-                        nUnit.getEntity().setC3iNextUUIDAsString(pos, null);
-                    }
-                }
-            }
-        }
-        refreshNetworks();
-        MekHQ.triggerEvent(new NetworkChangedEvent(addedUnits));
+        playerForce.addUnitsToNetwork(addedUnits, networkID, game);
     }
 
     public Vector<String[]> getAvailableC3iNetworks() {
-        Vector<String[]> networks = new Vector<>();
-        Vector<String> networkNames = new Vector<>();
-
-        for (Unit u : getUnits()) {
-
-            if (u.getFormationId() < 0) {
-                // only units currently in the TO&E
-                continue;
-            }
-            Entity en = u.getEntity();
-            if (null == en) {
-                continue;
-            }
-            if (en.hasC3i() && en.calculateFreeC3Nodes() <= 5 && en.calculateFreeC3Nodes() > 0) {
-                String[] network = new String[2];
-                network[0] = en.getC3NetId();
-                network[1] = "" + en.calculateFreeC3Nodes();
-                if (!networkNames.contains(network[0])) {
-                    networks.add(network);
-                    networkNames.add(network[0]);
-                }
-            }
-        }
-        return networks;
+        return playerForce.getAvailableC3iNetworks();
     }
 
-    /**
-     * @return returns a Vector of the unique name Strings of all Naval C3 networks that have at least 1 free node
-     *       Adapted from getAvailableC3iNetworks() as the two technologies have very similar workings
-     */
     public Vector<String[]> getAvailableNC3Networks() {
-        Vector<String[]> networks = new Vector<>();
-        Vector<String> networkNames = new Vector<>();
-
-        for (Unit u : getUnits()) {
-
-            if (u.getFormationId() < 0) {
-                // only units currently in the TO&E
-                continue;
-            }
-            Entity en = u.getEntity();
-            if (null == en) {
-                continue;
-            }
-            if (en.hasNavalC3() && en.calculateFreeC3Nodes() <= 5 && en.calculateFreeC3Nodes() > 0) {
-                String[] network = new String[2];
-                network[0] = en.getC3NetId();
-                network[1] = "" + en.calculateFreeC3Nodes();
-                if (!networkNames.contains(network[0])) {
-                    networks.add(network);
-                    networkNames.add(network[0]);
-                }
-            }
-        }
-        return networks;
+        return playerForce.getAvailableNC3Networks();
     }
 
-    /**
-     * @return returns a Vector of the unique name Strings of all Nova CEWS networks that have at least 1 free node Nova
-     *       CEWS networks support a maximum of 3 units
-     */
     public Vector<String[]> getAvailableNovaCEWSNetworks() {
-        Vector<String[]> networks = new Vector<>();
-        Vector<String> networkNames = new Vector<>();
-
-        for (Unit u : getUnits()) {
-
-            if (u.getFormationId() < 0) {
-                // only units currently in the TO&E
-                continue;
-            }
-            Entity en = u.getEntity();
-            if (null == en) {
-                continue;
-            }
-            // Nova CEWS max is 3 nodes, so unnetworked unit has 2 free nodes
-            if (en.hasNovaCEWS() && en.calculateFreeC3Nodes() <= 2 && en.calculateFreeC3Nodes() > 0) {
-                String[] network = new String[2];
-                network[0] = en.getC3NetId();
-                network[1] = "" + en.calculateFreeC3Nodes();
-                if (!networkNames.contains(network[0])) {
-                    networks.add(network);
-                    networkNames.add(network[0]);
-                }
-            }
-        }
-        return networks;
+        return playerForce.getAvailableNovaCEWSNetworks();
     }
 
     public Vector<String[]> getAvailableC3MastersForSlaves() {
-        Vector<String[]> networks = new Vector<>();
-        Vector<String> networkNames = new Vector<>();
-
-        for (Unit u : getUnits()) {
-
-            if (u.getFormationId() < 0) {
-                // only units currently in the TO&E
-                continue;
-            }
-            Entity en = u.getEntity();
-            if (null == en) {
-                continue;
-            }
-            // count of free c3 nodes for single company-level masters
-            // will not be right so skip
-            if (en.hasC3M() && !en.hasC3MM() && en.C3MasterIs(en)) {
-                continue;
-            }
-            if (en.calculateFreeC3Nodes() > 0) {
-                String[] network = new String[3];
-                network[0] = en.getC3UUIDAsString();
-                network[1] = "" + en.calculateFreeC3Nodes();
-                network[2] = en.getShortName();
-                if (!networkNames.contains(network[0])) {
-                    networks.add(network);
-                    networkNames.add(network[0]);
-                }
-            }
-        }
-
-        return networks;
+        return playerForce.getAvailableC3MastersForSlaves();
     }
 
     public Vector<String[]> getAvailableC3MastersForMasters() {
-        Vector<String[]> networks = new Vector<>();
-        Vector<String> networkNames = new Vector<>();
-
-        for (Unit u : getUnits()) {
-
-            if (u.getFormationId() < 0) {
-                // only units currently in the TO&E
-                continue;
-            }
-            Entity en = u.getEntity();
-            if (null == en) {
-                continue;
-            }
-            if (en.calculateFreeC3MNodes() > 0) {
-                String[] network = new String[3];
-                network[0] = en.getC3UUIDAsString();
-                network[1] = "" + en.calculateFreeC3MNodes();
-                network[2] = en.getShortName();
-                if (!networkNames.contains(network[0])) {
-                    networks.add(network);
-                    networkNames.add(network[0]);
-                }
-            }
-        }
-
-        return networks;
+        return playerForce.getAvailableC3MastersForMasters();
     }
 
     public void removeUnitsFromC3Master(Unit master) {
-        List<Unit> removed = new ArrayList<>();
-        for (Unit unit : getUnits()) {
-            if (null != unit.getEntity().getC3MasterIsUUIDAsString() &&
-                      unit.getEntity().getC3MasterIsUUIDAsString().equals(master.getEntity().getC3UUIDAsString())) {
-                unit.getEntity().setC3MasterIsUUIDAsString(null);
-                unit.getEntity().setC3Master(null, true);
-                removed.add(unit);
-            }
-        }
-        refreshNetworks();
-        MekHQ.triggerEvent(new NetworkChangedEvent(removed));
+        playerForce.removeUnitsFromC3Master(master, game);
     }
 
     /**
@@ -8137,9 +7594,8 @@ public class Campaign implements ITechManager, IPlace {
      *
      * @see PartInventory
      */
-    @Override
     public PartInventory getPartInventory(Part part) {
-        PartInventory inventory = IPlace.super.getPartInventory(part);
+        PartInventory inventory = playerForce.getPartInventory(part);
 
         int nOrdered = 0;
         IAcquisitionWork onOrder = getShoppingList().getShoppingItem(part);
@@ -8392,7 +7848,7 @@ public class Campaign implements ITechManager, IPlace {
                 }
             }
 
-            addAllCombatTeams(this.formations);
+            playerForce.addAllCombatTeams(getFormations(), this);
 
             // Determine whether there is an active contract
             setHasActiveContract();
@@ -8653,7 +8109,6 @@ public class Campaign implements ITechManager, IPlace {
         this.processProcurement = processProcurement;
     }
 
-    @Override
     public RequestedStockLevels getRequestedStockLevels() {
         return playerForce.getRequestedStockLevels();
     }
@@ -8670,33 +8125,33 @@ public class Campaign implements ITechManager, IPlace {
     }
 
     public boolean getIgnoreMothballed() {
-        return ignoreMothballed;
+        return playerForce.getIgnoreMothballed();
     }
 
     public void setIgnoreMothballed(boolean ignoreMothballed) {
-        this.ignoreMothballed = ignoreMothballed;
+        playerForce.setIgnoreMothballed(ignoreMothballed);
     }
 
     public boolean getTopUpWeekly() {
-        return topUpWeekly;
+        return playerForce.getTopUpWeekly();
     }
 
     public void setTopUpWeekly(boolean topUpWeekly) {
-        this.topUpWeekly = topUpWeekly;
+        playerForce.setTopUpWeekly(topUpWeekly);
     }
 
     public PartQuality getIgnoreSparesUnderQuality() {
-        return ignoreSparesUnderQuality;
+        return playerForce.getIgnoreSparesUnderQuality();
     }
 
     public void setIgnoreSparesUnderQuality(PartQuality ignoreSparesUnderQuality) {
-        this.ignoreSparesUnderQuality = ignoreSparesUnderQuality;
+        playerForce.setIgnoreSparesUnderQuality(ignoreSparesUnderQuality);
     }
 
     public void writePartInUseToXML(final PrintWriter pw, int indent) {
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "ignoreMothBalled", ignoreMothballed);
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "topUpWeekly", topUpWeekly);
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "ignoreSparesUnderQuality", ignoreSparesUnderQuality.name());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "ignoreMothBalled", getIgnoreMothballed());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "topUpWeekly", getTopUpWeekly());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "ignoreSparesUnderQuality", getIgnoreSparesUnderQuality().name());
         getRequestedStockLevels().writeToXML(pw, indent);
     }
 

--- a/MekHQ/src/mekhq/campaign/CampaignLocationManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignLocationManager.java
@@ -554,7 +554,7 @@ public class CampaignLocationManager {
             }
         }
         AcademyCampusLocation campus = new AcademyCampusLocation(academySet, academyName);
-        LocationNode.LocationManager.setLocation(campus, campaign);
+        LocationNode.LocationManager.setLocation(campus, campaign.getPlayerForce().getForceDetachment());
         return campus;
     }
 
@@ -588,7 +588,7 @@ public class CampaignLocationManager {
         MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "locations");
         for (AbstractLocation location : locations) {
             // Skip locations parented to another node — they are serialized inside their parent's XML.
-            // Skip the main force's current location — written separately by ForceLocationManager as <location>.
+            // Skip the main force's current location — written separately by DetachmentLocationManager as <location>.
             if (location.isParented() || location == mainForceLocation) {
                 continue;
             }

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -580,7 +580,7 @@ public class CampaignNewDayManager {
         if (campaign.getTopUpWeekly() && isMonday) {
             // Each location keeps its own stock levels, so top up the main force and every base independently.
             List<IPlace> places = new ArrayList<>();
-            places.add(campaign);
+            places.add(campaign.getPlayerForce().getForceDetachment());
             places.addAll(campaign.getCampaignLocationManager().getPlayerBases());
 
             int bought = 0;

--- a/MekHQ/src/mekhq/campaign/DetachmentLocationManager.java
+++ b/MekHQ/src/mekhq/campaign/DetachmentLocationManager.java
@@ -41,8 +41,7 @@ import java.util.ArrayList;
 import jakarta.annotation.Nonnull;
 import mekhq.MekHQ;
 import mekhq.campaign.events.LocationChangedEvent;
-import mekhq.campaign.force.AbstractForce;
-import mekhq.campaign.force.PlayerForce;
+import mekhq.campaign.force.Detachment;
 import mekhq.campaign.location.ILocation;
 import mekhq.campaign.location.LocationDispatch;
 import mekhq.campaign.location.LocationNode;
@@ -50,48 +49,39 @@ import mekhq.campaign.personnel.medical.advancedMedicalAlternate.Inoculations;
 import mekhq.campaign.universe.PlanetarySystem;
 
 /**
- * Manages the campaign's own position in the {@link LocationNode} tree — the local location of the main force.
+ * Manages a {@link Detachment}'s position in the {@link LocationNode} tree.
  *
- * <p>This class owns the {@link LocationNode} that represents {@link Campaign} itself in the location hierarchy, and
- * provides methods for moving the main force to a new location, processing arrivals at the campaign's position, and
- * serializing the node's children.</p>
+ * <p>This class owns the {@link LocationNode} that represents its {@link Detachment} in the location hierarchy —
+ * keeping the location plumbing separate from the detachment's own state — and provides methods for moving the
+ * detachment to a new location, processing arrivals at its position, and serializing the node's children.</p>
  */
-public class ForceLocationManager {
+public class DetachmentLocationManager {
 
-    private final AbstractForce force;
+    private final Detachment detachment;
+    private final LocationNode locationNode;
 
-    public ForceLocationManager(AbstractForce force) {
-        this.force = force;
-    }
-
-    /**
-     * The player's main force — the {@link PlayerForce} that owns the {@link LocationNode} this manager anchors to a
-     * location, along with the hangar, warehouse, and personnel that travel with it.
-     *
-     * <p>Resolved on demand rather than cached, because the manager is constructed as a {@link Campaign} field before
-     * the campaign builds its {@code PlayerForce}.</p>
-     */
-    private PlayerForce mainForce() {
-        return force;
+    public DetachmentLocationManager(Detachment detachment) {
+        this.detachment = detachment;
+        this.locationNode = new LocationNode(detachment);
     }
 
     @Nonnull
     public LocationNode getLocationNode() {
-        return mainForce().getLocationNode();
+        return locationNode;
     }
 
     /**
-     * Updates the campaign's position in the location tree to {@code location}.
+     * Updates the detachment's position in the location tree to {@code location}.
      *
      * <p>If {@code location} is not yet tracked by the campaign's location collection, it is added. The previous
      * location is removed from the collection when it no longer has any children.</p>
      */
     public void setLocation(CampaignLocationManager locationManager, AbstractLocation location) {
-        AbstractLocation old = mainForce().getCurrentLocation();
+        AbstractLocation old = detachment.getCurrentLocation();
         if (location != null && !locationManager.getLocations().contains(location)) {
             locationManager.addLocation(location);
         }
-        mainForce().setParent(location);
+        detachment.setParent(location);
         if (old != null && old != location && old.getChildLocations().isEmpty()) {
             locationManager.removeLocation(old);
         }
@@ -99,11 +89,11 @@ public class ForceLocationManager {
 
     /**
      * Processes {@link AbstractMobileLocation} travel nodes (interplanetary {@link CurrentLocation} or on-planet
-     * {@link GroundTransitLocation}) that are parented directly to the campaign and have completed their journey,
-     * landing their passengers into the campaign's main force resources.
+     * {@link GroundTransitLocation}) that are parented directly to the detachment and have completed their journey,
+     * landing their passengers into the detachment's resources.
      */
     public void processArrivals(Campaign campaign) {
-        for (ILocation child : new ArrayList<>(mainForce().getChildLocations())) {
+        for (ILocation child : new ArrayList<>(detachment.getChildLocations())) {
             if (!(child instanceof AbstractMobileLocation travelLocation)) {
                 continue;
             }
@@ -111,32 +101,32 @@ public class ForceLocationManager {
                 continue;
             }
             LocationDispatch.landFromTravelNode(travelLocation,
-                  mainForce().getPersonnel(),
-                  mainForce().getHangar(),
-                  mainForce().getWarehouse(),
-                  campaign,
+                  detachment.getPersonnel(),
+                  detachment.getHangar(),
+                  detachment.getWarehouse(),
+                  detachment,
                   campaign.getCampaignLocationManager());
         }
     }
 
     /**
-     * Relocates the campaign immediately to the specified {@link PlanetarySystem}, updating the current location and
+     * Relocates the detachment immediately to the specified {@link PlanetarySystem}, updating the current location and
      * firing any associated events or automated behaviors.
      *
      * <p>This method performs the following actions:</p>
      * <ul>
-     *     <li>Updates the campaign's {@link CurrentLocation} to the given planetary system.</li>
+     *     <li>Updates the detachment's {@link CurrentLocation} to the given planetary system.</li>
      *     <li>Triggers a {@link LocationChangedEvent} to notify listeners of the move.</li>
      *     <li>If there are no units in automated mothball mode, performs automated activation.</li>
      *     <li>If enabled by campaign options, checks for possible inoculation prompts related to the Random Diseases
      *     and Alternative Advanced Medical systems.</li>
      * </ul>
      *
-     * @param planetarySystem the destination {@link PlanetarySystem} to move the campaign to
+     * @param planetarySystem the destination {@link PlanetarySystem} to move to
      */
     public void moveToPlanetarySystem(Campaign campaign, PlanetarySystem planetarySystem) {
         setLocation(campaign.getCampaignLocationManager(), new CurrentLocation(planetarySystem, 0.0));
-        MekHQ.triggerEvent(new LocationChangedEvent(mainForce().getCurrentLocation(), false));
+        MekHQ.triggerEvent(new LocationChangedEvent(detachment.getCurrentLocation(), false));
 
         if (campaign.getAutomatedMothballUnits().isEmpty()) {
             performAutomatedActivation(campaign);
@@ -149,11 +139,10 @@ public class ForceLocationManager {
     }
 
     /**
-     * Writes the {@code <location>} block for the campaign's current location and the
-     * {@code <locationNodeChildren>} block for Campaign's direct children in the location tree.
+     * Writes the {@code <location>} block for the detachment's current location and the
+     * {@code <locationNodeChildren>} block for the detachment's direct children in the location tree.
      */
     public void writeToXML(PrintWriter pw, int indent) {
-        LocationNode locationNode = getLocationNode();
         AbstractLocation currentLocation = locationNode.getNearestAbstractLocation();
         if (currentLocation != null) {
             currentLocation.writeToXML(pw, indent);

--- a/MekHQ/src/mekhq/campaign/ForceLocationManager.java
+++ b/MekHQ/src/mekhq/campaign/ForceLocationManager.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import jakarta.annotation.Nonnull;
 import mekhq.MekHQ;
 import mekhq.campaign.events.LocationChangedEvent;
+import mekhq.campaign.force.AbstractForce;
 import mekhq.campaign.force.PlayerForce;
 import mekhq.campaign.location.ILocation;
 import mekhq.campaign.location.LocationDispatch;
@@ -57,10 +58,10 @@ import mekhq.campaign.universe.PlanetarySystem;
  */
 public class ForceLocationManager {
 
-    private final Campaign campaign;
+    private final AbstractForce force;
 
-    public ForceLocationManager(Campaign campaign) {
-        this.campaign = campaign;
+    public ForceLocationManager(AbstractForce force) {
+        this.force = force;
     }
 
     /**
@@ -71,7 +72,7 @@ public class ForceLocationManager {
      * the campaign builds its {@code PlayerForce}.</p>
      */
     private PlayerForce mainForce() {
-        return campaign.getPlayerForce();
+        return force;
     }
 
     @Nonnull

--- a/MekHQ/src/mekhq/campaign/ForceLocationManager.java
+++ b/MekHQ/src/mekhq/campaign/ForceLocationManager.java
@@ -37,14 +37,12 @@ import static mekhq.campaign.market.contractMarket.ContractAutomation.performAut
 
 import java.io.PrintWriter;
 import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 
 import jakarta.annotation.Nonnull;
 import mekhq.MekHQ;
 import mekhq.campaign.events.LocationChangedEvent;
+import mekhq.campaign.force.PlayerForce;
 import mekhq.campaign.location.ILocation;
-import mekhq.campaign.location.IPlace;
 import mekhq.campaign.location.LocationDispatch;
 import mekhq.campaign.location.LocationNode;
 import mekhq.campaign.personnel.medical.advancedMedicalAlternate.Inoculations;
@@ -59,68 +57,26 @@ import mekhq.campaign.universe.PlanetarySystem;
  */
 public class ForceLocationManager {
 
-    /**
-     * Temporary {@link IPlace} facade exposing only the force-level operations {@link ForceLocationManager} needs
-     * from the {@link Campaign} that currently doubles as the player's main force.
-     *
-     * <p><strong>Remove this class once {@link Campaign} is properly split into a standalone {@code Force} class.
-     * </strong> Right now {@code Force} is just a thin wrapper around {@link Campaign}: it has no {@link LocationNode}
-     * of its own and simply borrows the wrapped campaign's node and resources. Because of that,
-     * {@code getCurrentLocation()}, {@code setParent(...)} and {@code getChildLocations()} are inherited from the
-     * {@link IPlace}/{@link ILocation} defaults operating on that shared node, and only the node and the owned
-     * resources are overridden here.</p>
-     *
-     * <p>Anything at the whole-campaign level (campaign options, the universe, the shared location collection) is
-     * intentionally <em>not</em> exposed here and is passed in as a {@link Campaign} argument instead. Keeping the
-     * surface this small documents exactly which operations belong to the force and keeps the eventual split
-     * mechanical.</p>
-     */
-    private static final class Force implements IPlace {
-        private final Campaign campaign;
-
-        Force(Campaign campaign) {
-            this.campaign = campaign;
-        }
-
-        @Override
-        public LocationNode getLocationNode() {
-            return campaign.getLocationNode();
-        }
-
-        @Override
-        @Nonnull
-        public Hangar getHangar() {
-            return campaign.getHangar();
-        }
-
-        @Override
-        @Nonnull
-        public Warehouse getWarehouse() {
-            return campaign.getWarehouse();
-        }
-
-        @Override
-        @Nonnull
-        public Personnel getPersonnel() {
-            return campaign.getMainForcePersonnel();
-        }
-
-        List<UUID> getAutomatedMothballUnits() {
-            return campaign.getAutomatedMothballUnits();
-        }
-    }
-
-    private final Force mainForce;
-    private final LocationNode locationNode;
+    private final Campaign campaign;
 
     public ForceLocationManager(Campaign campaign) {
-        this.mainForce = new Force(campaign);
-        this.locationNode = new LocationNode(campaign);
+        this.campaign = campaign;
+    }
+
+    /**
+     * The player's main force — the {@link PlayerForce} that owns the {@link LocationNode} this manager anchors to a
+     * location, along with the hangar, warehouse, and personnel that travel with it.
+     *
+     * <p>Resolved on demand rather than cached, because the manager is constructed as a {@link Campaign} field before
+     * the campaign builds its {@code PlayerForce}.</p>
+     */
+    private PlayerForce mainForce() {
+        return campaign.getPlayerForce();
     }
 
     @Nonnull
     public LocationNode getLocationNode() {
-        return locationNode;
+        return mainForce().getLocationNode();
     }
 
     /**
@@ -130,11 +86,11 @@ public class ForceLocationManager {
      * location is removed from the collection when it no longer has any children.</p>
      */
     public void setLocation(CampaignLocationManager locationManager, AbstractLocation location) {
-        AbstractLocation old = mainForce.getCurrentLocation();
+        AbstractLocation old = mainForce().getCurrentLocation();
         if (location != null && !locationManager.getLocations().contains(location)) {
             locationManager.addLocation(location);
         }
-        mainForce.setParent(location);
+        mainForce().setParent(location);
         if (old != null && old != location && old.getChildLocations().isEmpty()) {
             locationManager.removeLocation(old);
         }
@@ -146,7 +102,7 @@ public class ForceLocationManager {
      * landing their passengers into the campaign's main force resources.
      */
     public void processArrivals(Campaign campaign) {
-        for (ILocation child : new ArrayList<>(mainForce.getChildLocations())) {
+        for (ILocation child : new ArrayList<>(mainForce().getChildLocations())) {
             if (!(child instanceof AbstractMobileLocation travelLocation)) {
                 continue;
             }
@@ -154,9 +110,9 @@ public class ForceLocationManager {
                 continue;
             }
             LocationDispatch.landFromTravelNode(travelLocation,
-                  mainForce.getPersonnel(),
-                  mainForce.getHangar(),
-                  mainForce.getWarehouse(),
+                  mainForce().getPersonnel(),
+                  mainForce().getHangar(),
+                  mainForce().getWarehouse(),
                   campaign,
                   campaign.getCampaignLocationManager());
         }
@@ -179,9 +135,9 @@ public class ForceLocationManager {
      */
     public void moveToPlanetarySystem(Campaign campaign, PlanetarySystem planetarySystem) {
         setLocation(campaign.getCampaignLocationManager(), new CurrentLocation(planetarySystem, 0.0));
-        MekHQ.triggerEvent(new LocationChangedEvent(mainForce.getCurrentLocation(), false));
+        MekHQ.triggerEvent(new LocationChangedEvent(mainForce().getCurrentLocation(), false));
 
-        if (mainForce.getAutomatedMothballUnits().isEmpty()) {
+        if (campaign.getAutomatedMothballUnits().isEmpty()) {
             performAutomatedActivation(campaign);
         }
 
@@ -196,6 +152,7 @@ public class ForceLocationManager {
      * {@code <locationNodeChildren>} block for Campaign's direct children in the location tree.
      */
     public void writeToXML(PrintWriter pw, int indent) {
+        LocationNode locationNode = getLocationNode();
         AbstractLocation currentLocation = locationNode.getNearestAbstractLocation();
         if (currentLocation != null) {
             currentLocation.writeToXML(pw, indent);

--- a/MekHQ/src/mekhq/campaign/force/AbstractForce.java
+++ b/MekHQ/src/mekhq/campaign/force/AbstractForce.java
@@ -52,7 +52,6 @@ import java.util.Objects;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.Vector;
-import java.util.stream.Collectors;
 import javax.swing.JOptionPane;
 
 import megamek.client.ui.util.PlayerColour;
@@ -167,16 +166,20 @@ public abstract class AbstractForce {
 
     /** All units across every {@link Detachment} of this force. Multi-detachment-safe. */
     public Collection<Unit> allUnits() {
-        return getDetachments().stream()
-                     .flatMap(detachment -> detachment.getHangar().getUnits().stream())
-                     .collect(Collectors.toList());
+        List<Unit> units = new ArrayList<>();
+        for (Detachment detachment : getDetachments()) {
+            units.addAll(detachment.getHangar().getUnits());
+        }
+        return units;
     }
 
     /** All personnel across every {@link Detachment} of this force. Multi-detachment-safe. */
     public Collection<Person> allPersonnel() {
-        return getDetachments().stream()
-                     .flatMap(detachment -> detachment.getPersonnel().values().stream())
-                     .collect(Collectors.toList());
+        List<Person> personnel = new ArrayList<>();
+        for (Detachment detachment : getDetachments()) {
+            personnel.addAll(detachment.getPersonnel().values());
+        }
+        return personnel;
     }
 
     /**
@@ -653,10 +656,13 @@ public abstract class AbstractForce {
     }
 
     public ArrayList<CombatTeam> getCombatTeamsAsList(Campaign campaign) {
-        return getCombatTeamsAsMap(campaign).values()
-                     .stream()
-                     .filter(l -> formationIds.containsKey(l.getFormationId()))
-                     .collect(Collectors.toCollection(ArrayList::new));
+        ArrayList<CombatTeam> combatTeamsList = new ArrayList<>();
+        for (CombatTeam combatTeam : getCombatTeamsAsMap(campaign).values()) {
+            if (formationIds.containsKey(combatTeam.getFormationId())) {
+                combatTeamsList.add(combatTeam);
+            }
+        }
+        return combatTeamsList;
     }
 
     /**
@@ -807,37 +813,37 @@ public abstract class AbstractForce {
      * this drives.
      */
     public void removeFormation(Formation formation, Campaign campaign) {
-        int fid = formation.getId();
-        formationIds.remove(fid);
+        int formationId = formation.getId();
+        formationIds.remove(formationId);
         // clear formationIds of all personnel with this formation
-        for (UUID uid : formation.getUnits()) {
-            Unit u = requireSingleDetachment().getHangar().getUnit(uid);
-            if (null == u) {
+        for (UUID unitId : formation.getUnits()) {
+            Unit unit = requireSingleDetachment().getHangar().getUnit(unitId);
+            if (null == unit) {
                 continue;
             }
-            if (u.getFormationId() == fid) {
-                u.setFormationId(FORMATION_NONE);
+            if (unit.getFormationId() == formationId) {
+                unit.setFormationId(FORMATION_NONE);
                 if (formation.isDeployed()) {
-                    u.setScenarioId(NO_ASSIGNED_SCENARIO);
+                    unit.setScenarioId(NO_ASSIGNED_SCENARIO);
                 }
             }
         }
 
         // also remove this formation's id from any scenarios
         if (formation.isDeployed()) {
-            Scenario s = campaign.getScenario(formation.getScenarioId());
-            s.removeFormation(fid);
+            Scenario scenario = campaign.getScenario(formation.getScenarioId());
+            scenario.removeFormation(formationId);
         }
 
         if (null != formation.getParentFormation()) {
-            formation.getParentFormation().removeSubFormation(fid);
+            formation.getParentFormation().removeSubFormation(formationId);
         }
 
         // clear out StratCon formation assignments
         for (AtBContract contract : campaign.getActiveAtBContracts()) {
             if (contract.getStratConCampaignState() != null) {
                 for (StratConTrackState track : contract.getStratConCampaignState().getTracks()) {
-                    track.unassignFormation(fid);
+                    track.unassignFormation(formationId);
                 }
             }
         }
@@ -853,13 +859,13 @@ public abstract class AbstractForce {
      * combat-teams table. The {@link Campaign} is supplied as a parameter for the game and combat-team updates this
      * drives.
      */
-    public void removeUnitFromFormation(Unit u, Campaign campaign) {
-        Formation formation = getFormation(u.getFormationId());
+    public void removeUnitFromFormation(Unit unit, Campaign campaign) {
+        Formation formation = getFormation(unit.getFormationId());
         if (null != formation) {
-            formation.removeUnit(campaign, u.getId(), true);
-            u.setFormationId(FORMATION_NONE);
-            u.setScenarioId(NO_ASSIGNED_SCENARIO);
-            detachUnitFromC3Networks(u, campaign.getGame());
+            formation.removeUnit(campaign, unit.getId(), true);
+            unit.setFormationId(FORMATION_NONE);
+            unit.setScenarioId(NO_ASSIGNED_SCENARIO);
+            detachUnitFromC3Networks(unit, campaign.getGame());
 
             if (campaign.getCampaignOptions().isUseStratCon() && formation.getUnits().isEmpty()) {
                 combatTeams.remove(formation.getId());
@@ -886,11 +892,11 @@ public abstract class AbstractForce {
         if (unit != null) {
             return getFormationFor(unit);
         } else if (person.isTech()) {
-            return formationIds.values()
-                         .stream()
-                         .filter(formation -> person.getId().equals(formation.getTechID()))
-                         .findFirst()
-                         .orElse(null);
+            for (Formation formation : formationIds.values()) {
+                if (person.getId().equals(formation.getTechID())) {
+                    return formation;
+                }
+            }
         }
 
         return null;

--- a/MekHQ/src/mekhq/campaign/force/AbstractForce.java
+++ b/MekHQ/src/mekhq/campaign/force/AbstractForce.java
@@ -679,11 +679,11 @@ public abstract class AbstractForce {
     }
 
     /**
-     * Moves {@code formation} to sit directly under {@code superFormation} in the TO&E, detaching it from its current
+     * Moves {@code formation} to sit directly under {@code superFormation} in the TOE, detaching it from its current
      * parent and inheriting the target's scenario assignment. Formation-type standardization is then applied per the
      * moved formation's {@link FormationType} (parents may be standardized, children may inherit), and formation levels
-     * are repopulated across the TO&E. No-ops if {@code formation} is {@code null} or equals {@code superFormation}.
-     * The {@link Campaign} is supplied as a parameter for the scenario and TO&E updates this drives.
+     * are repopulated across the TOE. No-ops if {@code formation} is {@code null} or equals {@code superFormation}.
+     * The {@link Campaign} is supplied as a parameter for the scenario and TOE updates this drives.
      */
     public void moveFormation(Formation formation, Formation superFormation, Campaign campaign) {
         // Can't move a null formation under a subformation and can't move a formation under itself.
@@ -801,7 +801,7 @@ public abstract class AbstractForce {
     }
 
     /**
-     * Removes {@code formation} from the TO&E: unassigns its units (clearing their scenario if it was deployed),
+     * Removes {@code formation} from the TOE: unassigns its units (clearing their scenario if it was deployed),
      * removes it from any scenario it was deployed to and from its parent formation, and clears any StratCon track
      * assignments. The {@link Campaign} is supplied as a parameter for the scenario, contract, and combat-team updates
      * this drives.
@@ -1073,7 +1073,7 @@ public abstract class AbstractForce {
     }
 
     /**
-     * @return one entry per C3i network in the TO&E that has at least one free node; each entry is a
+     * @return one entry per C3i network in the TOE that has at least one free node; each entry is a
      *       {@code {networkId, freeNodeCount}} pair
      */
     public Vector<String[]> getAvailableC3iNetworks() {
@@ -1104,7 +1104,7 @@ public abstract class AbstractForce {
     }
 
     /**
-     * @return one entry per Naval C3 network in the TO&E that has at least one free node; each entry is a
+     * @return one entry per Naval C3 network in the TOE that has at least one free node; each entry is a
      *       {@code {networkId, freeNodeCount}} pair. Naval C3 mirrors C3i, so this parallels
      *       {@link #getAvailableC3iNetworks()}.
      */
@@ -1136,7 +1136,7 @@ public abstract class AbstractForce {
     }
 
     /**
-     * @return one entry per Nova CEWS network in the TO&E that has at least one free node; each entry is a
+     * @return one entry per Nova CEWS network in the TOE that has at least one free node; each entry is a
      *       {@code {networkId, freeNodeCount}} pair. Nova CEWS networks hold at most three units.
      */
     public Vector<String[]> getAvailableNovaCEWSNetworks() {
@@ -1168,7 +1168,7 @@ public abstract class AbstractForce {
     }
 
     /**
-     * @return the C3 masters in the TO&E that can accept a slave (have a free C3 node), excluding company-level masters
+     * @return the C3 masters in the TOE that can accept a slave (have a free C3 node), excluding company-level masters
      *       whose free-node count is unreliable; each entry is a {@code {c3UUID, freeNodeCount, shortName}} triple
      */
     public Vector<String[]> getAvailableC3MastersForSlaves() {
@@ -1206,7 +1206,7 @@ public abstract class AbstractForce {
     }
 
     /**
-     * @return the C3 masters in the TO&E that can accept another master (have a free C3-M node); each entry is a
+     * @return the C3 masters in the TOE that can accept another master (have a free C3-M node); each entry is a
      *       {@code {c3UUID, freeMasterNodeCount, shortName}} triple
      */
     public Vector<String[]> getAvailableC3MastersForMasters() {

--- a/MekHQ/src/mekhq/campaign/force/AbstractForce.java
+++ b/MekHQ/src/mekhq/campaign/force/AbstractForce.java
@@ -45,6 +45,7 @@ import megamek.common.icons.Camouflage;
 import mekhq.campaign.AbstractLocation;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignNewDayManager;
+import mekhq.campaign.ForceLocationManager;
 import mekhq.campaign.Hangar;
 import mekhq.campaign.HumanResources;
 import mekhq.campaign.Personnel;
@@ -91,6 +92,8 @@ public abstract class AbstractForce implements IPlace {
     private HumanResources humanResources = new HumanResources();
     private final RequestedStockLevels requestedStockLevels = new RequestedStockLevels();
     private ShoppingList shoppingList = new ShoppingList();
+
+    private final ForceLocationManager forceLocationManager = new ForceLocationManager(this);
 
     private final ForceOptions forceOptions;
 
@@ -175,6 +178,11 @@ public abstract class AbstractForce implements IPlace {
 
     public ShoppingList getShoppingList() {
         return shoppingList;
+    }
+
+    @Nonnull
+    public ForceLocationManager getForceLocationManager() {
+        return forceLocationManager;
     }
 
 

--- a/MekHQ/src/mekhq/campaign/force/AbstractForce.java
+++ b/MekHQ/src/mekhq/campaign/force/AbstractForce.java
@@ -1,0 +1,480 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.force;
+
+import static mekhq.campaign.market.contractMarket.ContractAutomation.performAutomatedActivation;
+import static mekhq.campaign.mission.RandomFactionCamouflage.pickRandomCamouflage;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+import jakarta.annotation.Nonnull;
+import megamek.client.ui.util.PlayerColour;
+import megamek.common.annotations.Nullable;
+import megamek.common.icons.Camouflage;
+import mekhq.campaign.AbstractLocation;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.CampaignNewDayManager;
+import mekhq.campaign.Hangar;
+import mekhq.campaign.HumanResources;
+import mekhq.campaign.Personnel;
+import mekhq.campaign.Warehouse;
+import mekhq.campaign.camOpsReputation.ReputationController;
+import mekhq.campaign.campaignOptions.CampaignOptions;
+import mekhq.campaign.finances.Finances;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.finances.enums.TransactionType;
+import mekhq.campaign.icons.StandardFormationIcon;
+import mekhq.campaign.icons.UnitIcon;
+import mekhq.campaign.location.IPlace;
+import mekhq.campaign.location.LocationNode;
+import mekhq.campaign.market.RequestedStockLevels;
+import mekhq.campaign.market.ShoppingList;
+import mekhq.campaign.personnel.ranks.RankSystem;
+import mekhq.campaign.personnel.ranks.RankValidator;
+import mekhq.campaign.unit.UnitTechProgression;
+import mekhq.campaign.universe.Faction;
+import mekhq.campaign.universe.factionStanding.FactionStandings;
+
+/**
+ * Base class holding the state and logic extracted from {@link mekhq.campaign.Campaign} that belongs to a player force:
+ * faction identity and appearance, finances, reputation/standing, and the owned {@link Hangar}/{@link Warehouse}/
+ * personnel roster.
+ *
+ * <p>An {@code AbstractForce} is the {@link IPlace} that owns those resources: it holds its own {@link LocationNode}
+ * and
+ * parents its hangar, warehouse, and personnel to itself, exactly like {@link mekhq.campaign.base.AbstractBase}. The
+ * upward {@code IPlace} walk therefore terminates here.</p>
+ *
+ * <p>A force holds <em>no</em> reference back to its {@link mekhq.campaign.Campaign}. Campaign-level concerns — the
+ * current date, and writing daily-report lines — are the campaign's responsibility: it passes values such as the date
+ * in as method parameters and does its own reporting around the force's state changes.</p>
+ */
+public abstract class AbstractForce implements IPlace {
+
+    private final LocationNode locationNode;
+
+    // Owned resources — this force is the IPlace that owns them.
+    private final Hangar units = new Hangar();
+    private Warehouse parts = new Warehouse();
+    private final Personnel mainForcePersonnel = new Personnel();
+    private HumanResources humanResources = new HumanResources();
+    private final RequestedStockLevels requestedStockLevels = new RequestedStockLevels();
+    private ShoppingList shoppingList = new ShoppingList();
+
+    private final ForceOptions forceOptions;
+
+    // Identity / appearance
+    private String name;
+    private RankSystem rankSystem;
+    private Camouflage camouflage = pickRandomCamouflage(3025, "Root");
+    private PlayerColour colour = PlayerColour.BLUE;
+    private StandardFormationIcon unitIcon = new UnitIcon(null, null);
+    private String retainerEmployerCode = null;
+    private LocalDate retainerStartDate = null;
+    private megamek.common.enums.Faction techFaction;
+
+    private Finances finances;
+
+    // Reputation / standing / crime / initiative
+    private ReputationController reputation;
+    private FactionStandings factionStandings;
+    private int crimeRating = 0;
+    private int crimePirateModifier = 0;
+    private LocalDate dateOfLastCrime = null;
+    private int initiativeBonus = 0;
+    private int initiativeMaxBonus = 1;
+
+    protected AbstractForce(ForceOptions forceOptions, megamek.common.enums.Faction techFaction, RankSystem rankSystem,
+          Finances finances, ReputationController reputation, FactionStandings factionStandings) {
+        this.forceOptions = forceOptions;
+        this.techFaction = techFaction;
+        this.rankSystem = rankSystem;
+        this.finances = finances;
+        this.reputation = reputation;
+        this.factionStandings = factionStandings;
+
+        this.locationNode = new LocationNode(this);
+        LocationNode.LocationManager.setLocation(mainForcePersonnel, this);
+        LocationNode.LocationManager.setLocation(units, this);
+        LocationNode.LocationManager.setLocation(parts, this);
+    }
+
+    // region IPlace resources
+
+    @Override
+    public @Nonnull LocationNode getLocationNode() {
+        return locationNode;
+    }
+
+    @Override
+    public Hangar getHangar() {
+        return units;
+    }
+
+    @Override
+    public Warehouse getWarehouse() {
+        return parts;
+    }
+
+    public void setWarehouse(Warehouse warehouse) {
+        parts = Objects.requireNonNull(warehouse);
+    }
+
+    @Override
+    public Personnel getPersonnel() {
+        return mainForcePersonnel;
+    }
+
+    public HumanResources getHumanResources() {
+        return humanResources;
+    }
+
+    public void setHumanResources(HumanResources humanResources) {
+        this.humanResources = humanResources;
+    }
+
+    @Override
+    public RequestedStockLevels getRequestedStockLevels() {
+        return requestedStockLevels;
+    }
+
+    public void setShoppingList(ShoppingList shoppingList) {
+        this.shoppingList = shoppingList;
+    }
+
+    public ShoppingList getShoppingList() {
+        return shoppingList;
+    }
+
+
+    /**
+     * Runs the main force's arrival behavior when it finishes travelling to a location. The {@link Campaign} is
+     * supplied as a parameter (a force holds no campaign reference) for the systems this drives: automated mothball
+     * activation, disease/inoculation checks, early-arrival contract checks, and refreshing local applicants.
+     */
+    @Override
+    public void onArrival(Campaign campaign, boolean isSilentProcessing) {
+        // This should be before inoculations so that we can correctly read the TO&E.
+        if (!campaign.getAutomatedMothballUnits().isEmpty()) {
+            performAutomatedActivation(campaign);
+        }
+
+        CampaignOptions campaignOptions = campaign.getCampaignOptions();
+        if (campaignOptions.isUseRandomDiseases() && campaignOptions.isUseAlternativeAdvancedMedical()) {
+            if (getParentLocation() instanceof AbstractLocation loc) {
+                loc.checkForDiseaseOrBioweaponOutbreaks(campaign, campaign.getLocalDate());
+            }
+        }
+
+        // Inoculations (generic IPlace behavior)
+        IPlace.super.onArrival(campaign, isSilentProcessing);
+
+        if (getParentLocation() instanceof AbstractLocation loc) {
+            loc.testForEarlyArrival(campaign);
+        }
+
+        // We've just stopped traveling, so we should see if there are any local applicants.
+        if (!HumanResources.isUsingLegacyPersonnelMarket(campaign.getCampaignOptions())) {
+            campaign.refreshApplicants(true);
+            CampaignNewDayManager.showRarePersonnelDialog(campaign, false);
+        }
+    }
+
+    // endregion IPlace resources
+
+    // region Options / faction
+
+    public ForceOptions getForceOptions() {
+        return forceOptions;
+    }
+
+    public Faction getFaction() {
+        return forceOptions.getFaction();
+    }
+
+    public void setFaction(final Faction faction) {
+        setFactionDirect(faction);
+        updateTechFactionCode();
+    }
+
+    public void setFactionDirect(final Faction faction) {
+        forceOptions.setFaction(faction);
+    }
+
+    public megamek.common.enums.Faction getTechFaction() {
+        return techFaction;
+    }
+
+    public void updateTechFactionCode() {
+        if (forceOptions.isFactionIntroDate()) {
+            for (megamek.common.enums.Faction f : megamek.common.enums.Faction.values()) {
+                if (f.equals(megamek.common.enums.Faction.NONE)) {
+                    continue;
+                }
+                if (f.getCodeMM().equals(getFaction().getShortName())) {
+                    techFaction = f;
+                    UnitTechProgression.loadFaction(techFaction);
+                    return;
+                }
+            }
+            // If the tech progression data does not include the current faction, use a generic.
+            if (getFaction().isClan()) {
+                techFaction = megamek.common.enums.Faction.CLAN;
+            } else if (getFaction().isPeriphery()) {
+                techFaction = megamek.common.enums.Faction.PER;
+            } else {
+                techFaction = megamek.common.enums.Faction.IS;
+            }
+        } else {
+            techFaction = megamek.common.enums.Faction.NONE;
+        }
+        // Unit tech level will be calculated if the code has changed.
+        UnitTechProgression.loadFaction(techFaction);
+    }
+
+    // endregion Options / faction
+
+    // region Identity / appearance
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public RankSystem getRankSystem() {
+        return rankSystem;
+    }
+
+    public void setRankSystem(final @Nullable RankSystem rankSystem) {
+        // If they are the same object, there hasn't been a change and thus don't need to process further
+        if (Objects.equals(getRankSystem(), rankSystem)) {
+            return;
+        }
+
+        // Then, we need to validate the rank system. Null isn't valid to be set but may be the result of a cancelled
+        // load. However, validation will prevent that
+        final RankValidator rankValidator = new RankValidator();
+        if (!rankValidator.validate(rankSystem, false)) {
+            return;
+        }
+
+        // We need to know the old rank system for personnel processing
+        final RankSystem oldRankSystem = getRankSystem();
+
+        // And with that, we can set the rank system
+        setRankSystemDirect(rankSystem);
+
+        // Finally, we fix all personnel ranks and ensure they are properly set
+        getPersonnel().values().stream()
+              .filter(person -> person.getRankSystem().equals(oldRankSystem))
+              .forEach(person -> person.setRankSystem(rankValidator, rankSystem));
+    }
+
+    public void setRankSystemDirect(final RankSystem rankSystem) {
+        this.rankSystem = rankSystem;
+    }
+
+    public Camouflage getCamouflage() {
+        return camouflage;
+    }
+
+    public void setCamouflage(final Camouflage camouflage) {
+        this.camouflage = camouflage;
+    }
+
+    public PlayerColour getColour() {
+        return colour;
+    }
+
+    public void setColour(final PlayerColour colour) {
+        this.colour = Objects.requireNonNull(colour, "Colour cannot be set to null");
+    }
+
+    public StandardFormationIcon getUnitIcon() {
+        return unitIcon;
+    }
+
+    public void setUnitIcon(final StandardFormationIcon unitIcon) {
+        this.unitIcon = unitIcon;
+    }
+
+    public String getRetainerEmployerCode() {
+        return retainerEmployerCode;
+    }
+
+    public void setRetainerEmployerCode(String code) {
+        retainerEmployerCode = code;
+    }
+
+    public LocalDate getRetainerStartDate() {
+        return retainerStartDate;
+    }
+
+    public void setRetainerStartDate(LocalDate retainerStartDate) {
+        this.retainerStartDate = retainerStartDate;
+    }
+
+    // endregion Identity / appearance
+
+    // region Finances
+
+    public Finances getFinances() {
+        return finances;
+    }
+
+    public void setFinances(Finances finances) {
+        this.finances = finances;
+    }
+
+    public Money getFunds() {
+        return finances.getBalance();
+    }
+
+    /**
+     * Credits {@code quantity} to this force's finances. The campaign is responsible for defaulting the description and
+     * writing any daily-report line.
+     */
+    public void addFunds(final TransactionType type, final LocalDate date, final Money quantity,
+          final String description) {
+        finances.credit(type, date, quantity, description);
+    }
+
+    /**
+     * Debits {@code quantity} from this force's finances. The campaign is responsible for defaulting the description
+     * and writing any daily-report line.
+     */
+    public void removeFunds(final TransactionType type, final LocalDate date, final Money quantity,
+          final String description) {
+        finances.debit(type, date, quantity, description);
+    }
+
+    // endregion Finances
+
+    // region Reputation / standing / crime / initiative
+
+    public ReputationController getReputation() {
+        return reputation;
+    }
+
+    public void setReputation(ReputationController reputation) {
+        this.reputation = reputation;
+    }
+
+    public FactionStandings getFactionStandings() {
+        return factionStandings;
+    }
+
+    public void setFactionStandings(FactionStandings factionStandings) {
+        this.factionStandings = factionStandings;
+    }
+
+    public int getRawCrimeRating() {
+        return crimeRating;
+    }
+
+    public void setCrimeRating(int crimeRating) {
+        this.crimeRating = crimeRating;
+    }
+
+    public void changeCrimeRating(int change) {
+        this.crimeRating = Math.min(0, crimeRating + change);
+    }
+
+    public int getCrimePirateModifier() {
+        return crimePirateModifier;
+    }
+
+    public void setCrimePirateModifier(int crimePirateModifier) {
+        this.crimePirateModifier = crimePirateModifier;
+    }
+
+    public void changeCrimePirateModifier(int change) {
+        this.crimePirateModifier = Math.min(0, crimePirateModifier + change);
+    }
+
+    public int getAdjustedCrimeRating() {
+        return crimeRating + crimePirateModifier;
+    }
+
+    public @Nullable LocalDate getDateOfLastCrime() {
+        return dateOfLastCrime;
+    }
+
+    public void setDateOfLastCrime(LocalDate dateOfLastCrime) {
+        this.dateOfLastCrime = dateOfLastCrime;
+    }
+
+    public int getInitiativeBonus() {
+        return initiativeBonus;
+    }
+
+    public void setInitiativeBonus(int bonus) {
+        initiativeBonus = bonus;
+    }
+
+    public void applyInitiativeBonus(int bonus) {
+        if (bonus > initiativeMaxBonus) {
+            initiativeMaxBonus = bonus;
+        }
+        if ((bonus + initiativeBonus) > initiativeMaxBonus) {
+            initiativeBonus = initiativeMaxBonus;
+        } else {
+            initiativeBonus += bonus;
+        }
+    }
+
+    public void initiativeBonusIncrement(boolean change) {
+        if (change) {
+            setInitiativeBonus(++initiativeBonus);
+        } else {
+            setInitiativeBonus(--initiativeBonus);
+        }
+        if (initiativeBonus > initiativeMaxBonus) {
+            initiativeBonus = initiativeMaxBonus;
+        }
+    }
+
+    public int getInitiativeMaxBonus() {
+        return initiativeMaxBonus;
+    }
+
+    public void setInitiativeMaxBonus(int bonus) {
+        initiativeMaxBonus = bonus;
+    }
+
+    // endregion Reputation / standing / crime / initiative
+}

--- a/MekHQ/src/mekhq/campaign/force/AbstractForce.java
+++ b/MekHQ/src/mekhq/campaign/force/AbstractForce.java
@@ -678,6 +678,13 @@ public abstract class AbstractForce {
         }
     }
 
+    /**
+     * Moves {@code formation} to sit directly under {@code superFormation} in the TO&E, detaching it from its current
+     * parent and inheriting the target's scenario assignment. Formation-type standardization is then applied per the
+     * moved formation's {@link FormationType} (parents may be standardized, children may inherit), and formation levels
+     * are repopulated across the TO&E. No-ops if {@code formation} is {@code null} or equals {@code superFormation}.
+     * The {@link Campaign} is supplied as a parameter for the scenario and TO&E updates this drives.
+     */
     public void moveFormation(Formation formation, Formation superFormation, Campaign campaign) {
         // Can't move a null formation under a subformation and can't move a formation under itself.
         if (formation == null || formation.equals(superFormation)) {
@@ -793,6 +800,12 @@ public abstract class AbstractForce {
         }
     }
 
+    /**
+     * Removes {@code formation} from the TO&E: unassigns its units (clearing their scenario if it was deployed),
+     * removes it from any scenario it was deployed to and from its parent formation, and clears any StratCon track
+     * assignments. The {@link Campaign} is supplied as a parameter for the scenario, contract, and combat-team updates
+     * this drives.
+     */
     public void removeFormation(Formation formation, Campaign campaign) {
         int fid = formation.getId();
         formationIds.remove(fid);
@@ -834,6 +847,12 @@ public abstract class AbstractForce {
         }
     }
 
+    /**
+     * Removes {@code u} from its current formation, clearing its formation and scenario assignments and detaching it
+     * from any C3 networks. When StratCon is enabled and this empties the formation, the formation is dropped from the
+     * combat-teams table. The {@link Campaign} is supplied as a parameter for the game and combat-team updates this
+     * drives.
+     */
     public void removeUnitFromFormation(Unit u, Campaign campaign) {
         Formation formation = getFormation(u.getFormationId());
         if (null != formation) {
@@ -848,10 +867,20 @@ public abstract class AbstractForce {
         }
     }
 
+    /**
+     * @return the {@link Formation} {@code unit} is currently assigned to, or {@code null} if {@code unit} is
+     *       {@code null} or unassigned
+     */
     public @Nullable Formation getFormationFor(final @Nullable Unit unit) {
         return (unit == null) ? null : getFormation(unit.getFormationId());
     }
 
+    /**
+     * Resolves the {@link Formation} a person belongs to: the formation of their assigned unit if they crew one,
+     * otherwise — for techs — the formation they are the assigned tech of.
+     *
+     * @return the person's formation, or {@code null} if none applies
+     */
     public @Nullable Formation getFormationFor(final Person person) {
         final Unit unit = person.getUnit();
         if (unit != null) {
@@ -929,6 +958,10 @@ public abstract class AbstractForce {
         }
     }
 
+    /**
+     * Disbands the entire C3i/Naval C3 network that {@code u} belongs to, clearing the stored next-node UUIDs of every
+     * unit on that network and refreshing networks against the supplied {@link Game}.
+     */
     public void disbandNetworkOf(Unit u, Game game) {
         // collect all the other units on this network to rebuild the uuids
         Vector<Unit> networkedUnits = new Vector<>();
@@ -951,6 +984,11 @@ public abstract class AbstractForce {
         MekHQ.triggerEvent(new NetworkChangedEvent(networkedUnits));
     }
 
+    /**
+     * Removes {@code removedUnits} from their shared C3i/Naval C3 network and rebuilds the remaining members' node
+     * UUIDs so the network stays contiguous, refreshing networks against the supplied {@link Game}. All removed units
+     * are assumed to share the first unit's network id.
+     */
     public void removeUnitsFromNetwork(Vector<Unit> removedUnits, Game game) {
         // collect all the other units on this network to rebuild the uuids
         Vector<String> uuids = new Vector<>();
@@ -992,6 +1030,10 @@ public abstract class AbstractForce {
         refreshNetworks(game);
     }
 
+    /**
+     * Adds {@code addedUnits} to the C3i/Naval C3 network identified by {@code networkID}, rebuilding every member's
+     * node UUIDs, and refreshes networks against the supplied {@link Game}.
+     */
     public void addUnitsToNetwork(Vector<Unit> addedUnits, String networkID, Game game) {
         // collect all the other units on this network to rebuild the uuids
         Vector<String> uuids = new Vector<>();
@@ -1030,6 +1072,10 @@ public abstract class AbstractForce {
         MekHQ.triggerEvent(new NetworkChangedEvent(addedUnits));
     }
 
+    /**
+     * @return one entry per C3i network in the TO&E that has at least one free node; each entry is a
+     *       {@code {networkId, freeNodeCount}} pair
+     */
     public Vector<String[]> getAvailableC3iNetworks() {
         Vector<String[]> networks = new Vector<>();
         Vector<String> networkNames = new Vector<>();
@@ -1058,8 +1104,9 @@ public abstract class AbstractForce {
     }
 
     /**
-     * @return returns a Vector of the unique name Strings of all Naval C3 networks that have at least 1 free node
-     *       Adapted from getAvailableC3iNetworks() as the two technologies have very similar workings
+     * @return one entry per Naval C3 network in the TO&E that has at least one free node; each entry is a
+     *       {@code {networkId, freeNodeCount}} pair. Naval C3 mirrors C3i, so this parallels
+     *       {@link #getAvailableC3iNetworks()}.
      */
     public Vector<String[]> getAvailableNC3Networks() {
         Vector<String[]> networks = new Vector<>();
@@ -1089,8 +1136,8 @@ public abstract class AbstractForce {
     }
 
     /**
-     * @return returns a Vector of the unique name Strings of all Nova CEWS networks that have at least 1 free node Nova
-     *       CEWS networks support a maximum of 3 units
+     * @return one entry per Nova CEWS network in the TO&E that has at least one free node; each entry is a
+     *       {@code {networkId, freeNodeCount}} pair. Nova CEWS networks hold at most three units.
      */
     public Vector<String[]> getAvailableNovaCEWSNetworks() {
         Vector<String[]> networks = new Vector<>();
@@ -1120,6 +1167,10 @@ public abstract class AbstractForce {
         return networks;
     }
 
+    /**
+     * @return the C3 masters in the TO&E that can accept a slave (have a free C3 node), excluding company-level masters
+     *       whose free-node count is unreliable; each entry is a {@code {c3UUID, freeNodeCount, shortName}} triple
+     */
     public Vector<String[]> getAvailableC3MastersForSlaves() {
         Vector<String[]> networks = new Vector<>();
         Vector<String> networkNames = new Vector<>();
@@ -1154,6 +1205,10 @@ public abstract class AbstractForce {
         return networks;
     }
 
+    /**
+     * @return the C3 masters in the TO&E that can accept another master (have a free C3-M node); each entry is a
+     *       {@code {c3UUID, freeMasterNodeCount, shortName}} triple
+     */
     public Vector<String[]> getAvailableC3MastersForMasters() {
         Vector<String[]> networks = new Vector<>();
         Vector<String> networkNames = new Vector<>();
@@ -1183,6 +1238,10 @@ public abstract class AbstractForce {
         return networks;
     }
 
+    /**
+     * Detaches every unit slaved to {@code master} from it, clearing their C3 master reference and refreshing networks
+     * against the supplied {@link Game}.
+     */
     public void removeUnitsFromC3Master(Unit master, Game game) {
         List<Unit> removed = new ArrayList<>();
         for (Unit unit : allUnits()) {

--- a/MekHQ/src/mekhq/campaign/force/AbstractForce.java
+++ b/MekHQ/src/mekhq/campaign/force/AbstractForce.java
@@ -32,68 +32,80 @@
  */
 package mekhq.campaign.force;
 
-import static mekhq.campaign.market.contractMarket.ContractAutomation.performAutomatedActivation;
+import static java.lang.Math.max;
+import static mekhq.campaign.force.CombatTeam.recalculateCombatTeams;
+import static mekhq.campaign.force.Formation.FORMATION_NONE;
+import static mekhq.campaign.force.Formation.FORMATION_ORIGIN;
+import static mekhq.campaign.force.Formation.NO_ASSIGNED_SCENARIO;
+import static mekhq.campaign.force.FormationType.STANDARD;
 import static mekhq.campaign.mission.RandomFactionCamouflage.pickRandomCamouflage;
+import static mekhq.campaign.parts.enums.PartQuality.QUALITY_A;
+import static mekhq.campaign.randomEvents.prisoners.PrisonerEventManager.DEFAULT_TEMPORARY_CAPACITY;
+import static mekhq.campaign.randomEvents.prisoners.PrisonerEventManager.MINIMUM_TEMPORARY_CAPACITY;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Hashtable;
+import java.util.List;
 import java.util.Objects;
+import java.util.TreeMap;
+import java.util.UUID;
+import java.util.Vector;
+import java.util.stream.Collectors;
+import javax.swing.JOptionPane;
 
-import jakarta.annotation.Nonnull;
 import megamek.client.ui.util.PlayerColour;
 import megamek.common.annotations.Nullable;
+import megamek.common.game.Game;
 import megamek.common.icons.Camouflage;
-import mekhq.campaign.AbstractLocation;
+import megamek.common.units.Entity;
+import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.CampaignNewDayManager;
-import mekhq.campaign.ForceLocationManager;
-import mekhq.campaign.Hangar;
 import mekhq.campaign.HumanResources;
-import mekhq.campaign.Personnel;
-import mekhq.campaign.Warehouse;
 import mekhq.campaign.camOpsReputation.ReputationController;
-import mekhq.campaign.campaignOptions.CampaignOptions;
+import mekhq.campaign.events.NetworkChangedEvent;
+import mekhq.campaign.events.OrganizationChangedEvent;
 import mekhq.campaign.finances.Finances;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.enums.TransactionType;
 import mekhq.campaign.icons.StandardFormationIcon;
 import mekhq.campaign.icons.UnitIcon;
-import mekhq.campaign.location.IPlace;
-import mekhq.campaign.location.LocationNode;
-import mekhq.campaign.market.RequestedStockLevels;
 import mekhq.campaign.market.ShoppingList;
+import mekhq.campaign.mission.AtBContract;
+import mekhq.campaign.mission.Scenario;
+import mekhq.campaign.mission.rentals.ContractRentalType;
+import mekhq.campaign.mission.rentals.FacilityRentals;
+import mekhq.campaign.parts.enums.PartQuality;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.medical.MASHCapacity;
 import mekhq.campaign.personnel.ranks.RankSystem;
 import mekhq.campaign.personnel.ranks.RankValidator;
+import mekhq.campaign.stratCon.StratConTrackState;
+import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.UnitTechProgression;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.factionStanding.FactionStandings;
 
 /**
- * Base class holding the state and logic extracted from {@link mekhq.campaign.Campaign} that belongs to a player force:
- * faction identity and appearance, finances, reputation/standing, and the owned {@link Hangar}/{@link Warehouse}/
- * personnel roster.
+ * Base class holding the force-level state and logic extracted from {@link mekhq.campaign.Campaign}: faction identity
+ * and appearance, finances, reputation/standing, the TO&amp;E, and force options.
  *
- * <p>An {@code AbstractForce} is the {@link IPlace} that owns those resources: it holds its own {@link LocationNode}
- * and
- * parents its hangar, warehouse, and personnel to itself, exactly like {@link mekhq.campaign.base.AbstractBase}. The
- * upward {@code IPlace} walk therefore terminates here.</p>
+ * <p>The located resources (hangar, warehouse, personnel, location) are <em>not</em> owned by the force — they belong
+ * to its {@link Detachment}(s). A force is not itself a location node; {@link #getDetachments()} is the
+ * detachment-count-agnostic way to reach them, and the aggregate helpers ({@link #allUnits()},
+ * {@link #allPersonnel()}) project across every detachment. Convenience accessors that assume a single detachment live
+ * on {@link SingleDetachmentForce}; force-internal operations that still assume one go through
+ * {@link #requireSingleDetachment()}.</p>
  *
  * <p>A force holds <em>no</em> reference back to its {@link mekhq.campaign.Campaign}. Campaign-level concerns — the
  * current date, and writing daily-report lines — are the campaign's responsibility: it passes values such as the date
  * in as method parameters and does its own reporting around the force's state changes.</p>
  */
-public abstract class AbstractForce implements IPlace {
+public abstract class AbstractForce {
 
-    private final LocationNode locationNode;
-
-    // Owned resources — this force is the IPlace that owns them.
-    private final Hangar units = new Hangar();
-    private Warehouse parts = new Warehouse();
-    private final Personnel mainForcePersonnel = new Personnel();
     private HumanResources humanResources = new HumanResources();
-    private final RequestedStockLevels requestedStockLevels = new RequestedStockLevels();
     private ShoppingList shoppingList = new ShoppingList();
-
-    private final ForceLocationManager forceLocationManager = new ForceLocationManager(this);
 
     private final ForceOptions forceOptions;
 
@@ -118,6 +130,25 @@ public abstract class AbstractForce implements IPlace {
     private int initiativeBonus = 0;
     private int initiativeMaxBonus = 1;
 
+    private final TreeMap<Integer, Formation> formationIds = new TreeMap<>();
+    // Navigation toggles
+    private boolean isAvoidingEmptySystems = true;
+    private boolean isOverridingCommandCircuitRequirements = false;
+    // Parts-in-use / restock options
+    private boolean ignoreMothballed = true;
+    private boolean topUpWeekly = false;
+    private PartQuality ignoreSparesUnderQuality = QUALITY_A;
+    // Capacity / facility state
+    private int temporaryPrisonerCapacity = DEFAULT_TEMPORARY_CAPACITY;
+    private int mashTheatreCapacity = 0;
+    private boolean fieldKitchenWithinCapacity = false;
+    private int repairBaysRented = 0;
+    private List<UUID> automatedMothballUnits = new ArrayList<>();
+    // Table of Organisation & Equipment (TO&E) and StratCon combat teams
+    private Formation formations;
+    private int lastFormationId;
+    private Hashtable<Integer, CombatTeam> combatTeams = new Hashtable<>();
+
     protected AbstractForce(ForceOptions forceOptions, megamek.common.enums.Faction techFaction, RankSystem rankSystem,
           Finances finances, ReputationController reputation, FactionStandings factionStandings) {
         this.forceOptions = forceOptions;
@@ -126,37 +157,43 @@ public abstract class AbstractForce implements IPlace {
         this.finances = finances;
         this.reputation = reputation;
         this.factionStandings = factionStandings;
-
-        this.locationNode = new LocationNode(this);
-        LocationNode.LocationManager.setLocation(mainForcePersonnel, this);
-        LocationNode.LocationManager.setLocation(units, this);
-        LocationNode.LocationManager.setLocation(parts, this);
     }
 
-    // region IPlace resources
+    /**
+     * The {@link Detachment}s this force is currently split across. A {@link PlayerForce} tracks exactly one; the
+     * located resources (hangar, warehouse, personnel, location) are owned by the detachment(s), not the force.
+     */
+    public abstract Collection<Detachment> getDetachments();
 
-    @Override
-    public @Nonnull LocationNode getLocationNode() {
-        return locationNode;
+    /** All units across every {@link Detachment} of this force. Multi-detachment-safe. */
+    public Collection<Unit> allUnits() {
+        return getDetachments().stream()
+                     .flatMap(detachment -> detachment.getHangar().getUnits().stream())
+                     .collect(Collectors.toList());
     }
 
-    @Override
-    public Hangar getHangar() {
-        return units;
+    /** All personnel across every {@link Detachment} of this force. Multi-detachment-safe. */
+    public Collection<Person> allPersonnel() {
+        return getDetachments().stream()
+                     .flatMap(detachment -> detachment.getPersonnel().values().stream())
+                     .collect(Collectors.toList());
     }
 
-    @Override
-    public Warehouse getWarehouse() {
-        return parts;
-    }
-
-    public void setWarehouse(Warehouse warehouse) {
-        parts = Objects.requireNonNull(warehouse);
-    }
-
-    @Override
-    public Personnel getPersonnel() {
-        return mainForcePersonnel;
+    /**
+     * The sole {@link Detachment}, asserting the single-detachment assumption. Throws {@link IllegalStateException} if
+     * the force does not have exactly one detachment.
+     *
+     * <p>This is the internal counterpart to {@link SingleDetachmentForce}: grep {@code requireSingleDetachment} to
+     * find the force-internal operations that are <em>not yet</em> multi-detachment-safe and must be reworked before a
+     * multi-detachment force can use them.</p>
+     */
+    protected Detachment requireSingleDetachment() {
+        Collection<Detachment> detachments = getDetachments();
+        if (detachments.size() != 1) {
+            throw new IllegalStateException("Operation assumes a single detachment but the force has "
+                                                  + detachments.size());
+        }
+        return detachments.iterator().next();
     }
 
     public HumanResources getHumanResources() {
@@ -167,11 +204,6 @@ public abstract class AbstractForce implements IPlace {
         this.humanResources = humanResources;
     }
 
-    @Override
-    public RequestedStockLevels getRequestedStockLevels() {
-        return requestedStockLevels;
-    }
-
     public void setShoppingList(ShoppingList shoppingList) {
         this.shoppingList = shoppingList;
     }
@@ -179,49 +211,6 @@ public abstract class AbstractForce implements IPlace {
     public ShoppingList getShoppingList() {
         return shoppingList;
     }
-
-    @Nonnull
-    public ForceLocationManager getForceLocationManager() {
-        return forceLocationManager;
-    }
-
-
-    /**
-     * Runs the main force's arrival behavior when it finishes travelling to a location. The {@link Campaign} is
-     * supplied as a parameter (a force holds no campaign reference) for the systems this drives: automated mothball
-     * activation, disease/inoculation checks, early-arrival contract checks, and refreshing local applicants.
-     */
-    @Override
-    public void onArrival(Campaign campaign, boolean isSilentProcessing) {
-        // This should be before inoculations so that we can correctly read the TO&E.
-        if (!campaign.getAutomatedMothballUnits().isEmpty()) {
-            performAutomatedActivation(campaign);
-        }
-
-        CampaignOptions campaignOptions = campaign.getCampaignOptions();
-        if (campaignOptions.isUseRandomDiseases() && campaignOptions.isUseAlternativeAdvancedMedical()) {
-            if (getParentLocation() instanceof AbstractLocation loc) {
-                loc.checkForDiseaseOrBioweaponOutbreaks(campaign, campaign.getLocalDate());
-            }
-        }
-
-        // Inoculations (generic IPlace behavior)
-        IPlace.super.onArrival(campaign, isSilentProcessing);
-
-        if (getParentLocation() instanceof AbstractLocation loc) {
-            loc.testForEarlyArrival(campaign);
-        }
-
-        // We've just stopped traveling, so we should see if there are any local applicants.
-        if (!HumanResources.isUsingLegacyPersonnelMarket(campaign.getCampaignOptions())) {
-            campaign.refreshApplicants(true);
-            CampaignNewDayManager.showRarePersonnelDialog(campaign, false);
-        }
-    }
-
-    // endregion IPlace resources
-
-    // region Options / faction
 
     public ForceOptions getForceOptions() {
         return forceOptions;
@@ -271,10 +260,6 @@ public abstract class AbstractForce implements IPlace {
         UnitTechProgression.loadFaction(techFaction);
     }
 
-    // endregion Options / faction
-
-    // region Identity / appearance
-
     public String getName() {
         return name;
     }
@@ -307,7 +292,7 @@ public abstract class AbstractForce implements IPlace {
         setRankSystemDirect(rankSystem);
 
         // Finally, we fix all personnel ranks and ensure they are properly set
-        getPersonnel().values().stream()
+        allPersonnel().stream()
               .filter(person -> person.getRankSystem().equals(oldRankSystem))
               .forEach(person -> person.setRankSystem(rankValidator, rankSystem));
     }
@@ -356,10 +341,6 @@ public abstract class AbstractForce implements IPlace {
         this.retainerStartDate = retainerStartDate;
     }
 
-    // endregion Identity / appearance
-
-    // region Finances
-
     public Finances getFinances() {
         return finances;
     }
@@ -389,10 +370,6 @@ public abstract class AbstractForce implements IPlace {
           final String description) {
         finances.debit(type, date, quantity, description);
     }
-
-    // endregion Finances
-
-    // region Reputation / standing / crime / initiative
 
     public ReputationController getReputation() {
         return reputation;
@@ -484,5 +461,775 @@ public abstract class AbstractForce implements IPlace {
         initiativeMaxBonus = bonus;
     }
 
-    // endregion Reputation / standing / crime / initiative
+    public boolean isAvoidingEmptySystems() {
+        return isAvoidingEmptySystems;
+    }
+
+    public void setIsAvoidingEmptySystems(boolean isAvoidingEmptySystems) {
+        this.isAvoidingEmptySystems = isAvoidingEmptySystems;
+    }
+
+    public boolean isOverridingCommandCircuitRequirements() {
+        return isOverridingCommandCircuitRequirements;
+    }
+
+    public void setIsOverridingCommandCircuitRequirements(boolean isOverridingCommandCircuitRequirements) {
+        this.isOverridingCommandCircuitRequirements = isOverridingCommandCircuitRequirements;
+    }
+
+    public boolean getIgnoreMothballed() {
+        return ignoreMothballed;
+    }
+
+    public void setIgnoreMothballed(boolean ignoreMothballed) {
+        this.ignoreMothballed = ignoreMothballed;
+    }
+
+    public boolean getTopUpWeekly() {
+        return topUpWeekly;
+    }
+
+    public void setTopUpWeekly(boolean topUpWeekly) {
+        this.topUpWeekly = topUpWeekly;
+    }
+
+    public PartQuality getIgnoreSparesUnderQuality() {
+        return ignoreSparesUnderQuality;
+    }
+
+    public void setIgnoreSparesUnderQuality(PartQuality ignoreSparesUnderQuality) {
+        this.ignoreSparesUnderQuality = ignoreSparesUnderQuality;
+    }
+
+    public int getTemporaryPrisonerCapacity() {
+        return temporaryPrisonerCapacity;
+    }
+
+    public void setTemporaryPrisonerCapacity(int temporaryPrisonerCapacity) {
+        this.temporaryPrisonerCapacity = max(MINIMUM_TEMPORARY_CAPACITY, temporaryPrisonerCapacity);
+    }
+
+    /**
+     * Adjusts the temporary prisoner capacity by {@code delta}, clamped to at least
+     * {@link mekhq.campaign.randomEvents.prisoners.PrisonerEventManager#MINIMUM_TEMPORARY_CAPACITY}.
+     */
+    public void changeTemporaryPrisonerCapacity(int delta) {
+        temporaryPrisonerCapacity = max(MINIMUM_TEMPORARY_CAPACITY, temporaryPrisonerCapacity + delta);
+    }
+
+    public int getCachedMashTheaterCapacity() {
+        return mashTheatreCapacity;
+    }
+
+    public void setMashTheatreCapacity(int mashTheatreCapacity) {
+        this.mashTheatreCapacity = mashTheatreCapacity;
+    }
+
+    /**
+     * Whether the force's MASH theatre capacity covers its patients assigned to doctors. Off-contract or in transit
+     * there is no cap. Takes a {@link Campaign} for the contract/location context the force does not hold.
+     */
+    public boolean getMashTheatresWithinCapacity(Campaign campaign) {
+        return !campaign.isOnContractAndPlanetside()
+                     ||
+                     calculateMASHTheaterCapacity(campaign) >=
+                           getHumanResources().getPatientsAssignedToDoctors().size();
+    }
+
+    public int calculateMASHTheaterCapacity(Campaign campaign) {
+        List<Unit> unitsInTOE = getFormation(FORMATION_ORIGIN).getAllUnitsAsUnits(requireSingleDetachment().getHangar(),
+              false);
+        int baseCapacity = MASHCapacity.checkMASHCapacity(unitsInTOE,
+              campaign.getCampaignOptions().getMASHTheatreCapacity());
+        int rentedCapacity = FacilityRentals.getCapacityIncreaseFromRentals(campaign.getActiveContracts(),
+              ContractRentalType.HOSPITAL_BEDS);
+        return baseCapacity + rentedCapacity;
+    }
+
+    public boolean getFieldKitchenWithinCapacity() {
+        return fieldKitchenWithinCapacity;
+    }
+
+    public void setFieldKitchenWithinCapacity(boolean fieldKitchenWithinCapacity) {
+        this.fieldKitchenWithinCapacity = fieldKitchenWithinCapacity;
+    }
+
+    public int getRepairBaysRented() {
+        return repairBaysRented;
+    }
+
+    public void setRepairBaysRented(int repairBaysRented) {
+        this.repairBaysRented = repairBaysRented;
+    }
+
+    public void changeRepairBaysRented(int delta) {
+        repairBaysRented = max(0, repairBaysRented + delta);
+    }
+
+    public List<UUID> getAutomatedMothballUnits() {
+        return automatedMothballUnits;
+    }
+
+    public void setAutomatedMothballUnits(List<UUID> automatedMothballUnits) {
+        this.automatedMothballUnits = automatedMothballUnits;
+    }
+
+    public Formation getFormations() {
+        return formations;
+    }
+
+    public void setFormations(Formation formations) {
+        this.formations = formations;
+    }
+
+    public List<Formation> getAllFormations() {
+        return new ArrayList<>(formationIds.values());
+    }
+
+    public TreeMap<Integer, Formation> getFormationIds() {
+        return formationIds;
+    }
+
+    public int getLastFormationId() {
+        return lastFormationId;
+    }
+
+    /** The raw, unsanitized combat-team table (keyed by formation id); used for serialization and iteration. */
+    public Hashtable<Integer, CombatTeam> getCombatTeamsMap() {
+        return combatTeams;
+    }
+
+    @Nullable
+    public Formation getFormation(int id) {
+        return formationIds.get(id);
+    }
+
+    /**
+     * Retrieves all units in the Table of Organization and Equipment (TOE).
+     *
+     * @param standardFormationsOnly if {@code true}, returns only units in {@link FormationType#STANDARD} formations;
+     *                               if {@code false}, returns all units.
+     *
+     * @return a List of UUID objects representing all units in the TOE according to the specified filter
+     */
+    public List<UUID> getAllUnitsInTheTOE(boolean standardFormationsOnly) {
+        return formations.getAllUnits(standardFormationsOnly);
+    }
+
+    public void addCombatTeam(CombatTeam combatTeam) {
+        combatTeams.put(combatTeam.getFormationId(), combatTeam);
+    }
+
+    public void removeCombatTeam(final int formationId) {
+        combatTeams.remove(formationId);
+    }
+
+    /**
+     * Returns the {@link Hashtable} keyed by the combat team's {@code formationId}, after removing ineligible teams.
+     * The sanitization removes the need for {@code isEligible()} checks whenever the table is fetched.
+     */
+    public Hashtable<Integer, CombatTeam> getCombatTeamsAsMap(Campaign campaign) {
+        for (Formation formation : getAllFormations()) {
+            int formationId = formation.getId();
+            if (combatTeams.containsKey(formationId)) {
+                CombatTeam combatTeam = combatTeams.get(formationId);
+
+                if (combatTeam.isEligible(campaign)) {
+                    continue;
+                }
+            } else {
+                CombatTeam combatTeam = new CombatTeam(formationId, campaign);
+
+                if (combatTeam.isEligible(campaign)) {
+                    combatTeams.put(formationId, combatTeam);
+                    continue;
+                }
+            }
+
+            combatTeams.remove(formationId);
+        }
+
+        return combatTeams;
+    }
+
+    public ArrayList<CombatTeam> getCombatTeamsAsList(Campaign campaign) {
+        return getCombatTeamsAsMap(campaign).values()
+                     .stream()
+                     .filter(l -> formationIds.containsKey(l.getFormationId()))
+                     .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    /**
+     * Add formation to an existing superformation. This method will also assign the formation an id and place it in the
+     * formationId hash.
+     */
+    public void addFormation(Formation formation, Formation superFormation, Campaign campaign) {
+        int id = lastFormationId + 1;
+        formation.setId(id);
+        superFormation.addSubFormation(formation, true);
+        formation.setScenarioId(superFormation.getScenarioId(), campaign);
+        formationIds.put(id, formation);
+        lastFormationId = id;
+
+        formation.updateCommander(campaign);
+
+        if (campaign.getCampaignOptions().isUseStratCon()) {
+            recalculateCombatTeams(campaign);
+        }
+    }
+
+    public void moveFormation(Formation formation, Formation superFormation, Campaign campaign) {
+        // Can't move a null formation under a subformation and can't move a formation under itself.
+        if (formation == null || formation.equals(superFormation)) {
+            return;
+        }
+        Formation parentFormation = formation.getParentFormation();
+
+        if (null != parentFormation) {
+            parentFormation.removeSubFormation(formation.getId());
+        }
+
+        superFormation.addSubFormation(formation, true);
+        formation.setScenarioId(superFormation.getScenarioId(), campaign);
+
+        FormationType formationType = formation.getFormationType();
+
+        if (formationType.shouldStandardizeParents()) {
+            for (Formation individualParentFormation : formation.getAllParents()) {
+                individualParentFormation.setFormationType(STANDARD, false);
+            }
+        }
+
+        if (formationType.shouldChildrenInherit()) {
+            for (Formation childFormation : formation.getAllSubFormations()) {
+                childFormation.setFormationType(formationType, false);
+            }
+        }
+
+        // repopulate formation levels across the TO&E
+        Formation.populateFormationLevelsFromOrigin(campaign);
+    }
+
+    /**
+     * This is used by the XML loader. The id should already be set for this formation so don't increment.
+     */
+    public void importFormation(Formation formation) {
+        lastFormationId = max(lastFormationId, formation.getId());
+        formationIds.put(formation.getId(), formation);
+    }
+
+    public void addUnitToFormation(final @Nullable Unit unit, final Formation formation, Campaign campaign) {
+        addUnitToFormation(unit, formation.getId(), campaign);
+    }
+
+    /**
+     * Add unit to an existing formation. This method will also assign that formation's id to the unit.
+     */
+    public void addUnitToFormation(@Nullable Unit unit, int id, Campaign campaign) {
+        if (unit == null) {
+            return;
+        }
+
+        if (id == FORMATION_NONE) {
+            Formation currentFormation = getFormation(unit.getFormationId());
+            unit.setFormationId(FORMATION_NONE);
+            unit.setScenarioId(NO_ASSIGNED_SCENARIO);
+            MekHQ.triggerEvent(new OrganizationChangedEvent(campaign, currentFormation, unit));
+            return;
+        }
+
+        Formation formation = formationIds.get(id);
+        Formation prevFormation = formationIds.get(unit.getFormationId());
+        boolean useTransfers = false;
+        boolean transferLog = !campaign.getCampaignOptions().isUseTransfers();
+
+        if (null != prevFormation) {
+            if (null != prevFormation.getTechID()) {
+                unit.removeTech();
+            }
+            // We log removal if we don't use transfers or if it can't be assigned to a new formation
+            prevFormation.removeUnit(campaign, unit.getId(), transferLog || (formation == null));
+            useTransfers = !transferLog;
+            MekHQ.triggerEvent(new OrganizationChangedEvent(campaign, prevFormation, unit));
+        }
+
+        if (null != formation) {
+            unit.setFormationId(id);
+            unit.setScenarioId(formation.getScenarioId());
+            if (null != formation.getTechID()) {
+                Person formationTech = campaign.getPerson(formation.getTechID());
+                if (formationTech.canTech(unit.getEntity())) {
+                    if (null != unit.getTech()) {
+                        unit.removeTech();
+                    }
+
+                    unit.setTech(formationTech);
+                } else {
+                    String cantTech = formationTech.getFullName() +
+                                            " cannot maintain " +
+                                            unit.getName() +
+                                            '\n' +
+                                            "You will need to assign a tech manually.";
+                    JOptionPane.showMessageDialog(null, cantTech, "Warning", JOptionPane.WARNING_MESSAGE);
+                }
+            }
+            formation.addUnit(campaign, unit.getId(), useTransfers, prevFormation);
+            MekHQ.triggerEvent(new OrganizationChangedEvent(campaign, formation, unit));
+        }
+
+        if (campaign.getCampaignOptions().isUseStratCon()) {
+            recalculateCombatTeams(campaign);
+        }
+    }
+
+    /**
+     * Adds formation and all its sub-formations to the Combat Teams table.
+     */
+    public void addAllCombatTeams(Formation formation, Campaign campaign) {
+        recalculateCombatTeams(campaign);
+
+        for (Formation subFormation : formation.getSubFormations()) {
+            addAllCombatTeams(subFormation, campaign);
+        }
+    }
+
+    public void removeFormation(Formation formation, Campaign campaign) {
+        int fid = formation.getId();
+        formationIds.remove(fid);
+        // clear formationIds of all personnel with this formation
+        for (UUID uid : formation.getUnits()) {
+            Unit u = requireSingleDetachment().getHangar().getUnit(uid);
+            if (null == u) {
+                continue;
+            }
+            if (u.getFormationId() == fid) {
+                u.setFormationId(FORMATION_NONE);
+                if (formation.isDeployed()) {
+                    u.setScenarioId(NO_ASSIGNED_SCENARIO);
+                }
+            }
+        }
+
+        // also remove this formation's id from any scenarios
+        if (formation.isDeployed()) {
+            Scenario s = campaign.getScenario(formation.getScenarioId());
+            s.removeFormation(fid);
+        }
+
+        if (null != formation.getParentFormation()) {
+            formation.getParentFormation().removeSubFormation(fid);
+        }
+
+        // clear out StratCon formation assignments
+        for (AtBContract contract : campaign.getActiveAtBContracts()) {
+            if (contract.getStratConCampaignState() != null) {
+                for (StratConTrackState track : contract.getStratConCampaignState().getTracks()) {
+                    track.unassignFormation(fid);
+                }
+            }
+        }
+
+        if (campaign.getCampaignOptions().isUseStratCon()) {
+            recalculateCombatTeams(campaign);
+        }
+    }
+
+    public void removeUnitFromFormation(Unit u, Campaign campaign) {
+        Formation formation = getFormation(u.getFormationId());
+        if (null != formation) {
+            formation.removeUnit(campaign, u.getId(), true);
+            u.setFormationId(FORMATION_NONE);
+            u.setScenarioId(NO_ASSIGNED_SCENARIO);
+            detachUnitFromC3Networks(u, campaign.getGame());
+
+            if (campaign.getCampaignOptions().isUseStratCon() && formation.getUnits().isEmpty()) {
+                combatTeams.remove(formation.getId());
+            }
+        }
+    }
+
+    public @Nullable Formation getFormationFor(final @Nullable Unit unit) {
+        return (unit == null) ? null : getFormation(unit.getFormationId());
+    }
+
+    public @Nullable Formation getFormationFor(final Person person) {
+        final Unit unit = person.getUnit();
+        if (unit != null) {
+            return getFormationFor(unit);
+        } else if (person.isTech()) {
+            return formationIds.values()
+                         .stream()
+                         .filter(formation -> person.getId().equals(formation.getTechID()))
+                         .findFirst()
+                         .orElse(null);
+        }
+
+        return null;
+    }
+
+    /**
+     * Rebuilds this force's C3, Naval C3, and C3i networks from the units' stored C3 UUIDs. The MegaMek {@link Game} is
+     * supplied as a parameter (the force holds no game reference) because network membership is resolved against the
+     * live game entities.
+     */
+    public void refreshNetworks(Game game) {
+        for (Unit unit : allUnits()) {
+            // we are going to rebuild the c3, nc3 and c3i networks based on the c3UUIDs
+            Entity entity = unit.getEntity();
+            if (null != entity && (entity.hasC3() || entity.hasC3i() || entity.hasNavalC3())) {
+                boolean C3iSet = false;
+                boolean NC3Set = false;
+
+                for (Entity e : game.getEntitiesVector()) {
+                    // C3 Checks
+                    if (entity.hasC3()) {
+                        if ((entity.getC3MasterIsUUIDAsString() != null) &&
+                                  entity.getC3MasterIsUUIDAsString().equals(e.getC3UUIDAsString())) {
+                            entity.setC3Master(e, false);
+                            break;
+                        }
+                    }
+                    // Naval C3 checks
+                    if (entity.hasNavalC3() && !NC3Set) {
+                        entity.setC3NetIdSelf();
+                        int pos = 0;
+                        // Well, they're the same value of 6...
+                        while (pos < Entity.MAX_C3i_NODES) {
+                            // We've found a network, join it.
+                            if ((entity.getNC3NextUUIDAsString(pos) != null) &&
+                                      (e.getC3UUIDAsString() != null) &&
+                                      entity.getNC3NextUUIDAsString(pos).equals(e.getC3UUIDAsString())) {
+                                entity.setC3NetId(e);
+                                NC3Set = true;
+                                break;
+                            }
+
+                            pos++;
+                        }
+                    }
+                    // C3i Checks
+                    if (entity.hasC3i() && !C3iSet) {
+                        entity.setC3NetIdSelf();
+                        int pos = 0;
+                        while (pos < Entity.MAX_C3i_NODES) {
+                            // We've found a network, join it.
+                            if ((entity.getC3iNextUUIDAsString(pos) != null) &&
+                                      (e.getC3UUIDAsString() != null) &&
+                                      entity.getC3iNextUUIDAsString(pos).equals(e.getC3UUIDAsString())) {
+                                entity.setC3NetId(e);
+                                C3iSet = true;
+                                break;
+                            }
+
+                            pos++;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public void disbandNetworkOf(Unit u, Game game) {
+        // collect all the other units on this network to rebuild the uuids
+        Vector<Unit> networkedUnits = new Vector<>();
+        for (Unit unit : allUnits()) {
+            if (null != unit.getEntity().getC3NetId() &&
+                      unit.getEntity().getC3NetId().equals(u.getEntity().getC3NetId())) {
+                networkedUnits.add(unit);
+            }
+        }
+        for (int pos = 0; pos < Entity.MAX_C3i_NODES; pos++) {
+            for (Unit nUnit : networkedUnits) {
+                if (nUnit.getEntity().hasNavalC3()) {
+                    nUnit.getEntity().setNC3NextUUIDAsString(pos, null);
+                } else {
+                    nUnit.getEntity().setC3iNextUUIDAsString(pos, null);
+                }
+            }
+        }
+        refreshNetworks(game);
+        MekHQ.triggerEvent(new NetworkChangedEvent(networkedUnits));
+    }
+
+    public void removeUnitsFromNetwork(Vector<Unit> removedUnits, Game game) {
+        // collect all the other units on this network to rebuild the uuids
+        Vector<String> uuids = new Vector<>();
+        Vector<Unit> networkedUnits = new Vector<>();
+        String network = removedUnits.getFirst().getEntity().getC3NetId();
+        for (Unit unit : allUnits()) {
+            if (removedUnits.contains(unit)) {
+                continue;
+            }
+            if (null != unit.getEntity().getC3NetId() && unit.getEntity().getC3NetId().equals(network)) {
+                networkedUnits.add(unit);
+                uuids.add(unit.getEntity().getC3UUIDAsString());
+            }
+        }
+        for (int pos = 0; pos < Entity.MAX_C3i_NODES; pos++) {
+            for (Unit u : removedUnits) {
+                if (u.getEntity().hasNavalC3()) {
+                    u.getEntity().setNC3NextUUIDAsString(pos, null);
+                } else {
+                    u.getEntity().setC3iNextUUIDAsString(pos, null);
+                }
+            }
+            for (Unit nUnit : networkedUnits) {
+                if (pos < uuids.size()) {
+                    if (nUnit.getEntity().hasNavalC3()) {
+                        nUnit.getEntity().setNC3NextUUIDAsString(pos, uuids.get(pos));
+                    } else {
+                        nUnit.getEntity().setC3iNextUUIDAsString(pos, uuids.get(pos));
+                    }
+                } else {
+                    if (nUnit.getEntity().hasNavalC3()) {
+                        nUnit.getEntity().setNC3NextUUIDAsString(pos, null);
+                    } else {
+                        nUnit.getEntity().setC3iNextUUIDAsString(pos, null);
+                    }
+                }
+            }
+        }
+        refreshNetworks(game);
+    }
+
+    public void addUnitsToNetwork(Vector<Unit> addedUnits, String networkID, Game game) {
+        // collect all the other units on this network to rebuild the uuids
+        Vector<String> uuids = new Vector<>();
+        Vector<Unit> networkedUnits = new Vector<>();
+        for (Unit u : addedUnits) {
+            uuids.add(u.getEntity().getC3UUIDAsString());
+            networkedUnits.add(u);
+        }
+        for (Unit unit : allUnits()) {
+            if (addedUnits.contains(unit)) {
+                continue;
+            }
+            if (null != unit.getEntity().getC3NetId() && unit.getEntity().getC3NetId().equals(networkID)) {
+                networkedUnits.add(unit);
+                uuids.add(unit.getEntity().getC3UUIDAsString());
+            }
+        }
+        for (int pos = 0; pos < Entity.MAX_C3i_NODES; pos++) {
+            for (Unit nUnit : networkedUnits) {
+                if (pos < uuids.size()) {
+                    if (nUnit.getEntity().hasNavalC3()) {
+                        nUnit.getEntity().setNC3NextUUIDAsString(pos, uuids.get(pos));
+                    } else {
+                        nUnit.getEntity().setC3iNextUUIDAsString(pos, uuids.get(pos));
+                    }
+                } else {
+                    if (nUnit.getEntity().hasNavalC3()) {
+                        nUnit.getEntity().setNC3NextUUIDAsString(pos, null);
+                    } else {
+                        nUnit.getEntity().setC3iNextUUIDAsString(pos, null);
+                    }
+                }
+            }
+        }
+        refreshNetworks(game);
+        MekHQ.triggerEvent(new NetworkChangedEvent(addedUnits));
+    }
+
+    public Vector<String[]> getAvailableC3iNetworks() {
+        Vector<String[]> networks = new Vector<>();
+        Vector<String> networkNames = new Vector<>();
+
+        for (Unit u : allUnits()) {
+
+            if (u.getFormationId() < 0) {
+                // only units currently in the TO&E
+                continue;
+            }
+            Entity en = u.getEntity();
+            if (null == en) {
+                continue;
+            }
+            if (en.hasC3i() && en.calculateFreeC3Nodes() <= 5 && en.calculateFreeC3Nodes() > 0) {
+                String[] network = new String[2];
+                network[0] = en.getC3NetId();
+                network[1] = "" + en.calculateFreeC3Nodes();
+                if (!networkNames.contains(network[0])) {
+                    networks.add(network);
+                    networkNames.add(network[0]);
+                }
+            }
+        }
+        return networks;
+    }
+
+    /**
+     * @return returns a Vector of the unique name Strings of all Naval C3 networks that have at least 1 free node
+     *       Adapted from getAvailableC3iNetworks() as the two technologies have very similar workings
+     */
+    public Vector<String[]> getAvailableNC3Networks() {
+        Vector<String[]> networks = new Vector<>();
+        Vector<String> networkNames = new Vector<>();
+
+        for (Unit u : allUnits()) {
+
+            if (u.getFormationId() < 0) {
+                // only units currently in the TO&E
+                continue;
+            }
+            Entity en = u.getEntity();
+            if (null == en) {
+                continue;
+            }
+            if (en.hasNavalC3() && en.calculateFreeC3Nodes() <= 5 && en.calculateFreeC3Nodes() > 0) {
+                String[] network = new String[2];
+                network[0] = en.getC3NetId();
+                network[1] = "" + en.calculateFreeC3Nodes();
+                if (!networkNames.contains(network[0])) {
+                    networks.add(network);
+                    networkNames.add(network[0]);
+                }
+            }
+        }
+        return networks;
+    }
+
+    /**
+     * @return returns a Vector of the unique name Strings of all Nova CEWS networks that have at least 1 free node Nova
+     *       CEWS networks support a maximum of 3 units
+     */
+    public Vector<String[]> getAvailableNovaCEWSNetworks() {
+        Vector<String[]> networks = new Vector<>();
+        Vector<String> networkNames = new Vector<>();
+
+        for (Unit u : allUnits()) {
+
+            if (u.getFormationId() < 0) {
+                // only units currently in the TO&E
+                continue;
+            }
+            Entity en = u.getEntity();
+            if (null == en) {
+                continue;
+            }
+            // Nova CEWS max is 3 nodes, so unnetworked unit has 2 free nodes
+            if (en.hasNovaCEWS() && en.calculateFreeC3Nodes() <= 2 && en.calculateFreeC3Nodes() > 0) {
+                String[] network = new String[2];
+                network[0] = en.getC3NetId();
+                network[1] = "" + en.calculateFreeC3Nodes();
+                if (!networkNames.contains(network[0])) {
+                    networks.add(network);
+                    networkNames.add(network[0]);
+                }
+            }
+        }
+        return networks;
+    }
+
+    public Vector<String[]> getAvailableC3MastersForSlaves() {
+        Vector<String[]> networks = new Vector<>();
+        Vector<String> networkNames = new Vector<>();
+
+        for (Unit u : allUnits()) {
+
+            if (u.getFormationId() < 0) {
+                // only units currently in the TO&E
+                continue;
+            }
+            Entity en = u.getEntity();
+            if (null == en) {
+                continue;
+            }
+            // count of free c3 nodes for single company-level masters
+            // will not be right so skip
+            if (en.hasC3M() && !en.hasC3MM() && en.C3MasterIs(en)) {
+                continue;
+            }
+            if (en.calculateFreeC3Nodes() > 0) {
+                String[] network = new String[3];
+                network[0] = en.getC3UUIDAsString();
+                network[1] = "" + en.calculateFreeC3Nodes();
+                network[2] = en.getShortName();
+                if (!networkNames.contains(network[0])) {
+                    networks.add(network);
+                    networkNames.add(network[0]);
+                }
+            }
+        }
+
+        return networks;
+    }
+
+    public Vector<String[]> getAvailableC3MastersForMasters() {
+        Vector<String[]> networks = new Vector<>();
+        Vector<String> networkNames = new Vector<>();
+
+        for (Unit u : allUnits()) {
+
+            if (u.getFormationId() < 0) {
+                // only units currently in the TO&E
+                continue;
+            }
+            Entity en = u.getEntity();
+            if (null == en) {
+                continue;
+            }
+            if (en.calculateFreeC3MNodes() > 0) {
+                String[] network = new String[3];
+                network[0] = en.getC3UUIDAsString();
+                network[1] = "" + en.calculateFreeC3MNodes();
+                network[2] = en.getShortName();
+                if (!networkNames.contains(network[0])) {
+                    networks.add(network);
+                    networkNames.add(network[0]);
+                }
+            }
+        }
+
+        return networks;
+    }
+
+    public void removeUnitsFromC3Master(Unit master, Game game) {
+        List<Unit> removed = new ArrayList<>();
+        for (Unit unit : allUnits()) {
+            if (null != unit.getEntity().getC3MasterIsUUIDAsString() &&
+                      unit.getEntity().getC3MasterIsUUIDAsString().equals(master.getEntity().getC3UUIDAsString())) {
+                unit.getEntity().setC3MasterIsUUIDAsString(null);
+                unit.getEntity().setC3Master(null, true);
+                removed.add(unit);
+            }
+        }
+        refreshNetworks(game);
+        MekHQ.triggerEvent(new NetworkChangedEvent(removed));
+    }
+
+    /**
+     * Detaches {@code u} from any C3 network it participates in (Naval C3, C3i, Nova CEWS, or a C3 master), refreshing
+     * the affected networks against the supplied {@link Game}.
+     */
+    public void detachUnitFromC3Networks(Unit u, Game game) {
+        if (u.getEntity().hasNavalC3() && u.getEntity().calculateFreeC3Nodes() < 5) {
+            Vector<Unit> removedUnits = new Vector<>();
+            removedUnits.add(u);
+            removeUnitsFromNetwork(removedUnits, game);
+            u.getEntity().setC3MasterIsUUIDAsString(null);
+            u.getEntity().setC3Master(null, true);
+            refreshNetworks(game);
+        } else if (u.getEntity().hasC3i() && u.getEntity().calculateFreeC3Nodes() < 5) {
+            Vector<Unit> removedUnits = new Vector<>();
+            removedUnits.add(u);
+            removeUnitsFromNetwork(removedUnits, game);
+            u.getEntity().setC3MasterIsUUIDAsString(null);
+            u.getEntity().setC3Master(null, true);
+            refreshNetworks(game);
+        } else if (u.getEntity().hasNovaCEWS() && u.getEntity().calculateFreeC3Nodes() < 2) {
+            // Nova CEWS max is 3 nodes, so < 2 free means unit is networked
+            Vector<Unit> removedUnits = new Vector<>();
+            removedUnits.add(u);
+            removeUnitsFromNetwork(removedUnits, game);
+            u.getEntity().setC3MasterIsUUIDAsString(null);
+            u.getEntity().setC3Master(null, true);
+            refreshNetworks(game);
+        }
+        if (u.getEntity().hasC3M()) {
+            removeUnitsFromC3Master(u, game);
+            u.getEntity().setC3MasterIsUUIDAsString(null);
+            u.getEntity().setC3Master(null, true);
+        }
+    }
+
 }

--- a/MekHQ/src/mekhq/campaign/force/Detachment.java
+++ b/MekHQ/src/mekhq/campaign/force/Detachment.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.force;
+
+import static mekhq.campaign.market.contractMarket.ContractAutomation.performAutomatedActivation;
+
+import java.util.Objects;
+
+import jakarta.annotation.Nonnull;
+import megamek.common.annotations.Nullable;
+import mekhq.campaign.AbstractLocation;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.CampaignNewDayManager;
+import mekhq.campaign.DetachmentLocationManager;
+import mekhq.campaign.Hangar;
+import mekhq.campaign.HumanResources;
+import mekhq.campaign.Personnel;
+import mekhq.campaign.Warehouse;
+import mekhq.campaign.campaignOptions.CampaignOptions;
+import mekhq.campaign.location.ILocation;
+import mekhq.campaign.location.IPlace;
+import mekhq.campaign.location.LocationNode;
+import mekhq.campaign.market.RequestedStockLevels;
+import org.w3c.dom.Node;
+
+/**
+ * A group of a force's units, spare parts, and personnel that sits at a single location in the {@link LocationNode}
+ * tree.
+ *
+ * <p>A {@code Detachment} is the {@link IPlace} that owns those resources: it holds its own
+ * {@link mekhq.campaign.DetachmentLocationManager} (which owns the {@link LocationNode}) and parents its hangar,
+ * warehouse, and personnel to itself, exactly like {@link mekhq.campaign.base.AbstractBase}. The upward {@code IPlace}
+ * walk therefore terminates here.</p>
+ *
+ * <p>An {@link AbstractForce} owns one or more detachments (see {@link AbstractForce#getDetachments()}); a
+ * {@link PlayerForce} owns exactly one. A detachment holds <em>no</em> reference back to its force or the
+ * {@link Campaign} — campaign-level concerns are passed in as method parameters.</p>
+ */
+public class Detachment implements IPlace {
+
+    /** Discriminator identifying a detachment as a serialized {@link ILocation} reference. */
+    public static final String LOCATION_REFERENCE_TYPE = "detachment";
+
+    private final DetachmentLocationManager detachmentLocationManager;
+
+    // Owned resources — this detachment is the IPlace that owns them.
+    private final Hangar units = new Hangar();
+    private final Personnel personnel = new Personnel();
+    private final RequestedStockLevels requestedStockLevels = new RequestedStockLevels();
+    private Warehouse parts = new Warehouse();
+
+    public Detachment() {
+        // The manager owns the LocationNode; build it first so parenting the resources can resolve this node.
+        this.detachmentLocationManager = new DetachmentLocationManager(this);
+        LocationNode.LocationManager.setLocation(personnel, this);
+        LocationNode.LocationManager.setLocation(units, this);
+        LocationNode.LocationManager.setLocation(parts, this);
+    }
+
+    /**
+     * Resolves a serialized reference to the player force's detachment back to the live instance. Because a campaign
+     * has a single player force with a single detachment, the reference carries no identity beyond its discriminator.
+     */
+    public static @Nullable ILocation resolveReference(Campaign campaign, Node node) {
+        return campaign.getPlayerForce().getForceDetachment();
+    }
+
+    public DetachmentLocationManager getDetachmentLocationManager() {
+        return detachmentLocationManager;
+    }
+
+    @Override
+    public @Nonnull LocationNode getLocationNode() {
+        return detachmentLocationManager.getLocationNode();
+    }
+
+    @Override
+    public Hangar getHangar() {
+        return units;
+    }
+
+    @Override
+    public Warehouse getWarehouse() {
+        return parts;
+    }
+
+    public void setWarehouse(Warehouse warehouse) {
+        parts = Objects.requireNonNull(warehouse);
+    }
+
+    @Override
+    public Personnel getPersonnel() {
+        return personnel;
+    }
+
+    @Override
+    public RequestedStockLevels getRequestedStockLevels() {
+        return requestedStockLevels;
+    }
+
+    /**
+     * Runs the detachment's arrival behavior when it finishes travelling to a location. The {@link Campaign} is
+     * supplied as a parameter (a detachment holds no campaign reference) for the systems this drives: automated
+     * mothball activation, disease/inoculation checks, early-arrival contract checks, and refreshing local applicants.
+     */
+    @Override
+    public void onArrival(Campaign campaign, boolean isSilentProcessing) {
+        // This should be before inoculations so that we can correctly read the TO&E.
+        if (!campaign.getPlayerForce().getAutomatedMothballUnits().isEmpty()) {
+            performAutomatedActivation(campaign);
+        }
+
+        CampaignOptions campaignOptions = campaign.getCampaignOptions();
+        if (campaignOptions.isUseRandomDiseases() && campaignOptions.isUseAlternativeAdvancedMedical()) {
+            if (getParentLocation() instanceof AbstractLocation loc) {
+                loc.checkForDiseaseOrBioweaponOutbreaks(campaign, campaign.getLocalDate());
+            }
+        }
+
+        // Inoculations (generic IPlace behavior)
+        IPlace.super.onArrival(campaign, isSilentProcessing);
+
+        if (getParentLocation() instanceof AbstractLocation loc) {
+            loc.testForEarlyArrival(campaign);
+        }
+
+        // We've just stopped traveling, so we should see if there are any local applicants.
+        if (!HumanResources.isUsingLegacyPersonnelMarket(campaign.getCampaignOptions())) {
+            campaign.refreshApplicants(true);
+            CampaignNewDayManager.showRarePersonnelDialog(campaign, false);
+        }
+    }
+
+    @Override
+    public String locationReferenceType() {
+        return LOCATION_REFERENCE_TYPE;
+    }
+}

--- a/MekHQ/src/mekhq/campaign/force/ForceOption.java
+++ b/MekHQ/src/mekhq/campaign/force/ForceOption.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.force;
+
+/**
+ * A single typed force-scoped option holding a current {@code value} and the {@code defaultValue} it
+ * falls back to.
+ *
+ * <p>This is the {@link mekhq.campaign.force.ForceOptions} building block. It intentionally mirrors the role that
+ * {@code megamek.common.options.Option}/{@code IOption} plays for game options, but is generic and type-safe rather than
+ * {@link Object}-based, so callers get a concrete {@code T} without casting.</p>
+ *
+ * @param <T> the type of value this option holds
+ */
+public class ForceOption<T> {
+    private final String name;
+    private T value;
+    private final T defaultValue;
+
+    /**
+     * Creates a new option whose current value starts equal to {@code defaultValue}.
+     *
+     * @param name         the option's identifier
+     * @param defaultValue the value this option holds until changed, and reverts to on
+     *                     {@link #resetToDefault()}
+     */
+    public ForceOption(String name, T defaultValue) {
+        this.name = name;
+        this.defaultValue = defaultValue;
+        this.value = defaultValue;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public T getValue() {
+        return value;
+    }
+
+    public void setValue(T value) {
+        this.value = value;
+    }
+
+    public T getDefault() {
+        return defaultValue;
+    }
+
+    public void resetToDefault() {
+        this.value = defaultValue;
+    }
+}

--- a/MekHQ/src/mekhq/campaign/force/ForceOptions.java
+++ b/MekHQ/src/mekhq/campaign/force/ForceOptions.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.force;
+
+import mekhq.campaign.campaignOptions.CampaignOptions;
+import mekhq.campaign.universe.Faction;
+
+/**
+ * Force-scoped options for an {@link AbstractForce}, modeled loosely on {@link CampaignOptions}.
+ *
+ * <p>This is deliberately thin for now: most settings still live on {@link CampaignOptions} and are reached through the
+ * {@link #getCampaignOptions() wrapped} instance (pass-through accessors are added here as force logic needs them). What
+ * it <em>does</em> own outright is the force's {@link Faction}, stored as a typed {@link ForceOption}. Over time,
+ * force-specific settings will migrate off {@link CampaignOptions} and become real {@link ForceOption}s here.</p>
+ */
+public class ForceOptions {
+    /** Identifier for the {@link Faction} option. */
+    public static final String FACTION = "faction";
+
+    private CampaignOptions campaignOptions;
+    private final ForceOption<Faction> faction;
+
+    /**
+     * @param campaignOptions the campaign options this force passes non-force settings through to
+     * @param initialFaction  the force's starting faction
+     */
+    public ForceOptions(CampaignOptions campaignOptions, Faction initialFaction) {
+        this.campaignOptions = campaignOptions;
+        this.faction = new ForceOption<>(FACTION, initialFaction);
+    }
+
+    public CampaignOptions getCampaignOptions() {
+        return campaignOptions;
+    }
+
+    /** Keeps the pass-through target in sync when the campaign swaps its options wholesale. */
+    public void setCampaignOptions(CampaignOptions campaignOptions) {
+        this.campaignOptions = campaignOptions;
+    }
+
+    public Faction getFaction() {
+        return faction.getValue();
+    }
+
+    public void setFaction(Faction faction) {
+        this.faction.setValue(faction);
+    }
+
+    // region CampaignOptions pass-throughs
+
+    public boolean isFactionIntroDate() {
+        return campaignOptions.isFactionIntroDate();
+    }
+
+    // endregion CampaignOptions pass-throughs
+}

--- a/MekHQ/src/mekhq/campaign/force/PlayerForce.java
+++ b/MekHQ/src/mekhq/campaign/force/PlayerForce.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.force;
+
+import megamek.common.annotations.Nullable;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.camOpsReputation.ReputationController;
+import mekhq.campaign.campaignOptions.CampaignOptions;
+import mekhq.campaign.finances.Finances;
+import mekhq.campaign.location.ILocation;
+import mekhq.campaign.personnel.ranks.RankSystem;
+import mekhq.campaign.universe.Faction;
+import mekhq.campaign.universe.factionStanding.FactionStandings;
+import org.w3c.dom.Node;
+
+/**
+ * The human player's active force: the single {@link AbstractForce} a {@link Campaign} is played through.
+ *
+ * <p>It is the {@link mekhq.campaign.location.IPlace} node representing the main force in the location tree (its
+ * {@link mekhq.campaign.location.LocationNode}, owned by {@link AbstractForce}, is what
+ * {@link mekhq.campaign.ForceLocationManager} anchors to a location) and the referable node that survives an XML
+ * save/load round-trip. Like every force, it holds no reference back to the campaign.</p>
+ *
+ * <p>For now a {@link Campaign} owns exactly one {@code PlayerForce}; multiple forces per campaign is a later
+ * refactor.</p>
+ */
+public class PlayerForce extends AbstractForce {
+
+    /** Discriminator identifying the player's main force as a serialized {@link ILocation} reference. */
+    public static final String LOCATION_REFERENCE_TYPE = "playerForce";
+
+    /**
+     * @param faction              the force's starting faction
+     * @param techFaction          the resolved MegaMek tech faction
+     * @param rankSystem           the force's rank system
+     * @param finances             the force's finances ledger
+     * @param reputationController the force's reputation controller
+     * @param factionStandings     the force's standings with the wider universe
+     * @param campaignOptions      the campaign options the force's {@link ForceOptions} passes through to
+     */
+    public PlayerForce(Faction faction, megamek.common.enums.Faction techFaction, RankSystem rankSystem,
+          Finances finances, ReputationController reputationController, FactionStandings factionStandings,
+          CampaignOptions campaignOptions) {
+        super(new ForceOptions(campaignOptions, faction), techFaction, rankSystem, finances, reputationController,
+              factionStandings);
+    }
+
+    @Override
+    public String locationReferenceType() {
+        return LOCATION_REFERENCE_TYPE;
+    }
+
+    /**
+     * Resolves a serialized reference to the player force back to the live instance. Because a campaign has a single
+     * player force, the reference carries no identity beyond its discriminator.
+     */
+    public static @Nullable ILocation resolveReference(Campaign campaign, Node node) {
+        return campaign.getPlayerForce();
+    }
+}

--- a/MekHQ/src/mekhq/campaign/force/PlayerForce.java
+++ b/MekHQ/src/mekhq/campaign/force/PlayerForce.java
@@ -32,32 +32,29 @@
  */
 package mekhq.campaign.force;
 
-import megamek.common.annotations.Nullable;
-import mekhq.campaign.Campaign;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import mekhq.campaign.camOpsReputation.ReputationController;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.finances.Finances;
-import mekhq.campaign.location.ILocation;
 import mekhq.campaign.personnel.ranks.RankSystem;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.factionStanding.FactionStandings;
-import org.w3c.dom.Node;
 
 /**
- * The human player's active force: the single {@link AbstractForce} a {@link Campaign} is played through.
+ * The human player's active force: the single {@link AbstractForce} a {@link mekhq.campaign.Campaign} is played
+ * through.
  *
- * <p>It is the {@link mekhq.campaign.location.IPlace} node representing the main force in the location tree (its
- * {@link mekhq.campaign.location.LocationNode}, owned by {@link AbstractForce}, is what
- * {@link mekhq.campaign.ForceLocationManager} anchors to a location) and the referable node that survives an XML
- * save/load round-trip. Like every force, it holds no reference back to the campaign.</p>
- *
- * <p>For now a {@link Campaign} owns exactly one {@code PlayerForce}; multiple forces per campaign is a later
- * refactor.</p>
+ * <p>For now a player force owns exactly one {@link Detachment} — hence it implements
+ * {@link SingleDetachmentForce}, which supplies the located-resource passthroughs (hangar, warehouse, personnel, …).
+ * Multiple detachments per force is a later refactor, at which point a multi-detachment variant will simply not
+ * implement {@code SingleDetachmentForce} and the compiler will flag every single-detachment assumption.</p>
  */
-public class PlayerForce extends AbstractForce {
+public class PlayerForce extends AbstractForce implements SingleDetachmentForce {
 
-    /** Discriminator identifying the player's main force as a serialized {@link ILocation} reference. */
-    public static final String LOCATION_REFERENCE_TYPE = "playerForce";
+    private final Detachment forceDetachment = new Detachment();
 
     /**
      * @param faction              the force's starting faction
@@ -76,15 +73,12 @@ public class PlayerForce extends AbstractForce {
     }
 
     @Override
-    public String locationReferenceType() {
-        return LOCATION_REFERENCE_TYPE;
+    public Detachment getForceDetachment() {
+        return forceDetachment;
     }
 
-    /**
-     * Resolves a serialized reference to the player force back to the live instance. Because a campaign has a single
-     * player force, the reference carries no identity beyond its discriminator.
-     */
-    public static @Nullable ILocation resolveReference(Campaign campaign, Node node) {
-        return campaign.getPlayerForce();
+    @Override
+    public Collection<Detachment> getDetachments() {
+        return new ArrayList<>(List.of(forceDetachment));
     }
 }

--- a/MekHQ/src/mekhq/campaign/force/SingleDetachmentForce.java
+++ b/MekHQ/src/mekhq/campaign/force/SingleDetachmentForce.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.force;
+
+import mekhq.campaign.DetachmentLocationManager;
+import mekhq.campaign.Hangar;
+import mekhq.campaign.Personnel;
+import mekhq.campaign.Warehouse;
+import mekhq.campaign.market.RequestedStockLevels;
+import mekhq.campaign.parts.Part;
+import mekhq.campaign.parts.PartInventory;
+
+/**
+ * The single-detachment seam for an {@link AbstractForce}.
+ *
+ * <p>Everything here is convenience that <em>only makes sense when a force has exactly one
+ * {@link Detachment}</em> — "the" hangar, "the" warehouse, "the" personnel roster. A force implements this interface
+ * only while it is single-detachment; the sole method it must supply is {@link #getForceDetachment()}, and every other
+ * accessor is a default passthrough to that detachment.</p>
+ *
+ * <p><b>This is deliberately a distinct type so the single-detachment assumption is greppable and
+ * compiler-checked.</b> When multi-detachment forces arrive they simply will not implement
+ * {@code SingleDetachmentForce}, and the compiler will flag every call site that assumed a single detachment. Prefer
+ * {@link AbstractForce#getDetachments()} (and the aggregate helpers on {@link AbstractForce}) for any logic that can be
+ * made detachment-count-agnostic; reach for these accessors only where a caller genuinely has not been taught about
+ * multiple detachments yet.</p>
+ */
+public interface SingleDetachmentForce {
+
+    /** The single detachment this force tracks. */
+    Detachment getForceDetachment();
+
+    default Hangar getHangar() {
+        return getForceDetachment().getHangar();
+    }
+
+    default Warehouse getWarehouse() {
+        return getForceDetachment().getWarehouse();
+    }
+
+    default void setWarehouse(Warehouse warehouse) {
+        getForceDetachment().setWarehouse(warehouse);
+    }
+
+    default Personnel getPersonnel() {
+        return getForceDetachment().getPersonnel();
+    }
+
+    default RequestedStockLevels getRequestedStockLevels() {
+        return getForceDetachment().getRequestedStockLevels();
+    }
+
+    default PartInventory getPartInventory(Part part) {
+        return getForceDetachment().getPartInventory(part);
+    }
+
+    default DetachmentLocationManager getDetachmentLocationManager() {
+        return getForceDetachment().getDetachmentLocationManager();
+    }
+}

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -99,8 +99,8 @@ import mekhq.campaign.campaignOptions.CampaignOptionsUnmarshaller;
 import mekhq.campaign.enums.CampaignTransportType;
 import mekhq.campaign.finances.Finances;
 import mekhq.campaign.force.CombatTeam;
+import mekhq.campaign.force.Detachment;
 import mekhq.campaign.force.Formation;
-import mekhq.campaign.force.PlayerForce;
 import mekhq.campaign.icons.UnitIcon;
 import mekhq.campaign.location.AcademyCampusLocation;
 import mekhq.campaign.location.ILocation;
@@ -1987,7 +1987,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                 ILocation parentLocation = person.getParentLocation();
                 if (parentLocation != null
                           && !(parentLocation instanceof Personnel personnel
-                                     && personnel.getParentLocation() instanceof PlayerForce)) {
+                                     && personnel.getParentLocation() instanceof Detachment)) {
                     LOGGER.debug("migrateLegacyEducationTravel: skipping {} — already reconnected (stage={})",
                           person.getFullTitle(), stage);
                     continue;

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -2078,8 +2078,8 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                 travelLocation.setParent(campusLocation);
             } else if (stage == EducationStage.JOURNEY_FROM_CAMPUS) {
                 LOGGER.info("migrateLegacyEducationTravel: no campus found for {} (JOURNEY_FROM_CAMPUS)"
-                      + " — parenting travel node under Campaign root", person.getFullTitle());
-                travelLocation.setParent(campaign);
+                                  + " — parenting travel node under the main force", person.getFullTitle());
+                travelLocation.setParent(campaign.getPlayerForce().getForceDetachment());
             }
             person.setParent(travelLocation);
             campaign.getCampaignLocationManager().addLocation(travelLocation);

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -100,6 +100,7 @@ import mekhq.campaign.enums.CampaignTransportType;
 import mekhq.campaign.finances.Finances;
 import mekhq.campaign.force.CombatTeam;
 import mekhq.campaign.force.Formation;
+import mekhq.campaign.force.PlayerForce;
 import mekhq.campaign.icons.UnitIcon;
 import mekhq.campaign.location.AcademyCampusLocation;
 import mekhq.campaign.location.ILocation;
@@ -1986,7 +1987,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                 ILocation parentLocation = person.getParentLocation();
                 if (parentLocation != null
                           && !(parentLocation instanceof Personnel personnel
-                                && personnel.getParentLocation() instanceof Campaign)) {
+                                     && personnel.getParentLocation() instanceof PlayerForce)) {
                     LOGGER.debug("migrateLegacyEducationTravel: skipping {} — already reconnected (stage={})",
                           person.getFullTitle(), stage);
                     continue;

--- a/MekHQ/src/mekhq/campaign/location/ILocation.java
+++ b/MekHQ/src/mekhq/campaign/location/ILocation.java
@@ -49,6 +49,7 @@ import mekhq.campaign.JumpPath;
 import mekhq.campaign.Personnel;
 import mekhq.campaign.Warehouse;
 import mekhq.campaign.base.PlayerBase;
+import mekhq.campaign.force.PlayerForce;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
@@ -523,7 +524,9 @@ public interface ILocation {
      * constant.
      */
     Map<String, ReferenceResolver> REFERENCE_RESOLVERS = Map.of(
-          Campaign.LOCATION_REFERENCE_TYPE, (campaign, node) -> campaign,
+          PlayerForce.LOCATION_REFERENCE_TYPE, PlayerForce::resolveReference,
+          // Legacy alias: pre-split saves referenced the main force as "campaign".
+          Campaign.LOCATION_REFERENCE_TYPE, PlayerForce::resolveReference,
           PlayerBase.LOCATION_REFERENCE_TYPE, PlayerBase::resolveReference,
           FixedLocation.LOCATION_REFERENCE_TYPE, FixedLocation::resolveReference,
           AcademyCampusLocation.CAMPUS_REFERENCE_TYPE, AcademyCampusLocation::resolveCampusReference,

--- a/MekHQ/src/mekhq/campaign/location/ILocation.java
+++ b/MekHQ/src/mekhq/campaign/location/ILocation.java
@@ -49,7 +49,7 @@ import mekhq.campaign.JumpPath;
 import mekhq.campaign.Personnel;
 import mekhq.campaign.Warehouse;
 import mekhq.campaign.base.PlayerBase;
-import mekhq.campaign.force.PlayerForce;
+import mekhq.campaign.force.Detachment;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
@@ -524,9 +524,11 @@ public interface ILocation {
      * constant.
      */
     Map<String, ReferenceResolver> REFERENCE_RESOLVERS = Map.of(
-          PlayerForce.LOCATION_REFERENCE_TYPE, PlayerForce::resolveReference,
-          // Legacy alias: pre-split saves referenced the main force as "campaign".
-          Campaign.LOCATION_REFERENCE_TYPE, PlayerForce::resolveReference,
+          Detachment.LOCATION_REFERENCE_TYPE, Detachment::resolveReference,
+          // Legacy aliases: pre-detachment saves referenced the main force as "playerForce", and pre-force saves
+          // referenced it as "campaign". Both now resolve to the player force's detachment.
+          "playerForce", Detachment::resolveReference,
+          Campaign.LOCATION_REFERENCE_TYPE, Detachment::resolveReference,
           PlayerBase.LOCATION_REFERENCE_TYPE, PlayerBase::resolveReference,
           FixedLocation.LOCATION_REFERENCE_TYPE, FixedLocation::resolveReference,
           AcademyCampusLocation.CAMPUS_REFERENCE_TYPE, AcademyCampusLocation::resolveCampusReference,

--- a/MekHQ/src/mekhq/campaign/location/IPlace.java
+++ b/MekHQ/src/mekhq/campaign/location/IPlace.java
@@ -105,9 +105,9 @@ public interface IPlace extends ILocation {
     /**
      * Returns the per-part "requested stock percent" targets this place maintains for its warehouse.
      *
-     * <p>Only {@link mekhq.campaign.Campaign} (main force) and {@link mekhq.campaign.base.AbstractBase} own real stock
-     * levels; every other place inherits the empty {@link RequestedStockLevels#NO_RESTOCK}, so its parts fall through to
-     * default stock percentages.</p>
+     * <p>Only the main force's {@link mekhq.campaign.force.Detachment} and {@link mekhq.campaign.base.AbstractBase} own
+     * real stock levels; every other place inherits the empty {@link RequestedStockLevels#NO_RESTOCK}, so its parts fall
+     * through to default stock percentages.</p>
      */
     default RequestedStockLevels getRequestedStockLevels() {
         return RequestedStockLevels.NO_RESTOCK;
@@ -116,8 +116,9 @@ public interface IPlace extends ILocation {
     /**
      * Returns a {@link PartInventory} counting spare parts that match {@code part} in this place's warehouse.
      *
-     * <p>Supply counts present spares; transit counts non-present spares. The ordered count is
-     * zero by default — {@link mekhq.campaign.Campaign} overrides this to add shopping-list orders.</p>
+     * <p>Supply counts present spares; transit counts non-present spares. The ordered count is zero here;
+     * {@link mekhq.campaign.Campaign#getPartInventory} wraps this result to add the main force's shopping-list
+     * orders.</p>
      */
     default PartInventory getPartInventory(Part part) {
         PartInventory inventory = new PartInventory();

--- a/MekHQ/src/mekhq/campaign/location/IPlace.java
+++ b/MekHQ/src/mekhq/campaign/location/IPlace.java
@@ -200,8 +200,8 @@ public interface IPlace extends ILocation {
             if (!travelNode.hasArrived()) {
                 continue;
             }
-            LocationDispatch.landFromTravelNode(travelNode, personnel, hangar, warehouse, campaign,
-                  campaign.getCampaignLocationManager());
+            LocationDispatch.landFromTravelNode(travelNode, personnel, hangar, warehouse,
+                  campaign.getPlayerForce().getForceDetachment(), campaign.getCampaignLocationManager());
         }
     }
 }

--- a/MekHQ/src/mekhq/campaign/location/LocationNode.java
+++ b/MekHQ/src/mekhq/campaign/location/LocationNode.java
@@ -147,7 +147,7 @@ public class LocationNode {
      * serialized through the location tree.</p>
      */
     public static void reconnectChildren(Node xmlNode, Campaign campaign) {
-        reconnectChildren(xmlNode, campaign, campaign);
+        reconnectChildren(xmlNode, campaign.getPlayerForce().getForceDetachment(), campaign);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/market/PartsInUseManager.java
+++ b/MekHQ/src/mekhq/campaign/market/PartsInUseManager.java
@@ -109,7 +109,7 @@ public class PartsInUseManager {
      * @param campaign the {@link Campaign} to manage parts for
      */
     public PartsInUseManager(Campaign campaign) {
-        this(campaign, campaign);
+        this(campaign, campaign.getPlayerForce().getForceDetachment());
     }
 
     /**
@@ -135,7 +135,7 @@ public class PartsInUseManager {
     /** The place a part is located at — its unit's location for installed parts, its warehouse for spares. */
     private IPlace placeOf(Part part) {
         IPlace partPlace = part.getPlace();
-        return (partPlace != null) ? partPlace : campaign;
+        return (partPlace != null) ? partPlace : campaign.getPlayerForce().getForceDetachment();
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/market/ShoppingList.java
+++ b/MekHQ/src/mekhq/campaign/market/ShoppingList.java
@@ -47,7 +47,7 @@ import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.events.ProcurementEvent;
 import mekhq.campaign.finances.Money;
-import mekhq.campaign.force.PlayerForce;
+import mekhq.campaign.force.Detachment;
 import mekhq.campaign.location.IPlace;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.Refit;
@@ -178,12 +178,12 @@ public class ShoppingList {
      * eventually delivered from it) resolves to that base's warehouse. Orders bound for different places are kept as
      * separate line items even when they are the same equipment.</p>
      *
-     * @param place the destination; {@code null} or the campaign itself means the main force
+     * @param place the destination; {@code null} or the main force's {@link Detachment} means the main force
      */
     public void addShoppingItem(IAcquisitionWork newWork, int quantity, Campaign campaign, @Nullable IPlace place) {
-        // The main force leaves orders unanchored (their part resolves to the campaign warehouse); a base anchors the
+        // The main force leaves orders unanchored (their part resolves to the main force warehouse); a base anchors the
         // order at that base so it resolves to the base warehouse.
-        IPlace destination = (place instanceof Campaign || place instanceof PlayerForce) ? null : place;
+        IPlace destination = (place instanceof Detachment) ? null : place;
         if (destination != null) {
             newWork.setParent(destination);
         }

--- a/MekHQ/src/mekhq/campaign/market/ShoppingList.java
+++ b/MekHQ/src/mekhq/campaign/market/ShoppingList.java
@@ -47,6 +47,7 @@ import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.events.ProcurementEvent;
 import mekhq.campaign.finances.Money;
+import mekhq.campaign.force.PlayerForce;
 import mekhq.campaign.location.IPlace;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.Refit;
@@ -182,7 +183,7 @@ public class ShoppingList {
     public void addShoppingItem(IAcquisitionWork newWork, int quantity, Campaign campaign, @Nullable IPlace place) {
         // The main force leaves orders unanchored (their part resolves to the campaign warehouse); a base anchors the
         // order at that base so it resolves to the base warehouse.
-        IPlace destination = (place instanceof Campaign) ? null : place;
+        IPlace destination = (place instanceof Campaign || place instanceof PlayerForce) ? null : place;
         if (destination != null) {
             newWork.setParent(destination);
         }

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
@@ -587,7 +587,7 @@ public class Resupply {
      */
     private Set<PartInUse> collectPartsInUseAcrossLocations() {
         List<IPlace> places = new ArrayList<>();
-        places.add(campaign);
+        places.add(campaign.getPlayerForce().getForceDetachment());
         places.addAll(campaign.getCampaignLocationManager().getPlayerBases());
 
         Map<PartInUse, PartInUse> merged = new HashMap<>();

--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -800,7 +800,8 @@ public class EducationController {
             // the travel-progress display; arrival is driven by the travel node.
             person.setEduJourneyTime(2);
             person.setEduDaysOfTravel(0);
-            campaign.getCampaignLocationManager().queueTravel(List.of(person), campaign);
+            campaign.getCampaignLocationManager()
+                  .queueTravel(List.of(person), campaign.getPlayerForce().getForceDetachment());
             campaign.addReport(PERSONNEL, String.format(resources.getString("returningFromSchool.text"),
                   person.getHyperlinkedFullTitle(), 2));
             person.setEduEducationStage(EducationStage.JOURNEY_FROM_CAMPUS);
@@ -829,7 +830,8 @@ public class EducationController {
             }
         }
 
-        campaign.getCampaignLocationManager().queueTravel(List.of(person), campaign);
+        campaign.getCampaignLocationManager()
+              .queueTravel(List.of(person), campaign.getPlayerForce().getForceDetachment());
 
         JumpPath returnPath = LocationUtils.planJumpPath(academySystem, campaign.getCurrentSystem(), campaign);
         int travelDays = returnPath != null
@@ -853,7 +855,7 @@ public class EducationController {
             }
             current = current.getParentLocation();
         }
-        return campaign;
+        return campaign.getPlayerForce().getForceDetachment();
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelStatus.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelStatus.java
@@ -586,7 +586,7 @@ public enum PersonnelStatus {
             return false;
         }
         for (ILocation cursor = person.getParentLocation(); cursor != null; cursor = cursor.getParentLocation()) {
-            if (cursor == campaign) {
+            if (cursor == campaign.getPlayerForce().getForceDetachment()) {
                 return false;
             }
             if (cursor instanceof AbstractLocation) {

--- a/MekHQ/src/mekhq/gui/LocationsTab.java
+++ b/MekHQ/src/mekhq/gui/LocationsTab.java
@@ -55,6 +55,7 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.base.AbstractBase;
 import mekhq.campaign.base.PlayerBase;
 import mekhq.campaign.events.LocationEvent;
+import mekhq.campaign.force.PlayerForce;
 import mekhq.campaign.location.ILocation;
 import mekhq.campaign.location.IPlace;
 import mekhq.campaign.parts.Part;
@@ -240,7 +241,7 @@ public class LocationsTab extends CampaignGuiTab {
         }
 
         private static String resolveType(IPlace place) {
-            if (place instanceof Campaign) {
+            if (place instanceof PlayerForce) {
                 return getText("LocationPlacePanel.type.mainForce");
             }
             if (place instanceof AbstractBase base) {

--- a/MekHQ/src/mekhq/gui/LocationsTab.java
+++ b/MekHQ/src/mekhq/gui/LocationsTab.java
@@ -439,7 +439,7 @@ public class LocationsTab extends CampaignGuiTab {
 
         void refresh(Campaign campaign) {
             List<IPlace> places = new ArrayList<>();
-            places.add(campaign);
+            places.add(campaign.getPlayerForce().getForceDetachment());
             places.addAll(campaign.getCampaignLocationManager().getPlayerBases());
             model.setData(places, campaign);
         }

--- a/MekHQ/src/mekhq/gui/LocationsTab.java
+++ b/MekHQ/src/mekhq/gui/LocationsTab.java
@@ -55,7 +55,7 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.base.AbstractBase;
 import mekhq.campaign.base.PlayerBase;
 import mekhq.campaign.events.LocationEvent;
-import mekhq.campaign.force.PlayerForce;
+import mekhq.campaign.force.Detachment;
 import mekhq.campaign.location.ILocation;
 import mekhq.campaign.location.IPlace;
 import mekhq.campaign.parts.Part;
@@ -241,7 +241,7 @@ public class LocationsTab extends CampaignGuiTab {
         }
 
         private static String resolveType(IPlace place) {
-            if (place instanceof PlayerForce) {
+            if (place instanceof Detachment) {
                 return getText("LocationPlacePanel.type.mainForce");
             }
             if (place instanceof AbstractBase base) {

--- a/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
@@ -130,8 +130,8 @@ public class PartsReportDialog extends JDialog {
         super(gui.getFrame(), modal);
         this.gui = gui;
         this.campaign = gui.getCampaign();
-        this.activePlace = campaign;
-        this.partsInUseManager = new PartsInUseManager(campaign, campaign);
+        this.activePlace = campaign.getPlayerForce().getForceDetachment();
+        this.partsInUseManager = new PartsInUseManager(campaign, campaign.getPlayerForce().getForceDetachment());
         initComponents();
         // initComponents() selects the dropdown to match the main GUI's active location; sync the scoped manager to it.
         activePlace = getSelectedPlace();
@@ -655,7 +655,7 @@ public class PartsReportDialog extends JDialog {
     private IPlace getSelectedPlace() {
         LocationFilterItem item = (LocationFilterItem) choiceLocation.getSelectedItem();
         if (item == null || item.isMainForce()) {
-            return campaign;
+            return campaign.getPlayerForce().getForceDetachment();
         }
         return item.getBase();
     }

--- a/MekHQ/src/mekhq/gui/menus/SendToLocationMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/SendToLocationMenu.java
@@ -124,9 +124,9 @@ public class SendToLocationMenu extends JScrollableMenu {
               ? currentLocations.iterator().next()
               : null;
 
-        // Main Force entry (= the campaign itself).
-        // Items at main force are parented to mainForcePersonnel, hangar, or warehouse — not
-        // to the campaign object directly — so check all three sub-resources.
+        // Main Force entry (= the main force's Detachment).
+        // Items at main force are parented to mainForcePersonnel, hangar, or warehouse — not to the
+        // Detachment itself — so check the Detachment and all three sub-resources.
         boolean alreadyAtMainForce = sharedCurrent == campaign.getPlayerForce().getForceDetachment()
               || sharedCurrent == campaign.getMainForcePersonnel()
               || sharedCurrent == campaign.getHangar()

--- a/MekHQ/src/mekhq/gui/menus/SendToLocationMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/SendToLocationMenu.java
@@ -127,13 +127,13 @@ public class SendToLocationMenu extends JScrollableMenu {
         // Main Force entry (= the campaign itself).
         // Items at main force are parented to mainForcePersonnel, hangar, or warehouse — not
         // to the campaign object directly — so check all three sub-resources.
-        boolean alreadyAtMainForce = sharedCurrent == campaign
+        boolean alreadyAtMainForce = sharedCurrent == campaign.getPlayerForce().getForceDetachment()
               || sharedCurrent == campaign.getMainForcePersonnel()
               || sharedCurrent == campaign.getHangar()
               || sharedCurrent == campaign.getWarehouse();
         if (!alreadyAtMainForce) {
             JMenuItem mainForce = new JMenuItem(getTextAt(RESOURCE_BUNDLE, "label.mainForce.text"));
-            mainForce.addActionListener(e -> dispatcher.accept(campaign));
+            mainForce.addActionListener(e -> dispatcher.accept(campaign.getPlayerForce().getForceDetachment()));
             add(mainForce);
         }
 

--- a/MekHQ/src/mekhq/gui/view/LocationPlacePanel.java
+++ b/MekHQ/src/mekhq/gui/view/LocationPlacePanel.java
@@ -47,6 +47,7 @@ import javax.swing.JPanel;
 import megamek.client.ui.util.UIUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.base.AbstractBase;
+import mekhq.campaign.force.PlayerForce;
 import mekhq.campaign.location.IPlace;
 import mekhq.gui.baseComponents.JScrollablePanel;
 import mekhq.gui.model.LocationDisplay;
@@ -97,7 +98,7 @@ public class LocationPlacePanel extends JScrollablePanel {
         }
 
         private static String resolveType(IPlace place) {
-            if (place instanceof Campaign) {
+            if (place instanceof PlayerForce) {
                 return getText("LocationPlacePanel.type.mainForce");
             }
             if (place instanceof AbstractBase base) {

--- a/MekHQ/src/mekhq/gui/view/LocationPlacePanel.java
+++ b/MekHQ/src/mekhq/gui/view/LocationPlacePanel.java
@@ -47,7 +47,7 @@ import javax.swing.JPanel;
 import megamek.client.ui.util.UIUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.base.AbstractBase;
-import mekhq.campaign.force.PlayerForce;
+import mekhq.campaign.force.Detachment;
 import mekhq.campaign.location.IPlace;
 import mekhq.gui.baseComponents.JScrollablePanel;
 import mekhq.gui.model.LocationDisplay;
@@ -98,7 +98,7 @@ public class LocationPlacePanel extends JScrollablePanel {
         }
 
         private static String resolveType(IPlace place) {
-            if (place instanceof PlayerForce) {
+            if (place instanceof Detachment) {
                 return getText("LocationPlacePanel.type.mainForce");
             }
             if (place instanceof AbstractBase base) {

--- a/MekHQ/unittests/mekhq/campaign/C3NetworkTest.java
+++ b/MekHQ/unittests/mekhq/campaign/C3NetworkTest.java
@@ -43,6 +43,7 @@ import java.util.UUID;
 import java.util.Vector;
 
 import megamek.common.units.Entity;
+import mekhq.campaign.force.PlayerForce;
 import mekhq.campaign.unit.Unit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -55,21 +56,21 @@ import org.junit.jupiter.api.Test;
  */
 class C3NetworkTest {
 
-    private Campaign campaign;
+    private PlayerForce force;
     private List<Unit> units;
 
     @BeforeEach
     void setUp() {
-        campaign = mock(Campaign.class);
+        force = mock(PlayerForce.class);
         units = new ArrayList<>();
 
-        // Configure mock to call real methods for the network methods we're testing
-        doCallRealMethod().when(campaign).getAvailableC3iNetworks();
-        doCallRealMethod().when(campaign).getAvailableNC3Networks();
-        doCallRealMethod().when(campaign).getAvailableNovaCEWSNetworks();
+        // The C3 network query logic lives on the force; call the real methods under test.
+        doCallRealMethod().when(force).getAvailableC3iNetworks();
+        doCallRealMethod().when(force).getAvailableNC3Networks();
+        doCallRealMethod().when(force).getAvailableNovaCEWSNetworks();
 
-        // Return our test units list
-        when(campaign.getUnits()).thenReturn(units);
+        // Those methods aggregate over the force's detachments via allUnits(); return our test units list.
+        when(force.allUnits()).thenReturn(units);
     }
 
     /**
@@ -149,7 +150,7 @@ class C3NetworkTest {
             units.add(unnetworkedUnit);
 
             // Act
-            Vector<String[]> networks = campaign.getAvailableC3iNetworks();
+            Vector<String[]> networks = force.getAvailableC3iNetworks();
 
             // Assert - should find the network with 5 free nodes
             assertEquals(1, networks.size(), "Should find one available C3i network");
@@ -165,7 +166,7 @@ class C3NetworkTest {
             units.add(partialUnit);
 
             // Act
-            Vector<String[]> networks = campaign.getAvailableC3iNetworks();
+            Vector<String[]> networks = force.getAvailableC3iNetworks();
 
             // Assert
             assertEquals(1, networks.size());
@@ -180,7 +181,7 @@ class C3NetworkTest {
             units.add(fullUnit);
 
             // Act
-            Vector<String[]> networks = campaign.getAvailableC3iNetworks();
+            Vector<String[]> networks = force.getAvailableC3iNetworks();
 
             // Assert - should not find full networks
             assertEquals(0, networks.size(), "Should not include full networks");
@@ -194,7 +195,7 @@ class C3NetworkTest {
             units.add(unassignedUnit);
 
             // Act
-            Vector<String[]> networks = campaign.getAvailableC3iNetworks();
+            Vector<String[]> networks = force.getAvailableC3iNetworks();
 
             // Assert
             assertEquals(0, networks.size(), "Should not include units not in TO&E");
@@ -208,7 +209,7 @@ class C3NetworkTest {
             units.add(nonC3iUnit);
 
             // Act
-            Vector<String[]> networks = campaign.getAvailableC3iNetworks();
+            Vector<String[]> networks = force.getAvailableC3iNetworks();
 
             // Assert
             assertEquals(0, networks.size(), "Should not include non-C3i units");
@@ -224,7 +225,7 @@ class C3NetworkTest {
             units.add(unit2);
 
             // Act
-            Vector<String[]> networks = campaign.getAvailableC3iNetworks();
+            Vector<String[]> networks = force.getAvailableC3iNetworks();
 
             // Assert - should only return one network entry
             assertEquals(1, networks.size(), "Should return unique networks only");
@@ -243,7 +244,7 @@ class C3NetworkTest {
             units.add(unnetworkedUnit);
 
             // Act
-            Vector<String[]> networks = campaign.getAvailableNC3Networks();
+            Vector<String[]> networks = force.getAvailableNC3Networks();
 
             // Assert
             assertEquals(1, networks.size(), "Should find one available NC3 network");
@@ -258,7 +259,7 @@ class C3NetworkTest {
             units.add(fullUnit);
 
             // Act
-            Vector<String[]> networks = campaign.getAvailableNC3Networks();
+            Vector<String[]> networks = force.getAvailableNC3Networks();
 
             // Assert
             assertEquals(0, networks.size());
@@ -277,7 +278,7 @@ class C3NetworkTest {
             units.add(unnetworkedUnit);
 
             // Act
-            Vector<String[]> networks = campaign.getAvailableNovaCEWSNetworks();
+            Vector<String[]> networks = force.getAvailableNovaCEWSNetworks();
 
             // Assert
             assertEquals(1, networks.size(), "Should find one available Nova CEWS network");
@@ -293,7 +294,7 @@ class C3NetworkTest {
             units.add(partialUnit);
 
             // Act
-            Vector<String[]> networks = campaign.getAvailableNovaCEWSNetworks();
+            Vector<String[]> networks = force.getAvailableNovaCEWSNetworks();
 
             // Assert
             assertEquals(1, networks.size());
@@ -308,7 +309,7 @@ class C3NetworkTest {
             units.add(fullUnit);
 
             // Act
-            Vector<String[]> networks = campaign.getAvailableNovaCEWSNetworks();
+            Vector<String[]> networks = force.getAvailableNovaCEWSNetworks();
 
             // Assert
             assertEquals(0, networks.size(), "Should not include full Nova CEWS networks");
@@ -322,7 +323,7 @@ class C3NetworkTest {
             units.add(unassignedUnit);
 
             // Act
-            Vector<String[]> networks = campaign.getAvailableNovaCEWSNetworks();
+            Vector<String[]> networks = force.getAvailableNovaCEWSNetworks();
 
             // Assert
             assertEquals(0, networks.size(), "Should not include units not in TO&E");
@@ -336,7 +337,7 @@ class C3NetworkTest {
             units.add(nonNovaUnit);
 
             // Act
-            Vector<String[]> networks = campaign.getAvailableNovaCEWSNetworks();
+            Vector<String[]> networks = force.getAvailableNovaCEWSNetworks();
 
             // Assert
             assertEquals(0, networks.size(), "Should not include non-Nova CEWS units");
@@ -350,7 +351,7 @@ class C3NetworkTest {
             units.add(invalidUnit);
 
             // Act
-            Vector<String[]> networks = campaign.getAvailableNovaCEWSNetworks();
+            Vector<String[]> networks = force.getAvailableNovaCEWSNetworks();
 
             // Assert - condition is <= 2, so 3 should be excluded
             assertEquals(0, networks.size(), "Should not include invalid free node counts");

--- a/MekHQ/unittests/mekhq/campaign/CampaignLocationManagerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/CampaignLocationManagerTest.java
@@ -76,8 +76,9 @@ class CampaignLocationManagerTest {
         CampaignLocationManager manager = new CampaignLocationManager();
         Campaign campaign = mock(Campaign.class);
         Unit unit = mock(Unit.class);
+        ILocation destination = mock(ILocation.class);
 
-        manager.queueTravel(List.of(unit), campaign);
+        manager.queueTravel(List.of(unit), destination);
 
         assertTrue(manager.isQueuedForTravel(unit));
     }
@@ -90,8 +91,9 @@ class CampaignLocationManagerTest {
         UUID unitId = UUID.randomUUID();
         when(soldUnit.getId()).thenReturn(unitId);
         when(campaign.getUnit(unitId)).thenReturn(null);
+        ILocation destination = mock(ILocation.class);
 
-        manager.queueTravel(List.of(soldUnit), campaign);
+        manager.queueTravel(List.of(soldUnit), destination);
 
         try (MockedStatic<LocationDispatch> dispatch = mockStatic(LocationDispatch.class)) {
             manager.dispatchPendingTravel(campaign);
@@ -108,12 +110,13 @@ class CampaignLocationManagerTest {
         UUID unitId = UUID.randomUUID();
         when(unit.getId()).thenReturn(unitId);
         when(campaign.getUnit(unitId)).thenReturn(unit);
+        ILocation destination = mock(ILocation.class);
 
-        manager.queueTravel(List.of(unit), campaign);
+        manager.queueTravel(List.of(unit), destination);
 
         try (MockedStatic<LocationDispatch> dispatch = mockStatic(LocationDispatch.class)) {
             manager.dispatchPendingTravel(campaign);
-            dispatch.verify(() -> LocationDispatch.dispatchTravelers(List.of(unit), campaign, campaign));
+            dispatch.verify(() -> LocationDispatch.dispatchTravelers(List.of(unit), destination, campaign));
         }
         assertFalse(manager.isQueuedForTravel(unit));
     }
@@ -178,10 +181,11 @@ class CampaignLocationManagerTest {
         CampaignLocationManager manager = new CampaignLocationManager();
         Campaign campaign = mock(Campaign.class);
         Unit unit = mock(Unit.class);
+        ILocation destination = mock(ILocation.class);
 
         try (MockedStatic<LocationDispatch> dispatch = mockStatic(LocationDispatch.class)) {
-            manager.gmTeleport(campaign, List.of(unit), campaign);
-            dispatch.verify(() -> LocationDispatch.dispatchTravelers(List.of(unit), campaign, campaign));
+            manager.gmTeleport(campaign, List.of(unit), destination);
+            dispatch.verify(() -> LocationDispatch.dispatchTravelers(List.of(unit), destination, campaign));
         }
         verify(campaign).processArrivals(campaign);
     }
@@ -192,12 +196,13 @@ class CampaignLocationManagerTest {
         Campaign campaign = mock(Campaign.class);
         Unit unit = mock(Unit.class);
 
-        // Queue the unit to travel to the campaign (used here as the destination ILocation).
-        manager.queueTravel(List.of(unit), campaign);
+        // Queue the unit to travel to a destination ILocation (the main force, in production).
+        ILocation destination = mock(ILocation.class);
+        manager.queueTravel(List.of(unit), destination);
 
         try (MockedStatic<LocationDispatch> dispatch = mockStatic(LocationDispatch.class)) {
             manager.gmCompleteTravel(campaign, List.of(unit));
-            dispatch.verify(() -> LocationDispatch.dispatchTravelers(List.of(unit), campaign, campaign));
+            dispatch.verify(() -> LocationDispatch.dispatchTravelers(List.of(unit), destination, campaign));
         }
         assertFalse(manager.isQueuedForTravel(unit));
         verify(campaign).processArrivals(campaign);

--- a/MekHQ/unittests/mekhq/campaign/personnel/PersonTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/PersonTest.java
@@ -74,6 +74,8 @@ import mekhq.campaign.Warehouse;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.enums.DailyReportType;
 import mekhq.campaign.events.persons.PersonStatusChangedEvent;
+import mekhq.campaign.force.Detachment;
+import mekhq.campaign.force.PlayerForce;
 import mekhq.campaign.location.AcademyCampusLocation;
 import mekhq.campaign.personnel.education.Academy;
 import mekhq.campaign.personnel.education.EducationController;
@@ -1597,6 +1599,9 @@ public class PersonTest {
             @BeforeEach
             void setUp() {
                 campaign = mock(Campaign.class);
+                PlayerForce playerForce = mock(PlayerForce.class);
+                when(campaign.getPlayerForce()).thenReturn(playerForce);
+                when(playerForce.getForceDetachment()).thenReturn(mock(Detachment.class));
                 when(campaign.getCampaignLocationManager()).thenReturn(mock(CampaignLocationManager.class));
                 when(campaign.getLocalDate()).thenReturn(LocalDate.of(3025, 1, 1));
 
@@ -1678,6 +1683,9 @@ public class PersonTest {
             @BeforeEach
             void setUp() {
                 campaign = mock(Campaign.class);
+                PlayerForce playerForce = mock(PlayerForce.class);
+                when(campaign.getPlayerForce()).thenReturn(playerForce);
+                when(playerForce.getForceDetachment()).thenReturn(mock(Detachment.class));
                 when(campaign.getCampaignLocationManager()).thenReturn(mock(CampaignLocationManager.class));
                 when(campaign.getLocalDate()).thenReturn(LocalDate.of(3025, 1, 1));
 

--- a/MekHQ/unittests/mekhq/campaign/personnel/education/EducationControllerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/education/EducationControllerTest.java
@@ -54,6 +54,8 @@ import mekhq.campaign.Hangar;
 import mekhq.campaign.JumpPath;
 import mekhq.campaign.Warehouse;
 import mekhq.campaign.campaignOptions.CampaignOptions;
+import mekhq.campaign.force.Detachment;
+import mekhq.campaign.force.PlayerForce;
 import mekhq.campaign.location.AcademyCampusLocation;
 import mekhq.campaign.location.LocationUtils;
 import mekhq.campaign.personnel.Person;
@@ -115,6 +117,10 @@ class EducationControllerTest {
 
         when(campaign.getCampaignLocationManager()).thenReturn(mock(CampaignLocationManager.class));
 
+        PlayerForce playerForce = mock(PlayerForce.class);
+        when(campaign.getPlayerForce()).thenReturn(playerForce);
+        when(playerForce.getForceDetachment()).thenReturn(mock(Detachment.class));
+
         return campaign;
     }
 
@@ -139,6 +145,9 @@ class EducationControllerTest {
             person.setEduAcademySystem("TestSystem");
             person.setEduEducationStage(EducationStage.JOURNEY_TO_CAMPUS);
             campaign = mock(Campaign.class);
+            PlayerForce playerForce = mock(PlayerForce.class);
+            when(campaign.getPlayerForce()).thenReturn(playerForce);
+            when(playerForce.getForceDetachment()).thenReturn(mock(Detachment.class));
             when(campaign.getCampaignLocationManager()).thenReturn(mock(CampaignLocationManager.class));
             PlanetarySystem destSystem = mock(PlanetarySystem.class);
             when(campaign.getSystemById("TestSystem")).thenReturn(destSystem);
@@ -235,6 +244,9 @@ class EducationControllerTest {
 
             destSystem = mock(PlanetarySystem.class);
             campaign = mock(Campaign.class);
+            PlayerForce playerForce = mock(PlayerForce.class);
+            when(campaign.getPlayerForce()).thenReturn(playerForce);
+            when(playerForce.getForceDetachment()).thenReturn(mock(Detachment.class));
             when(campaign.getCampaignLocationManager()).thenReturn(mock(CampaignLocationManager.class));
             when(campaign.getSystemById("TestSystem")).thenReturn(destSystem);
             when(campaign.getSimplifiedTravelTime(destSystem)).thenReturn(5);


### PR DESCRIPTION
`Campaign` is a very large class - dare I say “bloated”. This PR begins the process of extracting a player’s forces’s specific information into its own dedicated class that `Campaign` can delegate to.  - `AbstractForce` and `PlayerForce`: “Player” specific information - list of all personnel, finances, faction, etc.   - Currently `PlayerForce` uses an interface `SingleDetachmentForce` to hold the intentionally stunted logic that only works if a force is on an active contract non a single spot, like `getWarehouse()` (there will be multiple for a force, so this method won’t work eventually!) - `Detachment` - Implements `IPlace` - The `Hangar`, `Personnel`, and `Warehouse` live under this node.  

Once this is merged, I can begin deprecating the passthrough methods in `Campaign` - I intend to go through the methods that pass through from `Campaign` to `AbstractForce`/`PlayerForce` and `Detachment`, mark them deprecated, and replace the usages of `campaign.foo()` with `campaign.getPlayerForce().foo()` / `campaign.getPlayerForce().getForceDetachment().foo()`. Then I can mark the deprecated methods as forRemoval, and we can formally remove them in a few versions.