### PR TITLE
Fix intermittent crash when opening Campaign Options in a new campaign

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -373,8 +373,18 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
                     Thread.currentThread().interrupt();
                     return null;
                 } catch (InvocationTargetException exception) {
+                    // Let a genuine UI-construction failure propagate through the worker so done() reports it via its
+                    // ExecutionException handling, rather than returning null (which looks like a normal cancel and
+                    // silently hides the error). The Runnable can only fail with an unchecked throwable, so unwrap the
+                    // cause to keep done()'s per-type error dialogs working.
                     LOGGER.error("Failed to display the Campaign Options dialog", exception);
-                    return null;
+                    if (exception.getCause() instanceof RuntimeException runtimeException) {
+                        throw runtimeException;
+                    }
+                    if (exception.getCause() instanceof Error error) {
+                        throw error;
+                    }
+                    throw exception;
                 }
                 if (optionsCanceled[0]) {
                     return null;

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -363,24 +363,12 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
                 campaign.getGameOptions().getOption(OptionsConstants.ALLOWED_YEAR).setValue(campaign.getGameYear());
 
                 CampaignOptionsDialogMode mode = isSelect ? STARTUP_ABRIDGED : STARTUP;
-                // The Campaign Options dialog and its entire component tree must be built and shown on the EDT.
-                // doInBackground() runs on a SwingWorker worker thread, so constructing the dialog here touched Swing
-                // off the EDT and intermittently crashed (e.g. RankSystemsPane rebuilt its shared table columns on this
-                // worker thread while a deferred EDT task read them). invokeAndWait builds and shows the modal dialog on
-                // the EDT and blocks this worker thread until the user closes it, preserving the original sequencing.
+                // This method runs in a worker thread, but the construction of the UI for Campaign Options must run on
+                // the EDT, so dispatch it there using invokeAndWait.
                 final boolean[] optionsCanceled = { false };
                 try {
-                    SwingUtilities.invokeAndWait(() -> {
-                        CampaignOptionsDialog optionsDialog = new CampaignOptionsDialog(getFrame(), campaign, preset,
-                              mode);
-                        setVisible(false); // cede visibility to `optionsDialog`
-                        optionsDialog.setVisible(true);
-                        if (optionsDialog.wasCanceled()) {
-                            optionsCanceled[0] = true;
-                        } else {
-                            setVisible(true); // restore loader visibility
-                        }
-                    });
+                    SwingUtilities.invokeAndWait(
+                          () -> optionsCanceled[0] = showStartupCampaignOptionsDialog(campaign, preset, mode));
                 } catch (InterruptedException exception) {
                     Thread.currentThread().interrupt();
                     return null;
@@ -525,6 +513,31 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
          */
         private static void handleCampaignUpgrading(MekHQ app, Campaign campaign) {
             CampaignUpgradeDialog.campaignUpgradeDialog(app, campaign);
+        }
+
+        /**
+         * Builds and shows the modal Campaign Options dialog for a brand-new campaign, then reports whether the user
+         * canceled it.
+         *
+         * <p>Must run on the Event Dispatch Thread (it is invoked through {@link SwingUtilities#invokeAndWait} from the
+         * worker thread) because it constructs the dialog's entire Swing component tree.</p>
+         *
+         * @param campaign the new campaign being configured
+         * @param preset   the preset to seed the dialog with, or {@code null}
+         * @param mode     the dialog mode (abridged or full startup)
+         *
+         * @return {@code true} if the user canceled the dialog; {@code false} if the settings were applied
+         */
+        private boolean showStartupCampaignOptionsDialog(final Campaign campaign, final @Nullable CampaignPreset preset,
+              final CampaignOptionsDialogMode mode) {
+            final CampaignOptionsDialog optionsDialog = new CampaignOptionsDialog(getFrame(), campaign, preset, mode);
+            setVisible(false); // cede visibility to `optionsDialog`
+            optionsDialog.setVisible(true);
+            if (optionsDialog.wasCanceled()) {
+                return true;
+            }
+            setVisible(true); // restore loader visibility
+            return false;
         }
 
         /**

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -44,6 +44,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.FileInputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -56,6 +57,7 @@ import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import javax.swing.JProgressBar;
+import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
 
 import megamek.Version;
@@ -361,13 +363,33 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
                 campaign.getGameOptions().getOption(OptionsConstants.ALLOWED_YEAR).setValue(campaign.getGameYear());
 
                 CampaignOptionsDialogMode mode = isSelect ? STARTUP_ABRIDGED : STARTUP;
-                CampaignOptionsDialog optionsDialog = new CampaignOptionsDialog(getFrame(), campaign, preset, mode);
-                setVisible(false); // cede visibility to `optionsDialog`
-                optionsDialog.setVisible(true);
-                if (optionsDialog.wasCanceled()) {
+                // The Campaign Options dialog and its entire component tree must be built and shown on the EDT.
+                // doInBackground() runs on a SwingWorker worker thread, so constructing the dialog here touched Swing
+                // off the EDT and intermittently crashed (e.g. RankSystemsPane rebuilt its shared table columns on this
+                // worker thread while a deferred EDT task read them). invokeAndWait builds and shows the modal dialog on
+                // the EDT and blocks this worker thread until the user closes it, preserving the original sequencing.
+                final boolean[] optionsCanceled = { false };
+                try {
+                    SwingUtilities.invokeAndWait(() -> {
+                        CampaignOptionsDialog optionsDialog = new CampaignOptionsDialog(getFrame(), campaign, preset,
+                              mode);
+                        setVisible(false); // cede visibility to `optionsDialog`
+                        optionsDialog.setVisible(true);
+                        if (optionsDialog.wasCanceled()) {
+                            optionsCanceled[0] = true;
+                        } else {
+                            setVisible(true); // restore loader visibility
+                        }
+                    });
+                } catch (InterruptedException exception) {
+                    Thread.currentThread().interrupt();
                     return null;
-                } else {
-                    setVisible(true); // restore loader visibility
+                } catch (InvocationTargetException exception) {
+                    LOGGER.error("Failed to display the Campaign Options dialog", exception);
+                    return null;
+                }
+                if (optionsCanceled[0]) {
+                    return null;
                 }
 
                 // Starting planet: the campaign options General page resolves and sets the starting system during


### PR DESCRIPTION
## Summary
New-campaign startup built and showed the Campaign Options dialog from `DataLoadingDialog.doInBackground()`, a SwingWorker worker thread. Building the dialog's Swing tree off the EDT let `RankSystemsPane` rebuild its shared table
columns on the worker thread while a deferred EDT task read them, intermittently throwing `ArrayIndexOutOfBoundsException: 0 >= 0`.

## Fix
- Build and show the dialog on the EDT via `SwingUtilities.invokeAndWait`. The worker thread blocks until the modal dialog closes, preserving the original sequencing and cancel behavior.