### PR TITLE
PR: Rename classes to reflect if it is for `Campaign`, `Force`, or is location specific

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -125,11 +125,11 @@ import mekhq.MHQConstants;
 import mekhq.MHQOptions;
 import mekhq.MekHQ;
 import mekhq.Utilities;
-import mekhq.campaign.Quartermaster.PartAcquisitionResult;
+import mekhq.campaign.ForceQuartermaster.PartAcquisitionResult;
 import mekhq.campaign.againstTheBot.AtBConfiguration;
 import mekhq.campaign.base.PlayerBase;
+import mekhq.campaign.camOpsReputation.ForceReputationController;
 import mekhq.campaign.camOpsReputation.IUnitRating;
-import mekhq.campaign.camOpsReputation.ReputationController;
 import mekhq.campaign.campaignOptions.AcquisitionsType;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.campaignOptions.CampaignOptionsMarshaller;
@@ -165,10 +165,10 @@ import mekhq.campaign.location.LocationUtils;
 import mekhq.campaign.log.HistoricalLogEntry;
 import mekhq.campaign.log.LogEntry;
 import mekhq.campaign.log.ServiceLogger;
+import mekhq.campaign.market.ForceShoppingList;
 import mekhq.campaign.market.PartsStore;
 import mekhq.campaign.market.PersonnelMarket;
 import mekhq.campaign.market.RequestedStockLevels;
-import mekhq.campaign.market.ShoppingList;
 import mekhq.campaign.market.contractMarket.AbstractContractMarket;
 import mekhq.campaign.market.personnelMarket.markets.NewPersonnelMarket;
 import mekhq.campaign.market.unitMarket.AbstractUnitMarket;
@@ -288,7 +288,7 @@ public class Campaign implements ITechManager {
     private final PlayerForce playerForce;
     // TODO (campaign split): Quartermaster holds a Campaign back-reference. Remove that coupling so it can
     //   move onto the force (AbstractForce/PlayerForce) alongside the other owned state.
-    private final Quartermaster quartermaster;
+    private final ForceQuartermaster quartermaster;
     CampaignTransporterMap tacticalTransporters = new CampaignTransporterMap(this,
           CampaignTransportType.TACTICAL_TRANSPORT);
     CampaignTransporterMap towTransporters = new CampaignTransporterMap(this, CampaignTransportType.TOW_TRANSPORT);
@@ -481,7 +481,7 @@ public class Campaign implements ITechManager {
           PartsStore partsStore, NewPersonnelMarket newPersonnelMarket,
           RandomDeath randomDeath, CampaignSummary campaignSummary,
           Faction faction, megamek.common.enums.Faction techFaction, CurrencyManager currencyManager,
-          Systems systemsInstance, AbstractLocation startLocation, ReputationController reputationController,
+          Systems systemsInstance, AbstractLocation startLocation, ForceReputationController reputationController,
           FactionStandings factionStandings, RankSystem rankSystem, Formation formation, Finances finances,
           RandomEventLibraries randomEvents, FactionStandingUltimatumsLibrary ultimatums,
           RetirementDefectionTracker retDefTracker, IAutosaveService autosave,
@@ -524,7 +524,7 @@ public class Campaign implements ITechManager {
         this.campaignSummary = campaignSummary;
 
         // Members that take `this` as an argument
-        this.quartermaster = new Quartermaster(this);
+        this.quartermaster = new ForceQuartermaster(this);
 
         // Primary init, sets state from passed values
         setFaction(faction);
@@ -607,7 +607,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * Returns the campaign's resource bundle (for use by extracted subsystems such as {@link HumanResources}).
+     * Returns the campaign's resource bundle (for use by extracted subsystems such as {@link ForceHumanResources}).
      *
      * @return the campaign {@link ResourceBundle}
      */
@@ -616,26 +616,26 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * Returns the {@link HumanResources} subsystem for this campaign.
+     * Returns the {@link ForceHumanResources} subsystem for this campaign.
      *
      * @return the human resources subsystem
      *
      * @deprecated Use {@link PlayerForce#getHumanResources()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
-    public HumanResources getHumanResources() {
+    public ForceHumanResources getHumanResources() {
         return getPlayerForce().getHumanResources();
     }
 
     /**
-     * Replaces the {@link HumanResources} subsystem, used when loading from XML.
+     * Replaces the {@link ForceHumanResources} subsystem, used when loading from XML.
      *
      * @param humanResources the new human resources subsystem
      *
-     * @deprecated Use {@link PlayerForce#setHumanResources(HumanResources)} directly.
+     * @deprecated Use {@link PlayerForce#setHumanResources(ForceHumanResources)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
-    public void setHumanResources(HumanResources humanResources) {
+    public void setHumanResources(ForceHumanResources humanResources) {
         getPlayerForce().setHumanResources(humanResources);
     }
 
@@ -956,22 +956,22 @@ public class Campaign implements ITechManager {
      * @deprecated Use {@link PlayerForce#getShoppingList()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
-    public ShoppingList getShoppingList() {
+    public ForceShoppingList getShoppingList() {
         return getPlayerForce().getShoppingList();
     }
 
     /**
-     * @deprecated Use {@link PlayerForce#setShoppingList(ShoppingList)} directly.
+     * @deprecated Use {@link PlayerForce#setShoppingList(ForceShoppingList)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
-    public void setShoppingList(ShoppingList sl) {
+    public void setShoppingList(ForceShoppingList sl) {
         getPlayerForce().setShoppingList(sl);
     }
 
     // region Markets
 
     /**
-     * @deprecated Use {@link HumanResources#getPersonnelMarket()} directly.
+     * @deprecated Use {@link ForceHumanResources#getPersonnelMarket()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public PersonnelMarket getPersonnelMarket() {
@@ -979,7 +979,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#setPersonnelMarket(PersonnelMarket)} directly.
+     * @deprecated Use {@link ForceHumanResources#setPersonnelMarket(PersonnelMarket)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void setPersonnelMarket(final PersonnelMarket personnelMarket) {
@@ -1003,7 +1003,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#getNewPersonnelMarket()} directly.
+     * @deprecated Use {@link ForceHumanResources#getNewPersonnelMarket()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public NewPersonnelMarket getNewPersonnelMarket() {
@@ -1031,7 +1031,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#getDivorce()} directly.
+     * @deprecated Use {@link ForceHumanResources#getDivorce()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public AbstractDivorce getDivorce() {
@@ -1039,7 +1039,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#setDivorce(AbstractDivorce)} directly.
+     * @deprecated Use {@link ForceHumanResources#setDivorce(AbstractDivorce)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void setDivorce(final AbstractDivorce divorce) {
@@ -1047,7 +1047,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#getMarriage()} directly.
+     * @deprecated Use {@link ForceHumanResources#getMarriage()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public AbstractMarriage getMarriage() {
@@ -1055,7 +1055,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#setMarriage(AbstractMarriage)} directly.
+     * @deprecated Use {@link ForceHumanResources#setMarriage(AbstractMarriage)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void setMarriage(final AbstractMarriage marriage) {
@@ -1063,7 +1063,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#getProcreation()} directly.
+     * @deprecated Use {@link ForceHumanResources#getProcreation()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public AbstractProcreation getProcreation() {
@@ -1071,7 +1071,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#setProcreation(AbstractProcreation)} directly.
+     * @deprecated Use {@link ForceHumanResources#setProcreation(AbstractProcreation)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void setProcreation(final AbstractProcreation procreation) {
@@ -1080,7 +1080,7 @@ public class Campaign implements ITechManager {
     // endregion Personnel Modules
 
     /**
-     * @deprecated Use {@link HumanResources#getRetirementDefectionTracker()} directly.
+     * @deprecated Use {@link ForceHumanResources#getRetirementDefectionTracker()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public RetirementDefectionTracker getRetirementDefectionTracker() {
@@ -1088,7 +1088,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#setRetirementDefectionTracker(RetirementDefectionTracker)} directly.
+     * @deprecated Use {@link ForceHumanResources#setRetirementDefectionTracker(RetirementDefectionTracker)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void setRetirementDefectionTracker(RetirementDefectionTracker rdt) {
@@ -1100,7 +1100,7 @@ public class Campaign implements ITechManager {
      *
      * @return a {@link List} of {@link Person} objects representing personnel who have gained XP.
      *
-     * @deprecated Use {@link HumanResources#getPersonnelWhoAdvancedInXP()} directly.
+     * @deprecated Use {@link ForceHumanResources#getPersonnelWhoAdvancedInXP()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public List<Person> getPersonnelWhoAdvancedInXP() {
@@ -1113,7 +1113,7 @@ public class Campaign implements ITechManager {
      * @param personnelWhoAdvancedInXP a {@link List} of {@link Person} objects representing personnel who have gained
      *                                 XP.
      *
-     * @deprecated Use {@link HumanResources#setPersonnelWhoAdvancedInXP(List)} directly.
+     * @deprecated Use {@link ForceHumanResources#setPersonnelWhoAdvancedInXP(List)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void setPersonnelWhoAdvancedInXP(List<Person> personnelWhoAdvancedInXP) {
@@ -1704,7 +1704,7 @@ public class Campaign implements ITechManager {
      * @deprecated Use {@link PlayerForce#getPersonnel()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
-    public Personnel getMainForcePersonnel() {
+    public LocalPersonnel getMainForcePersonnel() {
         return getPlayerForce().getPersonnel();
     }
 
@@ -1773,7 +1773,7 @@ public class Campaign implements ITechManager {
                                           .filter(unit -> !getCampaignLocationManager().isQueuedForTravel(unit))
                                           .toList();
         return new TransportCostCalculations(travelingUnits,
-              Warehouse.getSpareParts(getParts()),
+              LocalWarehouse.getSpareParts(getParts()),
               getPersonnelFilteringOutDepartedAndAbsent(),
               crewExperienceLevel);
     }
@@ -2013,7 +2013,7 @@ public class Campaign implements ITechManager {
      * @deprecated Use {@link PlayerForce#getHangar()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
-    public Hangar getHangar() {
+    public LocalHangar getHangar() {
         return getPlayerForce().getHangar();
     }
 
@@ -2024,7 +2024,7 @@ public class Campaign implements ITechManager {
      * @deprecated Use {@link PlayerForce#getHangar()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
-    public Hangar getAllHangar() {
+    public LocalHangar getAllHangar() {
         return getPlayerForce().getHangar();
     }
 
@@ -2095,7 +2095,7 @@ public class Campaign implements ITechManager {
      *
      * @return Return a {@link Person} object representing the new dependent.
      *
-     * @deprecated Use {@link HumanResources#newDependent(Campaign, Gender)} directly.
+     * @deprecated Use {@link ForceHumanResources#newDependent(Campaign, Gender)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public Person newDependent(Gender gender) {
@@ -2111,7 +2111,7 @@ public class Campaign implements ITechManager {
      *
      * @return Return a {@link Person} object representing the new dependent.
      *
-     * @deprecated Use {@link HumanResources#newDependent(Campaign, Gender, Faction, Planet)} directly.
+     * @deprecated Use {@link ForceHumanResources#newDependent(Campaign, Gender, Faction, Planet)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public Person newDependent(Gender gender, @Nullable Faction originFaction, @Nullable Planet originPlanet) {
@@ -2126,7 +2126,7 @@ public class Campaign implements ITechManager {
      *
      * @return A new {@link Person}.
      *
-     * @deprecated Use {@link HumanResources#newPerson(Campaign, PersonnelRole)} directly.
+     * @deprecated Use {@link ForceHumanResources#newPerson(Campaign, PersonnelRole)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public Person newPerson(final PersonnelRole role) {
@@ -2142,7 +2142,7 @@ public class Campaign implements ITechManager {
      *
      * @return A new {@link Person}.
      *
-     * @deprecated Use {@link HumanResources#newPerson(Campaign, PersonnelRole, PersonnelRole)} directly.
+     * @deprecated Use {@link ForceHumanResources#newPerson(Campaign, PersonnelRole, PersonnelRole)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public Person newPerson(final PersonnelRole primaryRole, final PersonnelRole secondaryRole) {
@@ -2159,7 +2159,7 @@ public class Campaign implements ITechManager {
      *
      * @return A new {@link Person}.
      *
-     * @deprecated Use {@link HumanResources#newPerson(Campaign, PersonnelRole, String, Gender)} directly.
+     * @deprecated Use {@link ForceHumanResources#newPerson(Campaign, PersonnelRole, String, Gender)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public Person newPerson(final PersonnelRole primaryRole, final String factionCode, final Gender gender) {
@@ -2178,7 +2178,7 @@ public class Campaign implements ITechManager {
      *
      * @return A new {@link Person}.
      *
-     * @deprecated Use {@link HumanResources#newPerson(Campaign, PersonnelRole, PersonnelRole, AbstractFactionSelector, AbstractPlanetSelector, Gender)} directly.
+     * @deprecated Use {@link ForceHumanResources#newPerson(Campaign, PersonnelRole, PersonnelRole, AbstractFactionSelector, AbstractPlanetSelector, Gender)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public Person newPerson(final PersonnelRole primaryRole, final PersonnelRole secondaryRole,
@@ -2196,7 +2196,7 @@ public class Campaign implements ITechManager {
      *
      * @return A new {@link Person} configured using {@code personnelGenerator}.
      *
-     * @deprecated Use {@link HumanResources#newPerson(Campaign, PersonnelRole, AbstractPersonnelGenerator)} directly.
+     * @deprecated Use {@link ForceHumanResources#newPerson(Campaign, PersonnelRole, AbstractPersonnelGenerator)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public Person newPerson(final PersonnelRole primaryRole, final AbstractPersonnelGenerator personnelGenerator) {
@@ -2213,7 +2213,7 @@ public class Campaign implements ITechManager {
      *
      * @return A new {@link Person} configured using {@code personnelGenerator}.
      *
-     * @deprecated Use {@link HumanResources#newPerson(Campaign, PersonnelRole, PersonnelRole, AbstractPersonnelGenerator, Gender)} directly.
+     * @deprecated Use {@link ForceHumanResources#newPerson(Campaign, PersonnelRole, PersonnelRole, AbstractPersonnelGenerator, Gender)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public Person newPerson(final PersonnelRole primaryRole, final PersonnelRole secondaryRole,
@@ -2311,7 +2311,7 @@ public class Campaign implements ITechManager {
      * @see #recruitPerson(Person, PrisonerStatus, boolean, boolean, boolean, boolean)
      * @see #importPerson(Person)
      *
-     * @deprecated Use {@link HumanResources#recruitPerson(Campaign, Person)} directly.
+     * @deprecated Use {@link ForceHumanResources#recruitPerson(Campaign, Person)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public boolean recruitPerson(Person person) {
@@ -2346,7 +2346,7 @@ public class Campaign implements ITechManager {
      * @see #recruitPerson(Person, PrisonerStatus, boolean, boolean, boolean, boolean)
      * @see #importPerson(Person)
      *
-     * @deprecated Use {@link HumanResources#recruitPerson(Campaign, Person, boolean, boolean)} directly.
+     * @deprecated Use {@link ForceHumanResources#recruitPerson(Campaign, Person, boolean, boolean)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public boolean recruitPerson(Person person, boolean gmAdd, boolean employ) {
@@ -2380,7 +2380,7 @@ public class Campaign implements ITechManager {
      * @see #recruitPerson(Person, PrisonerStatus, boolean, boolean, boolean, boolean)
      * @see #importPerson(Person)
      *
-     * @deprecated Use {@link HumanResources#recruitPerson(Campaign, Person, PrisonerStatus, boolean)} directly.
+     * @deprecated Use {@link ForceHumanResources#recruitPerson(Campaign, Person, PrisonerStatus, boolean)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public boolean recruitPerson(Person person, PrisonerStatus prisonerStatus, boolean employ) {
@@ -2409,7 +2409,7 @@ public class Campaign implements ITechManager {
      * @see #importPerson(Person)
      * @since 0.50.07
      *
-     * @deprecated Use {@link HumanResources#recruitPerson(Campaign, Person, PrisonerStatus, boolean, boolean, boolean)} directly.
+     * @deprecated Use {@link ForceHumanResources#recruitPerson(Campaign, Person, PrisonerStatus, boolean, boolean, boolean)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public boolean recruitPerson(Person person, PrisonerStatus prisonerStatus, boolean gmAdd, boolean log,
@@ -2445,7 +2445,7 @@ public class Campaign implements ITechManager {
      *
      * @see #importPerson(Person)
      *
-     * @deprecated Use {@link HumanResources#recruitPerson(Campaign, Person, PrisonerStatus, boolean, boolean, boolean, boolean)} directly.
+     * @deprecated Use {@link ForceHumanResources#recruitPerson(Campaign, Person, PrisonerStatus, boolean, boolean, boolean, boolean)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public boolean recruitPerson(Person person, PrisonerStatus prisonerStatus, boolean gmAdd, boolean log,
@@ -2459,7 +2459,7 @@ public class Campaign implements ITechManager {
      *
      * @param person the {@code Person} being employed; may be {@code null}
      *
-     * @deprecated Use {@link HumanResources#employCampFollower(Campaign, Person)} directly.
+     * @deprecated Use {@link ForceHumanResources#employCampFollower(Campaign, Person)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void employCampFollower(Person person) {
@@ -2477,7 +2477,7 @@ public class Campaign implements ITechManager {
      * @param person     The Bloodname candidate
      * @param ignoreDice If true, skips the random roll and assigns a Bloodname automatically
      *
-     * @deprecated Use {@link HumanResources#checkBloodnameAdd(Campaign, Person, boolean)} directly.
+     * @deprecated Use {@link ForceHumanResources#checkBloodnameAdd(Campaign, Person, boolean)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void checkBloodnameAdd(Person person, boolean ignoreDice) {
@@ -2505,7 +2505,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#getPerson(UUID)} directly.
+     * @deprecated Use {@link ForceHumanResources#getPerson(UUID)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public @Nullable Person getPerson(final UUID id) {
@@ -2516,14 +2516,14 @@ public class Campaign implements ITechManager {
      * @deprecated Use {@link PlayerForce#getPersonnel()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
-    public Personnel getPersonnel() {
+    public LocalPersonnel getPersonnel() {
         return getPlayerForce().getPersonnel();
     }
 
     /**
      * @return all personnel across all locations associated with this campaign.
      *
-     * @deprecated Use {@link HumanResources#getPersonnel()} directly.
+     * @deprecated Use {@link ForceHumanResources#getPersonnel()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public Collection<Person> getAllPersonnel() {
@@ -2535,7 +2535,7 @@ public class Campaign implements ITechManager {
      *
      * @return a {@code List} of {@link Person} objects who have not left the unit
      *
-     * @deprecated Use {@link HumanResources#getPersonnelFilteringOutDeparted()} directly.
+     * @deprecated Use {@link ForceHumanResources#getPersonnelFilteringOutDeparted()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public List<Person> getPersonnelFilteringOutDeparted() {
@@ -2548,7 +2548,7 @@ public class Campaign implements ITechManager {
      *
      * @return a {@code List} of {@link Person} objects who have not left the unit
      *
-     * @deprecated Use {@link HumanResources#getPersonnelFilteringOutDepartedAndAbsent()} directly.
+     * @deprecated Use {@link ForceHumanResources#getPersonnelFilteringOutDepartedAndAbsent()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public List<Person> getPersonnelFilteringOutDepartedAndAbsent() {
@@ -2571,7 +2571,7 @@ public class Campaign implements ITechManager {
      *
      * @return a {@link List} of {@link Person} objects matching the criteria
      *
-     * @deprecated Use {@link HumanResources#getActivePersonnel(boolean, boolean)} directly.
+     * @deprecated Use {@link ForceHumanResources#getActivePersonnel(boolean, boolean)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public List<Person> getActivePersonnel(boolean includePrisoners, boolean includeCampFollowers) {
@@ -2581,7 +2581,7 @@ public class Campaign implements ITechManager {
     /**
      * Clears the {@code activePersonnelCache} so it's recalculated next time we getActivePersonnel
      *
-     * @deprecated Use {@link HumanResources#invalidateActivePersonnelCache()} directly.
+     * @deprecated Use {@link ForceHumanResources#invalidateActivePersonnelCache()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void invalidateActivePersonnelCache() {
@@ -2594,7 +2594,7 @@ public class Campaign implements ITechManager {
      * @author Illiani
      * @since 0.50.06
      *
-     * @deprecated Use {@link HumanResources#getSalaryEligiblePersonnel()} directly.
+     * @deprecated Use {@link ForceHumanResources#getSalaryEligiblePersonnel()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public List<Person> getSalaryEligiblePersonnel() {
@@ -2608,7 +2608,7 @@ public class Campaign implements ITechManager {
      */
     @Deprecated(since = "0.51.0", forRemoval = true)
     public List<Person> getActiveCombatPersonnel() {
-        return HumanResources.getActiveCombatPersonnel(getHumanResources().getActivePersonnel(false, false));
+        return ForceHumanResources.getActiveCombatPersonnel(getHumanResources().getActivePersonnel(false, false));
     }
 
     /**
@@ -2616,7 +2616,7 @@ public class Campaign implements ITechManager {
      *
      * @return a {@link Person} <code>List</code> containing all active personnel
      *
-     * @deprecated Use {@link HumanResources#getActiveDependents()} directly.
+     * @deprecated Use {@link ForceHumanResources#getActiveDependents()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public List<Person> getActiveDependents() {
@@ -2628,7 +2628,7 @@ public class Campaign implements ITechManager {
      *
      * @return a {@link Person} <code>List</code> containing all active personnel
      *
-     * @deprecated Use {@link HumanResources#getCurrentPrisoners()} directly.
+     * @deprecated Use {@link ForceHumanResources#getCurrentPrisoners()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public List<Person> getCurrentPrisoners() {
@@ -2640,7 +2640,7 @@ public class Campaign implements ITechManager {
      *
      * @return a {@link Person} <code>List</code> containing all active personnel
      *
-     * @deprecated Use {@link HumanResources#getPrisonerDefectors()} directly.
+     * @deprecated Use {@link ForceHumanResources#getPrisonerDefectors()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public List<Person> getPrisonerDefectors() {
@@ -2652,7 +2652,7 @@ public class Campaign implements ITechManager {
      *
      * @return a {@link Person} <code>List</code> containing all active personnel
      *
-     * @deprecated Use {@link HumanResources#getFriendlyPrisoners()} directly.
+     * @deprecated Use {@link ForceHumanResources#getFriendlyPrisoners()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public List<Person> getFriendlyPrisoners() {
@@ -2664,7 +2664,7 @@ public class Campaign implements ITechManager {
      *
      * @return a {@link Person} <code>List</code> containing all active personnel
      *
-     * @deprecated Use {@link HumanResources#getStudents()} directly.
+     * @deprecated Use {@link ForceHumanResources#getStudents()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public List<Person> getStudents() {
@@ -2679,7 +2679,7 @@ public class Campaign implements ITechManager {
      *
      * @return An {@link AbstractFactionSelector} to use when selecting a {@link Faction}.
      *
-     * @deprecated Use {@link HumanResources#getFactionSelector(CampaignOptions)} directly.
+     * @deprecated Use {@link ForceHumanResources#getFactionSelector(CampaignOptions)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public AbstractFactionSelector getFactionSelector() {
@@ -2693,7 +2693,7 @@ public class Campaign implements ITechManager {
      *
      * @return An {@link AbstractFactionSelector} to use when selecting a {@link Faction}.
      *
-     * @deprecated Use {@link HumanResources#getFactionSelector(RandomOriginOptions)} directly.
+     * @deprecated Use {@link ForceHumanResources#getFactionSelector(RandomOriginOptions)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public AbstractFactionSelector getFactionSelector(final RandomOriginOptions options) {
@@ -2705,7 +2705,7 @@ public class Campaign implements ITechManager {
      *
      * @return An {@link AbstractPlanetSelector} to use when selecting a {@link Planet}.
      *
-     * @deprecated Use {@link HumanResources#getPlanetSelector(CampaignOptions)} directly.
+     * @deprecated Use {@link ForceHumanResources#getPlanetSelector(CampaignOptions)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public AbstractPlanetSelector getPlanetSelector() {
@@ -2719,7 +2719,7 @@ public class Campaign implements ITechManager {
      *
      * @return An {@link AbstractPlanetSelector} to use when selecting a {@link Planet}.
      *
-     * @deprecated Use {@link HumanResources#getPlanetSelector(RandomOriginOptions)} directly.
+     * @deprecated Use {@link ForceHumanResources#getPlanetSelector(RandomOriginOptions)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public AbstractPlanetSelector getPlanetSelector(final RandomOriginOptions options) {
@@ -2734,7 +2734,7 @@ public class Campaign implements ITechManager {
      *
      * @return An {@link AbstractPersonnelGenerator} to use when creating new personnel.
      *
-     * @deprecated Use {@link HumanResources#getPersonnelGenerator(CampaignOptions, AbstractFactionSelector, AbstractPlanetSelector)} directly.
+     * @deprecated Use {@link ForceHumanResources#getPersonnelGenerator(CampaignOptions, AbstractFactionSelector, AbstractPlanetSelector)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public AbstractPersonnelGenerator getPersonnelGenerator(final AbstractFactionSelector factionSelector,
@@ -2746,7 +2746,7 @@ public class Campaign implements ITechManager {
     // endregion Personnel
 
     /**
-     * @deprecated Use {@link HumanResources#getPatients()} directly.
+     * @deprecated Use {@link ForceHumanResources#getPatients()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public List<Person> getPatients() {
@@ -2754,7 +2754,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#getPatientsAssignedToDoctors()} directly.
+     * @deprecated Use {@link ForceHumanResources#getPatientsAssignedToDoctors()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public List<Person> getPatientsAssignedToDoctors() {
@@ -2762,7 +2762,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#getPatientsWithNonPermanentInjuries()} directly.
+     * @deprecated Use {@link ForceHumanResources#getPatientsWithNonPermanentInjuries()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public List<Person> getPatientsWithNonPermanentInjuries() {
@@ -2811,7 +2811,7 @@ public class Campaign implements ITechManager {
      * @deprecated Use {@link PlayerForce#getWarehouse()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
-    public Warehouse getWarehouse() {
+    public LocalWarehouse getWarehouse() {
         return getPlayerForce().getWarehouse();
     }
 
@@ -2820,10 +2820,10 @@ public class Campaign implements ITechManager {
      *
      * @param warehouse The warehouse in which to store parts.
      *
-     * @deprecated Use {@link PlayerForce#setWarehouse(Warehouse)} directly.
+     * @deprecated Use {@link PlayerForce#setWarehouse(LocalWarehouse)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
-    public void setWarehouse(Warehouse warehouse) {
+    public void setWarehouse(LocalWarehouse warehouse) {
         getPlayerForce().setWarehouse(warehouse);
     }
 
@@ -2833,12 +2833,12 @@ public class Campaign implements ITechManager {
      * @deprecated Use {@link PlayerForce#getWarehouse()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
-    public Warehouse getAllWarehouse() {
+    public LocalWarehouse getAllWarehouse() {
         //TODO: This won't work once we support multiple warehouse. Method separated from getWarehouse() for future
         return getPlayerForce().getWarehouse();
     }
 
-    public Quartermaster getQuartermaster() {
+    public ForceQuartermaster getQuartermaster() {
         return quartermaster;
     }
 
@@ -3145,7 +3145,7 @@ public class Campaign implements ITechManager {
      *
      * @return The person in the designated role with the most experience.
      *
-     * @deprecated Use {@link HumanResources#findBestInRole(PersonnelRole, String, String, CampaignOptions, boolean, LocalDate)} directly.
+     * @deprecated Use {@link ForceHumanResources#findBestInRole(PersonnelRole, String, String, CampaignOptions, boolean, LocalDate)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public Person findBestInRole(PersonnelRole role, String primary, @Nullable String secondary) {
@@ -3158,7 +3158,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#findBestInRole(PersonnelRole, String, CampaignOptions, boolean, LocalDate)}
+     * @deprecated Use {@link ForceHumanResources#findBestInRole(PersonnelRole, String, CampaignOptions, boolean, LocalDate)}
      *       directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
@@ -3175,7 +3175,7 @@ public class Campaign implements ITechManager {
      * @return the {@link Person} with the highest calculated total skill level in the specified skill, or {@code null}
      *       if no qualifying person is found
      *
-     * @deprecated Use {@link HumanResources#findBestAtSkill(String, CampaignOptions, boolean, LocalDate)} directly.
+     * @deprecated Use {@link ForceHumanResources#findBestAtSkill(String, CampaignOptions, boolean, LocalDate)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public @Nullable Person findBestAtSkill(String skillName) {
@@ -3186,7 +3186,7 @@ public class Campaign implements ITechManager {
     /**
      * @return The list of all active {@link Person}s who qualify as technicians ({@link Person#isTech()});
      *
-     * @deprecated Use {@link HumanResources#getTechs(Collection, CampaignOptions, boolean, LocalDate)} directly.
+     * @deprecated Use {@link ForceHumanResources#getTechs(Collection, CampaignOptions, boolean, LocalDate)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public List<Person> getTechs() {
@@ -3197,7 +3197,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#getTechs(Collection, CampaignOptions, boolean, LocalDate, boolean)}
+     * @deprecated Use {@link ForceHumanResources#getTechs(Collection, CampaignOptions, boolean, LocalDate, boolean)}
      *       directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
@@ -3210,7 +3210,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#getTechsExpanded(Collection, CampaignOptions, boolean, LocalDate)}
+     * @deprecated Use {@link ForceHumanResources#getTechsExpanded(Collection, CampaignOptions, boolean, LocalDate)}
      *       directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
@@ -3223,7 +3223,7 @@ public class Campaign implements ITechManager {
 
     /**
      * @deprecated Use
-     *       {@link HumanResources#getTechs(Collection, CampaignOptions, boolean, LocalDate, boolean, boolean)}
+     *       {@link ForceHumanResources#getTechs(Collection, CampaignOptions, boolean, LocalDate, boolean, boolean)}
      *       directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
@@ -3245,7 +3245,7 @@ public class Campaign implements ITechManager {
      *
      * @return A list of active technicians sorted appropriately.
      *
-     * @deprecated Use {@link HumanResources#getTechsExpanded(Collection, CampaignOptions, boolean, LocalDate, boolean, boolean, boolean)} directly.
+     * @deprecated Use {@link ForceHumanResources#getTechsExpanded(Collection, CampaignOptions, boolean, LocalDate, boolean, boolean, boolean)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public List<Person> getTechsExpanded(final boolean noZeroMinute, final boolean eliteFirst, final boolean expanded) {
@@ -3259,7 +3259,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#getAdmins()} directly.
+     * @deprecated Use {@link ForceHumanResources#getAdmins()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public List<Person> getAdmins() {
@@ -3267,7 +3267,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#isWorkingOnRefit(Hangar, Person)} directly.
+     * @deprecated Use {@link ForceHumanResources#isWorkingOnRefit(LocalHangar, Person)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public boolean isWorkingOnRefit(Person person) {
@@ -3275,7 +3275,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#getDoctors()} directly.
+     * @deprecated Use {@link ForceHumanResources#getDoctors()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public List<Person> getDoctors() {
@@ -3283,7 +3283,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#getPatientsFor(Person)} directly.
+     * @deprecated Use {@link ForceHumanResources#getPatientsFor(Person)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public int getPatientsFor(Person doctor) {
@@ -3313,7 +3313,7 @@ public class Campaign implements ITechManager {
      * @return The {@link Person} representing the best logistics character, or {@code null} if no suitable person is
      *       found.
      *
-     * @deprecated Use {@link HumanResources#getLogisticsPerson(CampaignOptions, boolean, LocalDate)} directly.
+     * @deprecated Use {@link ForceHumanResources#getLogisticsPerson(CampaignOptions, boolean, LocalDate)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public @Nullable Person getLogisticsPerson() {
@@ -3370,7 +3370,7 @@ public class Campaign implements ITechManager {
      *
      * @throws IllegalStateException if {@code type} is null or an unsupported value.
      *
-     * @deprecated Use {@link HumanResources#getSeniorAdminPerson(AdministratorSpecialization, CampaignOptions, boolean, LocalDate)} directly.
+     * @deprecated Use {@link ForceHumanResources#getSeniorAdminPerson(AdministratorSpecialization, CampaignOptions, boolean, LocalDate)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public @Nullable Person getSeniorAdminPerson(AdministratorSpecialization type) {
@@ -3379,7 +3379,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#getSeniorMedicalPerson(CampaignOptions, boolean, LocalDate)} directly.
+     * @deprecated Use {@link ForceHumanResources#getSeniorMedicalPerson(CampaignOptions, boolean, LocalDate)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public @Nullable Person getSeniorMedicalPerson() {
@@ -3388,7 +3388,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#getSeniorTechPerson(CampaignOptions, boolean, LocalDate)} directly.
+     * @deprecated Use {@link ForceHumanResources#getSeniorTechPerson(CampaignOptions, boolean, LocalDate)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public @Nullable Person getSeniorTechPerson() {
@@ -3401,7 +3401,7 @@ public class Campaign implements ITechManager {
      *
      * @return the {@link Person} who is the commander, or {@code null} if there are no suitable candidates.
      *
-     * @deprecated Use {@link HumanResources#getCommander(CampaignOptions, boolean, LocalDate)} directly.
+     * @deprecated Use {@link ForceHumanResources#getCommander(CampaignOptions, boolean, LocalDate)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public @Nullable Person getCommander() {
@@ -3415,7 +3415,7 @@ public class Campaign implements ITechManager {
      * @return the {@link Person} who is considered the second-in-command, or {@code null} if there are no suitable
      *       candidates.
      *
-     * @deprecated Use {@link HumanResources#getSecondInCommand(CampaignOptions, boolean, LocalDate)} directly.
+     * @deprecated Use {@link ForceHumanResources#getSecondInCommand(CampaignOptions, boolean, LocalDate)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public @Nullable Person getSecondInCommand() {
@@ -3452,7 +3452,7 @@ public class Campaign implements ITechManager {
      * @return A {@link List} of {@link Person} objects who are eligible and sorted to perform logistical actions, or an
      *       empty list if acquisitions automatically succeed.
      *
-     * @deprecated Use {@link HumanResources#getLogisticsPersonnel(CampaignOptions, boolean, LocalDate)} directly.
+     * @deprecated Use {@link ForceHumanResources#getLogisticsPersonnel(CampaignOptions, boolean, LocalDate)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public List<Person> getLogisticsPersonnel() {
@@ -3470,7 +3470,7 @@ public class Campaign implements ITechManager {
      * @return A <code>ShoppingList</code> object that includes all items that were
      *         not successfully acquired
      */
-    public ShoppingList goShopping(ShoppingList sList) {
+    public ForceShoppingList goShopping(ForceShoppingList sList) {
         // loop through shopping items and decrement days to wait
         for (IAcquisitionWork shoppingItem : sList.getShoppingList()) {
             shoppingItem.decrementDaysToWait();
@@ -3486,13 +3486,13 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * Shops for items on the {@link ShoppingList}, where each acquisition automatically succeeds.
+     * Shops for items on the {@link ForceShoppingList}, where each acquisition automatically succeeds.
      *
      * @param sList The shopping list to use when shopping.
      *
      * @return The new shopping list containing the items that were not acquired.
      */
-    private ShoppingList goShoppingAutomatically(ShoppingList sList) {
+    private ForceShoppingList goShoppingAutomatically(ForceShoppingList sList) {
         List<IAcquisitionWork> currentList = new ArrayList<>(sList.getShoppingList());
 
         List<IAcquisitionWork> remainingItems = new ArrayList<>(currentList.size());
@@ -3510,18 +3510,18 @@ public class Campaign implements ITechManager {
             }
         }
 
-        return new ShoppingList(remainingItems);
+        return new ForceShoppingList(remainingItems);
     }
 
     /**
-     * Shops for items on the {@link ShoppingList}, where each acquisition is performed by available logistics
+     * Shops for items on the {@link ForceShoppingList}, where each acquisition is performed by available logistics
      * personnel.
      *
      * @param sList The shopping list to use when shopping.
      *
      * @return The new shopping list containing the items that were not acquired.
      */
-    private ShoppingList goShoppingStandard(ShoppingList sList) {
+    private ForceShoppingList goShoppingStandard(ForceShoppingList sList) {
         List<Person> logisticsPersonnel = getLogisticsPersonnel();
         if (logisticsPersonnel.isEmpty()) {
             addReport(ACQUISITIONS, "Your force has no one capable of acquiring equipment.");
@@ -3553,18 +3553,18 @@ public class Campaign implements ITechManager {
             currentList = remainingItems;
         }
 
-        return new ShoppingList(currentList);
+        return new ForceShoppingList(currentList);
     }
 
     /**
-     * Shops for items on the {@link ShoppingList}, where each acquisition is attempted on nearby planets by available
+     * Shops for items on the {@link ForceShoppingList}, where each acquisition is attempted on nearby planets by available
      * logistics personnel.
      *
      * @param sList The shopping list to use when shopping.
      *
      * @return The new shopping list containing the items that were not acquired.
      */
-    private ShoppingList goShoppingByPlanet(ShoppingList sList) {
+    private ForceShoppingList goShoppingByPlanet(ForceShoppingList sList) {
         List<Person> logisticsPersonnel = getLogisticsPersonnel();
         if (logisticsPersonnel.isEmpty()) {
             addReport(ACQUISITIONS, "Your force has no one capable of acquiring equipment.");
@@ -3690,7 +3690,7 @@ public class Campaign implements ITechManager {
             }
         }
 
-        return new ShoppingList(currentList);
+        return new ForceShoppingList(currentList);
     }
 
     /**
@@ -4221,7 +4221,7 @@ public class Campaign implements ITechManager {
         Part repairable = part.clone();
         // Capture the original's effective warehouse before decrementing, since
         // decrementing to zero would remove the original and clear its locationNode.
-        Warehouse targetWarehouse = part.getWarehouse();
+        LocalWarehouse targetWarehouse = part.getWarehouse();
         part.changeQuantity(-1);
 
         fixPart(repairable, tech);
@@ -4691,7 +4691,7 @@ public class Campaign implements ITechManager {
      * @author Illiani
      * @since 0.50.06
      *
-     * @deprecated Use {@link HumanResources#refreshApplicants(Campaign, boolean)} directly.
+     * @deprecated Use {@link ForceHumanResources#refreshApplicants(Campaign, boolean)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void refreshApplicants(boolean bypassDateRestrictions) {
@@ -4847,7 +4847,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#removePerson(Campaign, Person)} directly.
+     * @deprecated Use {@link ForceHumanResources#removePerson(Campaign, Person)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void removePerson(final @Nullable Person person) {
@@ -4855,7 +4855,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#removePerson(Campaign, Person, boolean)} directly.
+     * @deprecated Use {@link ForceHumanResources#removePerson(Campaign, Person, boolean)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void removePerson(final @Nullable Person person, final boolean log) {
@@ -4863,7 +4863,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#removeAllPatientsFor(Person, CampaignOptions)} directly.
+     * @deprecated Use {@link ForceHumanResources#removeAllPatientsFor(Person, CampaignOptions)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void removeAllPatientsFor(Person doctor) {
@@ -5278,15 +5278,15 @@ public class Campaign implements ITechManager {
      * @deprecated Use {@link PlayerForce#getReputation()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
-    public ReputationController getReputation() {
+    public ForceReputationController getReputation() {
         return getPlayerForce().getReputation();
     }
 
     /**
-     * @deprecated Use {@link PlayerForce#setReputation(ReputationController)} directly.
+     * @deprecated Use {@link PlayerForce#setReputation(ForceReputationController)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
-    public void setReputation(ReputationController reputation) {
+    public void setReputation(ForceReputationController reputation) {
         getPlayerForce().setReputation(reputation);
     }
 
@@ -6806,7 +6806,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#personUpdated(Campaign, Person)} directly.
+     * @deprecated Use {@link ForceHumanResources#personUpdated(Campaign, Person)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void personUpdated(Person person) {
@@ -7147,7 +7147,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#resetAsTechMinutes(CampaignOptions)} directly.
+     * @deprecated Use {@link ForceHumanResources#resetAsTechMinutes(CampaignOptions)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void resetAsTechMinutes() {
@@ -7155,7 +7155,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#getAsTechPoolMinutes()} directly.
+     * @deprecated Use {@link ForceHumanResources#getAsTechPoolMinutes()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public int getAsTechPoolMinutes() {
@@ -7163,7 +7163,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#setAsTechPoolMinutes(int)} directly.
+     * @deprecated Use {@link ForceHumanResources#setAsTechPoolMinutes(int)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void setAsTechPoolMinutes(int minutes) {
@@ -7171,7 +7171,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#getAsTechPoolOvertime()} directly.
+     * @deprecated Use {@link ForceHumanResources#getAsTechPoolOvertime()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public int getAsTechPoolOvertime() {
@@ -7179,7 +7179,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#setAsTechPoolOvertime(int)} directly.
+     * @deprecated Use {@link ForceHumanResources#setAsTechPoolOvertime(int)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void setAsTechPoolOvertime(int overtime) {
@@ -7187,7 +7187,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#getPossibleAsTechPoolMinutes(CampaignOptions)} directly.
+     * @deprecated Use {@link ForceHumanResources#getPossibleAsTechPoolMinutes(CampaignOptions)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public int getPossibleAsTechPoolMinutes() {
@@ -7195,7 +7195,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#getPossibleAsTechPoolOvertime(CampaignOptions)} directly.
+     * @deprecated Use {@link ForceHumanResources#getPossibleAsTechPoolOvertime(CampaignOptions)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public int getPossibleAsTechPoolOvertime() {
@@ -7203,7 +7203,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#setAsTechPool(int)} directly.
+     * @deprecated Use {@link ForceHumanResources#setAsTechPool(int)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void setAsTechPool(int size) {
@@ -7217,7 +7217,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#getTemporaryAsTechPool()} directly.
+     * @deprecated Use {@link ForceHumanResources#getTemporaryAsTechPool()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public int getTemporaryAsTechPool() {
@@ -7225,7 +7225,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#setMedicPool(int)} directly.
+     * @deprecated Use {@link ForceHumanResources#setMedicPool(int)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void setMedicPool(int size) {
@@ -7239,7 +7239,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#getTemporaryMedicPool()} directly.
+     * @deprecated Use {@link ForceHumanResources#getTemporaryMedicPool()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public int getTemporaryMedicPool() {
@@ -7253,7 +7253,7 @@ public class Campaign implements ITechManager {
      *
      * @return the total number of temp crew in the pool for this role
      *
-     * @deprecated Use {@link HumanResources#getTempCrewPool(PersonnelRole)} directly.
+     * @deprecated Use {@link ForceHumanResources#getTempCrewPool(PersonnelRole)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public int getTempCrewPool(PersonnelRole role) {
@@ -7261,7 +7261,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#getTempCrewRoleKeys()} directly.
+     * @deprecated Use {@link ForceHumanResources#getTempCrewRoleKeys()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public Set<PersonnelRole> getTempCrewRoleKeys() {
@@ -7274,7 +7274,7 @@ public class Campaign implements ITechManager {
      * @param role the personnel role
      * @param size the total number of temp crew in the pool
      *
-     * @deprecated Use {@link HumanResources#setTempCrewPool(Campaign, PersonnelRole, int)} directly.
+     * @deprecated Use {@link ForceHumanResources#setTempCrewPool(Campaign, PersonnelRole, int)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void setTempCrewPool(PersonnelRole role, int size) {
@@ -7288,7 +7288,7 @@ public class Campaign implements ITechManager {
      *
      * @return true if this blob crew type is enabled
      *
-     * @deprecated Use {@link HumanResources#isBlobCrewEnabled(PersonnelRole, CampaignOptions)} directly.
+     * @deprecated Use {@link ForceHumanResources#isBlobCrewEnabled(PersonnelRole, CampaignOptions)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public boolean isBlobCrewEnabled(PersonnelRole role) {
@@ -7302,7 +7302,7 @@ public class Campaign implements ITechManager {
      *
      * @return the number of temp crew in use
      *
-     * @deprecated Use {@link HumanResources#getTempCrewInUse(Campaign, PersonnelRole)} directly.
+     * @deprecated Use {@link ForceHumanResources#getTempCrewInUse(Campaign, PersonnelRole)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public int getTempCrewInUse(PersonnelRole role) {
@@ -7316,7 +7316,7 @@ public class Campaign implements ITechManager {
      *
      * @return total pool minus crew currently in use
      *
-     * @deprecated Use {@link HumanResources#getAvailableTempCrewPool(Campaign, PersonnelRole)} directly.
+     * @deprecated Use {@link ForceHumanResources#getAvailableTempCrewPool(Campaign, PersonnelRole)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public int getAvailableTempCrewPool(PersonnelRole role) {
@@ -7324,7 +7324,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#requiresAdditionalAsTechs(CampaignOptions)} directly.
+     * @deprecated Use {@link ForceHumanResources#requiresAdditionalAsTechs(CampaignOptions)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public boolean requiresAdditionalAsTechs() {
@@ -7332,7 +7332,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#getAsTechNeed(CampaignOptions)} directly.
+     * @deprecated Use {@link ForceHumanResources#getAsTechNeed(CampaignOptions)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public int getAsTechNeed() {
@@ -7340,7 +7340,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#increaseAsTechPool(Campaign, int)} directly.
+     * @deprecated Use {@link ForceHumanResources#increaseAsTechPool(Campaign, int)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void increaseAsTechPool(int i) {
@@ -7365,7 +7365,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#decreaseAsTechPool(Campaign, int)} directly.
+     * @deprecated Use {@link ForceHumanResources#decreaseAsTechPool(Campaign, int)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void decreaseAsTechPool(int i) {
@@ -7449,7 +7449,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#getAvailableAsTechs(int, boolean, boolean, CampaignOptions)} directly.
+     * @deprecated Use {@link ForceHumanResources#getAvailableAsTechs(int, boolean, boolean, CampaignOptions)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public int getAvailableAsTechs(final int minutes, final boolean alreadyOvertime) {
@@ -7564,7 +7564,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#requiresAdditionalMedics()} directly.
+     * @deprecated Use {@link ForceHumanResources#requiresAdditionalMedics()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public boolean requiresAdditionalMedics() {
@@ -7572,7 +7572,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#getMedicsNeed()} directly.
+     * @deprecated Use {@link ForceHumanResources#getMedicsNeed()} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public int getMedicsNeed() {
@@ -7580,7 +7580,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#increaseMedicPool(Campaign, int)} directly.
+     * @deprecated Use {@link ForceHumanResources#increaseMedicPool(Campaign, int)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void increaseMedicPool(int i) {
@@ -7605,7 +7605,7 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @deprecated Use {@link HumanResources#decreaseMedicPool(Campaign, int)} directly.
+     * @deprecated Use {@link ForceHumanResources#decreaseMedicPool(Campaign, int)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void decreaseMedicPool(int i) {
@@ -7669,7 +7669,7 @@ public class Campaign implements ITechManager {
      *
      * @param role the personnel role to fill
      *
-     * @deprecated Use {@link HumanResources#fillTempCrewPoolForRole(Campaign, CampaignOptions, PersonnelRole)} directly.
+     * @deprecated Use {@link ForceHumanResources#fillTempCrewPoolForRole(Campaign, CampaignOptions, PersonnelRole)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void fillTempCrewPoolForRole(PersonnelRole role) {
@@ -7691,7 +7691,7 @@ public class Campaign implements ITechManager {
      * Releases surplus AsTechs from the pool, keeping only what is currently needed. If the pool already has fewer than
      * needed, no change is made.
      *
-     * @deprecated Use {@link HumanResources#releaseSurplusAsTechPool(Campaign)} directly.
+     * @deprecated Use {@link ForceHumanResources#releaseSurplusAsTechPool(Campaign)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void releaseSurplusAsTechPool() {
@@ -7702,7 +7702,7 @@ public class Campaign implements ITechManager {
      * Releases surplus Medics from the pool, keeping only what is currently needed. If the pool already has fewer than
      * needed, no change is made.
      *
-     * @deprecated Use {@link HumanResources#releaseSurplusMedicPool(Campaign)} directly.
+     * @deprecated Use {@link ForceHumanResources#releaseSurplusMedicPool(Campaign)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void releaseSurplusMedicPool() {
@@ -7717,7 +7717,7 @@ public class Campaign implements ITechManager {
      *
      * @param role the personnel role to trim
      *
-     * @deprecated Use {@link HumanResources#releaseSurplusBlobCrewForRole(Campaign, PersonnelRole)} directly.
+     * @deprecated Use {@link ForceHumanResources#releaseSurplusBlobCrewForRole(Campaign, PersonnelRole)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void releaseSurplusBlobCrewForRole(PersonnelRole role) {
@@ -7730,7 +7730,7 @@ public class Campaign implements ITechManager {
      *
      * @param role the personnel role to clear
      *
-     * @deprecated Use {@link HumanResources#clearBlobCrewForRole(Campaign, PersonnelRole)} directly.
+     * @deprecated Use {@link ForceHumanResources#clearBlobCrewForRole(Campaign, PersonnelRole)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void clearBlobCrewForRole(PersonnelRole role) {
@@ -7755,7 +7755,7 @@ public class Campaign implements ITechManager {
      *
      * @param role the personnel role to distribute
      *
-     * @deprecated Use {@link HumanResources#distributeTempCrewPoolToUnits(Campaign, CampaignOptions, PersonnelRole)} directly.
+     * @deprecated Use {@link ForceHumanResources#distributeTempCrewPoolToUnits(Campaign, CampaignOptions, PersonnelRole)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void distributeTempCrewPoolToUnits(PersonnelRole role) {
@@ -7950,7 +7950,7 @@ public class Campaign implements ITechManager {
      *
      * @param person The {@link Person} who should receive a randomized portrait.
      *
-     * @deprecated Use {@link HumanResources#assignRandomPortraitFor(CampaignOptions, Person)} directly.
+     * @deprecated Use {@link ForceHumanResources#assignRandomPortraitFor(CampaignOptions, Person)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void assignRandomPortraitFor(final Person person) {
@@ -7962,7 +7962,7 @@ public class Campaign implements ITechManager {
      *
      * @param person The {@link Person} who should receive a randomized origin.
      *
-     * @deprecated Use {@link HumanResources#assignRandomOriginFor(Campaign, CampaignOptions, Person)} directly.
+     * @deprecated Use {@link ForceHumanResources#assignRandomOriginFor(Campaign, CampaignOptions, Person)} directly.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
     public void assignRandomOriginFor(final Person person) {

--- a/MekHQ/src/mekhq/campaign/CampaignConfiguration.java
+++ b/MekHQ/src/mekhq/campaign/CampaignConfiguration.java
@@ -39,7 +39,6 @@ import megamek.client.bot.princess.BehaviorSettings;
 import megamek.common.Player;
 import megamek.common.game.Game;
 import megamek.common.options.GameOptions;
-import mekhq.campaign.camOpsReputation.ReputationController;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.finances.CurrencyManager;
 import mekhq.campaign.finances.Finances;
@@ -106,7 +105,7 @@ public class CampaignConfiguration {
     private FactionStandingUltimatumsLibrary factionStandingUltimatumsLibrary;
     private RetirementDefectionTracker retirementDefectionTracker;
 
-    private ReputationController reputation;
+    private mekhq.campaign.camOpsReputation.ForceReputationController reputation;
     private FactionStandings factionStandings;
     private BehaviorSettings autoResolveBehaviorSettings;
 
@@ -157,7 +156,7 @@ public class CampaignConfiguration {
           Faction faction,
           megamek.common.enums.Faction techFaction,
           CurrencyManager currencyManager,
-          ReputationController reputationController,
+            mekhq.campaign.camOpsReputation.ForceReputationController reputationController,
           FactionStandings factionStandings,
           RankSystem rankSystem,
           Formation formation,
@@ -253,7 +252,7 @@ public class CampaignConfiguration {
           CurrencyManager currencyManager,
           Systems systemsInstance,
           CurrentLocation startLocation,
-          ReputationController reputationController,
+            mekhq.campaign.camOpsReputation.ForceReputationController reputationController,
           FactionStandings factionStandings,
           RankSystem rankSystem,
           Formation formation,
@@ -363,7 +362,7 @@ public class CampaignConfiguration {
         return this.location;
     }
 
-    public ReputationController getReputationController() {
+    public mekhq.campaign.camOpsReputation.ForceReputationController getReputationController() {
         return this.reputation;
     }
 
@@ -518,7 +517,7 @@ public class CampaignConfiguration {
         this.retirementDefectionTracker = retirementDefectionTracker;
     }
 
-    public void setReputation(ReputationController reputation) {
+    public void setReputation(mekhq.campaign.camOpsReputation.ForceReputationController reputation) {
         this.reputation = reputation;
     }
 

--- a/MekHQ/src/mekhq/campaign/CampaignFactory.java
+++ b/MekHQ/src/mekhq/campaign/CampaignFactory.java
@@ -52,7 +52,7 @@ import megamek.logging.MMLogger;
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.NullEntityException;
-import mekhq.campaign.camOpsReputation.ReputationController;
+import mekhq.campaign.camOpsReputation.ForceReputationController;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.finances.CurrencyManager;
 import mekhq.campaign.finances.Finances;
@@ -177,7 +177,7 @@ public class CampaignFactory {
 
         megamek.common.enums.Faction techFaction = megamek.common.enums.Faction.MERC;
         CurrencyManager currencyManager = CurrencyManager.getInstance();
-        ReputationController reputationController = new ReputationController();
+        ForceReputationController reputationController = new ForceReputationController();
 
         FactionStandings factionStandings = new FactionStandings();
         RankSystem rankSystem = Ranks.getRankSystemFromCode(Ranks.DEFAULT_SYSTEM_CODE);

--- a/MekHQ/src/mekhq/campaign/ForceHumanResources.java
+++ b/MekHQ/src/mekhq/campaign/ForceHumanResources.java
@@ -128,11 +128,11 @@ import org.w3c.dom.NodeList;
  *
  * <p>No back-reference to Campaign is stored; dependencies are injected per call.</p>
  */
-public class HumanResources {
-    private static final MMLogger LOGGER = MMLogger.create(HumanResources.class);
+public class ForceHumanResources {
+    private static final MMLogger LOGGER = MMLogger.create(ForceHumanResources.class);
 
 
-    private final Personnel personnel = new Personnel();
+    private final LocalPersonnel personnel = new LocalPersonnel();
 
     /**
      * Transient cache of active personnel lists, keyed by filter options string. Can be null; rebuilt lazily.
@@ -1504,10 +1504,60 @@ public class HumanResources {
               noZeroMinute, eliteFirst, expanded);
     }
 
-    public boolean isWorkingOnRefit(Hangar hangar, Person person) {
-        Objects.requireNonNull(person);
-        Unit unit = hangar.findUnit(u -> u.isRefitting() && person.equals(u.getRefit().getTech()));
-        return unit != null;
+    /**
+     * Parses a {@code <humanResources>} node and returns a populated {@link ForceHumanResources} instance.
+     *
+     * @param wn       the {@code <humanResources>} node
+     * @param campaign the campaign (for context during personnel parsing)
+     * @param version  the save file version
+     *
+     * @return a populated {@link ForceHumanResources} instance
+     */
+    public static ForceHumanResources loadFromXML(Node wn, Campaign campaign, Version version) {
+        LOGGER.info("Loading HumanResources from XML...");
+        ForceHumanResources hr = campaign.getHumanResources();
+
+        NodeList wList = wn.getChildNodes();
+        for (int x = 0; x < wList.getLength(); x++) {
+            Node childNode = wList.item(x);
+            if (childNode.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+
+            String nodeName = childNode.getNodeName();
+            try {
+                if (nodeName.equalsIgnoreCase("asTechPool") || nodeName.equalsIgnoreCase("astechPool")) {
+                    hr.asTechPool = MathUtility.parseInt(childNode.getTextContent().trim());
+                } else if (nodeName.equalsIgnoreCase("asTechPoolMinutes") ||
+                                 nodeName.equalsIgnoreCase("astechPoolMinutes")) {
+                    hr.asTechPoolMinutes = MathUtility.parseInt(
+                          childNode.getTextContent().trim());
+                } else if (nodeName.equalsIgnoreCase("asTechPoolOvertime") ||
+                                 nodeName.equalsIgnoreCase("astechPoolOvertime")) {
+                    hr.asTechPoolOvertime = MathUtility.parseInt(
+                          childNode.getTextContent().trim());
+                } else if (nodeName.equalsIgnoreCase("medicPool")) {
+                    hr.medicPool = MathUtility.parseInt(childNode.getTextContent().trim());
+                } else if (nodeName.equalsIgnoreCase("tempCrewPools")) {
+                    parseTempCrewPools(hr, childNode);
+                } else if (nodeName.equalsIgnoreCase("personnelWhoAdvancedInXP")) {
+                    hr.personnelWhoAdvancedInXP = parsePersonnelWhoAdvancedInXP(childNode, campaign);
+                } else if (nodeName.equalsIgnoreCase("personnel")) {
+                    InjuryTypes.registerAll();
+                    LocalPersonnel.loadFromXML(childNode, campaign, version);
+                } else if (nodeName.equalsIgnoreCase("personnelMarket")) {
+                    hr.personnelMarket = PersonnelMarket.generateInstanceFromXML(childNode, campaign, version);
+                } else if (nodeName.equalsIgnoreCase("retirementDefectionTracker")) {
+                    hr.retirementDefectionTracker = RetirementDefectionTracker.generateInstanceFromXML(childNode,
+                          campaign);
+                }
+            } catch (Exception e) {
+                LOGGER.error("Error loading humanResources child node '{}'", nodeName, e);
+            }
+        }
+
+        LOGGER.info("Load HumanResources from XML complete.");
+        return hr;
     }
 
 
@@ -2537,63 +2587,7 @@ public class HumanResources {
         MHQXMLUtility.writeSimpleXMLCloseTag(writer, --indent, "humanResources");
     }
 
-    /**
-     * Parses a {@code <humanResources>} node and returns a populated {@link HumanResources} instance.
-     *
-     * @param wn       the {@code <humanResources>} node
-     * @param campaign the campaign (for context during personnel parsing)
-     * @param version  the save file version
-     *
-     * @return a populated {@link HumanResources} instance
-     */
-    public static HumanResources loadFromXML(Node wn, Campaign campaign, Version version) {
-        LOGGER.info("Loading HumanResources from XML...");
-        HumanResources hr = campaign.getHumanResources();
-
-        NodeList wList = wn.getChildNodes();
-        for (int x = 0; x < wList.getLength(); x++) {
-            Node childNode = wList.item(x);
-            if (childNode.getNodeType() != Node.ELEMENT_NODE) {
-                continue;
-            }
-
-            String nodeName = childNode.getNodeName();
-            try {
-                if (nodeName.equalsIgnoreCase("asTechPool") || nodeName.equalsIgnoreCase("astechPool")) {
-                    hr.asTechPool = MathUtility.parseInt(childNode.getTextContent().trim());
-                } else if (nodeName.equalsIgnoreCase("asTechPoolMinutes") ||
-                                 nodeName.equalsIgnoreCase("astechPoolMinutes")) {
-                    hr.asTechPoolMinutes = MathUtility.parseInt(
-                          childNode.getTextContent().trim());
-                } else if (nodeName.equalsIgnoreCase("asTechPoolOvertime") ||
-                                 nodeName.equalsIgnoreCase("astechPoolOvertime")) {
-                    hr.asTechPoolOvertime = MathUtility.parseInt(
-                          childNode.getTextContent().trim());
-                } else if (nodeName.equalsIgnoreCase("medicPool")) {
-                    hr.medicPool = MathUtility.parseInt(childNode.getTextContent().trim());
-                } else if (nodeName.equalsIgnoreCase("tempCrewPools")) {
-                    parseTempCrewPools(hr, childNode);
-                } else if (nodeName.equalsIgnoreCase("personnelWhoAdvancedInXP")) {
-                    hr.personnelWhoAdvancedInXP = parsePersonnelWhoAdvancedInXP(childNode, campaign);
-                } else if (nodeName.equalsIgnoreCase("personnel")) {
-                    InjuryTypes.registerAll();
-                    Personnel.loadFromXML(childNode, campaign, version);
-                } else if (nodeName.equalsIgnoreCase("personnelMarket")) {
-                    hr.personnelMarket = PersonnelMarket.generateInstanceFromXML(childNode, campaign, version);
-                } else if (nodeName.equalsIgnoreCase("retirementDefectionTracker")) {
-                    hr.retirementDefectionTracker = RetirementDefectionTracker.generateInstanceFromXML(childNode,
-                          campaign);
-                }
-            } catch (Exception e) {
-                LOGGER.error("Error loading humanResources child node '{}'", nodeName, e);
-            }
-        }
-
-        LOGGER.info("Load HumanResources from XML complete.");
-        return hr;
-    }
-
-    private static void parseTempCrewPools(HumanResources hr, Node tempCrewPoolsNode) {
+    private static void parseTempCrewPools(ForceHumanResources hr, Node tempCrewPoolsNode) {
         NodeList tempCrewNodes = tempCrewPoolsNode.getChildNodes();
         for (int i = 0; i < tempCrewNodes.getLength(); i++) {
             Node tempCrewNode = tempCrewNodes.item(i);
@@ -2627,6 +2621,12 @@ public class HumanResources {
                 }
             }
         }
+    }
+
+    public boolean isWorkingOnRefit(LocalHangar hangar, Person person) {
+        Objects.requireNonNull(person);
+        Unit unit = hangar.findUnit(u -> u.isRefitting() && person.equals(u.getRefit().getTech()));
+        return unit != null;
     }
 
     private static List<Person> parsePersonnelWhoAdvancedInXP(Node workingNode, Campaign campaign) {

--- a/MekHQ/src/mekhq/campaign/ForceQuartermaster.java
+++ b/MekHQ/src/mekhq/campaign/ForceQuartermaster.java
@@ -63,7 +63,7 @@ import mekhq.campaign.unit.Unit;
 /**
  * Manages machines and material for a campaign.
  */
-public record Quartermaster(Campaign campaign) {
+public record ForceQuartermaster(Campaign campaign) {
     public enum PartAcquisitionResult {
         PartInherentFailure,
         PlanetSpecificFailure,
@@ -75,7 +75,7 @@ public record Quartermaster(Campaign campaign) {
      *
      * @param campaign The campaign being managed by the Quartermaster.
      */
-    public Quartermaster(Campaign campaign) {
+    public ForceQuartermaster(Campaign campaign) {
         this.campaign = Objects.requireNonNull(campaign);
     }
 
@@ -97,7 +97,7 @@ public record Quartermaster(Campaign campaign) {
     /**
      * Gets the Warehouse from the Campaign.
      */
-    private Warehouse getWarehouse() {
+    private LocalWarehouse getWarehouse() {
         return campaign().getWarehouse();
     }
 
@@ -124,8 +124,8 @@ public record Quartermaster(Campaign campaign) {
      * Returns the warehouse a part physically lives in — its own (a base warehouse for a base spare, resolved through
      * the location tree), falling back to the campaign warehouse.
      */
-    private Warehouse warehouseFor(Part part) {
-        Warehouse partWarehouse = part.getWarehouse();
+    private LocalWarehouse warehouseFor(Part part) {
+        LocalWarehouse partWarehouse = part.getWarehouse();
         return (partWarehouse != null) ? partWarehouse : getWarehouse();
     }
 
@@ -161,7 +161,7 @@ public record Quartermaster(Campaign campaign) {
      *                    through its own location (a base warehouse for a base spare), falling back to the campaign
      *                    warehouse.
      */
-    public void addPart(Part part, int transitDays, boolean isBrandNew, @Nullable Warehouse target) {
+    public void addPart(Part part, int transitDays, boolean isBrandNew, @Nullable LocalWarehouse target) {
         Objects.requireNonNull(part);
 
         // Refit kits are special, if this is for a refit kit use that method
@@ -194,7 +194,7 @@ public record Quartermaster(Campaign campaign) {
 
         // Add the part to the requested target warehouse, or the warehouse local to the part (e.g. a base warehouse for
         // a unit or spare at a base), and merge it with any existing part if possible
-        Warehouse warehouse = (target != null) ? target : warehouseFor(part);
+        LocalWarehouse warehouse = (target != null) ? target : warehouseFor(part);
         warehouse.addPart(part, true);
     }
 
@@ -205,7 +205,7 @@ public record Quartermaster(Campaign campaign) {
      * @param ammoType  The type of ammo to add.
      * @param shots     The number of rounds of ammo to add.
      */
-    public void addAmmo(Warehouse warehouse, AmmoType ammoType, int shots) {
+    public void addAmmo(LocalWarehouse warehouse, AmmoType ammoType, int shots) {
         Objects.requireNonNull(ammoType);
         if (shots > 0) {
             AmmoStorage storage = new AmmoStorage(0, ammoType, shots, campaign());
@@ -234,7 +234,7 @@ public record Quartermaster(Campaign campaign) {
      * @param infantryWeapon The type of infantry weapon using the ammo.
      * @param shots          The number of rounds of ammo to add.
      */
-    public void addAmmo(Warehouse warehouse, AmmoType ammoType, InfantryWeapon infantryWeapon, int shots) {
+    public void addAmmo(LocalWarehouse warehouse, AmmoType ammoType, InfantryWeapon infantryWeapon, int shots) {
         Objects.requireNonNull(ammoType);
         Objects.requireNonNull(infantryWeapon);
         if (shots > 0) {
@@ -266,7 +266,7 @@ public record Quartermaster(Campaign campaign) {
      *
      * @return The number of rounds of ammo removed. This value may be less than or equal to {@code shotsNeeded}.
      */
-    public int removeAmmo(Warehouse warehouse, AmmoType ammoType, int shotsNeeded) {
+    public int removeAmmo(LocalWarehouse warehouse, AmmoType ammoType, int shotsNeeded) {
         Objects.requireNonNull(ammoType);
 
         if (shotsNeeded <= 0) {
@@ -300,7 +300,7 @@ public record Quartermaster(Campaign campaign) {
     /**
      * Remove ammo directly from an AmmoStorage part, using the given warehouse for cleanup.
      */
-    private int removeAmmo(Warehouse warehouse, @Nullable AmmoStorage ammoStorage, int shotsNeeded) {
+    private int removeAmmo(LocalWarehouse warehouse, @Nullable AmmoStorage ammoStorage, int shotsNeeded) {
         if (ammoStorage == null) {
             return 0;
         }
@@ -337,7 +337,7 @@ public record Quartermaster(Campaign campaign) {
      *
      * @return The number of rounds of ammo removed. This value may be less than or equal to {@code shotsNeeded}.
      */
-    public int removeCompatibleAmmo(Warehouse warehouse, AmmoType ammoType, int shotsNeeded) {
+    public int removeCompatibleAmmo(LocalWarehouse warehouse, AmmoType ammoType, int shotsNeeded) {
         Objects.requireNonNull(ammoType);
 
         if (shotsNeeded <= 0) {
@@ -388,7 +388,7 @@ public record Quartermaster(Campaign campaign) {
     /**
      * Finds spare ammo of a given type in a specific warehouse, if any.
      */
-    private @Nullable AmmoStorage findSpareAmmo(Warehouse warehouse, AmmoType ammoType) {
+    private @Nullable AmmoStorage findSpareAmmo(LocalWarehouse warehouse, AmmoType ammoType) {
         return (AmmoStorage) warehouse.findSparePart(part -> isAvailableAsSpareAmmo(part)
                                                                   &&
                                                                   ((AmmoStorage) part).isSameAmmoType(ammoType));
@@ -408,7 +408,7 @@ public record Quartermaster(Campaign campaign) {
     /**
      * Find compatible ammo in a specific warehouse.
      */
-    private List<AmmoStorage> findCompatibleSpareAmmo(Warehouse warehouse, AmmoType ammoType) {
+    private List<AmmoStorage> findCompatibleSpareAmmo(LocalWarehouse warehouse, AmmoType ammoType) {
         List<AmmoStorage> compatibleAmmo = new ArrayList<>();
         warehouse.forEachSparePart(part -> {
             if (!isAvailableAsSpareAmmo(part)) {
@@ -509,7 +509,7 @@ public record Quartermaster(Campaign campaign) {
             // all of those counts as viable and not just the first we find.
             return getWarehouse()
                          .streamSpareParts()
-                         .filter(Quartermaster::isAvailableAsSpareAmmo)
+                         .filter(ForceQuartermaster::isAvailableAsSpareAmmo)
                          .mapToInt(part -> {
                              AmmoStorage spare = (AmmoStorage) part;
                              if (spare.isSameAmmoType(ammoType)) {
@@ -524,7 +524,7 @@ public record Quartermaster(Campaign campaign) {
             // the ammo that matches strictly or is compatible.
             return getWarehouse()
                          .streamSpareParts()
-                         .filter(Quartermaster::isAvailableAsSpareAmmo)
+                         .filter(ForceQuartermaster::isAvailableAsSpareAmmo)
                          .mapToInt(part -> {
                              AmmoStorage spare = (AmmoStorage) part;
                              if (spare.isSameAmmoType(ammoType)) {
@@ -566,7 +566,8 @@ public record Quartermaster(Campaign campaign) {
     /**
      * Finds spare infantry ammo of a given type in a specific warehouse, if any.
      */
-    private @Nullable InfantryAmmoStorage findSpareAmmo(Warehouse warehouse, AmmoType ammoType, InfantryWeapon weaponType) {
+    private @Nullable InfantryAmmoStorage findSpareAmmo(LocalWarehouse warehouse, AmmoType ammoType,
+          InfantryWeapon weaponType) {
         return (InfantryAmmoStorage) warehouse.findSparePart(part -> {
             if (!(part instanceof InfantryAmmoStorage) || !isAvailableAsSpareAmmo(part)) {
                 return false;
@@ -597,7 +598,7 @@ public record Quartermaster(Campaign campaign) {
      *
      * @return The number of rounds of ammo removed. This value may be less than or equal to {@code shotsNeeded}.
      */
-    public int removeAmmo(Warehouse warehouse, AmmoType ammoType, InfantryWeapon infantryWeapon, int shotsNeeded) {
+    public int removeAmmo(LocalWarehouse warehouse, AmmoType ammoType, InfantryWeapon infantryWeapon, int shotsNeeded) {
         Objects.requireNonNull(ammoType);
 
         if (shotsNeeded <= 0) {
@@ -646,7 +647,7 @@ public record Quartermaster(Campaign campaign) {
         // Add the part back to the Warehouse it belongs to, asking that it be merged with
         // any existing spare part. Use the part's own warehouse (e.g., a base warehouse)
         // rather than always defaulting to the campaign's main warehouse.
-        Warehouse target = (part.getWarehouse() != null) ? part.getWarehouse() : getWarehouse();
+        LocalWarehouse target = (part.getWarehouse() != null) ? part.getWarehouse() : getWarehouse();
         part = target.addPart(part, true);
         MekHQ.triggerEvent(new PartArrivedEvent(part));
     }
@@ -951,7 +952,7 @@ public record Quartermaster(Campaign campaign) {
      *
      * @return True if the part was purchased, otherwise false.
      */
-    public boolean buyPart(Part part, double costMultiplier, int transitDays, @Nullable Warehouse target) {
+    public boolean buyPart(Part part, double costMultiplier, int transitDays, @Nullable LocalWarehouse target) {
         Objects.requireNonNull(part);
 
         if (getCampaignOptions().isPayForParts()) {

--- a/MekHQ/src/mekhq/campaign/LocalHangar.java
+++ b/MekHQ/src/mekhq/campaign/LocalHangar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -55,7 +55,7 @@ import mekhq.utilities.MHQXMLUtility;
 /**
  * Represents a hangar which contains zero or more units.
  */
-public class Hangar implements ILocation {
+public class LocalHangar implements ILocation {
     private final Map<UUID, Unit> units = new LinkedHashMap<>();
     private final LocationNode locationNode = new LocationNode(this);
 

--- a/MekHQ/src/mekhq/campaign/LocalPersonnel.java
+++ b/MekHQ/src/mekhq/campaign/LocalPersonnel.java
@@ -53,8 +53,8 @@ import org.w3c.dom.NodeList;
  * Adds {@link #writeToXML} and {@link #loadFromXML} to own the canonical save/load loop for
  * the {@code <personnel>} XML block.</p>
  */
-public class Personnel extends LinkedHashMap<UUID, Person> implements ILocation {
-    private static final MMLogger logger = MMLogger.create(Personnel.class);
+public class LocalPersonnel extends LinkedHashMap<UUID, Person> implements ILocation {
+    private static final MMLogger logger = MMLogger.create(LocalPersonnel.class);
 
     private final LocationNode locationNode = new LocationNode(this);
 
@@ -64,8 +64,8 @@ public class Personnel extends LinkedHashMap<UUID, Person> implements ILocation 
     }
 
     @Override
-    public Personnel clone() {
-        return (Personnel) super.clone();
+    public LocalPersonnel clone() {
+        return (LocalPersonnel) super.clone();
     }
 
     public void writeToXML(PrintWriter writer, int indent, Campaign campaign) {

--- a/MekHQ/src/mekhq/campaign/LocalWarehouse.java
+++ b/MekHQ/src/mekhq/campaign/LocalWarehouse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -60,8 +60,8 @@ import mekhq.utilities.MHQXMLUtility;
 /**
  * Stores parts for a Campaign.
  */
-public class Warehouse implements ILocation {
-    private static final MMLogger LOGGER = MMLogger.create(Warehouse.class);
+public class LocalWarehouse implements ILocation {
+    private static final MMLogger LOGGER = MMLogger.create(LocalWarehouse.class);
 
     private final LocationNode locationNode = new LocationNode(this);
     private final TreeMap<Integer, Part> parts = new TreeMap<>();

--- a/MekHQ/src/mekhq/campaign/base/AbstractBase.java
+++ b/MekHQ/src/mekhq/campaign/base/AbstractBase.java
@@ -40,9 +40,9 @@ import jakarta.annotation.Nonnull;
 import megamek.common.annotations.Nullable;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Hangar;
-import mekhq.campaign.Personnel;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalHangar;
+import mekhq.campaign.LocalPersonnel;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.location.ILocation;
 import mekhq.campaign.location.IPlace;
 import mekhq.campaign.location.LocationNode;
@@ -65,9 +65,9 @@ public abstract class AbstractBase implements IPlace {
     private String displayType;
     private String planetId;
     private final LocationNode locationNode;
-    private final Personnel basePersonnel = new Personnel();
-    private final Warehouse baseWarehouse = new Warehouse();
-    private final Hangar baseHangar = new Hangar();
+    private final LocalPersonnel basePersonnel = new LocalPersonnel();
+    private final LocalWarehouse baseWarehouse = new LocalWarehouse();
+    private final LocalHangar baseHangar = new LocalHangar();
     private final RequestedStockLevels baseRequestedStockLevels = new RequestedStockLevels();
 
     /**
@@ -108,33 +108,33 @@ public abstract class AbstractBase implements IPlace {
         return true;
     }
 
-    /** Returns the {@link Personnel} node that holds persons who have arrived at this base. */
-    public Personnel getBasePersonnel() {
+    /** Returns the {@link LocalPersonnel} node that holds persons who have arrived at this base. */
+    public LocalPersonnel getBasePersonnel() {
         return basePersonnel;
     }
 
-    /** Returns the {@link Warehouse} that holds spare parts stored at this base. */
-    public Warehouse getBaseWarehouse() {
+    /** Returns the {@link LocalWarehouse} that holds spare parts stored at this base. */
+    public LocalWarehouse getBaseWarehouse() {
         return baseWarehouse;
     }
 
-    /** Returns the {@link Hangar} that holds units stationed at this base. */
-    public Hangar getBaseHangar() {
+    /** Returns the {@link LocalHangar} that holds units stationed at this base. */
+    public LocalHangar getBaseHangar() {
         return baseHangar;
     }
     
     @Override
-    public Warehouse getWarehouse() {
+    public LocalWarehouse getWarehouse() {
         return baseWarehouse;
     }
 
     @Override
-    public Hangar getHangar() {
+    public LocalHangar getHangar() {
         return baseHangar;
     }
 
     @Override
-    public Personnel getPersonnel() {
+    public LocalPersonnel getPersonnel() {
         return basePersonnel;
     }
 

--- a/MekHQ/src/mekhq/campaign/camOpsReputation/AverageExperienceRating.java
+++ b/MekHQ/src/mekhq/campaign/camOpsReputation/AverageExperienceRating.java
@@ -45,7 +45,6 @@ import megamek.common.units.Jumpship;
 import megamek.common.units.SmallCraft;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Hangar;
 import mekhq.campaign.force.CombatTeam;
 import mekhq.campaign.force.Formation;
 import mekhq.campaign.personnel.Person;
@@ -123,7 +122,7 @@ public class AverageExperienceRating {
         int unitCount = 0;
         double totalExperience = 0;
 
-        Hangar hangar = campaign.getAllHangar();
+        mekhq.campaign.LocalHangar hangar = campaign.getAllHangar();
         ArrayList<CombatTeam> combatTeams = campaign.getCombatTeamsAsList();
 
         if (combatTeams.isEmpty()) {

--- a/MekHQ/src/mekhq/campaign/camOpsReputation/ForceReputationController.java
+++ b/MekHQ/src/mekhq/campaign/camOpsReputation/ForceReputationController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2024-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -63,9 +63,9 @@ import mekhq.utilities.MHQXMLUtility;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-public class ReputationController {
+public class ForceReputationController {
     // utilities
-    private static final MMLogger LOGGER = MMLogger.create(ReputationController.class);
+    private static final MMLogger LOGGER = MMLogger.create(ForceReputationController.class);
 
     private final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.CamOpsReputation",
           MekHQ.getMHQOptions().getLocale());
@@ -132,7 +132,7 @@ public class ReputationController {
     /**
      * Initializes the ReputationController class with default values.
      */
-    public ReputationController() {
+    public ForceReputationController() {
     }
 
     /**
@@ -696,7 +696,7 @@ public class ReputationController {
         }
     }
 
-    public ReputationController generateInstanceFromXML(final Node workingNode) {
+    public ForceReputationController generateInstanceFromXML(final Node workingNode) {
         NodeList newLine = workingNode.getChildNodes();
 
         try {

--- a/MekHQ/src/mekhq/campaign/finances/Accountant.java
+++ b/MekHQ/src/mekhq/campaign/finances/Accountant.java
@@ -50,7 +50,6 @@ import megamek.common.units.Entity;
 import megamek.logging.MMLogger;
 import mekhq.campaign.AbstractLocation;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Hangar;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.finances.enums.TransactionType;
 import mekhq.campaign.force.Formation;
@@ -83,8 +82,55 @@ public record Accountant(Campaign campaign) {
         return campaign().getCampaignOptions();
     }
 
-    private Hangar getHangar() {
-        return campaign().getAllHangar();
+    /**
+     * Calculates the peacetime operating costs (spare parts, fuel, ammo and, optionally, salaries) of the given
+     * formations.
+     *
+     * <p>Units and personnel are resolved by walking the given formations and all of their sub-formations, so
+     * callers only need to supply the formations they care about. This lets the method double as both a whole-campaign
+     * total (by passing every top-level formation) and, in future, a total scoped to some smaller grouping of
+     * formations without any change to this method.</p>
+     *
+     * <p>Salaries, when included, cover both the crews of the resolved units and the campaign's temporary
+     * personnel pools (astechs, medics, and other temporary crew), since those pools are not tied to any particular
+     * formation.</p>
+     *
+     * @param formations              the formations (and, recursively, their sub-formations) to total operating costs
+     *                                for
+     * @param hangar                  the hangar used to resolve unit ids into units
+     * @param campaignOptions         the campaign options used to resolve salaries and temporary crew pay
+     * @param isClanCampaign          whether the campaign is a Clan campaign, used to resolve each person's salary
+     * @param today                   the current campaign date, used to resolve each person's salary
+     * @param temporaryAsTechPoolSize the size of the campaign's temporary astech pool
+     * @param temporaryMedicPool      the size of the campaign's temporary medic pool
+     * @param tempCrewMap             the campaign's other temporary crew roles, mapped to their pool sizes
+     * @param includeSalaries         whether salaries should be included in the total
+     *
+     * @return the total {@link Money} peacetime operating cost of the given formations
+     */
+    public static Money getPeacetimeOperatingCosts(Collection<Formation> formations, mekhq.campaign.LocalHangar hangar,
+          CampaignOptions campaignOptions, boolean isClanCampaign, LocalDate today, int temporaryAsTechPoolSize,
+          int temporaryMedicPool, Map<PersonnelRole, Integer> tempCrewMap, boolean includeSalaries) {
+        Collection<Unit> units = getUnitsInFormations(formations, hangar);
+
+        Money peacetimeCosts = getSparePartsTotal(units).plus(getFuelTotal(units)).plus(getAmmoTotal(units));
+
+        if (includeSalaries && campaignOptions.isPayForSalaries()) {
+            Collection<Person> personnel = getCrewsOfUnits(units);
+            boolean noInfantry = campaignOptions.isInfantryDontCount();
+            peacetimeCosts = peacetimeCosts.plus(getSalaryTotal(personnel,
+                  campaignOptions,
+                  isClanCampaign,
+                  today,
+                  noInfantry));
+            peacetimeCosts = peacetimeCosts.plus(Money.of(sumTempCrewPay(campaignOptions,
+                  temporaryAsTechPoolSize,
+                  temporaryMedicPool,
+                  tempCrewMap,
+                  noInfantry)));
+        }
+
+        return peacetimeCosts;
     }
 
     private Collection<Unit> getAllUnits() {
@@ -554,57 +600,6 @@ public record Accountant(Campaign campaign) {
     }
 
     /**
-     * Calculates the peacetime operating costs (spare parts, fuel, ammo and, optionally, salaries) of the given
-     * formations.
-     *
-     * <p>Units and personnel are resolved by walking the given formations and all of their sub-formations, so
-     * callers only need to supply the formations they care about. This lets the method double as both a whole-campaign
-     * total (by passing every top-level formation) and, in future, a total scoped to some smaller grouping of
-     * formations without any change to this method.</p>
-     *
-     * <p>Salaries, when included, cover both the crews of the resolved units and the campaign's temporary
-     * personnel pools (astechs, medics, and other temporary crew), since those pools are not tied to any particular
-     * formation.</p>
-     *
-     * @param formations              the formations (and, recursively, their sub-formations) to total operating costs
-     *                                for
-     * @param hangar                  the hangar used to resolve unit ids into units
-     * @param campaignOptions         the campaign options used to resolve salaries and temporary crew pay
-     * @param isClanCampaign          whether the campaign is a Clan campaign, used to resolve each person's salary
-     * @param today                   the current campaign date, used to resolve each person's salary
-     * @param temporaryAsTechPoolSize the size of the campaign's temporary astech pool
-     * @param temporaryMedicPool      the size of the campaign's temporary medic pool
-     * @param tempCrewMap             the campaign's other temporary crew roles, mapped to their pool sizes
-     * @param includeSalaries         whether salaries should be included in the total
-     *
-     * @return the total {@link Money} peacetime operating cost of the given formations
-     */
-    public static Money getPeacetimeOperatingCosts(Collection<Formation> formations, Hangar hangar,
-          CampaignOptions campaignOptions, boolean isClanCampaign, LocalDate today, int temporaryAsTechPoolSize,
-          int temporaryMedicPool, Map<PersonnelRole, Integer> tempCrewMap, boolean includeSalaries) {
-        Collection<Unit> units = getUnitsInFormations(formations, hangar);
-
-        Money peacetimeCosts = getSparePartsTotal(units).plus(getFuelTotal(units)).plus(getAmmoTotal(units));
-
-        if (includeSalaries && campaignOptions.isPayForSalaries()) {
-            Collection<Person> personnel = getCrewsOfUnits(units);
-            boolean noInfantry = campaignOptions.isInfantryDontCount();
-            peacetimeCosts = peacetimeCosts.plus(getSalaryTotal(personnel,
-                  campaignOptions,
-                  isClanCampaign,
-                  today,
-                  noInfantry));
-            peacetimeCosts = peacetimeCosts.plus(Money.of(sumTempCrewPay(campaignOptions,
-                  temporaryAsTechPoolSize,
-                  temporaryMedicPool,
-                  tempCrewMap,
-                  noInfantry)));
-        }
-
-        return peacetimeCosts;
-    }
-
-    /**
      * Resolves every unit assigned to the given formations, recursing into their sub-formations.
      *
      * @param formations the formations to resolve units for
@@ -612,7 +607,8 @@ public record Accountant(Campaign campaign) {
      *
      * @return every unit assigned to the given formations and their sub-formations
      */
-    private static List<Unit> getUnitsInFormations(Collection<Formation> formations, Hangar hangar) {
+    private static List<Unit> getUnitsInFormations(Collection<Formation> formations,
+          mekhq.campaign.LocalHangar hangar) {
         List<Unit> units = new ArrayList<>();
         for (Formation formation : formations) {
             for (UUID unitId : formation.getUnits()) {
@@ -626,6 +622,108 @@ public record Accountant(Campaign campaign) {
         }
 
         return units;
+    }
+
+    /**
+     * Static version of {@link #getForceValue(boolean, boolean, double, double, double, boolean)}.
+     *
+     * @param formations                the formations to evaluate
+     * @param hangar                    the hangar used to resolve unit ids to units
+     * @param campaignFaction           the campaign's faction, used for diminishing returns calculations
+     * @param campaignOptions           the campaign options used to calculate per-unit contract values
+     * @param useDiminishingContractPay whether diminishing returns should be applied (only when the unit count exceeds
+     *                                  the diminishing-returns start)
+     * @param excludeInfantry           if {@code true}, conventional infantry units are excluded from the calculation
+     * @param dropShipContractPercent   inclusion flag for DropShips and Small Craft; if {@code 0}, these units are
+     *                                  excluded
+     * @param warShipContractPercent    inclusion flag for WarShips; if {@code 0}, these units are excluded
+     * @param jumpShipContractPercent   inclusion flag for JumpShips and Space Stations; if {@code 0}, these units are
+     *                                  excluded
+     * @param useEquipmentSaleValue     if {@code true},
+     *                                  {@link #getEquipmentContractValue(CampaignOptions, Unit, boolean)} uses
+     *                                  equipment sale values; if {@code false}, it uses standard values
+     *
+     * @return the total {@link Money} value of all included units, with diminishing returns applied when enabled and
+     *       relevant
+     */
+    public static Money getForceValue(Collection<Formation> formations, mekhq.campaign.LocalHangar hangar,
+          Faction campaignFaction,
+          CampaignOptions campaignOptions, boolean useDiminishingContractPay, boolean excludeInfantry,
+          double dropShipContractPercent, double warShipContractPercent, double jumpShipContractPercent,
+          boolean useEquipmentSaleValue) {
+        List<Money> unitValues = new ArrayList<>();
+
+        Money total = Money.zero();
+        for (Formation formation : formations) {
+            if (!formation.getFormationType().isStandard()) {
+                continue;
+            }
+            if (!formation.getCombatRoleInMemory().isCombatRole()) {
+                continue;
+            }
+
+            for (UUID uuid : formation.getUnits()) {
+                Unit unit = hangar.getUnit(uuid);
+                if (unit == null) {
+                    continue;
+                }
+
+                Entity entity = unit.getEntity();
+                if (entity == null) {
+                    continue;
+                }
+
+                // Infantry
+                if (unit.isConventionalInfantry() && excludeInfantry) {
+                    continue;
+                }
+
+                Money unitValue = getEquipmentContractValue(campaignOptions, unit, useEquipmentSaleValue);
+
+                // DropShips / Small Craft
+                if (entity.isDropShip() || entity.isSmallCraft()) {
+                    if (dropShipContractPercent != 0) {
+                        unitValues.add(unitValue);
+                        total = total.plus(unitValue);
+                    }
+                    continue;
+                }
+
+                // WarShips
+                if (entity.isWarShip()) {
+                    if (warShipContractPercent != 0) {
+                        unitValues.add(unitValue);
+                        total = total.plus(unitValue);
+                    }
+                    continue;
+                }
+
+                // JumpShips / Space Stations
+                if (entity.isJumpShip() || entity.isSpaceStation()) {
+                    if (jumpShipContractPercent != 0) {
+                        unitValues.add(unitValue);
+                        total = total.plus(unitValue);
+                    }
+                    continue;
+                }
+
+                // Other
+                unitValues.add(unitValue);
+                total = total.plus(unitValue);
+            }
+        }
+
+        if (unitValues.isEmpty()) {
+            return Money.zero();
+        }
+
+        // Only process diminishing returns if it is both enabled and relevant.
+        boolean isAffectedByDiminishingReturns = unitValues.size() > getDiminishingReturnsStart(campaignFaction);
+        if (useDiminishingContractPay && isAffectedByDiminishingReturns) {
+            return adjustValuesForDiminishingReturns(campaignFaction, unitValues);
+        }
+
+        return total;
     }
 
     /**
@@ -801,191 +899,6 @@ public record Accountant(Campaign campaign) {
     }
 
     /**
-     * Static version of {@link #getForceValue(boolean, boolean, double, double, double, boolean)}.
-     *
-     * @param formations                the formations to evaluate
-     * @param hangar                    the hangar used to resolve unit ids to units
-     * @param campaignFaction           the campaign's faction, used for diminishing returns calculations
-     * @param campaignOptions           the campaign options used to calculate per-unit contract values
-     * @param useDiminishingContractPay whether diminishing returns should be applied (only when the unit count exceeds
-     *                                  the diminishing-returns start)
-     * @param excludeInfantry           if {@code true}, conventional infantry units are excluded from the calculation
-     * @param dropShipContractPercent   inclusion flag for DropShips and Small Craft; if {@code 0}, these units are
-     *                                  excluded
-     * @param warShipContractPercent    inclusion flag for WarShips; if {@code 0}, these units are excluded
-     * @param jumpShipContractPercent   inclusion flag for JumpShips and Space Stations; if {@code 0}, these units are
-     *                                  excluded
-     * @param useEquipmentSaleValue     if {@code true},
-     *                                  {@link #getEquipmentContractValue(CampaignOptions, Unit, boolean)} uses
-     *                                  equipment sale values; if {@code false}, it uses standard values
-     *
-     * @return the total {@link Money} value of all included units, with diminishing returns applied when enabled and
-     *       relevant
-     */
-    public static Money getForceValue(Collection<Formation> formations, Hangar hangar, Faction campaignFaction,
-          CampaignOptions campaignOptions, boolean useDiminishingContractPay, boolean excludeInfantry,
-          double dropShipContractPercent, double warShipContractPercent, double jumpShipContractPercent,
-          boolean useEquipmentSaleValue) {
-        List<Money> unitValues = new ArrayList<>();
-
-        Money total = Money.zero();
-        for (Formation formation : formations) {
-            if (!formation.getFormationType().isStandard()) {
-                continue;
-            }
-            if (!formation.getCombatRoleInMemory().isCombatRole()) {
-                continue;
-            }
-
-            for (UUID uuid : formation.getUnits()) {
-                Unit unit = hangar.getUnit(uuid);
-                if (unit == null) {
-                    continue;
-                }
-
-                Entity entity = unit.getEntity();
-                if (entity == null) {
-                    continue;
-                }
-
-                // Infantry
-                if (unit.isConventionalInfantry() && excludeInfantry) {
-                    continue;
-                }
-
-                Money unitValue = getEquipmentContractValue(campaignOptions, unit, useEquipmentSaleValue);
-
-                // DropShips / Small Craft
-                if (entity.isDropShip() || entity.isSmallCraft()) {
-                    if (dropShipContractPercent != 0) {
-                        unitValues.add(unitValue);
-                        total = total.plus(unitValue);
-                    }
-                    continue;
-                }
-
-                // WarShips
-                if (entity.isWarShip()) {
-                    if (warShipContractPercent != 0) {
-                        unitValues.add(unitValue);
-                        total = total.plus(unitValue);
-                    }
-                    continue;
-                }
-
-                // JumpShips / Space Stations
-                if (entity.isJumpShip() || entity.isSpaceStation()) {
-                    if (jumpShipContractPercent != 0) {
-                        unitValues.add(unitValue);
-                        total = total.plus(unitValue);
-                    }
-                    continue;
-                }
-
-                // Other
-                unitValues.add(unitValue);
-                total = total.plus(unitValue);
-            }
-        }
-
-        if (unitValues.isEmpty()) {
-            return Money.zero();
-        }
-
-        // Only process diminishing returns if it is both enabled and relevant.
-        boolean isAffectedByDiminishingReturns = unitValues.size() > getDiminishingReturnsStart(campaignFaction);
-        if (useDiminishingContractPay && isAffectedByDiminishingReturns) {
-            return adjustValuesForDiminishingReturns(campaignFaction, unitValues);
-        }
-
-        return total;
-    }
-
-    public Money getTotalEquipmentValue() {
-        return getTotalEquipmentValue(getAllUnits(), campaign().getAllParts());
-    }
-
-    /**
-     * Static version of {@link #getTotalEquipmentValue()}.
-     *
-     * @param units the units to total sell value for
-     * @param parts the parts to evaluate
-     *
-     * @return the total {@link Money} value of all equipment
-     */
-    public static Money getTotalEquipmentValue(Collection<Unit> units, Collection<Part> parts) {
-        Money total = Money.zero();
-        for (Unit unit : units) {
-            total = total.plus(unit.getSellValue());
-        }
-
-        return parts.stream().filter(Part::isSpare).map(Part::getActualValue).reduce(total, Money::plus);
-    }
-
-    public Money getEquipmentContractValue(Unit unit, boolean useSaleValue) {
-        return getEquipmentContractValue(getCampaignOptions(), unit, useSaleValue);
-    }
-
-    /**
-     * Static version of {@link #getEquipmentContractValue(Unit, boolean)}.
-     *
-     * @param campaignOptions the campaign options containing the contract percentages for each unit category
-     * @param unit            the unit to evaluate
-     * @param useSaleValue    if {@code true}, the unit's sell value is used as the base; otherwise its buy cost is
-     *                        used
-     *
-     * @return the {@link Money} contract value of the unit
-     */
-    public static Money getEquipmentContractValue(CampaignOptions campaignOptions, Unit unit, boolean useSaleValue) {
-        Money value;
-        Money percentValue;
-
-        if (useSaleValue) {
-            value = unit.getSellValue();
-        } else {
-            value = unit.getBuyCost();
-        }
-
-        if (unit.getEntity().hasETypeFlag(Entity.ETYPE_DROPSHIP)) {
-            percentValue = value.multipliedBy(campaignOptions.getDropShipContractPercent()).dividedBy(100);
-        } else if (unit.getEntity().hasETypeFlag(Entity.ETYPE_WARSHIP)) {
-            percentValue = value.multipliedBy(campaignOptions.getWarShipContractPercent()).dividedBy(100);
-        } else if (unit.getEntity().hasETypeFlag(Entity.ETYPE_JUMPSHIP) ||
-                         unit.getEntity().hasETypeFlag(Entity.ETYPE_SPACE_STATION)) {
-            percentValue = value.multipliedBy(campaignOptions.getJumpShipContractPercent()).dividedBy(100);
-        } else {
-            percentValue = value.multipliedBy(campaignOptions.getEquipmentContractPercent()).dividedBy(100);
-        }
-
-        return percentValue;
-    }
-
-    /**
-     * Calculates the base monetary value for contracts in the campaign based on the specified campaign options. The
-     * calculation considers whether peacetime costs, equipment contracts, or theoretical payroll costs should be used
-     * as the base value.
-     *
-     * <p>This method retrieves relevant options from the campaign's {@link CampaignOptions}
-     * to control how the base contract value is computed. Based on the campaign settings, it takes into account factors
-     * such as infantry exclusion, contract percentages for different types of units (DropShips, WarShips, JumpShips),
-     * and whether to use the equipment's sale value in the calculations.</p>
-     *
-     * @return A {@link Money} object representing the calculated base contract value, adjusted according to the
-     *       campaign's configuration.
-     */
-    public Money getContractBase() {
-        return getContractBase(getCampaignOptions(),
-              campaign().getFaction(),
-              getLocalDate(),
-              getHangar(),
-              campaign().getSalaryEligiblePersonnel(),
-              getTemporaryAsTechPool(),
-              getTemporaryMedicPool(),
-              getTempCrewMap(),
-              campaign().getAllFormations());
-    }
-
-    /**
      * Static version of {@link #getContractBase()}.
      *
      * @param campaignOptions         the campaign options used to control how the base contract value is computed
@@ -1003,7 +916,8 @@ public record Accountant(Campaign campaign) {
      *       campaign's configuration
      */
     public static Money getContractBase(CampaignOptions campaignOptions, Faction campaignFaction, LocalDate today,
-          Hangar hangar, List<Person> salaryEligiblePersonnel, int temporaryAsTechPoolSize, int temporaryMedicPool,
+          mekhq.campaign.LocalHangar hangar, List<Person> salaryEligiblePersonnel, int temporaryAsTechPoolSize,
+          int temporaryMedicPool,
           Map<PersonnelRole, Integer> tempCrewMap, List<Formation> formations) {
         final boolean isClanCampaign = campaignFaction.isClan();
 
@@ -1080,6 +994,94 @@ public record Accountant(Campaign campaign) {
               temporaryMedicPool,
               tempCrewMap,
               campaignOptions.isInfantryDontCount());
+    }
+
+    /**
+     * Static version of {@link #getTotalEquipmentValue()}.
+     *
+     * @param units the units to total sell value for
+     * @param parts the parts to evaluate
+     *
+     * @return the total {@link Money} value of all equipment
+     */
+    public static Money getTotalEquipmentValue(Collection<Unit> units, Collection<Part> parts) {
+        Money total = Money.zero();
+        for (Unit unit : units) {
+            total = total.plus(unit.getSellValue());
+        }
+
+        return parts.stream().filter(Part::isSpare).map(Part::getActualValue).reduce(total, Money::plus);
+    }
+
+    /**
+     * Static version of {@link #getEquipmentContractValue(Unit, boolean)}.
+     *
+     * @param campaignOptions the campaign options containing the contract percentages for each unit category
+     * @param unit            the unit to evaluate
+     * @param useSaleValue    if {@code true}, the unit's sell value is used as the base; otherwise its buy cost is
+     *                        used
+     *
+     * @return the {@link Money} contract value of the unit
+     */
+    public static Money getEquipmentContractValue(CampaignOptions campaignOptions, Unit unit, boolean useSaleValue) {
+        Money value;
+        Money percentValue;
+
+        if (useSaleValue) {
+            value = unit.getSellValue();
+        } else {
+            value = unit.getBuyCost();
+        }
+
+        if (unit.getEntity().hasETypeFlag(Entity.ETYPE_DROPSHIP)) {
+            percentValue = value.multipliedBy(campaignOptions.getDropShipContractPercent()).dividedBy(100);
+        } else if (unit.getEntity().hasETypeFlag(Entity.ETYPE_WARSHIP)) {
+            percentValue = value.multipliedBy(campaignOptions.getWarShipContractPercent()).dividedBy(100);
+        } else if (unit.getEntity().hasETypeFlag(Entity.ETYPE_JUMPSHIP) ||
+                         unit.getEntity().hasETypeFlag(Entity.ETYPE_SPACE_STATION)) {
+            percentValue = value.multipliedBy(campaignOptions.getJumpShipContractPercent()).dividedBy(100);
+        } else {
+            percentValue = value.multipliedBy(campaignOptions.getEquipmentContractPercent()).dividedBy(100);
+        }
+
+        return percentValue;
+    }
+
+    public Money getTotalEquipmentValue() {
+        return getTotalEquipmentValue(getAllUnits(), campaign().getAllParts());
+    }
+
+    public Money getEquipmentContractValue(Unit unit, boolean useSaleValue) {
+        return getEquipmentContractValue(getCampaignOptions(), unit, useSaleValue);
+    }
+
+    /**
+     * Calculates the base monetary value for contracts in the campaign based on the specified campaign options. The
+     * calculation considers whether peacetime costs, equipment contracts, or theoretical payroll costs should be used
+     * as the base value.
+     *
+     * <p>This method retrieves relevant options from the campaign's {@link CampaignOptions}
+     * to control how the base contract value is computed. Based on the campaign settings, it takes into account factors
+     * such as infantry exclusion, contract percentages for different types of units (DropShips, WarShips, JumpShips),
+     * and whether to use the equipment's sale value in the calculations.</p>
+     *
+     * @return A {@link Money} object representing the calculated base contract value, adjusted according to the
+     *       campaign's configuration.
+     */
+    public Money getContractBase() {
+        return getContractBase(getCampaignOptions(),
+              campaign().getFaction(),
+              getLocalDate(),
+              getHangar(),
+              campaign().getSalaryEligiblePersonnel(),
+              getTemporaryAsTechPool(),
+              getTemporaryMedicPool(),
+              getTempCrewMap(),
+              campaign().getAllFormations());
+    }
+
+    private mekhq.campaign.LocalHangar getHangar() {
+        return campaign().getAllHangar();
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/force/AbstractForce.java
+++ b/MekHQ/src/mekhq/campaign/force/AbstractForce.java
@@ -61,8 +61,8 @@ import megamek.common.icons.Camouflage;
 import megamek.common.units.Entity;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.HumanResources;
-import mekhq.campaign.camOpsReputation.ReputationController;
+import mekhq.campaign.ForceHumanResources;
+import mekhq.campaign.camOpsReputation.ForceReputationController;
 import mekhq.campaign.events.NetworkChangedEvent;
 import mekhq.campaign.events.OrganizationChangedEvent;
 import mekhq.campaign.finances.Finances;
@@ -70,7 +70,7 @@ import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.enums.TransactionType;
 import mekhq.campaign.icons.StandardFormationIcon;
 import mekhq.campaign.icons.UnitIcon;
-import mekhq.campaign.market.ShoppingList;
+import mekhq.campaign.market.ForceShoppingList;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.Scenario;
 import mekhq.campaign.mission.rentals.ContractRentalType;
@@ -103,8 +103,8 @@ import mekhq.campaign.universe.factionStanding.FactionStandings;
  */
 public abstract class AbstractForce {
 
-    private HumanResources humanResources = new HumanResources();
-    private ShoppingList shoppingList = new ShoppingList();
+    private ForceHumanResources humanResources = new ForceHumanResources();
+    private ForceShoppingList shoppingList = new ForceShoppingList();
 
     private final ForceOptions forceOptions;
 
@@ -121,7 +121,7 @@ public abstract class AbstractForce {
     private Finances finances;
 
     // Reputation / standing / crime / initiative
-    private ReputationController reputation;
+    private ForceReputationController reputation;
     private FactionStandings factionStandings;
     private int crimeRating = 0;
     private int crimePirateModifier = 0;
@@ -149,7 +149,7 @@ public abstract class AbstractForce {
     private Hashtable<Integer, CombatTeam> combatTeams = new Hashtable<>();
 
     protected AbstractForce(ForceOptions forceOptions, megamek.common.enums.Faction techFaction, RankSystem rankSystem,
-          Finances finances, ReputationController reputation, FactionStandings factionStandings) {
+          Finances finances, ForceReputationController reputation, FactionStandings factionStandings) {
         this.forceOptions = forceOptions;
         this.techFaction = techFaction;
         this.rankSystem = rankSystem;
@@ -199,20 +199,20 @@ public abstract class AbstractForce {
         return detachments.iterator().next();
     }
 
-    public HumanResources getHumanResources() {
+    public ForceHumanResources getHumanResources() {
         return humanResources;
     }
 
-    public void setHumanResources(HumanResources humanResources) {
+    public void setHumanResources(ForceHumanResources humanResources) {
         this.humanResources = humanResources;
     }
 
-    public void setShoppingList(ShoppingList shoppingList) {
-        this.shoppingList = shoppingList;
+    public ForceShoppingList getShoppingList() {
+        return shoppingList;
     }
 
-    public ShoppingList getShoppingList() {
-        return shoppingList;
+    public void setShoppingList(ForceShoppingList shoppingList) {
+        this.shoppingList = shoppingList;
     }
 
     public ForceOptions getForceOptions() {
@@ -374,11 +374,11 @@ public abstract class AbstractForce {
         finances.debit(type, date, quantity, description);
     }
 
-    public ReputationController getReputation() {
+    public ForceReputationController getReputation() {
         return reputation;
     }
 
-    public void setReputation(ReputationController reputation) {
+    public void setReputation(ForceReputationController reputation) {
         this.reputation = reputation;
     }
 

--- a/MekHQ/src/mekhq/campaign/force/Detachment.java
+++ b/MekHQ/src/mekhq/campaign/force/Detachment.java
@@ -42,10 +42,10 @@ import mekhq.campaign.AbstractLocation;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignNewDayManager;
 import mekhq.campaign.DetachmentLocationManager;
-import mekhq.campaign.Hangar;
-import mekhq.campaign.HumanResources;
-import mekhq.campaign.Personnel;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.ForceHumanResources;
+import mekhq.campaign.LocalHangar;
+import mekhq.campaign.LocalPersonnel;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.location.ILocation;
 import mekhq.campaign.location.IPlace;
@@ -74,10 +74,10 @@ public class Detachment implements IPlace {
     private final DetachmentLocationManager detachmentLocationManager;
 
     // Owned resources — this detachment is the IPlace that owns them.
-    private final Hangar units = new Hangar();
-    private final Personnel personnel = new Personnel();
+    private final LocalHangar units = new LocalHangar();
+    private final LocalPersonnel personnel = new LocalPersonnel();
     private final RequestedStockLevels requestedStockLevels = new RequestedStockLevels();
-    private Warehouse parts = new Warehouse();
+    private LocalWarehouse parts = new LocalWarehouse();
 
     public Detachment() {
         // The manager owns the LocationNode; build it first so parenting the resources can resolve this node.
@@ -105,21 +105,21 @@ public class Detachment implements IPlace {
     }
 
     @Override
-    public Hangar getHangar() {
+    public LocalHangar getHangar() {
         return units;
     }
 
     @Override
-    public Warehouse getWarehouse() {
+    public LocalWarehouse getWarehouse() {
         return parts;
     }
 
-    public void setWarehouse(Warehouse warehouse) {
+    public void setWarehouse(LocalWarehouse warehouse) {
         parts = Objects.requireNonNull(warehouse);
     }
 
     @Override
-    public Personnel getPersonnel() {
+    public LocalPersonnel getPersonnel() {
         return personnel;
     }
 
@@ -155,7 +155,7 @@ public class Detachment implements IPlace {
         }
 
         // We've just stopped traveling, so we should see if there are any local applicants.
-        if (!HumanResources.isUsingLegacyPersonnelMarket(campaign.getCampaignOptions())) {
+        if (!ForceHumanResources.isUsingLegacyPersonnelMarket(campaign.getCampaignOptions())) {
             campaign.refreshApplicants(true);
             CampaignNewDayManager.showRarePersonnelDialog(campaign, false);
         }

--- a/MekHQ/src/mekhq/campaign/force/Formation.java
+++ b/MekHQ/src/mekhq/campaign/force/Formation.java
@@ -48,7 +48,7 @@ import megamek.common.units.Entity;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Hangar;
+import mekhq.campaign.LocalHangar;
 import mekhq.campaign.events.OrganizationChangedEvent;
 import mekhq.campaign.icons.FormationPieceIcon;
 import mekhq.campaign.icons.LayeredFormationIcon;
@@ -478,16 +478,16 @@ public class Formation {
      * Retrieves all units associated with the current formation as {@link Unit} objects.
      *
      * <p>This method converts the list of unit IDs from the formation into a list of
-     * {@link Unit} objects by fetching them from the provided {@link Hangar}. Units are only included if they can be
+     * {@link Unit} objects by fetching them from the provided {@link LocalHangar}. Units are only included if they can be
      * successfully resolved from the hangar.</p>
      *
-     * @param hangar                 the {@link Hangar} containing the units to retrieve.
+     * @param hangar                 the {@link LocalHangar} containing the units to retrieve.
      * @param standardFormationsOnly a flag indicating whether to include only standard formations. If {@code true},
      *                               only units belonging to standard formations are returned.
      *
      * @return a list of {@link Unit} objects associated with the formation.
      */
-    public List<Unit> getAllUnitsAsUnits(Hangar hangar, boolean standardFormationsOnly) {
+    public List<Unit> getAllUnitsAsUnits(mekhq.campaign.LocalHangar hangar, boolean standardFormationsOnly) {
         List<Unit> allUnits = new ArrayList<>();
 
         for (UUID unitId : getAllUnits(standardFormationsOnly)) {
@@ -502,22 +502,22 @@ public class Formation {
 
     /**
      * Resolves and returns the {@link Unit} objects that belong to this formation by looking them up in the provided
-     * {@link Hangar}.
+     * {@link LocalHangar}.
      *
      * <p>This method iterates over the unit IDs returned by {@link #getUnits()} and attempts to retrieve each unit
-     * from the hangar via {@link Hangar#getUnit(UUID)}. Any IDs that do not resolve to a unit (i.e.,
+     * from the hangar via {@link LocalHangar#getUnit(UUID)}. Any IDs that do not resolve to a unit (i.e.,
      * {@code getUnit(...)} returns {@code null}) are ignored.</p>
      *
      * <p>The returned list contains only non-null units and preserves the iteration order of {@link #getUnits()}.</p>
      *
-     * @param hangar the {@link Hangar} used to resolve unit IDs into {@link Unit} instances; must not be {@code null}
+     * @param hangar the {@link LocalHangar} used to resolve unit IDs into {@link Unit} instances; must not be {@code null}
      *
      * @return a list of resolved {@link Unit} instances for this formation; never {@code null}
      *
      * @author Illiani
      * @since 0.50.11
      */
-    public List<Unit> getUnitsAsUnits(Hangar hangar) {
+    public List<Unit> getUnitsAsUnits(mekhq.campaign.LocalHangar hangar) {
         List<Unit> allUnits = new ArrayList<>();
 
         for (UUID unitId : getUnits()) {
@@ -1231,12 +1231,12 @@ public class Formation {
      *   <li>Returns {@code true} if all resolved units meet the VTOL or WIGE criteria.</li>
      * </ul>
      *
-     * @param hangar                 The {@link Hangar} instance from which to retrieve the {@link Unit}.
+     * @param hangar                 The {@link LocalHangar} instance from which to retrieve the {@link Unit}.
      * @param standardFormationsOnly A flag to filter and include only standard formations from the formation.
      *
      * @return {@code true} if all resolved units in the formation are VTOL or WIGE units, {@code false} otherwise.
      */
-    public boolean formationContainsOnlyVTOLForces(Hangar hangar, boolean standardFormationsOnly) {
+    public boolean formationContainsOnlyVTOLForces(mekhq.campaign.LocalHangar hangar, boolean standardFormationsOnly) {
         for (UUID unitId : getAllUnits(standardFormationsOnly)) {
             Entity entity = getEntityFromUnitId(hangar, unitId);
 
@@ -1269,13 +1269,14 @@ public class Formation {
      *       all entities.</li>
      * </ul>
      *
-     * @param hangar                 The {@link Hangar} instance from which to retrieve the {@link Unit}.
+     * @param hangar                 The {@link LocalHangar} instance from which to retrieve the {@link Unit}.
      * @param standardFormationsOnly A flag to filter and include only standard formations from the formation.
      *
      * @return {@code true} if VTOL or WIGE units constitute at least half of the resolved formation units,
      *       {@code false} otherwise.
      */
-    public boolean formationContainsMajorityVTOLForces(Hangar hangar, boolean standardFormationsOnly) {
+    public boolean formationContainsMajorityVTOLForces(mekhq.campaign.LocalHangar hangar,
+            boolean standardFormationsOnly) {
         Vector<UUID> allUnits = getAllUnits(standardFormationsOnly);
         int formationSize = allUnits.size();
         int vtolCount = 0;
@@ -1318,7 +1319,7 @@ public class Formation {
      *   <li>Returns {@code true} if all units in the formation meet the aerial unit criteria.</li>
      * </ul>
      *
-     * @param hangar                      The {@link Hangar} instance from which to retrieve the {@link Unit}.
+     * @param hangar                      The {@link LocalHangar} instance from which to retrieve the {@link Unit}.
      * @param standardFormationsOnly      A flag to filter and include only standard formations from the formation.
      * @param excludeConventionalFighters A flag determining if conventional fighters should be excluded from the
      *                                    assessment.
@@ -1326,8 +1327,8 @@ public class Formation {
      * @return {@code true} if the formation consists only of aerial units (respecting the provided filters),
      *       {@code false} otherwise.
      */
-    public boolean formationContainsOnlyAerialForces(Hangar hangar, boolean standardFormationsOnly,
-          boolean excludeConventionalFighters) {
+    public boolean formationContainsOnlyAerialForces(mekhq.campaign.LocalHangar hangar, boolean standardFormationsOnly,
+            boolean excludeConventionalFighters) {
         for (UUID unitId : getAllUnits(standardFormationsOnly)) {
             Entity entity = getEntityFromUnitId(hangar, unitId);
 
@@ -1347,7 +1348,7 @@ public class Formation {
         return true;
     }
 
-    public int getSalvageUnitCount(Hangar hangar, boolean isInSpace) {
+    public int getSalvageUnitCount(mekhq.campaign.LocalHangar hangar, boolean isInSpace) {
         List<Unit> unitsInFormation = getAllUnitsAsUnits(hangar, false);
 
         int unitCount = 0;

--- a/MekHQ/src/mekhq/campaign/force/PlayerForce.java
+++ b/MekHQ/src/mekhq/campaign/force/PlayerForce.java
@@ -36,7 +36,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import mekhq.campaign.camOpsReputation.ReputationController;
+import mekhq.campaign.camOpsReputation.ForceReputationController;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.finances.Finances;
 import mekhq.campaign.personnel.ranks.RankSystem;
@@ -66,7 +66,7 @@ public class PlayerForce extends AbstractForce implements SingleDetachmentForce 
      * @param campaignOptions      the campaign options the force's {@link ForceOptions} passes through to
      */
     public PlayerForce(Faction faction, megamek.common.enums.Faction techFaction, RankSystem rankSystem,
-          Finances finances, ReputationController reputationController, FactionStandings factionStandings,
+          Finances finances, ForceReputationController reputationController, FactionStandings factionStandings,
           CampaignOptions campaignOptions) {
         super(new ForceOptions(campaignOptions, faction), techFaction, rankSystem, finances, reputationController,
               factionStandings);

--- a/MekHQ/src/mekhq/campaign/force/SingleDetachmentForce.java
+++ b/MekHQ/src/mekhq/campaign/force/SingleDetachmentForce.java
@@ -33,9 +33,9 @@
 package mekhq.campaign.force;
 
 import mekhq.campaign.DetachmentLocationManager;
-import mekhq.campaign.Hangar;
-import mekhq.campaign.Personnel;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalHangar;
+import mekhq.campaign.LocalPersonnel;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.market.RequestedStockLevels;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.PartInventory;
@@ -60,19 +60,19 @@ public interface SingleDetachmentForce {
     /** The single detachment this force tracks. */
     Detachment getForceDetachment();
 
-    default Hangar getHangar() {
+    default LocalHangar getHangar() {
         return getForceDetachment().getHangar();
     }
 
-    default Warehouse getWarehouse() {
+    default LocalWarehouse getWarehouse() {
         return getForceDetachment().getWarehouse();
     }
 
-    default void setWarehouse(Warehouse warehouse) {
+    default void setWarehouse(LocalWarehouse warehouse) {
         getForceDetachment().setWarehouse(warehouse);
     }
 
-    default Personnel getPersonnel() {
+    default LocalPersonnel getPersonnel() {
         return getForceDetachment().getPersonnel();
     }
 

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -93,7 +93,7 @@ import mekhq.Utilities;
 import mekhq.campaign.*;
 import mekhq.campaign.againstTheBot.AtBConfiguration;
 import mekhq.campaign.base.PlayerBase;
-import mekhq.campaign.camOpsReputation.ReputationController;
+import mekhq.campaign.camOpsReputation.ForceReputationController;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.campaignOptions.CampaignOptionsUnmarshaller;
 import mekhq.campaign.enums.CampaignTransportType;
@@ -105,9 +105,9 @@ import mekhq.campaign.icons.UnitIcon;
 import mekhq.campaign.location.AcademyCampusLocation;
 import mekhq.campaign.location.ILocation;
 import mekhq.campaign.location.LocationNode;
+import mekhq.campaign.market.ForceShoppingList;
 import mekhq.campaign.market.PersonnelMarket;
 import mekhq.campaign.market.RequestedStockLevels;
-import mekhq.campaign.market.ShoppingList;
 import mekhq.campaign.market.contractMarket.AbstractContractMarket;
 import mekhq.campaign.market.contractMarket.AtbMonthlyContractMarket;
 import mekhq.campaign.mission.AtBContract;
@@ -171,689 +171,6 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
 
     public void close() throws IOException {
         this.is.close();
-    }
-
-    /**
-     * Designed to create a campaign object from an input stream containing an XML structure.
-     *
-     * @return The created Campaign object, or null if there was a problem.
-     *
-     * @throws CampaignXmlParseException Thrown when there was a problem parsing the CPNX file
-     * @throws NullEntityException       Thrown when an entity is referenced but cannot be loaded or found
-     */
-    public Campaign parse() throws CampaignXmlParseException, NullEntityException {
-        LOGGER.info("Starting load of campaign file from XML...");
-        // Initialize variables.
-        Campaign campaign = CampaignFactory.createCampaign();
-        campaign.setGUI(app.getCampaigngui());
-
-        Document xmlDoc;
-
-        try {
-            xmlDoc = MHQXMLUtility.parseDocument(is);
-        } catch (Exception ex) {
-            LOGGER.error("", ex);
-            throw new CampaignXmlParseException(ex);
-        }
-
-        Element campaignEle = xmlDoc.getDocumentElement();
-        NodeList nl = campaignEle.getChildNodes();
-
-        // Get rid of empty text nodes and adjacent text nodes...
-        // Stupid weird parsing of XML. At least this cleans it up.
-        campaignEle.normalize();
-
-        final Version version = new Version(campaignEle.getAttribute("version"));
-        if (version.is("0.0.0")) {
-            throw new CampaignXmlParseException(String.format("Illegal version of %s failed to parse",
-                  campaignEle.getAttribute("version")));
-        }
-        // Confirm the campaign version is compatible with the current MekHQ version. This function lives here so that
-        // we don't attempt to load incompatible campaigns and risk running into errors that might prevent the player
-        // from viewing this dialog
-        new MilestoneUpgradePathDialog(app, campaign, version);
-
-        // Assuming there is no upgrade path, we set version and continue parsing the campaign.
-        campaign.setVersion(version);
-
-        // Indicates whether new units were written to disk while
-        // loading the Campaign file. If so, we need to kick back off loading
-        // all the unit data from disk.
-        boolean reloadUnitData = false;
-
-        // we need to iterate through three times, the first time to collect
-        // any custom units that might not be written yet
-        for (int x = 0; x < nl.getLength(); x++) {
-            Node wn = nl.item(x);
-
-            if (!wn.getParentNode().equals(campaignEle)) {
-                continue;
-            }
-
-            int xc = wn.getNodeType();
-
-            if (xc == Node.ELEMENT_NODE) {
-                // This is what we really care about.
-                // All the meat of our document is in this node type, at this
-                // level.
-                // Okay, so what element is it?
-                String xn = wn.getNodeName();
-
-                if (xn.equalsIgnoreCase("info")) { // This is needed so that the campaign name gets set in campaign
-                    try {
-                        processInfoNode(campaign, wn, version);
-                    } catch (DOMException e) {
-                        throw new CampaignXmlParseException(e);
-                    }
-                } else if (xn.equalsIgnoreCase("custom")) {
-                    reloadUnitData |= processCustom(campaign, wn);
-                } else if (xn.equalsIgnoreCase("campaignOptions")) {
-                    campaign.setCampaignOptions(CampaignOptionsUnmarshaller.generateCampaignOptionsFromXml(wn,
-                          version));
-                } else if (xn.equalsIgnoreCase("gameOptions")) {
-                    campaign.getGameOptions().fillFromXML(wn.getChildNodes());
-                } else if (xn.equalsIgnoreCase(PlanetarySystemCampaignXmlIO.XML_TAG)) {
-                    processPlanetarySystemOverrides(campaign, wn);
-                }
-            }
-            // If it's a text node or attribute or whatever at this level,
-            // it's probably white-space.
-            // We can safely ignore it even if it isn't, for now.
-        }
-
-        // Only reload unit data if we updated files on disk
-        if (reloadUnitData) {
-            MekSummaryCache.getInstance().loadMekData();
-        }
-
-        // the second time to check for any null entities
-        for (int x = 0; x < nl.getLength(); x++) {
-            Node wn = nl.item(x);
-
-            if (!wn.getParentNode().equals(campaignEle)) {
-                continue;
-            }
-
-            int xc = wn.getNodeType();
-
-            if (xc == Node.ELEMENT_NODE) {
-                // This is what we really care about.
-                // All the meat of our document is in this node type, at this
-                // level.
-                // Okay, so what element is it?
-                String xn = wn.getNodeName();
-
-                if (xn.equalsIgnoreCase("units")) {
-                    String missingList = checkUnits(wn);
-                    if (null != missingList) {
-                        throw new NullEntityException(missingList);
-                    }
-                }
-            }
-            // If it's a text node or attribute or whatever at this level,
-            // it's probably white-space.
-            // We can safely ignore it even if it isn't, for now.
-        }
-
-        boolean foundPersonnelMarket = false;
-        boolean foundContractMarket = false;
-        boolean foundUnitMarket = false;
-
-        // Saves made in 0.51.00 do not have a <location> but will have a <locations> with a single item.
-        boolean foundMainForceLocation = false;
-
-        // Pending travel references persons, units, parts, and bases, so it is resolved after those are all loaded.
-        Node pendingTravelNode = null;
-
-        // Okay, lets iterate through the children, eh?
-        for (int x = 0; x < nl.getLength(); x++) {
-            Node workingNode = nl.item(x);
-
-            if (!workingNode.getParentNode().equals(campaignEle)) {
-                continue;
-            }
-
-            int xc = workingNode.getNodeType();
-
-            if (xc == Node.ELEMENT_NODE) {
-                // This is what we really care about.
-                // All the meat of our document is in this node type, at this level.
-                // Okay, so what element is it?
-                String nodeName = workingNode.getNodeName();
-
-                if (nodeName.equalsIgnoreCase("pastVersions")) {
-                    processPastVersionNodes(campaign, workingNode);
-                } else if (nodeName.equalsIgnoreCase("randomSkillPreferences")) {
-                    campaign.setRandomSkillPreferences(RandomSkillPreferences.generateRandomSkillPreferencesFromXml(
-                          workingNode,
-                          version));
-                } else if (nodeName.equalsIgnoreCase("humanResources")) {
-                    campaign.setHumanResources(
-                          mekhq.campaign.HumanResources.loadFromXML(workingNode, campaign, version));
-                } else if (nodeName.equalsIgnoreCase("parts")) {
-                    processPartNodes(campaign, workingNode, version);
-                } else if (nodeName.equalsIgnoreCase("personnel")) {
-                    // backward compat: old save without <humanResources> wrapper
-                    // TODO: Make this depending on campaign options
-                    // TODO: hoist registerAll out of this
-                    InjuryTypes.registerAll();
-                    processPersonnelNodes(campaign, workingNode, version);
-                } else if (nodeName.equalsIgnoreCase("units")) {
-                    processUnitNodes(campaign, workingNode, version);
-                } else if (nodeName.equalsIgnoreCase("missions")) {
-                    processMissionNodes(campaign, workingNode, version);
-                } else if (nodeName.equalsIgnoreCase("forces")) {
-                    processForces(campaign, workingNode, version);
-                } else if (nodeName.equalsIgnoreCase("formations")) {
-                    processFormations(campaign, workingNode, version);
-                } else if (nodeName.equalsIgnoreCase("finances")) {
-                    processFinances(campaign, workingNode);
-                } else if (nodeName.equalsIgnoreCase("locations")) {
-                    processLocations(campaign, workingNode);
-                } else if (nodeName.equalsIgnoreCase("playerBases")) {
-                    processPlayerBaseNodes(campaign, workingNode, version);
-                } else if (nodeName.equalsIgnoreCase("pendingTravel")) {
-                    pendingTravelNode = workingNode;
-                } else if (nodeName.equalsIgnoreCase("location")) {
-                    // Campaign's current location — written as a top-level tag in new saves;
-                    // same tag was used as the only location entry in pre-<locations>-list saves.
-                    campaign.setLocation(CurrentLocation.generateInstanceFromXML(workingNode, campaign));
-                    foundMainForceLocation = true;
-                } else if (nodeName.equalsIgnoreCase("locationNodeChildren")) {
-                    LocationNode.reconnectChildren(workingNode, campaign);
-                } else if (nodeName.equalsIgnoreCase("isAvoidingEmptySystems")) {
-                    campaign.setIsAvoidingEmptySystems(Boolean.parseBoolean(workingNode.getTextContent().trim()));
-                } else if (nodeName.equalsIgnoreCase("skillTypes")) {
-                    processSkillTypeNodes(workingNode, version);
-                } else if (nodeName.equalsIgnoreCase("specialAbilities")) {
-                    processSpecialAbilityNodes(campaign, workingNode, version);
-                } else if (nodeName.equalsIgnoreCase("storyArc")) {
-                    processStoryArcNodes(campaign, workingNode, version);
-                } else if (nodeName.equalsIgnoreCase("kills")) {
-                    processKillNodes(campaign, workingNode, version);
-                } else if (nodeName.equalsIgnoreCase("shoppingList")) {
-                    campaign.setShoppingList(ShoppingList.generateInstanceFromXML(workingNode, campaign, version));
-                } else if (nodeName.equalsIgnoreCase("personnelMarket")) {
-                    campaign.setPersonnelMarket(PersonnelMarket.generateInstanceFromXML(workingNode,
-                          campaign,
-                          version));
-                    foundPersonnelMarket = true;
-                } else if (nodeName.equalsIgnoreCase("contractMarket")) {
-                    // CAW: implicit DEPENDS-ON to the <missions> node
-                    campaign.setContractMarket(AbstractContractMarket.generateInstanceFromXML(workingNode,
-                          campaign,
-                          version));
-                    foundContractMarket = true;
-                } else if (nodeName.equalsIgnoreCase("unitMarket")) {
-                    // Windchild: implicit DEPENDS ON to the <campaignOptions> nodes
-                    campaign.setUnitMarket(campaign.getCampaignOptions().getUnitMarketMethod().getUnitMarket());
-                    campaign.getUnitMarket().fillFromXML(workingNode, campaign, version);
-                    foundUnitMarket = true;
-                } else if (nodeName.equalsIgnoreCase("lances") || nodeName.equalsIgnoreCase("combatTeams")) {
-                    processCombatTeamNodes(campaign, workingNode);
-                } else if (nodeName.equalsIgnoreCase("retirementDefectionTracker")) {
-                    campaign.setRetirementDefectionTracker(RetirementDefectionTracker.generateInstanceFromXML(
-                          workingNode,
-                          campaign));
-                } else if (nodeName.equalsIgnoreCase("personnelWhoAdvancedInXP")) {
-                    campaign.setPersonnelWhoAdvancedInXP(processPersonnelWhoAdvancedInXP(workingNode, campaign));
-                } else if (nodeName.equalsIgnoreCase("automatedMothballUnits")) {
-                    campaign.setAutomatedMothballUnits(processAutomatedMothballNodes(workingNode));
-                } else if (nodeName.equalsIgnoreCase("autoResolveBehaviorSettings")) {
-                    campaign.setAutoResolveBehaviorSettings(firstNonNull(BehaviorSettingsFactory.getInstance()
-                                                                               .getBehavior(workingNode.getTextContent()),
-                          BehaviorSettingsFactory.getInstance().DEFAULT_BEHAVIOR));
-                } else if (nodeName.equalsIgnoreCase("customPlanetaryEvents")) {
-                    //TODO: deal with this
-                    updatePlanetaryEventsFromXML(workingNode);
-                } else if (nodeName.equalsIgnoreCase("partsInUse")) {
-                    processPartsInUse(campaign, workingNode, version);
-                } else if (nodeName.equalsIgnoreCase("temporaryPrisonerCapacity")) {
-                    campaign.setTemporaryPrisonerCapacity(MathUtility.parseInt(workingNode.getTextContent().trim()));
-                } else if (nodeName.equalsIgnoreCase("processProcurement")) {
-                    campaign.setProcessProcurement(Boolean.parseBoolean(workingNode.getTextContent().trim()));
-                }
-            }
-            // If it's a text node or attribute or whatever at this level,
-            // it's probably white-space.
-            // We can safely ignore it even if it isn't, for now.
-        }
-
-        // Okay, after we've gone through all the nodes and constructed the
-        // Campaign object...
-        final CampaignOptions options = campaign.getCampaignOptions();
-
-        // We need to do a post-process pass to restore a number of references.
-        // Fix any Person ID References
-        PersonIdReference.fixPersonIdReferences(campaign);
-
-        // Fixup any ghost kills
-        cleanupGhostKills(campaign);
-
-        // Update the Personnel Modules
-        campaign.setDivorce(options.getRandomDivorceMethod().getMethod(options));
-        campaign.setMarriage(options.getRandomMarriageMethod().getMethod(options));
-        campaign.setProcreation(options.getRandomProcreationMethod().getMethod(options));
-
-        long timestamp = System.currentTimeMillis();
-
-        // loop through forces to set force id
-        for (Formation f : campaign.getAllFormations()) {
-            Scenario s = campaign.getScenario(f.getScenarioId());
-            if (null != s && (null == f.getParentFormation() || !f.getParentFormation().isDeployed())) {
-                s.addForces(f.getId());
-            }
-            // some units may need force id set for backwards compatibility
-            // some may also need scenario id set
-            for (UUID uid : f.getUnits()) {
-                Unit u = campaign.getUnit(uid);
-                if (null != u) {
-                    u.setFormationId(f.getId());
-                    if (f.isDeployed()) {
-                        u.setScenarioId(f.getScenarioId());
-                    }
-                }
-            }
-        }
-
-        // determine if we've missed any lances and add those back into the campaign
-        if (options.isUseStratCon()) {
-            Hashtable<Integer, CombatTeam> lances = campaign.getCombatTeamsAsMap();
-            for (Formation f : campaign.getAllFormations()) {
-                if (!f.getUnits().isEmpty() && (null == lances.get(f.getId()))) {
-                    lances.put(f.getId(), new CombatTeam(f.getId(), campaign));
-                    LOGGER.warn("Added missing Lance {} to AtB list", f.getName());
-                }
-            }
-        }
-
-        LOGGER.info("[Campaign Load] Force IDs set in {}ms", System.currentTimeMillis() - timestamp);
-        timestamp = System.currentTimeMillis();
-
-        // Process parts...
-        // Note: Units must have their Entities set prior to reaching this point!
-        postProcessParts(campaign, version);
-        rehomeBaseHangarUnitParts(campaign);
-
-        LOGGER.info("[Campaign Load] Parts processed in {}ms", System.currentTimeMillis() - timestamp);
-        timestamp = System.currentTimeMillis();
-
-        LOGGER.info("[Campaign Load] Rank references fixed in {}ms", System.currentTimeMillis() - timestamp);
-        timestamp = System.currentTimeMillis();
-
-        // Okay, Units, need their pilot references fixed.
-        campaign.getAllHangar().forEachUnit(unit -> {
-            // Also, the unit should have its campaign set.
-            unit.setCampaign(campaign);
-            unit.fixReferences(campaign);
-
-            if (null != unit.getRefit()) {
-                unit.getRefit().fixReferences(campaign);
-
-                unit.getRefit().reCalc();
-                if (!unit.getRefit().isCustomJob() && !unit.getRefit().kitFound()) {
-                    campaign.getShoppingList().addShoppingItemWithoutChecking(unit.getRefit());
-                }
-            }
-
-            // lets make sure the force id set actually corresponds to a force
-            // TODO: we have some reports of force id relics - need to fix
-            if ((unit.getFormationId() > 0) && (campaign.getFormation(unit.getFormationId()) == null)) {
-                unit.setFormationId(FORMATION_NONE);
-            }
-
-            // It's annoying to have to do this, but this helps to ensure
-            // that equipment numbers correspond to the right parts - its
-            // possible that these might have changed if changes were made to
-            // the ordering of equipment in the underlying data file for the unit.
-            // We're not checking for refit here.
-            final EquipmentUnscrambler unscrambler = EquipmentUnscrambler.create(unit);
-            final EquipmentUnscramblerResult result = unscrambler.unscramble();
-            if (!result.succeeded()) {
-                LOGGER.warn(result.getMessage());
-            }
-
-            // some units might need to be assigned to scenarios
-            Scenario s = campaign.getScenario(unit.getScenarioId());
-            if (null != s) {
-                // most units will be properly assigned through their
-                // force, so check to make sure they aren't already here
-                if (!s.isAssigned(unit, campaign)) {
-                    s.addUnit(unit.getId());
-                }
-            }
-
-            //Update the campaign transport availability if this is transport.
-            //If it's empty we should be able to just ignore it
-            for (CampaignTransportType campaignTransportType : CampaignTransportType.values()) {
-                if (unit.hasTransportedUnits(campaignTransportType)) {
-                    campaign.updateTransportInTransports(campaignTransportType, unit);
-                }
-            }
-        });
-
-        LOGGER.info("[Campaign Load] Pilot references fixed in {}ms", System.currentTimeMillis() - timestamp);
-        timestamp = System.currentTimeMillis();
-
-        // Fix campaign references for units in base hangars.
-        // These units are NOT in campaign.getHangar(), so the loop above skips them.
-        // They need setCampaign() and fixReferences() just like main-force units.
-        for (PlayerBase base : campaign.getCampaignLocationManager().getPlayerBases()) {
-            base.getBaseHangar().forEachUnit(unit -> initializeBaseUnit(unit, campaign));
-        }
-
-        LOGGER.info("[Campaign Load] Base hangar references fixed in {}ms", System.currentTimeMillis() - timestamp);
-        timestamp = System.currentTimeMillis();
-
-        boolean skipAllDeprecationChecks = false;
-        boolean refundAllDeprecatedSkills = false;
-        for (Person person : campaign.getAllPersonnel()) {
-            // skill types might need resetting
-            person.resetSkillTypes();
-
-            // Seeing as we're already looping through all personnel, we might as well have the deprecation checks
-            // here, too.
-            if (!DEPRECATED_SKILLS.isEmpty() && !skipAllDeprecationChecks) {
-                // This checks to ensure the character doesn't have any Deprecated skills.
-                SkillDeprecationTool deprecationTool = new SkillDeprecationTool(campaign,
-                      person,
-                      refundAllDeprecatedSkills);
-                skipAllDeprecationChecks = deprecationTool.isSkipAll();
-                refundAllDeprecatedSkills = deprecationTool.isRefundAll();
-            }
-
-            // Self-correct any invalid personnel statuses (handles <50.05 campaigns)
-            // Any characters with invalid statuses will have their status set to 'Active'
-            if (person.getPrisonerStatus().isCurrentPrisoner()) {
-                statusValidator(campaign, person, true);
-            }
-
-            // <50.10 compatibility handler
-            LocalDate today = campaign.getLocalDate();
-            if (Person.updateSkillsForVehicleProfessions(today, person, person.getPrimaryRole(), true) ||
-                      Person.updateSkillsForVehicleProfessions(today, person, person.getSecondaryRole(), false)) {
-                String report = getFormattedTextAt(RESOURCE_BUNDLE, "vehicleProfessionSkillChange",
-                      spanOpeningWithCustomColor(getWarningColor()),
-                      CLOSING_SPAN_TAG,
-                      person.getHyperlinkedFullTitle());
-                campaign.addReport(GENERAL, report);
-            }
-
-            // This resolves a bug squashed in 2025 (50.03) but lurked in our codebase
-            // potentially as far back as 2014. The next two handlers should never be removed.
-            if (!person.canPerformRole(today, person.getSecondaryRole(), false)) {
-                person.setSecondaryRole(PersonnelRole.NONE);
-
-                campaign.addReport(GENERAL, getFormattedTextAt(RESOURCE_BUNDLE, "ineligibleForSecondaryRole",
-                      spanOpeningWithCustomColor(getWarningColor()),
-                      CLOSING_SPAN_TAG,
-                      person.getHyperlinkedFullTitle()));
-            }
-
-            if (!person.canPerformRole(today, person.getPrimaryRole(), true)) {
-                person.setPrimaryRole(campaign.getLocalDate(), PersonnelRole.DEPENDENT);
-
-                campaign.addReport(GENERAL, getFormattedTextAt(RESOURCE_BUNDLE, "ineligibleForPrimaryRole",
-                      spanOpeningWithCustomColor(getNegativeColor()),
-                      CLOSING_SPAN_TAG,
-                      person.getHyperlinkedFullTitle()));
-            }
-        }
-
-        campaign.getAllHangar().forEachUnit(unit -> {
-            // Some units have been incorrectly assigned a null C3UUID as a string. This
-            // should
-            // correct that by setting a new C3UUID
-            if ((unit.getEntity().hasC3() || unit.getEntity().hasC3i() || unit.getEntity().hasNavalC3()) &&
-                      (unit.getEntity().getC3UUIDAsString() == null ||
-                             unit.getEntity().getC3UUIDAsString().equals("null"))) {
-                unit.getEntity().setC3UUID();
-                unit.getEntity().setC3NetIdSelf();
-            }
-
-            // This needs to be down here so that it can factor in any changes made to personnel prior to this point.
-            unit.resetPilotAndEntity();
-        });
-        campaign.refreshNetworks();
-
-        LOGGER.info("[Campaign Load] C3 networks refreshed in {}ms", System.currentTimeMillis() - timestamp);
-        timestamp = System.currentTimeMillis();
-
-        // This removes the risk of having forces with invalid leadership getting locked in
-        for (Formation formation : campaign.getAllFormations()) {
-            formation.updateCommander(campaign);
-        }
-
-        // ok, once we are sure that campaign has been set for all units, we can
-        // now go through and initializeParts and run diagnostics
-        List<Unit> removeUnits = new ArrayList<>();
-        campaign.getAllHangar().forEachUnit(unit -> {
-            // just in case parts are missing (i.e. because they weren't tracked
-            // in previous versions)
-            unit.initializeParts(true);
-            unit.runDiagnostic(false);
-            if (!unit.isRepairable()) {
-                if (!unit.hasSalvageableParts()) {
-                    // we shouldn't get here but some units seem to stick around
-                    // for some reason
-                    removeUnits.add(unit);
-                } else {
-                    unit.setSalvage(true);
-                }
-            }
-
-            List<String> reports = unit.checkForOverCrewing();
-            for (String report : reports) {
-                campaign.addReport(GENERAL, report);
-            }
-        });
-
-        for (Unit unit : removeUnits) {
-            campaign.removeUnit(unit.getId());
-        }
-
-        for (PlayerBase base : campaign.getCampaignLocationManager().getPlayerBases()) {
-            base.getBaseHangar().forEachUnit(unit -> {
-                unit.initializeParts(false);
-                unit.runDiagnostic(false);
-
-                List<String> reports = unit.checkForOverCrewing();
-                for (String report : reports) {
-                    campaign.addReport(GENERAL, report);
-                }
-            });
-        }
-
-        LOGGER.info("[Campaign Load] Units initialized in {}ms", System.currentTimeMillis() - timestamp);
-        timestamp = System.currentTimeMillis();
-
-        for (Person person : campaign.getAllPersonnel()) {
-            person.fixReferences(campaign);
-        }
-
-        LOGGER.info("[Campaign Load] Personnel initialized in {}ms", System.currentTimeMillis() - timestamp);
-        timestamp = System.currentTimeMillis();
-
-        campaign.reloadNews();
-
-        LOGGER.info("[Campaign Load] News loaded in {}ms", System.currentTimeMillis() - timestamp);
-        timestamp = System.currentTimeMillis();
-
-        // If we don't have a personnel market, create one.
-        if (!foundPersonnelMarket) {
-            campaign.setPersonnelMarket(new PersonnelMarket(campaign));
-        }
-
-        if (!foundContractMarket) {
-            campaign.setContractMarket(new AtbMonthlyContractMarket());
-        }
-
-        if (!foundUnitMarket) {
-            campaign.setUnitMarket(campaign.getCampaignOptions().getUnitMarketMethod().getUnitMarket());
-        }
-
-        if (null == campaign.getRetirementDefectionTracker()) {
-            campaign.setRetirementDefectionTracker(new RetirementDefectionTracker());
-        }
-
-        if (campaign.getCampaignOptions().isUseStratCon()) {
-            campaign.setHasActiveContract();
-            campaign.setAtBConfig(AtBConfiguration.loadFromXml());
-        }
-
-        // Sanity Checks
-        fixupUnitTechProblems(campaign);
-
-        // unload any ammo bins in the warehouse
-        List<AmmoBin> binsToUnload = new ArrayList<>();
-        campaign.getAllWarehouse().forEachSparePart(prt -> {
-            if (prt instanceof AmmoBin && !prt.isReservedForRefit() && ((AmmoBin) prt).getShotsNeeded() == 0) {
-                binsToUnload.add((AmmoBin) prt);
-            }
-        });
-        for (AmmoBin bin : binsToUnload) {
-            bin.unload();
-        }
-
-        LOGGER.info("[Campaign Load] Ammo bins cleared in {}ms", System.currentTimeMillis() - timestamp);
-        timestamp = System.currentTimeMillis();
-
-        // Check all parts that are reserved for refit and if the refit id unit
-        // is not refitting or is gone then un-reserve
-        for (Part part : campaign.getAllWarehouse().getParts()) {
-            if (part.isReservedForRefit()) {
-                Unit u = part.getRefitUnit();
-                if ((null == u) || !u.isRefitting()) {
-                    part.setRefitUnit(null);
-                }
-            }
-        }
-
-        LOGGER.info("[Campaign Load] Reserved refit parts fixed in {}ms", System.currentTimeMillis() - timestamp);
-        timestamp = System.currentTimeMillis();
-
-        // Build a new, clean warehouse from the current parts
-        Warehouse warehouse = new Warehouse();
-        for (Part part : campaign.getAllWarehouse().getParts()) {
-            // Remove empty AmmoStorage entries that shouldn't exist (see #7414)
-            if (part instanceof AmmoStorage ammoStorage && ammoStorage.getShots() <= 0 && part.isSpare()) {
-                LOGGER.info("Discarding empty AmmoStorage: {}", part.getName());
-                continue;
-            }
-
-            // < 50.08 compatibility handler
-            if (part instanceof SVArmor svArmor) {
-                final int PROHIBITED_BAR_RATING = 0;
-
-                int bar = svArmor.getBAR();
-                if (bar == PROHIBITED_BAR_RATING) {
-                    LOGGER.info("Discarding untracked BAR 0 armor");
-                    continue;
-                }
-            }
-
-            warehouse.addPart(part, true);
-        }
-
-        // This will have aggregated all the possible spare parts together
-        campaign.setWarehouse(warehouse);
-
-        LOGGER.info("[Campaign Load] Warehouse cleaned up in {}ms", System.currentTimeMillis() - timestamp);
-
-        campaign.setUnitRating(null);
-
-        // this is used to handle characters from pre-50.01 campaigns
-        campaign.getAllPersonnel().stream().filter(person -> person.getJoinedCampaign() == null).forEach(person -> {
-            if (person.getRecruitment() != null) {
-                person.setJoinedCampaign(person.getRecruitment());
-                LOGGER.info(
-                      "{} doesn't have a date recorded showing when they joined the campaign. Using recruitment date.",
-                      person.getFullTitle());
-            } else {
-                person.setJoinedCampaign(campaign.getLocalDate());
-                LOGGER.info("{} doesn't have a date recorded showing when they joined the campaign. Using current date.",
-                      person.getFullTitle());
-            }
-        });
-
-        // Reset Random Death to match current campaign options
-        campaign.resetRandomDeath();
-
-        // Fix sexual preferences
-        if (version.isLowerThan(new Version("0.50.10"))) {
-            correctSexualPreferencesForCurrentSpouse(campaign.getAllPersonnel());
-        }
-
-        // Reconnect persons to the main-force personnel node. Skip persons already placed by
-        // processPlayerBaseNodes or reconnectChildren (base / travel / campus persons).
-        for (Person person : campaign.getAllPersonnel()) {
-            if (!person.isParented()) {
-                person.setParent(campaign.getMainForcePersonnel());
-            }
-        }
-
-
-        // Backward compat: Saves prior to 0.51.00 will have a single <location> tag, like we do now.
-        // However, saves from 0.51.00 will not have a location tag, but will have a <locations> tag with only
-        // one item. If we didn't find an explicit main force location, use that one. To check for this, if we didn't
-        // find a main force location, check if we have more than one location in our list (by default,
-        // will set and add a location to Campaign during the constructor.
-        if ((!foundMainForceLocation) && (campaign.getCampaignLocationManager().getLocations().size() > 1)) {
-            // Remove the location that was set by default, then use a valid location out of our locations list.
-            campaign.getCampaignLocationManager().removeLocation(campaign.getCurrentLocation());
-            campaign.getCampaignLocationManager().getLocations().stream()
-                  .filter(loc -> loc instanceof CurrentLocation)
-                  .findFirst()
-                  .ifPresent(campaign::setLocation);
-        }
-
-        if (pendingTravelNode != null) {
-            processPendingTravel(campaign, pendingTravelNode);
-        }
-
-        migrateLegacyEducationTravel(campaign);
-        reconnectPersonsToTravelLocations(campaign);
-        LOGGER.info("Load of campaign file complete!");
-
-        return campaign;
-    }
-
-    /**
-     * This will fixup unit-tech problems seen in some save games, such as techs having been double-assigned or being
-     * assigned to mothballed units.
-     */
-    private void fixupUnitTechProblems(Campaign retVal) {
-        // Cleanup problems with techs and units
-        for (Person tech : retVal.getTechs()) {
-            for (Unit u : new ArrayList<>(tech.getTechUnits())) {
-                String reason = null;
-                String unitDesc = u.getId().toString();
-                if (null == u.getTech()) {
-                    reason = "was not referenced by unit";
-                    u.setTech(tech);
-                } else if (u.isMothballed()) {
-                    reason = "referenced mothballed unit";
-                    unitDesc = u.getName();
-                    tech.removeTechUnit(u);
-                } else if (u.getTech() != null && !tech.getId().equals(u.getTech().getId())) {
-                    reason = String.format("referenced tech %s's maintained unit", u.getTech().getFullName());
-                    unitDesc = u.getName();
-                    tech.removeTechUnit(u);
-                }
-                if (null != reason) {
-                    LOGGER.warn("Tech {} {} {} (fixed)", tech.getFullName(), reason, unitDesc);
-                }
-            }
-        }
-    }
-
-    private static void processPlanetarySystemOverrides(Campaign campaign, Node parentNode)
-          throws CampaignXmlParseException {
-        try {
-            campaign.setPlanetarySystemOverrides(PlanetarySystemCampaignXmlIO.parse(parentNode));
-        } catch (IOException ex) {
-            throw new CampaignXmlParseException(ex);
-        }
     }
 
     /**
@@ -1141,7 +458,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                 } else if (nodeName.equalsIgnoreCase("dateOfLastCrime")) {
                     campaign.setDateOfLastCrime(LocalDate.parse(childNode.getTextContent()));
                 } else if (nodeName.equalsIgnoreCase("reputation")) {
-                    campaign.setReputation(new ReputationController().generateInstanceFromXML(childNode));
+                    campaign.setReputation(new ForceReputationController().generateInstanceFromXML(childNode));
                 } else if (nodeName.equalsIgnoreCase("newPersonnelMarket")) {
                     campaign.setNewPersonnelMarket(generatePersonnelMarketDataFromXML(campaign, childNode, version));
                 } else if (nodeName.equalsIgnoreCase("factionStandings")) {
@@ -1367,6 +684,209 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
             newTechnicalReports.add(report);
         }
         campaign.setNewTechnicalReports(newTechnicalReports);
+    }
+
+    private static void processPlanetarySystemOverrides(Campaign campaign, Node parentNode)
+          throws CampaignXmlParseException {
+        try {
+            campaign.setPlanetarySystemOverrides(PlanetarySystemCampaignXmlIO.parse(parentNode));
+        } catch (IOException ex) {
+            throw new CampaignXmlParseException(ex);
+        }
+    }
+
+    private static void processPersonnelNodes(Campaign campaign, Node wn, Version version) {
+        LOGGER.info("Loading Personnel Nodes from XML...");
+
+        LocalPersonnel.loadFromXML(wn, campaign, version);
+
+        // <50.10 compatibility handler (moves old SPA-based Edge to current Attribute-based)
+        for (Person person : campaign.getAllPersonnel()) {
+            performEdgeConversion(campaign, person);
+        }
+
+        // this block verifies all in-use academies are valid
+        List<String> missingList = new ArrayList<>();
+
+        for (Person person : campaign.getAllPersonnel()) {
+            String academySet = person.getEduAcademySet();
+            String academyNameInSet = person.getEduAcademyNameInSet();
+
+            if ((academyNameInSet != null) && (EducationController.getAcademy(academySet, academyNameInSet) == null)) {
+                String message = academyNameInSet + " from set " + academySet;
+                if ((!missingList.contains(message)) && (!missingList.contains('\n' + message))) {
+                    missingList.add((missingList.isEmpty() ? "" : "\n") + message);
+                }
+            }
+        }
+
+        if (!missingList.isEmpty()) {
+            throw new NullPointerException(missingList.toString());
+        }
+
+        LOGGER.info("Load Personnel Nodes Complete!");
+    }
+
+    /**
+     * Migrates persons mid-journey on legacy saves (pre-location-tree) into real {@link CurrentLocation} nodes so they
+     * are handled by the location-aware travel code.
+     *
+     * <p>For each person in JOURNEY_TO_CAMPUS or JOURNEY_FROM_CAMPUS whose location chain contains
+     * no {@link CurrentLocation}, a new {@code CurrentLocation} is created at the target system (academy system for
+     * outbound, campaign current system for return). Transit time is set from the jump-point approach time so they
+     * arrive on planet within a day or two via normal {@code newDay()} processing.</p>
+     */
+    private static void migrateLegacyEducationTravel(Campaign campaign) {
+        // Phase 1: scan for persons that need migration. All per-person logging here is DEBUG
+        // so post-refactor saves (where everyone is skipped) produce no INFO noise.
+        List<Person> toMigrate = new ArrayList<>();
+        for (Person person : campaign.getPersonnel().values()) {
+            EducationStage stage = person.getEduEducationStage();
+            if (stage != EducationStage.JOURNEY_TO_CAMPUS
+                      && stage != EducationStage.JOURNEY_FROM_CAMPUS
+                      && stage != EducationStage.EDUCATION
+                      && stage != EducationStage.GRADUATING
+                      && stage != EducationStage.DROPPING_OUT) {
+                continue;
+            }
+
+            // Skip persons already queued for (but not yet dispatched) travel — processPendingTravel re-queued them
+            // and they still sit at their origin. Migrating would wrongly move them into a travel node/campus.
+            if (campaign.getCampaignLocationManager().isQueuedForTravel(person)) {
+                LOGGER.debug("migrateLegacyEducationTravel: skipping {} — queued in pendingTravel (stage={})",
+                      person.getFullTitle(), stage);
+                continue;
+            }
+
+            Academy academy = getAcademy(person.getEduAcademySet(), person.getEduAcademyNameInSet());
+            if (academy != null && academy.isHomeSchool()) {
+                LOGGER.debug("migrateLegacyEducationTravel: skipping {} — homeSchool", person.getFullTitle());
+                continue;
+            }
+
+            if (stage == EducationStage.EDUCATION
+                      || stage == EducationStage.GRADUATING
+                      || stage == EducationStage.DROPPING_OUT) {
+                // Skip persons whose parent was already set to a non-Campaign-Personnel node
+                // during XML parsing (e.g., reconnected by an earlier load step). Without this
+                // guard, resolveAcademySystemId may return the wrong system for multi-location
+                // academies, creating a duplicate campus and displacing the person.
+                ILocation parentLocation = person.getParentLocation();
+                if (parentLocation != null
+                          && !(parentLocation instanceof LocalPersonnel personnel
+                                     && personnel.getParentLocation() instanceof Detachment)) {
+                    LOGGER.debug("migrateLegacyEducationTravel: skipping {} — already reconnected (stage={})",
+                          person.getFullTitle(), stage);
+                    continue;
+                }
+                // If a FixedLocation campus already holds this person's ID (post-refactor save),
+                // reconnectPersonsToTravelLocations will handle them.
+                if (hasFixedCampusPendingFor(campaign, person)) {
+                    LOGGER.debug(
+                          "migrateLegacyEducationTravel: skipping {} — pending in FixedLocation campus (stage={})",
+                          person.getFullTitle(),
+                          stage);
+                    continue;
+                }
+            } else {
+                // Journey stages: skip if a travel node already holds this person's pending ID
+                // (post-refactor save) — reconnectPersonsToTravelLocations will place them correctly.
+                if (hasTravelNodePendingFor(campaign, person)) {
+                    LOGGER.debug("migrateLegacyEducationTravel: skipping {} — pending in travel node (stage={})",
+                          person.getFullTitle(), stage);
+                    continue;
+                }
+            }
+
+            LOGGER.debug("migrateLegacyEducationTravel: {} needs migration (stage={}, academy='{}', set='{}')",
+                  person.getFullTitle(), stage, person.getEduAcademyNameInSet(), person.getEduAcademySet());
+            toMigrate.add(person);
+        }
+
+        // Phase 2: migrate. Only runs (and only logs at INFO) when legacy persons are found.
+        if (toMigrate.isEmpty()) {
+            LOGGER.debug("migrateLegacyEducationTravel: no persons need legacy migration");
+            return;
+        }
+
+        LOGGER.info("migrateLegacyEducationTravel: {} persons require legacy migration", toMigrate.size());
+        int campusMigrated = 0;
+        int travelMigrated = 0;
+
+        for (Person person : toMigrate) {
+            EducationStage stage = person.getEduEducationStage();
+
+            if (stage == EducationStage.EDUCATION
+                      || stage == EducationStage.GRADUATING
+                      || stage == EducationStage.DROPPING_OUT) {
+                String systemId = resolveAcademySystemId(campaign, person);
+                if (systemId == null) {
+                    LOGGER.warn("migrateLegacyEducationTravel: could not resolve academy system for {} (stage={})"
+                                      + " — skipping campus placement", person.getFullTitle(), stage);
+                    continue;
+                }
+                AcademyCampusLocation campusLocation = campaign.getCampaignLocationManager()
+                                                             .getOrCreateCampusLocation(campaign,
+                                                                   person.getEduAcademySet(),
+                                                                   person.getEduAcademyNameInSet(),
+                                                                   systemId);
+                if (campusLocation != null) {
+                    LOGGER.info("migrateLegacyEducationTravel: placed {} at campus '{}' in system {}",
+                          person.getFullTitle(), person.getEduAcademyNameInSet(), systemId);
+                    person.setParent(campusLocation.getPersonnel());
+                    campusMigrated++;
+                } else {
+                    LOGGER.warn("migrateLegacyEducationTravel: getOrCreateCampusLocation returned null for {}"
+                                      + " (academy='{}', system='{}') — skipping", person.getFullTitle(),
+                          person.getEduAcademyNameInSet(), systemId);
+                }
+                continue;
+            }
+
+            // Journey stages
+            String systemId = resolveAcademySystemId(campaign, person);
+            if (systemId == null) {
+                LOGGER.warn("migrateLegacyEducationTravel: could not resolve academy system for {} (stage={})"
+                                  + " — skipping travel node creation", person.getFullTitle(), stage);
+                continue;
+            }
+            PlanetarySystem targetSystem = campaign.getSystemById(systemId);
+            if (targetSystem == null) {
+                LOGGER.warn("migrateLegacyEducationTravel: system '{}' not found for {} (stage={})"
+                                  + " — skipping travel node creation", systemId, person.getFullTitle(), stage);
+                continue;
+            }
+
+            double transitTime = Math.max(0, person.getEduJourneyTime() - person.getEduDaysOfTravel());
+            LOGGER.info(
+                  "migrateLegacyEducationTravel: creating travel node for {} (stage={}, system={}, transitTime={} days)",
+                  person.getFullTitle(),
+                  stage,
+                  targetSystem.getId(),
+                  transitTime);
+
+            CurrentLocation travelLocation = new CurrentLocation(targetSystem, transitTime);
+            AcademyCampusLocation campusLocation = campaign.getCampaignLocationManager()
+                                                         .getOrCreateCampusLocation(campaign,
+                                                               person.getEduAcademySet(),
+                                                               person.getEduAcademyNameInSet(),
+                                                               systemId);
+            if (campusLocation != null) {
+                LOGGER.info("migrateLegacyEducationTravel: parenting travel node under campus '{}' for {}",
+                      person.getEduAcademyNameInSet(), person.getFullTitle());
+                travelLocation.setParent(campusLocation);
+            } else if (stage == EducationStage.JOURNEY_FROM_CAMPUS) {
+                LOGGER.info("migrateLegacyEducationTravel: no campus found for {} (JOURNEY_FROM_CAMPUS)"
+                                  + " — parenting travel node under the main force", person.getFullTitle());
+                travelLocation.setParent(campaign.getPlayerForce().getForceDetachment());
+            }
+            person.setParent(travelLocation);
+            campaign.getCampaignLocationManager().addLocation(travelLocation);
+            travelMigrated++;
+        }
+
+        LOGGER.info("migrateLegacyEducationTravel: complete — {} placed at campus, {} given travel nodes",
+              campusMigrated, travelMigrated);
     }
 
     private static void processCombatTeamNodes(Campaign campaign, Node workingNode) {
@@ -1616,36 +1136,25 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
         LOGGER.info("Load of Formation Organization complete!");
     }
 
-    private static void processPersonnelNodes(Campaign campaign, Node wn, Version version) {
-        LOGGER.info("Loading Personnel Nodes from XML...");
-
-        Personnel.loadFromXML(wn, campaign, version);
-
-        // <50.10 compatibility handler (moves old SPA-based Edge to current Attribute-based)
-        for (Person person : campaign.getAllPersonnel()) {
-            performEdgeConversion(campaign, person);
-        }
-
-        // this block verifies all in-use academies are valid
-        List<String> missingList = new ArrayList<>();
-
-        for (Person person : campaign.getAllPersonnel()) {
-            String academySet = person.getEduAcademySet();
-            String academyNameInSet = person.getEduAcademyNameInSet();
-
-            if ((academyNameInSet != null) && (EducationController.getAcademy(academySet, academyNameInSet) == null)) {
-                String message = academyNameInSet + " from set " + academySet;
-                if ((!missingList.contains(message)) && (!missingList.contains('\n' + message))) {
-                    missingList.add((missingList.isEmpty() ? "" : "\n") + message);
+    /**
+     * After {@link #postProcessParts} wires up unit references, parts that belong to base-hangar units are still
+     * locationNode-parented to the campaign warehouse (where they were loaded). Move them to the correct base warehouse
+     * so that {@link Part#getWarehouse()} returns the local warehouse for that base, keeping spare-part searches and
+     * fix-button availability scoped to the base the unit is stationed at.
+     */
+    private static void rehomeBaseHangarUnitParts(Campaign campaign) {
+        for (PlayerBase base : campaign.getCampaignLocationManager().getPlayerBases()) {
+            LocalWarehouse baseWarehouse = base.getBaseWarehouse();
+            base.getBaseHangar().forEachUnit(unit -> {
+                for (Part part : unit.getParts()) {
+                    LocalWarehouse current = part.getWarehouse();
+                    if (current != baseWarehouse) {
+                        current.removePart(part);
+                        baseWarehouse.addPart(part);
+                    }
                 }
-            }
+            });
         }
-
-        if (!missingList.isEmpty()) {
-            throw new NullPointerException(missingList.toString());
-        }
-
-        LOGGER.info("Load Personnel Nodes Complete!");
     }
 
     private static void performEdgeConversion(Campaign campaign, Person person) {
@@ -1940,154 +1449,192 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
         }
     }
 
-    /**
-     * Migrates persons mid-journey on legacy saves (pre-location-tree) into real {@link CurrentLocation} nodes so they
-     * are handled by the location-aware travel code.
-     *
-     * <p>For each person in JOURNEY_TO_CAMPUS or JOURNEY_FROM_CAMPUS whose location chain contains
-     * no {@link CurrentLocation}, a new {@code CurrentLocation} is created at the target system (academy system for
-     * outbound, campaign current system for return). Transit time is set from the jump-point approach time so they
-     * arrive on planet within a day or two via normal {@code newDay()} processing.</p>
-     */
-    private static void migrateLegacyEducationTravel(Campaign campaign) {
-        // Phase 1: scan for persons that need migration. All per-person logging here is DEBUG
-        // so post-refactor saves (where everyone is skipped) produce no INFO noise.
-        List<Person> toMigrate = new ArrayList<>();
-        for (Person person : campaign.getPersonnel().values()) {
-            EducationStage stage = person.getEduEducationStage();
-            if (stage != EducationStage.JOURNEY_TO_CAMPUS
-                      && stage != EducationStage.JOURNEY_FROM_CAMPUS
-                      && stage != EducationStage.EDUCATION
-                      && stage != EducationStage.GRADUATING
-                      && stage != EducationStage.DROPPING_OUT) {
+    private static void postProcessWarehouse(LocalWarehouse warehouse, Campaign retVal, List<Part> removeParts) {
+        Map<Integer, Part> replaceParts = new HashMap<>();
+        for (Part prt : warehouse.getParts()) {
+            prt.fixReferences(retVal);
+
+            // Remove fundamentally broken equipment parts
+            if (((prt instanceof EquipmentPart) && ((EquipmentPart) prt).getType() == null) ||
+                      ((prt instanceof MissingEquipmentPart) && ((MissingEquipmentPart) prt).getType() == null)) {
+                LOGGER.warn("Could not find matching EquipmentType for part {}", prt.getName());
+                removeParts.add(prt);
                 continue;
             }
 
-            // Skip persons already queued for (but not yet dispatched) travel — processPendingTravel re-queued them
-            // and they still sit at their origin. Migrating would wrongly move them into a travel node/campus.
-            if (campaign.getCampaignLocationManager().isQueuedForTravel(person)) {
-                LOGGER.debug("migrateLegacyEducationTravel: skipping {} — queued in pendingTravel (stage={})",
-                      person.getFullTitle(), stage);
-                continue;
+            // deal with equipment parts that are now sub typed
+            if (isLegacyMASC(prt) && prt instanceof EquipmentPart equipmentPart) {
+                Part replacement = new MASC(prt.getUnitTonnage(),
+                      equipmentPart.getType(),
+                      equipmentPart.getEquipmentNum(),
+                      retVal,
+                      0,
+                      prt.isOmniPodded());
+                replacement.setId(prt.getId());
+                replacement.setUnit(prt.getUnit());
+                replaceParts.put(prt.getId(), replacement);
             }
 
-            Academy academy = getAcademy(person.getEduAcademySet(), person.getEduAcademyNameInSet());
-            if (academy != null && academy.isHomeSchool()) {
-                LOGGER.debug("migrateLegacyEducationTravel: skipping {} — homeSchool", person.getFullTitle());
-                continue;
+            if (isLegacyMissingMASC(prt) && prt instanceof MissingEquipmentPart equipmentPart) {
+                Part replacement = new MissingMASC(prt.getUnitTonnage(),
+                      equipmentPart.getType(),
+                      equipmentPart.getEquipmentNum(),
+                      retVal,
+                      prt.getTonnage(),
+                      0,
+                      prt.isOmniPodded());
+                replacement.setId(prt.getId());
+                replacement.setUnit(prt.getUnit());
+                replaceParts.put(prt.getId(), replacement);
             }
-
-            if (stage == EducationStage.EDUCATION
-                      || stage == EducationStage.GRADUATING
-                      || stage == EducationStage.DROPPING_OUT) {
-                // Skip persons whose parent was already set to a non-Campaign-Personnel node
-                // during XML parsing (e.g., reconnected by an earlier load step). Without this
-                // guard, resolveAcademySystemId may return the wrong system for multi-location
-                // academies, creating a duplicate campus and displacing the person.
-                ILocation parentLocation = person.getParentLocation();
-                if (parentLocation != null
-                          && !(parentLocation instanceof Personnel personnel
-                                     && personnel.getParentLocation() instanceof Detachment)) {
-                    LOGGER.debug("migrateLegacyEducationTravel: skipping {} — already reconnected (stage={})",
-                          person.getFullTitle(), stage);
-                    continue;
-                }
-                // If a FixedLocation campus already holds this person's ID (post-refactor save),
-                // reconnectPersonsToTravelLocations will handle them.
-                if (hasFixedCampusPendingFor(campaign, person)) {
-                    LOGGER.debug("migrateLegacyEducationTravel: skipping {} — pending in FixedLocation campus (stage={})",
-                          person.getFullTitle(), stage);
-                    continue;
-                }
-            } else {
-                // Journey stages: skip if a travel node already holds this person's pending ID
-                // (post-refactor save) — reconnectPersonsToTravelLocations will place them correctly.
-                if (hasTravelNodePendingFor(campaign, person)) {
-                    LOGGER.debug("migrateLegacyEducationTravel: skipping {} — pending in travel node (stage={})",
-                          person.getFullTitle(), stage);
-                    continue;
-                }
-            }
-
-            LOGGER.debug("migrateLegacyEducationTravel: {} needs migration (stage={}, academy='{}', set='{}')",
-                  person.getFullTitle(), stage, person.getEduAcademyNameInSet(), person.getEduAcademySet());
-            toMigrate.add(person);
         }
 
-        // Phase 2: migrate. Only runs (and only logs at INFO) when legacy persons are found.
-        if (toMigrate.isEmpty()) {
-            LOGGER.debug("migrateLegacyEducationTravel: no persons need legacy migration");
-            return;
+        // Replace parts that need to be replaced
+        for (Entry<Integer, Part> entry : replaceParts.entrySet()) {
+            int partId = entry.getKey();
+            Part oldPart = warehouse.getPart(partId);
+            if (oldPart != null) {
+                warehouse.removePart(oldPart);
+            }
+            warehouse.addPart(entry.getValue());
         }
 
-        LOGGER.info("migrateLegacyEducationTravel: {} persons require legacy migration", toMigrate.size());
-        int campusMigrated = 0;
-        int travelMigrated = 0;
+        // After replacing parts, go back through and remove more broken parts
+        for (Part prt : warehouse.getParts()) {
+            // deal with the Weapon as Heat Sink problem from earlier versions
+            if ((prt instanceof HeatSink) && !prt.getName().contains("Heat Sink")) {
+                removeParts.add(prt);
+                continue;
+            }
 
-        for (Person person : toMigrate) {
-            EducationStage stage = person.getEduEducationStage();
+            Unit u = prt.getUnit();
+            if (u != null) {
+                // get rid of any equipment parts without types, locations or mounted
+                if (prt instanceof EquipmentPart ePart) {
 
-            if (stage == EducationStage.EDUCATION
-                      || stage == EducationStage.GRADUATING
-                      || stage == EducationStage.DROPPING_OUT) {
-                String systemId = resolveAcademySystemId(campaign, person);
-                if (systemId == null) {
-                    LOGGER.warn("migrateLegacyEducationTravel: could not resolve academy system for {} (stage={})"
-                          + " — skipping campus placement", person.getFullTitle(), stage);
+                    // Null Type... parsing failure
+                    if (ePart.getType() == null) {
+                        removeParts.add(prt);
+                        continue;
+                    }
+
+                    Mounted<?> m = u.getEntity().getEquipment(ePart.getEquipmentNum());
+
+                    // Remove equipment parts missing mounts
+                    if (m == null) {
+                        removeParts.add(prt);
+                        continue;
+                    }
+
+                    // Remove equipment parts without a valid location, unless they're an ammo bin
+                    // as they may not have a location
+                    if ((m.getLocation() == Entity.LOC_NONE) && !(prt instanceof AmmoBin)) {
+                        removeParts.add(prt);
+                        continue;
+                    }
+
+                    // Remove existing duplicate parts.
+                    Part duplicatePart = u.getPartForEquipmentNum(ePart.getEquipmentNum(), prt.getLocation());
+                    if ((duplicatePart instanceof EquipmentPart) &&
+                              ePart.getType().equals(((EquipmentPart) duplicatePart).getType())) {
+                        removeParts.add(prt);
+                        continue;
+                    }
+                }
+                if (prt instanceof MissingEquipmentPart) {
+                    Mounted<?> m = u.getEntity().getEquipment(((MissingEquipmentPart) prt).getEquipmentNum());
+
+                    // Remove equipment parts missing mounts
+                    if (m == null) {
+                        removeParts.add(prt);
+                        continue;
+                    }
+
+                    // Remove missing equipment parts without a valid location, unless they're an
+                    // ammo bin as they may not have a location
+                    if ((m.getLocation() == Entity.LOC_NONE) && !(prt instanceof MissingAmmoBin)) {
+                        removeParts.add(prt);
+                        continue;
+                    }
+                }
+
+                // if the type is a BayWeapon, remove
+                if ((prt instanceof EquipmentPart) && (((EquipmentPart) prt).getType() instanceof BayWeapon)) {
+                    removeParts.add(prt);
                     continue;
                 }
-                AcademyCampusLocation campusLocation = campaign.getCampaignLocationManager().getOrCreateCampusLocation(campaign, 
-                      person.getEduAcademySet(), person.getEduAcademyNameInSet(), systemId);
-                if (campusLocation != null) {
-                    LOGGER.info("migrateLegacyEducationTravel: placed {} at campus '{}' in system {}",
-                          person.getFullTitle(), person.getEduAcademyNameInSet(), systemId);
-                    person.setParent(campusLocation.getPersonnel());
-                    campusMigrated++;
+
+                if ((prt instanceof MissingEquipmentPart) &&
+                          (((MissingEquipmentPart) prt).getType() instanceof BayWeapon)) {
+                    removeParts.add(prt);
+                    continue;
+                }
+
+                // if actuators on units have no location (on version 1.23 and
+                // earlier) then remove them and let initializeParts (called
+                // later) create new ones
+                if ((prt instanceof MekActuator) && (prt.getLocation() == Entity.LOC_NONE)) {
+                    removeParts.add(prt);
+                } else if ((prt instanceof MissingMekActuator) && (prt.getLocation() == Entity.LOC_NONE)) {
+                    removeParts.add(prt);
+                } else if (((u.getEntity() instanceof SmallCraft) || (u.getEntity() instanceof Jumpship)) &&
+                                 ((prt instanceof EnginePart) || (prt instanceof MissingEnginePart))) {
+                    // units from earlier versions might have the wrong kind of engine
+                    removeParts.add(prt);
                 } else {
-                    LOGGER.warn("migrateLegacyEducationTravel: getOrCreateCampusLocation returned null for {}"
-                          + " (academy='{}', system='{}') — skipping", person.getFullTitle(),
-                          person.getEduAcademyNameInSet(), systemId);
+                    u.addPart(prt);
                 }
-                continue;
             }
 
-            // Journey stages
-            String systemId = resolveAcademySystemId(campaign, person);
-            if (systemId == null) {
-                LOGGER.warn("migrateLegacyEducationTravel: could not resolve academy system for {} (stage={})"
-                      + " — skipping travel node creation", person.getFullTitle(), stage);
-                continue;
-            }
-            PlanetarySystem targetSystem = campaign.getSystemById(systemId);
-            if (targetSystem == null) {
-                LOGGER.warn("migrateLegacyEducationTravel: system '{}' not found for {} (stage={})"
-                      + " — skipping travel node creation", systemId, person.getFullTitle(), stage);
-                continue;
+            // deal with true values for sensor and life support on non-Mek heads
+            if ((prt instanceof MekLocation) && (((MekLocation) prt).getLoc() != Mek.LOC_HEAD)) {
+                ((MekLocation) prt).setSensors(false);
+                ((MekLocation) prt).setLifeSupport(false);
             }
 
-            double transitTime = Math.max(0, person.getEduJourneyTime() - person.getEduDaysOfTravel());
-            LOGGER.info("migrateLegacyEducationTravel: creating travel node for {} (stage={}, system={}, transitTime={} days)",
-                  person.getFullTitle(), stage, targetSystem.getId(), transitTime);
-
-            CurrentLocation travelLocation = new CurrentLocation(targetSystem, transitTime);
-            AcademyCampusLocation campusLocation = campaign.getCampaignLocationManager().getOrCreateCampusLocation(campaign, 
-                  person.getEduAcademySet(), person.getEduAcademyNameInSet(), systemId);
-            if (campusLocation != null) {
-                LOGGER.info("migrateLegacyEducationTravel: parenting travel node under campus '{}' for {}",
-                      person.getEduAcademyNameInSet(), person.getFullTitle());
-                travelLocation.setParent(campusLocation);
-            } else if (stage == EducationStage.JOURNEY_FROM_CAMPUS) {
-                LOGGER.info("migrateLegacyEducationTravel: no campus found for {} (JOURNEY_FROM_CAMPUS)"
-                                  + " — parenting travel node under the main force", person.getFullTitle());
-                travelLocation.setParent(campaign.getPlayerForce().getForceDetachment());
+            if (prt instanceof MissingPart) {
+                // Missing Parts should only exist on units, but there have
+                // been cases where they continue to float around outside of units
+                // so this should clean that up
+                if (null == u) {
+                    removeParts.add(prt);
+                } else {
+                    // run this to make sure that slots for missing parts are set as
+                    // unrepairable
+                    // because they will not be in missing locations
+                    prt.updateConditionFromPart();
+                }
             }
-            person.setParent(travelLocation);
-            campaign.getCampaignLocationManager().addLocation(travelLocation);
-            travelMigrated++;
+
+            // old versions didn't distinguish tank engines
+            if ((prt instanceof EnginePart) && prt.getName().contains("Vehicle")) {
+                boolean isHover = null != u &&
+                                        u.getEntity().getMovementMode() == EntityMovementMode.HOVER &&
+                                        u.getEntity() instanceof Tank;
+                ((EnginePart) prt).fixTankFlag(isHover);
+            }
+
+            // clan flag might not have been properly set in early versions
+            if ((prt instanceof EnginePart) &&
+                      prt.getName().contains("(Clan") &&
+                      (prt.getTechBase() != TechBase.CLAN)) {
+                ((EnginePart) prt).fixClanFlag();
+            }
+            if ((prt instanceof MissingEnginePart) && (null != u) && (u.getEntity() instanceof Tank)) {
+                boolean isHover = u.getEntity().getMovementMode() == EntityMovementMode.HOVER;
+                ((MissingEnginePart) prt).fixTankFlag(isHover);
+            }
+            if ((prt instanceof MissingEnginePart) &&
+                      prt.getName().contains("(Clan") &&
+                      (prt.getTechBase() != TechBase.CLAN)) {
+                ((MissingEnginePart) prt).fixClanFlag();
+            }
+
+            // Spare Ammo bins are useless
+            if ((prt instanceof AmmoBin) && prt.isSpare()) {
+                removeParts.add(prt);
+            }
         }
-
-        LOGGER.info("migrateLegacyEducationTravel: complete — {} placed at campus, {} given travel nodes",
-              campusMigrated, travelMigrated);
     }
 
     private static boolean hasFixedCampusPendingFor(Campaign campaign, Person person) {
@@ -2602,28 +2149,6 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
         LOGGER.info("Load Part Nodes Complete!");
     }
 
-    /**
-     * After {@link #postProcessParts} wires up unit references, parts that belong to base-hangar
-     * units are still locationNode-parented to the campaign warehouse (where they were loaded).
-     * Move them to the correct base warehouse so that {@link Part#getWarehouse()} returns the
-     * local warehouse for that base, keeping spare-part searches and fix-button availability
-     * scoped to the base the unit is stationed at.
-     */
-    private static void rehomeBaseHangarUnitParts(Campaign campaign) {
-        for (PlayerBase base : campaign.getCampaignLocationManager().getPlayerBases()) {
-            Warehouse baseWarehouse = base.getBaseWarehouse();
-            base.getBaseHangar().forEachUnit(unit -> {
-                for (Part part : unit.getParts()) {
-                    Warehouse current = part.getWarehouse();
-                    if (current != baseWarehouse) {
-                        current.removePart(part);
-                        baseWarehouse.addPart(part);
-                    }
-                }
-            });
-        }
-    }
-
     private static void postProcessParts(Campaign retVal, Version version) {
         List<Part> removeParts = new ArrayList<>();
         postProcessWarehouse(retVal.getWarehouse(), retVal, removeParts);
@@ -2636,192 +2161,678 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
         }
     }
 
-    private static void postProcessWarehouse(Warehouse warehouse, Campaign retVal, List<Part> removeParts) {
-        Map<Integer, Part> replaceParts = new HashMap<>();
-        for (Part prt : warehouse.getParts()) {
-            prt.fixReferences(retVal);
+    /**
+     * This will fixup unit-tech problems seen in some save games, such as techs having been double-assigned or being
+     * assigned to mothballed units.
+     */
+    private void fixupUnitTechProblems(Campaign retVal) {
+        // Cleanup problems with techs and units
+        for (Person tech : retVal.getTechs()) {
+            for (Unit u : new ArrayList<>(tech.getTechUnits())) {
+                String reason = null;
+                String unitDesc = u.getId().toString();
+                if (null == u.getTech()) {
+                    reason = "was not referenced by unit";
+                    u.setTech(tech);
+                } else if (u.isMothballed()) {
+                    reason = "referenced mothballed unit";
+                    unitDesc = u.getName();
+                    tech.removeTechUnit(u);
+                } else if (u.getTech() != null && !tech.getId().equals(u.getTech().getId())) {
+                    reason = String.format("referenced tech %s's maintained unit", u.getTech().getFullName());
+                    unitDesc = u.getName();
+                    tech.removeTechUnit(u);
+                }
+                if (null != reason) {
+                    LOGGER.warn("Tech {} {} {} (fixed)", tech.getFullName(), reason, unitDesc);
+                }
+            }
+        }
+    }
 
-            // Remove fundamentally broken equipment parts
-            if (((prt instanceof EquipmentPart) && ((EquipmentPart) prt).getType() == null) ||
-                      ((prt instanceof MissingEquipmentPart) && ((MissingEquipmentPart) prt).getType() == null)) {
-                LOGGER.warn("Could not find matching EquipmentType for part {}", prt.getName());
-                removeParts.add(prt);
+    /**
+     * Designed to create a campaign object from an input stream containing an XML structure.
+     *
+     * @return The created Campaign object, or null if there was a problem.
+     *
+     * @throws CampaignXmlParseException Thrown when there was a problem parsing the CPNX file
+     * @throws NullEntityException       Thrown when an entity is referenced but cannot be loaded or found
+     */
+    public Campaign parse() throws CampaignXmlParseException, NullEntityException {
+        LOGGER.info("Starting load of campaign file from XML...");
+        // Initialize variables.
+        Campaign campaign = CampaignFactory.createCampaign();
+        campaign.setGUI(app.getCampaigngui());
+
+        Document xmlDoc;
+
+        try {
+            xmlDoc = MHQXMLUtility.parseDocument(is);
+        } catch (Exception ex) {
+            LOGGER.error("", ex);
+            throw new CampaignXmlParseException(ex);
+        }
+
+        Element campaignEle = xmlDoc.getDocumentElement();
+        NodeList nl = campaignEle.getChildNodes();
+
+        // Get rid of empty text nodes and adjacent text nodes...
+        // Stupid weird parsing of XML. At least this cleans it up.
+        campaignEle.normalize();
+
+        final Version version = new Version(campaignEle.getAttribute("version"));
+        if (version.is("0.0.0")) {
+            throw new CampaignXmlParseException(String.format("Illegal version of %s failed to parse",
+                  campaignEle.getAttribute("version")));
+        }
+        // Confirm the campaign version is compatible with the current MekHQ version. This function lives here so that
+        // we don't attempt to load incompatible campaigns and risk running into errors that might prevent the player
+        // from viewing this dialog
+        new MilestoneUpgradePathDialog(app, campaign, version);
+
+        // Assuming there is no upgrade path, we set version and continue parsing the campaign.
+        campaign.setVersion(version);
+
+        // Indicates whether new units were written to disk while
+        // loading the Campaign file. If so, we need to kick back off loading
+        // all the unit data from disk.
+        boolean reloadUnitData = false;
+
+        // we need to iterate through three times, the first time to collect
+        // any custom units that might not be written yet
+        for (int x = 0; x < nl.getLength(); x++) {
+            Node wn = nl.item(x);
+
+            if (!wn.getParentNode().equals(campaignEle)) {
                 continue;
             }
 
-            // deal with equipment parts that are now sub typed
-            if (isLegacyMASC(prt) && prt instanceof EquipmentPart equipmentPart) {
-                Part replacement = new MASC(prt.getUnitTonnage(),
-                      equipmentPart.getType(),
-                      equipmentPart.getEquipmentNum(),
-                      retVal,
-                      0,
-                      prt.isOmniPodded());
-                replacement.setId(prt.getId());
-                replacement.setUnit(prt.getUnit());
-                replaceParts.put(prt.getId(), replacement);
-            }
+            int xc = wn.getNodeType();
 
-            if (isLegacyMissingMASC(prt) && prt instanceof MissingEquipmentPart equipmentPart) {
-                Part replacement = new MissingMASC(prt.getUnitTonnage(),
-                      equipmentPart.getType(),
-                      equipmentPart.getEquipmentNum(),
-                      retVal,
-                      prt.getTonnage(),
-                      0,
-                      prt.isOmniPodded());
-                replacement.setId(prt.getId());
-                replacement.setUnit(prt.getUnit());
-                replaceParts.put(prt.getId(), replacement);
+            if (xc == Node.ELEMENT_NODE) {
+                // This is what we really care about.
+                // All the meat of our document is in this node type, at this
+                // level.
+                // Okay, so what element is it?
+                String xn = wn.getNodeName();
+
+                if (xn.equalsIgnoreCase("info")) { // This is needed so that the campaign name gets set in campaign
+                    try {
+                        processInfoNode(campaign, wn, version);
+                    } catch (DOMException e) {
+                        throw new CampaignXmlParseException(e);
+                    }
+                } else if (xn.equalsIgnoreCase("custom")) {
+                    reloadUnitData |= processCustom(campaign, wn);
+                } else if (xn.equalsIgnoreCase("campaignOptions")) {
+                    campaign.setCampaignOptions(CampaignOptionsUnmarshaller.generateCampaignOptionsFromXml(wn,
+                          version));
+                } else if (xn.equalsIgnoreCase("gameOptions")) {
+                    campaign.getGameOptions().fillFromXML(wn.getChildNodes());
+                } else if (xn.equalsIgnoreCase(PlanetarySystemCampaignXmlIO.XML_TAG)) {
+                    processPlanetarySystemOverrides(campaign, wn);
+                }
             }
+            // If it's a text node or attribute or whatever at this level,
+            // it's probably white-space.
+            // We can safely ignore it even if it isn't, for now.
         }
 
-        // Replace parts that need to be replaced
-        for (Entry<Integer, Part> entry : replaceParts.entrySet()) {
-            int partId = entry.getKey();
-            Part oldPart = warehouse.getPart(partId);
-            if (oldPart != null) {
-                warehouse.removePart(oldPart);
-            }
-            warehouse.addPart(entry.getValue());
+        // Only reload unit data if we updated files on disk
+        if (reloadUnitData) {
+            MekSummaryCache.getInstance().loadMekData();
         }
 
-        // After replacing parts, go back through and remove more broken parts
-        for (Part prt : warehouse.getParts()) {
-            // deal with the Weapon as Heat Sink problem from earlier versions
-            if ((prt instanceof HeatSink) && !prt.getName().contains("Heat Sink")) {
-                removeParts.add(prt);
+        // the second time to check for any null entities
+        for (int x = 0; x < nl.getLength(); x++) {
+            Node wn = nl.item(x);
+
+            if (!wn.getParentNode().equals(campaignEle)) {
                 continue;
             }
 
-            Unit u = prt.getUnit();
-            if (u != null) {
-                // get rid of any equipment parts without types, locations or mounted
-                if (prt instanceof EquipmentPart ePart) {
+            int xc = wn.getNodeType();
 
-                    // Null Type... parsing failure
-                    if (ePart.getType() == null) {
-                        removeParts.add(prt);
-                        continue;
-                    }
+            if (xc == Node.ELEMENT_NODE) {
+                // This is what we really care about.
+                // All the meat of our document is in this node type, at this
+                // level.
+                // Okay, so what element is it?
+                String xn = wn.getNodeName();
 
-                    Mounted<?> m = u.getEntity().getEquipment(ePart.getEquipmentNum());
-
-                    // Remove equipment parts missing mounts
-                    if (m == null) {
-                        removeParts.add(prt);
-                        continue;
-                    }
-
-                    // Remove equipment parts without a valid location, unless they're an ammo bin
-                    // as they may not have a location
-                    if ((m.getLocation() == Entity.LOC_NONE) && !(prt instanceof AmmoBin)) {
-                        removeParts.add(prt);
-                        continue;
-                    }
-
-                    // Remove existing duplicate parts.
-                    Part duplicatePart = u.getPartForEquipmentNum(ePart.getEquipmentNum(), prt.getLocation());
-                    if ((duplicatePart instanceof EquipmentPart) &&
-                              ePart.getType().equals(((EquipmentPart) duplicatePart).getType())) {
-                        removeParts.add(prt);
-                        continue;
+                if (xn.equalsIgnoreCase("units")) {
+                    String missingList = checkUnits(wn);
+                    if (null != missingList) {
+                        throw new NullEntityException(missingList);
                     }
                 }
-                if (prt instanceof MissingEquipmentPart) {
-                    Mounted<?> m = u.getEntity().getEquipment(((MissingEquipmentPart) prt).getEquipmentNum());
+            }
+            // If it's a text node or attribute or whatever at this level,
+            // it's probably white-space.
+            // We can safely ignore it even if it isn't, for now.
+        }
 
-                    // Remove equipment parts missing mounts
-                    if (m == null) {
-                        removeParts.add(prt);
-                        continue;
+        boolean foundPersonnelMarket = false;
+        boolean foundContractMarket = false;
+        boolean foundUnitMarket = false;
+
+        // Saves made in 0.51.00 do not have a <location> but will have a <locations> with a single item.
+        boolean foundMainForceLocation = false;
+
+        // Pending travel references persons, units, parts, and bases, so it is resolved after those are all loaded.
+        Node pendingTravelNode = null;
+
+        // Okay, lets iterate through the children, eh?
+        for (int x = 0; x < nl.getLength(); x++) {
+            Node workingNode = nl.item(x);
+
+            if (!workingNode.getParentNode().equals(campaignEle)) {
+                continue;
+            }
+
+            int xc = workingNode.getNodeType();
+
+            if (xc == Node.ELEMENT_NODE) {
+                // This is what we really care about.
+                // All the meat of our document is in this node type, at this level.
+                // Okay, so what element is it?
+                String nodeName = workingNode.getNodeName();
+
+                if (nodeName.equalsIgnoreCase("pastVersions")) {
+                    processPastVersionNodes(campaign, workingNode);
+                } else if (nodeName.equalsIgnoreCase("randomSkillPreferences")) {
+                    campaign.setRandomSkillPreferences(RandomSkillPreferences.generateRandomSkillPreferencesFromXml(
+                          workingNode,
+                          version));
+                } else if (nodeName.equalsIgnoreCase("humanResources")) {
+                    campaign.setHumanResources(
+                          mekhq.campaign.ForceHumanResources.loadFromXML(workingNode, campaign, version));
+                } else if (nodeName.equalsIgnoreCase("parts")) {
+                    processPartNodes(campaign, workingNode, version);
+                } else if (nodeName.equalsIgnoreCase("personnel")) {
+                    // backward compat: old save without <humanResources> wrapper
+                    // TODO: Make this depending on campaign options
+                    // TODO: hoist registerAll out of this
+                    InjuryTypes.registerAll();
+                    processPersonnelNodes(campaign, workingNode, version);
+                } else if (nodeName.equalsIgnoreCase("units")) {
+                    processUnitNodes(campaign, workingNode, version);
+                } else if (nodeName.equalsIgnoreCase("missions")) {
+                    processMissionNodes(campaign, workingNode, version);
+                } else if (nodeName.equalsIgnoreCase("forces")) {
+                    processForces(campaign, workingNode, version);
+                } else if (nodeName.equalsIgnoreCase("formations")) {
+                    processFormations(campaign, workingNode, version);
+                } else if (nodeName.equalsIgnoreCase("finances")) {
+                    processFinances(campaign, workingNode);
+                } else if (nodeName.equalsIgnoreCase("locations")) {
+                    processLocations(campaign, workingNode);
+                } else if (nodeName.equalsIgnoreCase("playerBases")) {
+                    processPlayerBaseNodes(campaign, workingNode, version);
+                } else if (nodeName.equalsIgnoreCase("pendingTravel")) {
+                    pendingTravelNode = workingNode;
+                } else if (nodeName.equalsIgnoreCase("location")) {
+                    // Campaign's current location — written as a top-level tag in new saves;
+                    // same tag was used as the only location entry in pre-<locations>-list saves.
+                    campaign.setLocation(CurrentLocation.generateInstanceFromXML(workingNode, campaign));
+                    foundMainForceLocation = true;
+                } else if (nodeName.equalsIgnoreCase("locationNodeChildren")) {
+                    LocationNode.reconnectChildren(workingNode, campaign);
+                } else if (nodeName.equalsIgnoreCase("isAvoidingEmptySystems")) {
+                    campaign.setIsAvoidingEmptySystems(Boolean.parseBoolean(workingNode.getTextContent().trim()));
+                } else if (nodeName.equalsIgnoreCase("skillTypes")) {
+                    processSkillTypeNodes(workingNode, version);
+                } else if (nodeName.equalsIgnoreCase("specialAbilities")) {
+                    processSpecialAbilityNodes(campaign, workingNode, version);
+                } else if (nodeName.equalsIgnoreCase("storyArc")) {
+                    processStoryArcNodes(campaign, workingNode, version);
+                } else if (nodeName.equalsIgnoreCase("kills")) {
+                    processKillNodes(campaign, workingNode, version);
+                } else if (nodeName.equalsIgnoreCase("shoppingList")) {
+                    campaign.setShoppingList(ForceShoppingList.generateInstanceFromXML(workingNode, campaign, version));
+                } else if (nodeName.equalsIgnoreCase("personnelMarket")) {
+                    campaign.setPersonnelMarket(PersonnelMarket.generateInstanceFromXML(workingNode,
+                          campaign,
+                          version));
+                    foundPersonnelMarket = true;
+                } else if (nodeName.equalsIgnoreCase("contractMarket")) {
+                    // CAW: implicit DEPENDS-ON to the <missions> node
+                    campaign.setContractMarket(AbstractContractMarket.generateInstanceFromXML(workingNode,
+                          campaign,
+                          version));
+                    foundContractMarket = true;
+                } else if (nodeName.equalsIgnoreCase("unitMarket")) {
+                    // Windchild: implicit DEPENDS ON to the <campaignOptions> nodes
+                    campaign.setUnitMarket(campaign.getCampaignOptions().getUnitMarketMethod().getUnitMarket());
+                    campaign.getUnitMarket().fillFromXML(workingNode, campaign, version);
+                    foundUnitMarket = true;
+                } else if (nodeName.equalsIgnoreCase("lances") || nodeName.equalsIgnoreCase("combatTeams")) {
+                    processCombatTeamNodes(campaign, workingNode);
+                } else if (nodeName.equalsIgnoreCase("retirementDefectionTracker")) {
+                    campaign.setRetirementDefectionTracker(RetirementDefectionTracker.generateInstanceFromXML(
+                          workingNode,
+                          campaign));
+                } else if (nodeName.equalsIgnoreCase("personnelWhoAdvancedInXP")) {
+                    campaign.setPersonnelWhoAdvancedInXP(processPersonnelWhoAdvancedInXP(workingNode, campaign));
+                } else if (nodeName.equalsIgnoreCase("automatedMothballUnits")) {
+                    campaign.setAutomatedMothballUnits(processAutomatedMothballNodes(workingNode));
+                } else if (nodeName.equalsIgnoreCase("autoResolveBehaviorSettings")) {
+                    campaign.setAutoResolveBehaviorSettings(firstNonNull(BehaviorSettingsFactory.getInstance()
+                                                                               .getBehavior(workingNode.getTextContent()),
+                          BehaviorSettingsFactory.getInstance().DEFAULT_BEHAVIOR));
+                } else if (nodeName.equalsIgnoreCase("customPlanetaryEvents")) {
+                    //TODO: deal with this
+                    updatePlanetaryEventsFromXML(workingNode);
+                } else if (nodeName.equalsIgnoreCase("partsInUse")) {
+                    processPartsInUse(campaign, workingNode, version);
+                } else if (nodeName.equalsIgnoreCase("temporaryPrisonerCapacity")) {
+                    campaign.setTemporaryPrisonerCapacity(MathUtility.parseInt(workingNode.getTextContent().trim()));
+                } else if (nodeName.equalsIgnoreCase("processProcurement")) {
+                    campaign.setProcessProcurement(Boolean.parseBoolean(workingNode.getTextContent().trim()));
+                }
+            }
+            // If it's a text node or attribute or whatever at this level,
+            // it's probably white-space.
+            // We can safely ignore it even if it isn't, for now.
+        }
+
+        // Okay, after we've gone through all the nodes and constructed the
+        // Campaign object...
+        final CampaignOptions options = campaign.getCampaignOptions();
+
+        // We need to do a post-process pass to restore a number of references.
+        // Fix any Person ID References
+        PersonIdReference.fixPersonIdReferences(campaign);
+
+        // Fixup any ghost kills
+        cleanupGhostKills(campaign);
+
+        // Update the Personnel Modules
+        campaign.setDivorce(options.getRandomDivorceMethod().getMethod(options));
+        campaign.setMarriage(options.getRandomMarriageMethod().getMethod(options));
+        campaign.setProcreation(options.getRandomProcreationMethod().getMethod(options));
+
+        long timestamp = System.currentTimeMillis();
+
+        // loop through forces to set force id
+        for (Formation f : campaign.getAllFormations()) {
+            Scenario s = campaign.getScenario(f.getScenarioId());
+            if (null != s && (null == f.getParentFormation() || !f.getParentFormation().isDeployed())) {
+                s.addForces(f.getId());
+            }
+            // some units may need force id set for backwards compatibility
+            // some may also need scenario id set
+            for (UUID uid : f.getUnits()) {
+                Unit u = campaign.getUnit(uid);
+                if (null != u) {
+                    u.setFormationId(f.getId());
+                    if (f.isDeployed()) {
+                        u.setScenarioId(f.getScenarioId());
                     }
-
-                    // Remove missing equipment parts without a valid location, unless they're an
-                    // ammo bin as they may not have a location
-                    if ((m.getLocation() == Entity.LOC_NONE) && !(prt instanceof MissingAmmoBin)) {
-                        removeParts.add(prt);
-                        continue;
-                    }
                 }
-
-                // if the type is a BayWeapon, remove
-                if ((prt instanceof EquipmentPart) && (((EquipmentPart) prt).getType() instanceof BayWeapon)) {
-                    removeParts.add(prt);
-                    continue;
-                }
-
-                if ((prt instanceof MissingEquipmentPart) &&
-                          (((MissingEquipmentPart) prt).getType() instanceof BayWeapon)) {
-                    removeParts.add(prt);
-                    continue;
-                }
-
-                // if actuators on units have no location (on version 1.23 and
-                // earlier) then remove them and let initializeParts (called
-                // later) create new ones
-                if ((prt instanceof MekActuator) && (prt.getLocation() == Entity.LOC_NONE)) {
-                    removeParts.add(prt);
-                } else if ((prt instanceof MissingMekActuator) && (prt.getLocation() == Entity.LOC_NONE)) {
-                    removeParts.add(prt);
-                } else if (((u.getEntity() instanceof SmallCraft) || (u.getEntity() instanceof Jumpship)) &&
-                                 ((prt instanceof EnginePart) || (prt instanceof MissingEnginePart))) {
-                    // units from earlier versions might have the wrong kind of engine
-                    removeParts.add(prt);
-                } else {
-                    u.addPart(prt);
-                }
-            }
-
-            // deal with true values for sensor and life support on non-Mek heads
-            if ((prt instanceof MekLocation) && (((MekLocation) prt).getLoc() != Mek.LOC_HEAD)) {
-                ((MekLocation) prt).setSensors(false);
-                ((MekLocation) prt).setLifeSupport(false);
-            }
-
-            if (prt instanceof MissingPart) {
-                // Missing Parts should only exist on units, but there have
-                // been cases where they continue to float around outside of units
-                // so this should clean that up
-                if (null == u) {
-                    removeParts.add(prt);
-                } else {
-                    // run this to make sure that slots for missing parts are set as
-                    // unrepairable
-                    // because they will not be in missing locations
-                    prt.updateConditionFromPart();
-                }
-            }
-
-            // old versions didn't distinguish tank engines
-            if ((prt instanceof EnginePart) && prt.getName().contains("Vehicle")) {
-                boolean isHover = null != u &&
-                                        u.getEntity().getMovementMode() == EntityMovementMode.HOVER &&
-                                        u.getEntity() instanceof Tank;
-                ((EnginePart) prt).fixTankFlag(isHover);
-            }
-
-            // clan flag might not have been properly set in early versions
-            if ((prt instanceof EnginePart) &&
-                      prt.getName().contains("(Clan") &&
-                      (prt.getTechBase() != TechBase.CLAN)) {
-                ((EnginePart) prt).fixClanFlag();
-            }
-            if ((prt instanceof MissingEnginePart) && (null != u) && (u.getEntity() instanceof Tank)) {
-                boolean isHover = u.getEntity().getMovementMode() == EntityMovementMode.HOVER;
-                ((MissingEnginePart) prt).fixTankFlag(isHover);
-            }
-            if ((prt instanceof MissingEnginePart) &&
-                      prt.getName().contains("(Clan") &&
-                      (prt.getTechBase() != TechBase.CLAN)) {
-                ((MissingEnginePart) prt).fixClanFlag();
-            }
-
-            // Spare Ammo bins are useless
-            if ((prt instanceof AmmoBin) && prt.isSpare()) {
-                removeParts.add(prt);
             }
         }
+
+        // determine if we've missed any lances and add those back into the campaign
+        if (options.isUseStratCon()) {
+            Hashtable<Integer, CombatTeam> lances = campaign.getCombatTeamsAsMap();
+            for (Formation f : campaign.getAllFormations()) {
+                if (!f.getUnits().isEmpty() && (null == lances.get(f.getId()))) {
+                    lances.put(f.getId(), new CombatTeam(f.getId(), campaign));
+                    LOGGER.warn("Added missing Lance {} to AtB list", f.getName());
+                }
+            }
+        }
+
+        LOGGER.info("[Campaign Load] Force IDs set in {}ms", System.currentTimeMillis() - timestamp);
+        timestamp = System.currentTimeMillis();
+
+        // Process parts...
+        // Note: Units must have their Entities set prior to reaching this point!
+        postProcessParts(campaign, version);
+        rehomeBaseHangarUnitParts(campaign);
+
+        LOGGER.info("[Campaign Load] Parts processed in {}ms", System.currentTimeMillis() - timestamp);
+        timestamp = System.currentTimeMillis();
+
+        LOGGER.info("[Campaign Load] Rank references fixed in {}ms", System.currentTimeMillis() - timestamp);
+        timestamp = System.currentTimeMillis();
+
+        // Okay, Units, need their pilot references fixed.
+        campaign.getAllHangar().forEachUnit(unit -> {
+            // Also, the unit should have its campaign set.
+            unit.setCampaign(campaign);
+            unit.fixReferences(campaign);
+
+            if (null != unit.getRefit()) {
+                unit.getRefit().fixReferences(campaign);
+
+                unit.getRefit().reCalc();
+                if (!unit.getRefit().isCustomJob() && !unit.getRefit().kitFound()) {
+                    campaign.getShoppingList().addShoppingItemWithoutChecking(unit.getRefit());
+                }
+            }
+
+            // lets make sure the force id set actually corresponds to a force
+            // TODO: we have some reports of force id relics - need to fix
+            if ((unit.getFormationId() > 0) && (campaign.getFormation(unit.getFormationId()) == null)) {
+                unit.setFormationId(FORMATION_NONE);
+            }
+
+            // It's annoying to have to do this, but this helps to ensure
+            // that equipment numbers correspond to the right parts - its
+            // possible that these might have changed if changes were made to
+            // the ordering of equipment in the underlying data file for the unit.
+            // We're not checking for refit here.
+            final EquipmentUnscrambler unscrambler = EquipmentUnscrambler.create(unit);
+            final EquipmentUnscramblerResult result = unscrambler.unscramble();
+            if (!result.succeeded()) {
+                LOGGER.warn(result.getMessage());
+            }
+
+            // some units might need to be assigned to scenarios
+            Scenario s = campaign.getScenario(unit.getScenarioId());
+            if (null != s) {
+                // most units will be properly assigned through their
+                // force, so check to make sure they aren't already here
+                if (!s.isAssigned(unit, campaign)) {
+                    s.addUnit(unit.getId());
+                }
+            }
+
+            //Update the campaign transport availability if this is transport.
+            //If it's empty we should be able to just ignore it
+            for (CampaignTransportType campaignTransportType : CampaignTransportType.values()) {
+                if (unit.hasTransportedUnits(campaignTransportType)) {
+                    campaign.updateTransportInTransports(campaignTransportType, unit);
+                }
+            }
+        });
+
+        LOGGER.info("[Campaign Load] Pilot references fixed in {}ms", System.currentTimeMillis() - timestamp);
+        timestamp = System.currentTimeMillis();
+
+        // Fix campaign references for units in base hangars.
+        // These units are NOT in campaign.getHangar(), so the loop above skips them.
+        // They need setCampaign() and fixReferences() just like main-force units.
+        for (PlayerBase base : campaign.getCampaignLocationManager().getPlayerBases()) {
+            base.getBaseHangar().forEachUnit(unit -> initializeBaseUnit(unit, campaign));
+        }
+
+        LOGGER.info("[Campaign Load] Base hangar references fixed in {}ms", System.currentTimeMillis() - timestamp);
+        timestamp = System.currentTimeMillis();
+
+        boolean skipAllDeprecationChecks = false;
+        boolean refundAllDeprecatedSkills = false;
+        for (Person person : campaign.getAllPersonnel()) {
+            // skill types might need resetting
+            person.resetSkillTypes();
+
+            // Seeing as we're already looping through all personnel, we might as well have the deprecation checks
+            // here, too.
+            if (!DEPRECATED_SKILLS.isEmpty() && !skipAllDeprecationChecks) {
+                // This checks to ensure the character doesn't have any Deprecated skills.
+                SkillDeprecationTool deprecationTool = new SkillDeprecationTool(campaign,
+                      person,
+                      refundAllDeprecatedSkills);
+                skipAllDeprecationChecks = deprecationTool.isSkipAll();
+                refundAllDeprecatedSkills = deprecationTool.isRefundAll();
+            }
+
+            // Self-correct any invalid personnel statuses (handles <50.05 campaigns)
+            // Any characters with invalid statuses will have their status set to 'Active'
+            if (person.getPrisonerStatus().isCurrentPrisoner()) {
+                statusValidator(campaign, person, true);
+            }
+
+            // <50.10 compatibility handler
+            LocalDate today = campaign.getLocalDate();
+            if (Person.updateSkillsForVehicleProfessions(today, person, person.getPrimaryRole(), true) ||
+                      Person.updateSkillsForVehicleProfessions(today, person, person.getSecondaryRole(), false)) {
+                String report = getFormattedTextAt(RESOURCE_BUNDLE, "vehicleProfessionSkillChange",
+                      spanOpeningWithCustomColor(getWarningColor()),
+                      CLOSING_SPAN_TAG,
+                      person.getHyperlinkedFullTitle());
+                campaign.addReport(GENERAL, report);
+            }
+
+            // This resolves a bug squashed in 2025 (50.03) but lurked in our codebase
+            // potentially as far back as 2014. The next two handlers should never be removed.
+            if (!person.canPerformRole(today, person.getSecondaryRole(), false)) {
+                person.setSecondaryRole(PersonnelRole.NONE);
+
+                campaign.addReport(GENERAL, getFormattedTextAt(RESOURCE_BUNDLE, "ineligibleForSecondaryRole",
+                      spanOpeningWithCustomColor(getWarningColor()),
+                      CLOSING_SPAN_TAG,
+                      person.getHyperlinkedFullTitle()));
+            }
+
+            if (!person.canPerformRole(today, person.getPrimaryRole(), true)) {
+                person.setPrimaryRole(campaign.getLocalDate(), PersonnelRole.DEPENDENT);
+
+                campaign.addReport(GENERAL, getFormattedTextAt(RESOURCE_BUNDLE, "ineligibleForPrimaryRole",
+                      spanOpeningWithCustomColor(getNegativeColor()),
+                      CLOSING_SPAN_TAG,
+                      person.getHyperlinkedFullTitle()));
+            }
+        }
+
+        campaign.getAllHangar().forEachUnit(unit -> {
+            // Some units have been incorrectly assigned a null C3UUID as a string. This
+            // should
+            // correct that by setting a new C3UUID
+            if ((unit.getEntity().hasC3() || unit.getEntity().hasC3i() || unit.getEntity().hasNavalC3()) &&
+                      (unit.getEntity().getC3UUIDAsString() == null ||
+                             unit.getEntity().getC3UUIDAsString().equals("null"))) {
+                unit.getEntity().setC3UUID();
+                unit.getEntity().setC3NetIdSelf();
+            }
+
+            // This needs to be down here so that it can factor in any changes made to personnel prior to this point.
+            unit.resetPilotAndEntity();
+        });
+        campaign.refreshNetworks();
+
+        LOGGER.info("[Campaign Load] C3 networks refreshed in {}ms", System.currentTimeMillis() - timestamp);
+        timestamp = System.currentTimeMillis();
+
+        // This removes the risk of having forces with invalid leadership getting locked in
+        for (Formation formation : campaign.getAllFormations()) {
+            formation.updateCommander(campaign);
+        }
+
+        // ok, once we are sure that campaign has been set for all units, we can
+        // now go through and initializeParts and run diagnostics
+        List<Unit> removeUnits = new ArrayList<>();
+        campaign.getAllHangar().forEachUnit(unit -> {
+            // just in case parts are missing (i.e. because they weren't tracked
+            // in previous versions)
+            unit.initializeParts(true);
+            unit.runDiagnostic(false);
+            if (!unit.isRepairable()) {
+                if (!unit.hasSalvageableParts()) {
+                    // we shouldn't get here but some units seem to stick around
+                    // for some reason
+                    removeUnits.add(unit);
+                } else {
+                    unit.setSalvage(true);
+                }
+            }
+
+            List<String> reports = unit.checkForOverCrewing();
+            for (String report : reports) {
+                campaign.addReport(GENERAL, report);
+            }
+        });
+
+        for (Unit unit : removeUnits) {
+            campaign.removeUnit(unit.getId());
+        }
+
+        for (PlayerBase base : campaign.getCampaignLocationManager().getPlayerBases()) {
+            base.getBaseHangar().forEachUnit(unit -> {
+                unit.initializeParts(false);
+                unit.runDiagnostic(false);
+
+                List<String> reports = unit.checkForOverCrewing();
+                for (String report : reports) {
+                    campaign.addReport(GENERAL, report);
+                }
+            });
+        }
+
+        LOGGER.info("[Campaign Load] Units initialized in {}ms", System.currentTimeMillis() - timestamp);
+        timestamp = System.currentTimeMillis();
+
+        for (Person person : campaign.getAllPersonnel()) {
+            person.fixReferences(campaign);
+        }
+
+        LOGGER.info("[Campaign Load] Personnel initialized in {}ms", System.currentTimeMillis() - timestamp);
+        timestamp = System.currentTimeMillis();
+
+        campaign.reloadNews();
+
+        LOGGER.info("[Campaign Load] News loaded in {}ms", System.currentTimeMillis() - timestamp);
+        timestamp = System.currentTimeMillis();
+
+        // If we don't have a personnel market, create one.
+        if (!foundPersonnelMarket) {
+            campaign.setPersonnelMarket(new PersonnelMarket(campaign));
+        }
+
+        if (!foundContractMarket) {
+            campaign.setContractMarket(new AtbMonthlyContractMarket());
+        }
+
+        if (!foundUnitMarket) {
+            campaign.setUnitMarket(campaign.getCampaignOptions().getUnitMarketMethod().getUnitMarket());
+        }
+
+        if (null == campaign.getRetirementDefectionTracker()) {
+            campaign.setRetirementDefectionTracker(new RetirementDefectionTracker());
+        }
+
+        if (campaign.getCampaignOptions().isUseStratCon()) {
+            campaign.setHasActiveContract();
+            campaign.setAtBConfig(AtBConfiguration.loadFromXml());
+        }
+
+        // Sanity Checks
+        fixupUnitTechProblems(campaign);
+
+        // unload any ammo bins in the warehouse
+        List<AmmoBin> binsToUnload = new ArrayList<>();
+        campaign.getAllWarehouse().forEachSparePart(prt -> {
+            if (prt instanceof AmmoBin && !prt.isReservedForRefit() && ((AmmoBin) prt).getShotsNeeded() == 0) {
+                binsToUnload.add((AmmoBin) prt);
+            }
+        });
+        for (AmmoBin bin : binsToUnload) {
+            bin.unload();
+        }
+
+        LOGGER.info("[Campaign Load] Ammo bins cleared in {}ms", System.currentTimeMillis() - timestamp);
+        timestamp = System.currentTimeMillis();
+
+        // Check all parts that are reserved for refit and if the refit id unit
+        // is not refitting or is gone then un-reserve
+        for (Part part : campaign.getAllWarehouse().getParts()) {
+            if (part.isReservedForRefit()) {
+                Unit u = part.getRefitUnit();
+                if ((null == u) || !u.isRefitting()) {
+                    part.setRefitUnit(null);
+                }
+            }
+        }
+
+        LOGGER.info("[Campaign Load] Reserved refit parts fixed in {}ms", System.currentTimeMillis() - timestamp);
+        timestamp = System.currentTimeMillis();
+
+        // Build a new, clean warehouse from the current parts
+        LocalWarehouse warehouse = new LocalWarehouse();
+        for (Part part : campaign.getAllWarehouse().getParts()) {
+            // Remove empty AmmoStorage entries that shouldn't exist (see #7414)
+            if (part instanceof AmmoStorage ammoStorage && ammoStorage.getShots() <= 0 && part.isSpare()) {
+                LOGGER.info("Discarding empty AmmoStorage: {}", part.getName());
+                continue;
+            }
+
+            // < 50.08 compatibility handler
+            if (part instanceof SVArmor svArmor) {
+                final int PROHIBITED_BAR_RATING = 0;
+
+                int bar = svArmor.getBAR();
+                if (bar == PROHIBITED_BAR_RATING) {
+                    LOGGER.info("Discarding untracked BAR 0 armor");
+                    continue;
+                }
+            }
+
+            warehouse.addPart(part, true);
+        }
+
+        // This will have aggregated all the possible spare parts together
+        campaign.setWarehouse(warehouse);
+
+        LOGGER.info("[Campaign Load] Warehouse cleaned up in {}ms", System.currentTimeMillis() - timestamp);
+
+        campaign.setUnitRating(null);
+
+        // this is used to handle characters from pre-50.01 campaigns
+        campaign.getAllPersonnel().stream().filter(person -> person.getJoinedCampaign() == null).forEach(person -> {
+            if (person.getRecruitment() != null) {
+                person.setJoinedCampaign(person.getRecruitment());
+                LOGGER.info(
+                      "{} doesn't have a date recorded showing when they joined the campaign. Using recruitment date.",
+                      person.getFullTitle());
+            } else {
+                person.setJoinedCampaign(campaign.getLocalDate());
+                LOGGER.info("{} doesn't have a date recorded showing when they joined the campaign. Using current date.",
+                      person.getFullTitle());
+            }
+        });
+
+        // Reset Random Death to match current campaign options
+        campaign.resetRandomDeath();
+
+        // Fix sexual preferences
+        if (version.isLowerThan(new Version("0.50.10"))) {
+            correctSexualPreferencesForCurrentSpouse(campaign.getAllPersonnel());
+        }
+
+        // Reconnect persons to the main-force personnel node. Skip persons already placed by
+        // processPlayerBaseNodes or reconnectChildren (base / travel / campus persons).
+        for (Person person : campaign.getAllPersonnel()) {
+            if (!person.isParented()) {
+                person.setParent(campaign.getMainForcePersonnel());
+            }
+        }
+
+
+        // Backward compat: Saves prior to 0.51.00 will have a single <location> tag, like we do now.
+        // However, saves from 0.51.00 will not have a location tag, but will have a <locations> tag with only
+        // one item. If we didn't find an explicit main force location, use that one. To check for this, if we didn't
+        // find a main force location, check if we have more than one location in our list (by default,
+        // will set and add a location to Campaign during the constructor.
+        if ((!foundMainForceLocation) && (campaign.getCampaignLocationManager().getLocations().size() > 1)) {
+            // Remove the location that was set by default, then use a valid location out of our locations list.
+            campaign.getCampaignLocationManager().removeLocation(campaign.getCurrentLocation());
+            campaign.getCampaignLocationManager().getLocations().stream()
+                  .filter(loc -> loc instanceof CurrentLocation)
+                  .findFirst()
+                  .ifPresent(campaign::setLocation);
+        }
+
+        if (pendingTravelNode != null) {
+            processPendingTravel(campaign, pendingTravelNode);
+        }
+
+        migrateLegacyEducationTravel(campaign);
+        reconnectPersonsToTravelLocations(campaign);
+        LOGGER.info("Load of campaign file complete!");
+
+        return campaign;
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/location/AcademyCampusLocation.java
+++ b/MekHQ/src/mekhq/campaign/location/AcademyCampusLocation.java
@@ -43,7 +43,7 @@ import megamek.logging.MMLogger;
 import mekhq.campaign.AbstractMobileLocation;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.FixedLocation;
-import mekhq.campaign.Personnel;
+import mekhq.campaign.LocalPersonnel;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.education.Academy;
 import mekhq.campaign.personnel.education.AcademyFactory;
@@ -63,7 +63,7 @@ public class AcademyCampusLocation implements IPlace {
     private static final MMLogger LOGGER = MMLogger.create(AcademyCampusLocation.class);
 
     private final LocationNode locationNode;
-    private final Personnel personnel = new Personnel();
+    private final LocalPersonnel personnel = new LocalPersonnel();
     private final String academySet;
     private final String academyName;
 
@@ -92,7 +92,7 @@ public class AcademyCampusLocation implements IPlace {
     }
 
     @Override
-    public Personnel getPersonnel() {
+    public LocalPersonnel getPersonnel() {
         return personnel;
     }
 

--- a/MekHQ/src/mekhq/campaign/location/ILocation.java
+++ b/MekHQ/src/mekhq/campaign/location/ILocation.java
@@ -44,10 +44,10 @@ import megamek.common.annotations.Nullable;
 import mekhq.campaign.AbstractLocation;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.FixedLocation;
-import mekhq.campaign.Hangar;
 import mekhq.campaign.JumpPath;
-import mekhq.campaign.Personnel;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalHangar;
+import mekhq.campaign.LocalPersonnel;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.base.PlayerBase;
 import mekhq.campaign.force.Detachment;
 import mekhq.campaign.parts.Part;
@@ -399,11 +399,11 @@ public interface ILocation {
     }
 
     /**
-     * Returns the {@link Hangar} owned by the nearest {@link mekhq.campaign.location.IPlace} ancestor of this location, or
+     * Returns the {@link LocalHangar} owned by the nearest {@link mekhq.campaign.location.IPlace} ancestor of this location, or
      * {@code null} if no such ancestor exists or it does not own a hangar.
      */
     @Nullable
-    default Hangar getHangar() {
+    default LocalHangar getHangar() {
         if (!hasLocationNode() || getLocationNode().getParent() == null) {
             return null;
         }
@@ -411,11 +411,11 @@ public interface ILocation {
     }
 
     /**
-     * Returns the {@link Warehouse} owned by the nearest {@link mekhq.campaign.location.IPlace} ancestor of this location,
+     * Returns the {@link LocalWarehouse} owned by the nearest {@link mekhq.campaign.location.IPlace} ancestor of this location,
      * or {@code null} if no such ancestor exists or it does not own a warehouse.
      */
     @Nullable
-    default Warehouse getWarehouse() {
+    default LocalWarehouse getWarehouse() {
         if (!hasLocationNode() || getLocationNode().getParent() == null) {
             return null;
         }
@@ -427,7 +427,7 @@ public interface ILocation {
      * or {@code null} if no such ancestor exists or it does not own a personnel roster.
      */
     @Nullable
-    default Personnel getPersonnel() {
+    default LocalPersonnel getPersonnel() {
         if (!hasLocationNode() || getLocationNode().getParent() == null) {
             return null;
         }

--- a/MekHQ/src/mekhq/campaign/location/IPlace.java
+++ b/MekHQ/src/mekhq/campaign/location/IPlace.java
@@ -39,9 +39,9 @@ import megamek.common.annotations.Nullable;
 import mekhq.campaign.AbstractLocation;
 import mekhq.campaign.AbstractMobileLocation;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Hangar;
-import mekhq.campaign.Personnel;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalHangar;
+import mekhq.campaign.LocalPersonnel;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.market.RequestedStockLevels;
 import mekhq.campaign.parts.AmmoStorage;
@@ -52,7 +52,7 @@ import mekhq.campaign.personnel.medical.advancedMedicalAlternate.Inoculations;
 
 /**
  * A sub-interface of {@link ILocation} that marks a node in the {@link LocationNode} tree as a
- * "place" — an anchor that owns campaign resources such as a {@link Hangar}, {@link Warehouse},
+ * "place" — an anchor that owns campaign resources such as a {@link LocalHangar}, {@link LocalWarehouse},
  * and personnel roster.
  *
  * <p>
@@ -67,26 +67,26 @@ import mekhq.campaign.personnel.medical.advancedMedicalAlternate.Inoculations;
 public interface IPlace extends ILocation {
 
     /**
-     * Returns the {@link Hangar} owned by this place, or {@code null} if this place does not own
+     * Returns the {@link LocalHangar} owned by this place, or {@code null} if this place does not own
      * one.
      *
      * <p>Overrides {@link ILocation#getHangar()} to stop the upward tree traversal.</p>
      */
     @Override
     @Nullable
-    default Hangar getHangar() {
+    default LocalHangar getHangar() {
         return null;
     }
 
     /**
-     * Returns the {@link Warehouse} owned by this place, or {@code null} if this place does not
+     * Returns the {@link LocalWarehouse} owned by this place, or {@code null} if this place does not
      * own one.
      *
      * <p>Overrides {@link ILocation#getWarehouse()} to stop the upward tree traversal.</p>
      */
     @Override
     @Nullable
-    default Warehouse getWarehouse() {
+    default LocalWarehouse getWarehouse() {
         return null;
     }
 
@@ -98,7 +98,7 @@ public interface IPlace extends ILocation {
      */
     @Override
     @Nullable
-    default Personnel getPersonnel() {
+    default LocalPersonnel getPersonnel() {
         return null;
     }
 
@@ -122,7 +122,7 @@ public interface IPlace extends ILocation {
      */
     default PartInventory getPartInventory(Part part) {
         PartInventory inventory = new PartInventory();
-        Warehouse warehouse = getWarehouse();
+        LocalWarehouse warehouse = getWarehouse();
         if (warehouse == null) {
             return inventory;
         }
@@ -188,12 +188,12 @@ public interface IPlace extends ILocation {
      */
     @Override
     default void processArrivals(Campaign campaign) {
-        Personnel personnel = getPersonnel();
+        LocalPersonnel personnel = getPersonnel();
         if (personnel == null || !hasLocationNode()) {
             return;
         }
-        Hangar hangar = getHangar() != null ? getHangar() : campaign.getHangar();
-        Warehouse warehouse = getWarehouse() != null ? getWarehouse() : campaign.getWarehouse();
+        LocalHangar hangar = getHangar() != null ? getHangar() : campaign.getHangar();
+        LocalWarehouse warehouse = getWarehouse() != null ? getWarehouse() : campaign.getWarehouse();
         for (LocationNode child : new ArrayList<>(getLocationNode().getChildren())) {
             if (!(child.getLocatable() instanceof AbstractMobileLocation travelNode)) {
                 continue;

--- a/MekHQ/src/mekhq/campaign/location/LocationDispatch.java
+++ b/MekHQ/src/mekhq/campaign/location/LocationDispatch.java
@@ -48,9 +48,9 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignLocationManager;
 import mekhq.campaign.CurrentLocation;
 import mekhq.campaign.GroundTransitLocation;
-import mekhq.campaign.Hangar;
 import mekhq.campaign.JumpPath;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalHangar;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.base.AbstractBase;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.personnel.Person;
@@ -267,21 +267,21 @@ public final class LocationDispatch {
           ILocation destination,
           Campaign campaign) {
 
-        Hangar arrivalHangar = (destination instanceof AbstractBase base)
+        LocalHangar arrivalHangar = (destination instanceof AbstractBase base)
               ? base.getBaseHangar()
               : campaign.getHangar();
-        Warehouse arrivalWarehouse = (destination instanceof AbstractBase base)
+        LocalWarehouse arrivalWarehouse = (destination instanceof AbstractBase base)
               ? base.getBaseWarehouse()
               : campaign.getWarehouse();
 
         // Move data structures immediately so hangar and warehouse filters stay correct.
         dispatch(units, destination, campaign, LOG_DISPATCH_UNITS, arrivalHangar, group -> {
             for (Unit unit : group) {
-                Hangar sourceHangar = unit.getHangar();
+                LocalHangar sourceHangar = unit.getHangar();
                 // Capture the unit's current warehouse BEFORE moving it: Hangar.addUnit reparents the unit's node, after
                 // which each installed part's getWarehouse() (resolved through the unit) would already read the arrival
                 // warehouse and the move below would be skipped.
-                Warehouse sourceWarehouse = unit.getWarehouse();
+                LocalWarehouse sourceWarehouse = unit.getWarehouse();
                 if (sourceWarehouse == null) {
                     sourceWarehouse = campaign.getWarehouse();
                 }
@@ -314,14 +314,14 @@ public final class LocationDispatch {
      */
     private static void dispatchPartsToLocation(Collection<Part> parts, ILocation destination, Campaign campaign) {
 
-        Warehouse arrivalWarehouse = (destination instanceof AbstractBase base)
+        LocalWarehouse arrivalWarehouse = (destination instanceof AbstractBase base)
               ? base.getBaseWarehouse()
               : campaign.getWarehouse();
 
         // Move the data structure immediately so warehouse filters stay correct.
         dispatch(parts, destination, campaign, LOG_DISPATCH_PARTS, arrivalWarehouse, group -> {
             for (Part part : group) {
-                Warehouse sourceWarehouse = part.getWarehouse();
+                LocalWarehouse sourceWarehouse = part.getWarehouse();
                 (sourceWarehouse != null ? sourceWarehouse : campaign.getWarehouse()).removePart(part);
                 arrivalWarehouse.addPart(part);
             }

--- a/MekHQ/src/mekhq/campaign/location/LocationNewDayUtil.java
+++ b/MekHQ/src/mekhq/campaign/location/LocationNewDayUtil.java
@@ -49,8 +49,7 @@ import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.AbstractLocation;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Hangar;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.Refit;
@@ -74,8 +73,8 @@ public final class LocationNewDayUtil {
      * hangar nor a warehouse return immediately.
      */
     public static void processNewDayUnits(IPlace place, Campaign campaign) {
-        Hangar hangar = place.getHangar();
-        Warehouse warehouse = place.getWarehouse();
+        mekhq.campaign.LocalHangar hangar = place.getHangar();
+        LocalWarehouse warehouse = place.getWarehouse();
 
         if (hangar != null) {
             // need to loop through units twice, the first time to do all maintenance and

--- a/MekHQ/src/mekhq/campaign/market/ForceShoppingList.java
+++ b/MekHQ/src/mekhq/campaign/market/ForceShoppingList.java
@@ -79,19 +79,19 @@ import org.w3c.dom.NodeList;
  * <p>
  * Do we use a separate shopping list for new units?
  */
-public class ShoppingList {
-    private static final MMLogger LOGGER = MMLogger.create(ShoppingList.class);
+public class ForceShoppingList {
+    private static final MMLogger LOGGER = MMLogger.create(ForceShoppingList.class);
 
     // region Variable Declarations
     private List<IAcquisitionWork> shoppingList;
     // endregion Variable Declarations
 
     // region Constructors
-    public ShoppingList() {
+    public ForceShoppingList() {
         setShoppingList(new ArrayList<>());
     }
 
-    public ShoppingList(List<IAcquisitionWork> shoppingList) {
+    public ForceShoppingList(List<IAcquisitionWork> shoppingList) {
         setShoppingList(shoppingList);
     }
     // endregion Constructors
@@ -254,8 +254,8 @@ public class ShoppingList {
         MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "shoppingList");
     }
 
-    public static ShoppingList generateInstanceFromXML(Node wn, Campaign c, Version version) {
-        ShoppingList retVal = new ShoppingList();
+    public static ForceShoppingList generateInstanceFromXML(Node wn, Campaign c, Version version) {
+        ForceShoppingList retVal = new ForceShoppingList();
 
         NodeList nl = wn.getChildNodes();
 

--- a/MekHQ/src/mekhq/campaign/market/PartsInUseManager.java
+++ b/MekHQ/src/mekhq/campaign/market/PartsInUseManager.java
@@ -46,8 +46,7 @@ import megamek.common.equipment.WeaponType;
 import megamek.common.units.Entity;
 import megamek.common.units.Mek;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Quartermaster;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.base.PlayerBase;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.location.IPlace;
@@ -98,9 +97,9 @@ public class PartsInUseManager {
     private final Campaign campaign;
     private final IPlace place;
     private final CampaignOptions campaignOptions;
-    private final Warehouse warehouse;
-    private final ShoppingList shoppingList;
-    private final Quartermaster quartermaster;
+    private final LocalWarehouse warehouse;
+    private final ForceShoppingList shoppingList;
+    private final mekhq.campaign.ForceQuartermaster quartermaster;
     private final Map<String, Double> partsInUseRequestedStockMap;
 
     /**
@@ -125,7 +124,7 @@ public class PartsInUseManager {
         this.campaign = campaign;
         this.place = place;
         this.campaignOptions = campaign.getCampaignOptions();
-        Warehouse placeWarehouse = place.getWarehouse();
+        LocalWarehouse placeWarehouse = place.getWarehouse();
         this.warehouse = (placeWarehouse != null) ? placeWarehouse : campaign.getWarehouse();
         this.shoppingList = campaign.getShoppingList();
         this.quartermaster = campaign.getQuartermaster();

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AlternatePaymentModelValues.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AlternatePaymentModelValues.java
@@ -50,7 +50,7 @@ import megamek.common.units.EntityMovementMode;
 import megamek.common.units.Infantry;
 import megamek.common.units.LandAirMek;
 import megamek.logging.MMLogger;
-import mekhq.campaign.Hangar;
+import mekhq.campaign.LocalHangar;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.force.CombatTeam;
 import mekhq.campaign.force.Formation;
@@ -68,7 +68,7 @@ import mekhq.campaign.universe.Faction;
  * <p>Primary usage:</p>
  * <ul>
  *     <li>Use {@link #getValue()} to retrieve the baseline {@link Money} value for a given category.</li>
- *     <li>Use {@link #getForceValue(Faction, List, Hangar, boolean, boolean, double, double, double, double)} to
+ *     <li>Use {@link #getForceValue(Faction, List, LocalHangar, boolean, boolean, double, double, double, double)} to
  *     compute the total contract value for a set of forces, applying contract percentage multipliers per category.</li>
  * </ul>
  *
@@ -158,7 +158,7 @@ public enum AlternatePaymentModelValues {
      *     <li>marked as a {@code combat role} (as determined by {@code force.getCombatRoleInMemory().isCombatRole()}).</li>
      * </ul>
      *
-     * <p>For each included force, all units returned by {@link Formation#getUnitsAsUnits(Hangar)} are examined.
+     * <p>For each included force, all units returned by {@link Formation#getUnitsAsUnits(LocalHangar)} are examined.
      * {@code null} units and units whose {@link Unit#getEntity()} is {@code null} are skipped.</p>
      *
      * <p>The category-specific percentage parameters are provided as whole percentages (for example, {@code 50.0} for
@@ -185,7 +185,8 @@ public enum AlternatePaymentModelValues {
      * @author Illiani
      * @since 0.50.11
      */
-    public static Money getForceValue(Faction campaignFaction, List<Formation> allFormations, Hangar hangar,
+    public static Money getForceValue(Faction campaignFaction, List<Formation> allFormations,
+            mekhq.campaign.LocalHangar hangar,
                                       boolean useDiminishingContractPay, boolean excludeInfantry, double combatUnitContractPercent,
                                       double dropShipContractPercent, double warShipContractPercent, double jumpShipContractPercent) {
         final double combatMultiplier = combatUnitContractPercent / 100.0;

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
@@ -69,7 +69,6 @@ import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.JumpPath;
-import mekhq.campaign.camOpsReputation.ReputationController;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.enums.DragoonRating;
 import mekhq.campaign.market.enums.ContractMarketMethod;
@@ -559,7 +558,7 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
                   campaign.getCurrentSystem().getName(campaign.getLocalDate()));
             return generateAtBContract(campaign, employer, unitRatingMod, retries - 1);
         }
-        final ReputationController reputation = campaign.getReputation();
+        final mekhq.campaign.camOpsReputation.ForceReputationController reputation = campaign.getReputation();
         final SkillLevel campaignSkillLevel = reputation == null ? REGULAR : reputation.getAverageSkillLevel();
         final boolean useDynamicDifficulty = campaign.getCampaignOptions().isUseDynamicDifficulty();
         final boolean useBolsterContractSkill = campaign.getCampaignOptions().isUseBolsterContractSkill();

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/CamOpsContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/CamOpsContractMarket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2024-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -53,7 +53,6 @@ import megamek.common.universe.FactionTag;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.camOpsReputation.ReputationController;
 import mekhq.campaign.enums.DragoonRating;
 import mekhq.campaign.market.enums.ContractMarketMethod;
 import mekhq.campaign.mission.AtBContract;
@@ -85,7 +84,7 @@ public class CamOpsContractMarket extends AbstractContractMarket {
     @Override
     public AtBContract addAtBContract(Campaign campaign) {
         HiringHallModifiers hiringHallModifiers = getHiringHallModifiers(campaign);
-        ReputationController reputation = campaign.getReputation();
+        mekhq.campaign.camOpsReputation.ForceReputationController reputation = campaign.getReputation();
         Optional<AtBContract> c = generateContract(campaign, reputation, hiringHallModifiers);
         if (c.isPresent()) {
             AtBContract atbContract = c.get();
@@ -249,7 +248,8 @@ public class CamOpsContractMarket extends AbstractContractMarket {
         }
     }
 
-    private Optional<AtBContract> generateContract(Campaign campaign, ReputationController reputation,
+    private Optional<AtBContract> generateContract(Campaign campaign,
+            mekhq.campaign.camOpsReputation.ForceReputationController reputation,
           HiringHallModifiers hiringHallModifiers) {
         AtBContract contract = new AtBContract("UnnamedContract");
         lastId++;

--- a/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketMekHQ.java
+++ b/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketMekHQ.java
@@ -54,7 +54,6 @@ import megamek.common.compute.Compute;
 import megamek.common.enums.Gender;
 import mekhq.MekHQ;
 import mekhq.campaign.AbstractLocation;
-import mekhq.campaign.camOpsReputation.ReputationController;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.market.personnelMarket.records.PersonnelMarketEntry;
@@ -245,7 +244,7 @@ public class PersonnelMarketMekHQ extends NewPersonnelMarket {
      */
     @Override
     public void generateApplicants() {
-        ReputationController reputation = getCampaign().getReputation();
+        mekhq.campaign.camOpsReputation.ForceReputationController reputation = getCampaign().getReputation();
         int averageSkillLevel = reputation.getAverageSkillLevel().getExperienceLevel();
 
         calculateNumberOfRecruitmentRolls();

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -108,7 +108,7 @@ import megamek.logging.MMLogger;
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Hangar;
+import mekhq.campaign.LocalHangar;
 import mekhq.campaign.againstTheBot.AtBConfiguration;
 import mekhq.campaign.camOpsReputation.IUnitRating;
 import mekhq.campaign.campaignOptions.BoardScalingType;
@@ -4540,7 +4540,7 @@ public class AtBDynamicScenarioFactory {
         // deployment turn explicitly or use a stagger algorithm.
         // For player forces where there's not an associated force template, we calculate the
         // deployment turn as if they were reinforcements
-        Hangar hangar = campaign.getAllHangar();
+        mekhq.campaign.LocalHangar hangar = campaign.getAllHangar();
         for (int forceID : scenario.getForceIDs()) {
             ScenarioForceTemplate forceTemplate = scenario.getPlayerForceTemplates().get(forceID);
 
@@ -4657,13 +4657,14 @@ public class AtBDynamicScenarioFactory {
      * setDeploymentTurnsForReinforcements}, including an additional delay reduction based on the scenario.</p>
      *
      * @param scenario the {@link AtBDynamicScenario} defining friendly delayed reinforcements
-     * @param hangar   the {@link Hangar} containing all possible entities for deployment
+     * @param hangar   the {@link LocalHangar} containing all possible entities for deployment
      * @param strategy an {@link Integer} value affecting the calculated delay for the arrivals
      *
      * @author Illiani
      * @since 0.50.07
      */
-    private static void processDelayedArrivals(AtBDynamicScenario scenario, Hangar hangar, int strategy) {
+    private static void processDelayedArrivals(AtBDynamicScenario scenario, mekhq.campaign.LocalHangar hangar,
+            int strategy) {
         List<Entity> delayedEntities = new ArrayList<>();
         for (UUID unitId : scenario.getFriendlyDelayedReinforcements()) {
             Entity entity = EntityUtilities.getEntityFromUnitId(hangar, unitId);
@@ -4689,12 +4690,12 @@ public class AtBDynamicScenarioFactory {
      * them available immediately.</p>
      *
      * @param scenario the {@link AtBDynamicScenario} defining friendly delayed reinforcements
-     * @param hangar   the {@link Hangar} containing all possible entities for deployment
+     * @param hangar   the {@link LocalHangar} containing all possible entities for deployment
      *
      * @author Illiani
      * @since 0.50.07
      */
-    private static void processInstantArrivals(AtBDynamicScenario scenario, Hangar hangar) {
+    private static void processInstantArrivals(AtBDynamicScenario scenario, mekhq.campaign.LocalHangar hangar) {
         List<UUID> instantReinforcements = scenario.getFriendlyInstantReinforcements();
         for (UUID unitId : instantReinforcements) {
             Unit unit = hangar.getUnit(unitId);
@@ -4804,7 +4805,7 @@ public class AtBDynamicScenarioFactory {
      * speeds, with an optional adjustment via the {@code turnModifier}. It assumes that the reinforcements are not
      * delayed, simplifying the calculation logic compared to the main method.</p>
      *
-     * @param hangar       The {@link Hangar} instance containing the available entities. Used to resolve
+     * @param hangar       The {@link LocalHangar} instance containing the available entities. Used to resolve
      *                     player-transported entities via unit IDs.
      * @param scenario     The {@link Scenario} under which the entities are being deployed. Provides transport linkage
      *                     information and overall deployment context.
@@ -4812,10 +4813,11 @@ public class AtBDynamicScenarioFactory {
      * @param turnModifier A value to subtract from the calculated deployment turn, typically reflecting a strategy
      *                     skill or similar modifier.
      *
-     * @see #setDeploymentTurnsForReinforcements(Hangar, Scenario, List, int, boolean)
+     * @see #setDeploymentTurnsForReinforcements(LocalHangar, Scenario, List, int, boolean)
      */
-    public static void setDeploymentTurnsForReinforcements(Hangar hangar, Scenario scenario, List<Entity> entityList,
-          int turnModifier) {
+    public static void setDeploymentTurnsForReinforcements(mekhq.campaign.LocalHangar hangar, Scenario scenario,
+            List<Entity> entityList,
+            int turnModifier) {
         setDeploymentTurnsForReinforcements(hangar, scenario, entityList, turnModifier, false);
     }
 
@@ -4839,7 +4841,7 @@ public class AtBDynamicScenarioFactory {
      *   <li>Updates the deployment round for all entities in the list to the calculated arrival turn.</li>
      * </ul>
      *
-     * @param hangar       The {@link Hangar} instance containing the available entities. Used to resolve
+     * @param hangar       The {@link LocalHangar} instance containing the available entities. Used to resolve
      *                     player-transported entities via unit IDs.
      * @param scenario     The {@link Scenario} under which the entities are being deployed. Provides transport linkage
      *                     information and overall deployment context.
@@ -4849,8 +4851,9 @@ public class AtBDynamicScenarioFactory {
      * @param isDelayed    A flag indicating whether the reinforcements were delayed. Delayed reinforcements are
      *                     assigned a higher arrival scale, increasing their arrival turn.
      */
-    public static void setDeploymentTurnsForReinforcements(Hangar hangar, Scenario scenario, List<Entity> entityList,
-          int turnModifier, boolean isDelayed) {
+    public static void setDeploymentTurnsForReinforcements(mekhq.campaign.LocalHangar hangar, Scenario scenario,
+            List<Entity> entityList,
+            int turnModifier, boolean isDelayed) {
         // Build a set of all player transported entities. We don't need to do this for NPC entities
         // as how they're transported is different and their arrival times are better isolated when
         // dealing with transported vs. untransported units.

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -75,7 +75,6 @@ import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Hangar;
 import mekhq.campaign.againstTheBot.AtBConfiguration;
 import mekhq.campaign.againstTheBot.AtBStaticWeightGenerator;
 import mekhq.campaign.campaignOptions.CampaignOptions;
@@ -875,7 +874,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         if (campaign.getCampaignOptions().isUseDropShips()) {
             if (canAddDropShips()) {
                 boolean dropshipFound = false;
-                Hangar hangar = campaign.getAllHangar();
+                mekhq.campaign.LocalHangar hangar = campaign.getAllHangar();
                 List<UUID> allCombatUnits = campaign.getAllUnitsInTheTOE(true);
                 Collections.shuffle(allCombatUnits); // Remove bias
                 for (UUID unitId : allCombatUnits) {

--- a/MekHQ/src/mekhq/campaign/mission/TransportCostCalculations.java
+++ b/MekHQ/src/mekhq/campaign/mission/TransportCostCalculations.java
@@ -57,7 +57,6 @@ import megamek.common.units.Jumpship;
 import megamek.common.units.LandAirMek;
 import megamek.common.units.SpaceStation;
 import megamek.logging.MMLogger;
-import mekhq.campaign.Hangar;
 import mekhq.campaign.JumpPath;
 import mekhq.campaign.finances.Finances;
 import mekhq.campaign.finances.Money;

--- a/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/SalvageFormationData.java
+++ b/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/SalvageFormationData.java
@@ -47,7 +47,6 @@ import megamek.common.units.Entity;
 import megamek.common.units.Mek;
 import megamek.common.units.Tank;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Hangar;
 import mekhq.campaign.enums.CampaignTransportType;
 import mekhq.campaign.force.Formation;
 import mekhq.campaign.force.FormationType;
@@ -74,7 +73,7 @@ public record SalvageFormationData(Formation formation, FormationType formationT
         int salvageCapableUnits = 0;
         boolean hasTug = false;
 
-        Hangar hangar = campaign.getAllHangar();
+        mekhq.campaign.LocalHangar hangar = campaign.getAllHangar();
         for (Unit unit : formation.getAllUnitsAsUnits(hangar, false)) {
             if (!unit.isFullyCrewed()) {
                 continue;
@@ -167,7 +166,7 @@ public record SalvageFormationData(Formation formation, FormationType formationT
     }
 
     public String getAllCrewTechTooltip(Campaign campaign, Formation formation) {
-        Hangar hangar = campaign.getAllHangar();
+        mekhq.campaign.LocalHangar hangar = campaign.getAllHangar();
 
         StringBuilder tooltip = new StringBuilder();
         for (Unit unit : formation.getAllUnitsAsUnits(hangar, false)) {
@@ -181,24 +180,24 @@ public record SalvageFormationData(Formation formation, FormationType formationT
         return tooltip.toString();
     }
 
-    public String getCargoCapacityTooltip(Hangar hangar) {
+    public String getCargoCapacityTooltip(mekhq.campaign.LocalHangar hangar) {
         LinkedHashMap<String, Double> capacityMap = getMap(hangar, false);
         StringBuilder tooltip = getTooltip(capacityMap);
         return tooltip.toString();
     }
 
-    public String getTowCapacityTooltip(Hangar hangar) {
+    public String getTowCapacityTooltip(mekhq.campaign.LocalHangar hangar) {
         LinkedHashMap<String, Double> capacityMap = getMap(hangar, true);
         StringBuilder tooltip = getTooltip(capacityMap);
         return tooltip.toString();
     }
 
-    private LinkedHashMap<String, Double> getMap(Hangar hangar, boolean isTow) {
+    private LinkedHashMap<String, Double> getMap(mekhq.campaign.LocalHangar hangar, boolean isTow) {
         Map<String, Double> unsortedMap = getUnsortedMap(hangar, isTow);
         return getSortedMap(unsortedMap);
     }
 
-    private Map<String, Double> getUnsortedMap(Hangar hangar, boolean isTow) {
+    private Map<String, Double> getUnsortedMap(mekhq.campaign.LocalHangar hangar, boolean isTow) {
         Map<String, Double> capacityMap = new HashMap<>();
         for (Unit unit : formation.getAllUnitsAsUnits(hangar, false)) {
             Entity entity = unit.getEntity();
@@ -236,7 +235,7 @@ public record SalvageFormationData(Formation formation, FormationType formationT
         return tooltip;
     }
 
-    public String getTugTooltip(Hangar hangar) {
+    public String getTugTooltip(mekhq.campaign.LocalHangar hangar) {
         Map<String, Boolean> capacityMap = new HashMap<>();
         for (Unit unit : formation.getAllUnitsAsUnits(hangar, false)) {
             Entity entity = unit.getEntity();

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/PerformResupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/PerformResupply.java
@@ -73,7 +73,6 @@ import megamek.common.enums.Gender;
 import megamek.common.units.Entity;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Hangar;
 import mekhq.campaign.force.Formation;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.AtBDynamicScenario;
@@ -648,7 +647,7 @@ public class PerformResupply {
         if (targetConvoy != null) {
             speaker = campaign.getPerson(targetConvoy.getFormationCommanderID());
 
-            Hangar hangar = campaign.getAllHangar();
+            mekhq.campaign.LocalHangar hangar = campaign.getAllHangar();
             if (targetConvoy.formationContainsOnlyVTOLForces(hangar, false) ||
                       targetConvoy.formationContainsOnlyAerialForces(hangar, false, false)) {
                 inCharacterMessage = getFormattedTextAt(RESOURCE_BUNDLE,

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -67,7 +67,7 @@ import megamek.common.units.Tank;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.location.ILocatable;
 import mekhq.campaign.location.ILocation;
@@ -413,7 +413,7 @@ public abstract class Part implements IPartWork, ITechnology, ILocatable {
     }
 
     @Override
-    public @Nullable Warehouse getWarehouse() {
+    public @Nullable LocalWarehouse getWarehouse() {
         IPlace place = getPlace();
         return place != null ? place.getWarehouse() : campaign.getWarehouse();
     }
@@ -512,7 +512,7 @@ public abstract class Part implements IPartWork, ITechnology, ILocatable {
         if (this.isSalvaging()) {
             int inStock = 0;
             if (this instanceof mekhq.campaign.parts.equipment.AmmoBin ammoBin) {
-                Warehouse localWarehouse = getWarehouse();
+                LocalWarehouse localWarehouse = getWarehouse();
                 if (localWarehouse != null) {
                     megamek.common.equipment.AmmoType ammoType = ammoBin.getType();
                     boolean useAmmoByType = campaign.getCampaignOptions().isUseAmmoByType();
@@ -525,7 +525,7 @@ public abstract class Part implements IPartWork, ITechnology, ILocatable {
                                         if (spare.isSameAmmoType(ammoType)) {
                                             return spare.getShots();
                                         } else if (useAmmoByType && spare.isCompatibleAmmo(ammoType)) {
-                                            return mekhq.campaign.Quartermaster.convertShots(
+                                            return mekhq.campaign.ForceQuartermaster.convertShots(
                                                   spare.getType(), spare.getShots(), ammoType);
                                         }
                                         return 0;

--- a/MekHQ/src/mekhq/campaign/parts/PodSpace.java
+++ b/MekHQ/src/mekhq/campaign/parts/PodSpace.java
@@ -46,7 +46,6 @@ import megamek.common.units.Mek;
 import megamek.common.units.Tank;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Warehouse;
 import mekhq.campaign.events.parts.PartChangedEvent;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.location.LocationNode;
@@ -313,7 +312,7 @@ public class PodSpace implements IPartWork {
     }
 
     @Override
-    public Warehouse getWarehouse() {
+    public mekhq.campaign.LocalWarehouse getWarehouse() {
         return campaign.getWarehouse();
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -60,7 +60,6 @@ import megamek.common.units.ProtoMek;
 import megamek.common.units.SmallCraft;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Warehouse;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.AmmoStorage;
 import mekhq.campaign.parts.Availability;
@@ -353,7 +352,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
      */
     protected int requisitionAmmo(AmmoType ammoType, int shotsNeeded) {
         Objects.requireNonNull(ammoType);
-        Warehouse warehouse = getWarehouse();
+        mekhq.campaign.LocalWarehouse warehouse = getWarehouse();
         int shotsLoaded = 0;
         while (shotsLoaded < shotsNeeded) {
             int shots = campaign.getQuartermaster().removeAmmo(warehouse, ammoType, shotsNeeded - shotsLoaded);

--- a/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
@@ -50,7 +50,6 @@ import megamek.common.units.Entity;
 import megamek.common.weapons.bayWeapons.BayWeapon;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Warehouse;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.unit.Unit;
@@ -260,7 +259,9 @@ public class EquipmentPart extends Part {
             }
 
             // Capture target warehouse before detaching from unit
-            Warehouse targetWarehouse = unit.getWarehouse() != null ? unit.getWarehouse() : campaign.getWarehouse();
+            mekhq.campaign.LocalWarehouse targetWarehouse = unit.getWarehouse() != null ?
+                                                                    unit.getWarehouse() :
+                                                                    campaign.getWarehouse();
 
             unit.removePart(this);
             setUnit(null);

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -107,7 +107,7 @@ import mekhq.Utilities;
 import mekhq.campaign.AbstractLocation;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.ExtraData;
-import mekhq.campaign.Personnel;
+import mekhq.campaign.LocalPersonnel;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.events.persons.PersonChangedEvent;
 import mekhq.campaign.events.persons.PersonStatusChangedEvent;
@@ -9466,10 +9466,10 @@ public class Person implements ILocatable {
     public boolean setParent(ILocation parent) {
         ILocation oldParent = getParentLocation();
         if (ILocatable.super.setParent(parent)) {
-            if (oldParent instanceof Personnel personnel) {
+            if (oldParent instanceof LocalPersonnel personnel) {
                 personnel.remove(getId());
             }
-            if (parent instanceof Personnel personnel) {
+            if (parent instanceof LocalPersonnel personnel) {
                 personnel.put(getId(), this);
             }
             return true;

--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -73,7 +73,7 @@ import mekhq.campaign.AbstractMobileLocation;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CurrentLocation;
 import mekhq.campaign.JumpPath;
-import mekhq.campaign.Personnel;
+import mekhq.campaign.LocalPersonnel;
 import mekhq.campaign.base.PlayerBase;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.events.persons.PersonChangedEvent;
@@ -940,7 +940,7 @@ public class EducationController {
           @Nullable AbstractMobileLocation returnLocation) {
         Academy returningFromAcademy = getAcademy(person.getEduAcademySet(), person.getEduAcademyNameInSet());
         boolean isLocal = returningFromAcademy != null && returningFromAcademy.isLocal();
-        Personnel arrivingAtPersonnel = isLocal ?
+        LocalPersonnel arrivingAtPersonnel = isLocal ?
                                               findPersonnelWhenReturningFromLocal(campaign,
                                                     person.getEduAcademySystem()) :
                                               campaign.getMainForcePersonnel();
@@ -958,7 +958,7 @@ public class EducationController {
         LocationDispatch.removeTravelNode(returnLocation, campaign.getCampaignLocationManager());
     }
 
-    private static Personnel findPersonnelWhenReturningFromLocal(Campaign campaign, @Nullable String systemId) {
+    private static LocalPersonnel findPersonnelWhenReturningFromLocal(Campaign campaign, @Nullable String systemId) {
         if (systemId != null) {
             for (PlayerBase base : campaign.getCampaignLocationManager().getPlayerBases()) {
                 PlanetarySystem system = base.getCurrentSystem();

--- a/MekHQ/src/mekhq/campaign/personnel/familyTree/Genealogy.java
+++ b/MekHQ/src/mekhq/campaign/personnel/familyTree/Genealogy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -46,7 +46,7 @@ import java.util.UUID;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.Gender;
 import megamek.logging.MMLogger;
-import mekhq.campaign.HumanResources;
+import mekhq.campaign.ForceHumanResources;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.FamilialRelationshipType;
 import mekhq.campaign.personnel.procreation.AbstractProcreation;
@@ -533,28 +533,6 @@ public class Genealogy {
     }
 
     /**
-     * Determines whether this family unit is considered "active" by checking whether any member of the extended family
-     * network is currently active (i.e., has not left the unit).
-     *
-     * <p>Traverses the full genealogical graph rooted at {@code origin}, including parents,
-     * children, current and former spouses, and pregnancy fathers, returning {@code true} as soon as any such relative
-     * is found to be active.</p>
-     *
-     * @param humanResources the {@link HumanResources} registry used to resolve person lookups by ID (e.g., pregnancy
-     *                       father resolution)
-     *
-     * @return {@code true} if at least one member of the extended family is active; {@code false} if all reachable
-     *       relatives have left the unit
-     *
-     * @author Illiani
-     * @since 0.51.0
-     */
-    public boolean isActive(HumanResources humanResources) {
-        HashSet<Person> allFamilyMembers = new HashSet<>();
-        return collectRelatives(humanResources, origin, allFamilyMembers, true);
-    }
-
-    /**
      * Recursively traverses the genealogical graph from {@code currentPerson}, collecting all reachable relatives and
      * optionally short-circuiting as soon as a genealogically active person is found.
      *
@@ -564,14 +542,14 @@ public class Genealogy {
      *     <li>Children</li>
      *     <li>Former spouses (via {@link FormerSpouse} wrapper)</li>
      *     <li>Current spouse</li>
-     *     <li>Pregnancy father, resolved through {@link HumanResources} when the current person
+     *     <li>Pregnancy father, resolved through {@link ForceHumanResources} when the current person
      *     is pregnant and father ID data is present</li>
      * </ul>
      *
      * <p>Already-visited persons are tracked in {@code allFamilyMembers} to prevent infinite
      * recursion across cyclical or bidirectional relationships.</p>
      *
-     * @param humanResources          the {@link HumanResources} registry for resolving persons by UUID
+     * @param humanResources          the {@link ForceHumanResources} registry for resolving persons by UUID
      * @param currentPerson           the person whose relatives are currently being examined
      * @param allFamilyMembers        the set of already-visited persons; modified in place
      * @param checkForActiveGenealogy if {@code true}, the traversal will return {@code true} immediately upon finding
@@ -583,7 +561,7 @@ public class Genealogy {
      * @author Illiani
      * @since 0.51.0
      */
-    private static boolean collectRelatives(HumanResources humanResources, Person currentPerson,
+    private static boolean collectRelatives(ForceHumanResources humanResources, Person currentPerson,
           HashSet<Person> allFamilyMembers, boolean checkForActiveGenealogy) {
         if (!allFamilyMembers.add(currentPerson)) {
             return false;
@@ -633,6 +611,28 @@ public class Genealogy {
         }
 
         return false;
+    }
+
+    /**
+     * Determines whether this family unit is considered "active" by checking whether any member of the extended family
+     * network is currently active (i.e., has not left the unit).
+     *
+     * <p>Traverses the full genealogical graph rooted at {@code origin}, including parents,
+     * children, current and former spouses, and pregnancy fathers, returning {@code true} as soon as any such relative
+     * is found to be active.</p>
+     *
+     * @param humanResources the {@link ForceHumanResources} registry used to resolve person lookups by ID (e.g.,
+     *                       pregnancy father resolution)
+     *
+     * @return {@code true} if at least one member of the extended family is active; {@code false} if all reachable
+     *       relatives have left the unit
+     *
+     * @author Illiani
+     * @since 0.51.0
+     */
+    public boolean isActive(ForceHumanResources humanResources) {
+        HashSet<Person> allFamilyMembers = new HashSet<>();
+        return collectRelatives(humanResources, origin, allFamilyMembers, true);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -90,7 +90,7 @@ import megamek.logging.MMLogger;
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Hangar;
+import mekhq.campaign.LocalHangar;
 import mekhq.campaign.ResolveScenarioTracker;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.events.NewDayEvent;
@@ -1895,7 +1895,7 @@ public class StratConRulesManager {
      * returned as a list. Units with no crew are logged and skipped.</p>
      *
      * @param formation the {@link Formation} containing units to evaluate
-     * @param hangar    the {@link Hangar} used to help retrieve units from the force
+     * @param hangar    the {@link LocalHangar} used to help retrieve units from the force
      * @param campaign  the {@link Campaign} context
      *
      * @return a list of {@link ScoutRecord} objects, each representing the best scout and their skill details for a
@@ -1904,7 +1904,7 @@ public class StratConRulesManager {
      * @author Illiani
      * @since 0.50.07
      */
-    static List<ScoutRecord> buildScoutMap(Formation formation, Hangar hangar, Campaign campaign) {
+    static List<ScoutRecord> buildScoutMap(Formation formation, LocalHangar hangar, Campaign campaign) {
         if (formation == null) {
             return new ArrayList<>();
         }
@@ -2214,12 +2214,12 @@ public class StratConRulesManager {
      *
      * @param formation The {@link Formation} instance that the scenario is based on. The force composition is used to
      *                  determine the appropriate scenario template.
-     * @param hangar    The {@link Hangar} instance from which to retrieve the {@link Unit}.
+     * @param hangar    The {@link LocalHangar} instance from which to retrieve the {@link Unit}.
      *
      * @return A {@link ScenarioTemplate} instance representing the chosen scenario template file based on the logic
      *       described, or a default template if no special conditions are satisfied.
      */
-    private static ScenarioTemplate getInterceptionScenarioTemplate(Formation formation, Hangar hangar) {
+    private static ScenarioTemplate getInterceptionScenarioTemplate(Formation formation, LocalHangar hangar) {
         String templateString = "data/scenariotemplates/%sReinforcements Intercepted.xml";
 
         ScenarioTemplate scenarioTemplate = ScenarioTemplate.Deserialize(String.format(templateString, ""));
@@ -2417,7 +2417,7 @@ public class StratConRulesManager {
      * Categorizes a list of force IDs into groups based on the type of map they can primarily support.
      *
      * <p>This overloaded method analyzes each force associated with the given force IDs in the context of
-     * the provided {@link Hangar} and a pre-resolved list of {@link Formation} objects. It determines whether each
+     * the provided {@link LocalHangar} and a pre-resolved list of {@link Formation} objects. It determines whether each
      * force is suited for ground, atmospheric, or space maps, assigning them to the appropriate map types. Forces may
      * belong to multiple map types based on their composition.</p>
      *
@@ -2437,7 +2437,7 @@ public class StratConRulesManager {
      * </ul>
      *
      * @param forceIDs      A list of force IDs to classify.
-     * @param hangar        The {@link Hangar} instance containing aerial or aerospace-related information about
+     * @param hangar        The {@link LocalHangar} instance containing aerial or aerospace-related information about
      *                      forces.
      * @param allFormations A pre-resolved list of {@link Formation} objects. Forces are accessed using their IDs as
      *                      indices, providing performance benefits when compared to fetching forces on demand.
@@ -2445,7 +2445,7 @@ public class StratConRulesManager {
      * @return A {@link Map} where each {@link MapLocation} key corresponds to a map type, and the value is a list of
      *       force IDs that can operate in that map type.
      */
-    public static Map<MapLocation, List<Integer>> sortForcesByMapType(List<Integer> forceIDs, Hangar hangar,
+    public static Map<MapLocation, List<Integer>> sortForcesByMapType(List<Integer> forceIDs, LocalHangar hangar,
           List<Formation> allFormations) {
         boolean airborneOnly;
         boolean aerospaceOnly;

--- a/MekHQ/src/mekhq/campaign/unit/CargoStatistics.java
+++ b/MekHQ/src/mekhq/campaign/unit/CargoStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -37,8 +37,7 @@ import java.util.Collection;
 
 import megamek.common.units.Entity;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Hangar;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.parts.Part;
 
 /**
@@ -46,7 +45,7 @@ import mekhq.campaign.parts.Part;
  */
 public record CargoStatistics(Campaign campaign) {
 
-    public Hangar getHangar() {
+    public mekhq.campaign.LocalHangar getHangar() {
         return campaign().getHangar();
     }
 
@@ -96,14 +95,14 @@ public record CargoStatistics(Campaign campaign) {
 
     public double getCargoTonnage(boolean inTransit) {
         Collection<Part> parts = campaign.getAllParts();
-        Collection<Part> spareParts = Warehouse.getSpareParts(parts);
+        Collection<Part> spareParts = LocalWarehouse.getSpareParts(parts);
         return getCargoTonnage(campaign.getAllUnits(), spareParts, inTransit, false);
     }
 
     public double getCargoTonnage(final boolean inTransit,
           final boolean mothballed) {
         Collection<Part> parts = campaign.getAllParts();
-        Collection<Part> spareParts = Warehouse.getSpareParts(parts);
+        Collection<Part> spareParts = LocalWarehouse.getSpareParts(parts);
         return getCargoTonnage(campaign.getAllUnits(), spareParts, inTransit, mothballed);
     }
 

--- a/MekHQ/src/mekhq/campaign/unit/HangarSorter.java
+++ b/MekHQ/src/mekhq/campaign/unit/HangarSorter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -40,7 +40,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import megamek.common.util.sorter.NaturalOrderComparator;
-import mekhq.campaign.Hangar;
 
 /**
  * Creates sorted views of a hangar.
@@ -86,7 +85,7 @@ public class HangarSorter {
      *
      * @return A sorted list of units.
      */
-    public List<Unit> getUnits(Hangar hangar) {
+    public List<Unit> getUnits(mekhq.campaign.LocalHangar hangar) {
         return sort(hangar.getUnitsStream()).collect(Collectors.toList());
     }
 
@@ -96,7 +95,7 @@ public class HangarSorter {
      * @param hangar   The hangar to retrieve units from in sorted order.
      * @param consumer A function to apply to each unit.
      */
-    public void forEachUnit(Hangar hangar, Consumer<Unit> consumer) {
+    public void forEachUnit(mekhq.campaign.LocalHangar hangar, Consumer<Unit> consumer) {
         sort(hangar.getUnitsStream()).forEach(consumer);
     }
 

--- a/MekHQ/src/mekhq/campaign/unit/HangarStatistics.java
+++ b/MekHQ/src/mekhq/campaign/unit/HangarStatistics.java
@@ -44,7 +44,6 @@ import megamek.common.units.FighterSquadron;
 import megamek.common.units.Jumpship;
 import megamek.common.units.SpaceStation;
 import megamek.logging.MMLogger;
-import mekhq.campaign.Hangar;
 
 /**
  * Provides methods to gather statistics on units in a hangar.
@@ -52,16 +51,16 @@ import mekhq.campaign.Hangar;
 public class HangarStatistics {
     private static final MMLogger logger = MMLogger.create(HangarStatistics.class);
 
-    private final Hangar hangar;
+    private final mekhq.campaign.LocalHangar hangar;
     private static final long UNMAPPED_BAY_TYPE = -1L;
     private static final long LIGHT_VEHICLE_BIT = 1L << 62;
     private static final long SUPER_HEAVY_BIT = 1L << 63;
 
-    public HangarStatistics(Hangar hangar) {
+    public HangarStatistics(mekhq.campaign.LocalHangar hangar) {
         this.hangar = hangar;
     }
 
-    public Hangar getHangar() {
+    public mekhq.campaign.LocalHangar getHangar() {
         return hangar;
     }
 

--- a/MekHQ/src/mekhq/campaign/unit/UnitOrder.java
+++ b/MekHQ/src/mekhq/campaign/unit/UnitOrder.java
@@ -46,7 +46,6 @@ import megamek.common.rolls.TargetRoll;
 import megamek.common.units.*;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Warehouse;
 import mekhq.campaign.parts.Availability;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.personnel.Person;
@@ -186,7 +185,7 @@ public class UnitOrder extends Unit implements IAcquisitionWork {
     }
 
     @Override
-    public Warehouse getWarehouse() {
+    public mekhq.campaign.LocalWarehouse getWarehouse() {
         return getCampaign().getWarehouse();
     }
 

--- a/MekHQ/src/mekhq/campaign/universe/generators/partGenerators/AbstractPartGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/generators/partGenerators/AbstractPartGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2021-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -36,7 +36,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import mekhq.campaign.Warehouse;
 import mekhq.campaign.parts.Armor;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.equipment.AmmoBin;
@@ -103,7 +102,7 @@ public abstract class AbstractPartGenerator {
      *
      * @return a warehouse containing the generated parts
      */
-    public abstract Warehouse generateWarehouse(List<Part> inputParts);
+    public abstract mekhq.campaign.LocalWarehouse generateWarehouse(List<Part> inputParts);
 
     /**
      * This creates a clone of the input part, with it not being omni-podded if it was originally.

--- a/MekHQ/src/mekhq/campaign/universe/generators/partGenerators/MishraPartGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/generators/partGenerators/MishraPartGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2021-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -35,7 +35,6 @@ package mekhq.campaign.universe.generators.partGenerators;
 import java.util.List;
 
 import megamek.common.units.Mek;
-import mekhq.campaign.Warehouse;
 import mekhq.campaign.parts.EnginePart;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.equipment.HeatSink;
@@ -70,8 +69,8 @@ public class MishraPartGenerator extends MultiplePartGenerator {
     }
 
     @Override
-    public Warehouse generateWarehouse(final List<Part> inputParts) {
-        final Warehouse warehouse = super.generateWarehouse(inputParts);
+    public mekhq.campaign.LocalWarehouse generateWarehouse(final List<Part> inputParts) {
+        final mekhq.campaign.LocalWarehouse warehouse = super.generateWarehouse(inputParts);
         warehouse.getParts().removeIf(part -> part instanceof EnginePart);
         warehouse.forEachPart(part -> {
             if (part instanceof HeatSink) {

--- a/MekHQ/src/mekhq/campaign/universe/generators/partGenerators/MultiplePartGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/generators/partGenerators/MultiplePartGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2021-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -34,7 +34,6 @@ package mekhq.campaign.universe.generators.partGenerators;
 
 import java.util.List;
 
-import mekhq.campaign.Warehouse;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.universe.enums.PartGenerationMethod;
 
@@ -60,8 +59,8 @@ public class MultiplePartGenerator extends AbstractPartGenerator {
     //endregion Getters
 
     @Override
-    public Warehouse generateWarehouse(final List<Part> inputParts) {
-        final Warehouse warehouse = new Warehouse();
+    public mekhq.campaign.LocalWarehouse generateWarehouse(final List<Part> inputParts) {
+        final mekhq.campaign.LocalWarehouse warehouse = new mekhq.campaign.LocalWarehouse();
         inputParts.forEach(part -> warehouse.addPart(clonePart(part), true));
         warehouse.forEachPart(part -> part.setQuantity(part.getQuantity() * getMultiple()));
         return warehouse;

--- a/MekHQ/src/mekhq/campaign/universe/generators/partGenerators/WindchildPartGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/generators/partGenerators/WindchildPartGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2021-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -34,7 +34,6 @@ package mekhq.campaign.universe.generators.partGenerators;
 
 import java.util.List;
 
-import mekhq.campaign.Warehouse;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.universe.enums.PartGenerationMethod;
 
@@ -52,8 +51,8 @@ public class WindchildPartGenerator extends AbstractPartGenerator {
     //endregion Constructors
 
     @Override
-    public Warehouse generateWarehouse(final List<Part> inputParts) {
-        final Warehouse warehouse = new Warehouse();
+    public mekhq.campaign.LocalWarehouse generateWarehouse(final List<Part> inputParts) {
+        final mekhq.campaign.LocalWarehouse warehouse = new mekhq.campaign.LocalWarehouse();
         inputParts.forEach(part -> warehouse.addPart(clonePart(part), true));
         warehouse.forEachPart(part -> part.setQuantity((int) Math.round(part.getQuantity() / 3.0)));
         return warehouse;

--- a/MekHQ/src/mekhq/campaign/utilities/AutomatedPersonnelCleanUp.java
+++ b/MekHQ/src/mekhq/campaign/utilities/AutomatedPersonnelCleanUp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -37,7 +37,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import mekhq.campaign.HumanResources;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
 import mekhq.campaign.personnel.familyTree.Genealogy;
@@ -54,7 +53,7 @@ import mekhq.campaign.personnel.familyTree.Genealogy;
  */
 public class AutomatedPersonnelCleanUp {
     private final LocalDate today;
-    private final HumanResources humanResources;
+    private final mekhq.campaign.ForceHumanResources humanResources;
     private final boolean isUseRemovalExemptRetirees;
     private final boolean isUseRemovalExemptCemetery;
     private final Collection<Person> personnelToProcess;
@@ -69,8 +68,8 @@ public class AutomatedPersonnelCleanUp {
      * @param humanResources             the container for all personnel, used to check whether a character is
      *                                   genealogically
      */
-    public AutomatedPersonnelCleanUp(HumanResources humanResources, LocalDate today,
-          boolean isUseRemovalExemptRetirees, boolean isUseRemovalExemptCemetery) {
+    public AutomatedPersonnelCleanUp(mekhq.campaign.ForceHumanResources humanResources, LocalDate today,
+            boolean isUseRemovalExemptRetirees, boolean isUseRemovalExemptCemetery) {
         this.humanResources = humanResources;
         this.today = today;
         this.personnelToProcess = humanResources.getPersonnel();

--- a/MekHQ/src/mekhq/campaign/utilities/JumpBlockers.java
+++ b/MekHQ/src/mekhq/campaign/utilities/JumpBlockers.java
@@ -49,7 +49,6 @@ import megamek.common.units.Jumpship;
 import megamek.common.units.SpaceStation;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Quartermaster;
 import mekhq.campaign.base.PlayerBase;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Planet;
@@ -246,7 +245,7 @@ public class JumpBlockers {
             case gmOverrideChoiceIndex -> true;
             case leaveAtNewBase -> true; // units dispatched to base in loop above
             case sellUnits -> {
-                Quartermaster quartermaster = campaign.getQuartermaster();
+                mekhq.campaign.ForceQuartermaster quartermaster = campaign.getQuartermaster();
                 for (Unit unit : nonJumpCapableUnits) {
                     quartermaster.sellUnit(unit);
                 }

--- a/MekHQ/src/mekhq/campaign/work/IWork.java
+++ b/MekHQ/src/mekhq/campaign/work/IWork.java
@@ -36,7 +36,6 @@ package mekhq.campaign.work;
 import megamek.common.annotations.Nullable;
 import megamek.common.rolls.TargetRoll;
 import mekhq.campaign.location.ILocation;
-import mekhq.campaign.Warehouse;
 import mekhq.campaign.personnel.Person;
 
 public interface IWork extends ILocation {
@@ -71,5 +70,5 @@ public interface IWork extends ILocation {
      * @return the {@code Warehouse} relevant to this work
      */
     @Nullable
-    Warehouse getWarehouse();
+    mekhq.campaign.LocalWarehouse getWarehouse();
 }

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -33,7 +33,7 @@
 package mekhq.gui;
 
 import static megamek.client.ratgenerator.ForceDescriptor.RATING_5;
-import static mekhq.campaign.HumanResources.isUsingLegacyPersonnelMarket;
+import static mekhq.campaign.ForceHumanResources.isUsingLegacyPersonnelMarket;
 import static mekhq.campaign.enums.DailyReportType.PERSONNEL;
 import static mekhq.campaign.enums.DailyReportType.POLITICS;
 import static mekhq.campaign.force.Formation.NO_ASSIGNED_SCENARIO;
@@ -87,7 +87,7 @@ import megameklab.util.UnitPrintManager;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignNewDayManager;
-import mekhq.campaign.Hangar;
+import mekhq.campaign.LocalHangar;
 import mekhq.campaign.autoResolve.AutoResolveMethod;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.events.DeploymentChangedEvent;
@@ -1388,7 +1388,7 @@ public final class BriefingTab extends CampaignGuiTab {
         boolean wasConfirmed = forcePicker.wasConfirmed();
         if (wasConfirmed) {
             scenario.clearSalvageFormations();
-            Hangar hangar = getCampaign().getHangar();
+            LocalHangar hangar = getCampaign().getHangar();
             List<Formation> selectedFormations = forcePicker.getSelectedFormations();
             for (Formation formation : selectedFormations) {
                 scenario.addSalvageFormation(formation.getId());
@@ -1578,7 +1578,7 @@ public final class BriefingTab extends CampaignGuiTab {
 
         // Collect eligible salvage forces (We want salvage forces first)
         List<AtBContract> activeContracts = getCampaign().getActiveAtBContracts();
-        Hangar hangar = campaign.getHangar();
+        LocalHangar hangar = campaign.getHangar();
         List<Formation> eligibleSalvageFormations = new ArrayList<>();
         for (Formation formation : getCampaign().getAllFormations()) {
             Formation parentFormation = formation.getParentFormation();

--- a/MekHQ/src/mekhq/gui/dialog/CompanyGenerationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CompanyGenerationDialog.java
@@ -54,7 +54,6 @@ import megamek.common.ui.FastJScrollPane;
 import megamek.common.units.Entity;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.camOpsReputation.ReputationController;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.events.OrganizationChangedEvent;
 import mekhq.campaign.parts.AmmoStorage;
@@ -64,7 +63,6 @@ import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.autoAwards.AutoAwardsController;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.ranks.AutoAssignRankForCompanyGenerator;
-import mekhq.campaign.personnel.skills.RandomSkillPreferences;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.companyGeneration.CompanyGenerationOptions;
@@ -214,7 +212,7 @@ public class CompanyGenerationDialog extends AbstractMHQValidationButtonDialog {
             autoAwardsController.ManualController(campaign, false);
         }
 
-        ReputationController reputationController = new ReputationController();
+        mekhq.campaign.camOpsReputation.ForceReputationController reputationController = new mekhq.campaign.camOpsReputation.ForceReputationController();
         reputationController.initializeReputation(campaign);
         campaign.setReputation(reputationController);
 

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -76,7 +76,7 @@ import mekhq.NullEntityException;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.Campaign.AdministratorSpecialization;
 import mekhq.campaign.CampaignFactory;
-import mekhq.campaign.camOpsReputation.ReputationController;
+import mekhq.campaign.camOpsReputation.ForceReputationController;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.events.OptionsChangedEvent;
 import mekhq.campaign.finances.CurrencyManager;
@@ -377,7 +377,7 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
                 }
 
                 // initialize reputation
-                ReputationController reputationController = new ReputationController();
+                ForceReputationController reputationController = new ForceReputationController();
                 reputationController.initializeReputation(campaign);
                 campaign.setReputation(reputationController);
 

--- a/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
@@ -60,7 +60,6 @@ import megamek.common.equipment.WeaponType;
 import megamek.common.ui.FastJScrollPane;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Quartermaster;
 import mekhq.campaign.base.PlayerBase;
 import mekhq.campaign.location.IPlace;
 import mekhq.campaign.market.PartsInUseManager;
@@ -265,7 +264,7 @@ public class PartsReportDialog extends JDialog {
                 if (sellQty > spareQty) {
                     sellQty = spareQty;
                 }
-                Quartermaster quartermaster = campaign.getQuartermaster();
+                mekhq.campaign.ForceQuartermaster quartermaster = campaign.getQuartermaster();
                 int i = 0;
                 while (sellQty > 0 && i < spares.size()) {
                     Part spare = spares.get(i);

--- a/MekHQ/src/mekhq/gui/dialog/ShoppingListPriorityDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ShoppingListPriorityDialog.java
@@ -58,7 +58,7 @@ import megamek.common.ui.FastJScrollPane;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.market.ShoppingList;
+import mekhq.campaign.market.ForceShoppingList;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.unit.UnitOrder;
 import mekhq.campaign.work.IAcquisitionWork;
@@ -67,7 +67,7 @@ import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
 /**
  * Dialog for reviewing the campaign shopping list and adjusting procurement priority.
  *
- * <p>The dialog displays the current {@link ShoppingList} in a table and provides controls for moving the selected
+ * <p>The dialog displays the current {@link ForceShoppingList} in a table and provides controls for moving the selected
  * item to the top, up one position, down one position, or to the bottom of the list. Row order shows procurement
  * priority: items nearer the top are attempted first.</p>
  *
@@ -77,7 +77,7 @@ import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
  * @since 0.51.0
  */
 public class ShoppingListPriorityDialog extends JDialog {
-    private final ShoppingList shoppingList;
+    private final mekhq.campaign.market.ForceShoppingList shoppingList;
     private final ShoppingListTableModel tableModel;
     private final JTable shoppingTable;
 
@@ -323,7 +323,7 @@ public class ShoppingListPriorityDialog extends JDialog {
         private static final int N_COL = 8;
 
         private final Campaign campaign;
-        private final ShoppingList shoppingList;
+        private final mekhq.campaign.market.ForceShoppingList shoppingList;
 
         /**
          * Creates a table model backed by the supplied shopping list.
@@ -334,7 +334,7 @@ public class ShoppingListPriorityDialog extends JDialog {
          * @author Illiani
          * @since 0.51.0
          */
-        private ShoppingListTableModel(Campaign campaign, ShoppingList shoppingList) {
+        private ShoppingListTableModel(Campaign campaign, mekhq.campaign.market.ForceShoppingList shoppingList) {
             this.campaign = campaign;
             this.shoppingList = shoppingList;
         }

--- a/MekHQ/src/mekhq/gui/dialog/camOpsSalvage/SalvageFormationPicker.java
+++ b/MekHQ/src/mekhq/gui/dialog/camOpsSalvage/SalvageFormationPicker.java
@@ -64,7 +64,6 @@ import megamek.common.util.sorter.NaturalOrderComparator;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Hangar;
 import mekhq.campaign.force.Formation;
 import mekhq.campaign.force.FormationType;
 import mekhq.campaign.mission.ScenarioTemplate;
@@ -594,7 +593,7 @@ public class SalvageFormationPicker extends JDialog {
             }
         }
 
-        private int getCrewTechCount(Hangar hangar, Formation formation) {
+        private int getCrewTechCount(mekhq.campaign.LocalHangar hangar, Formation formation) {
             int counter = 0;
             for (Unit unit : formation.getAllUnitsAsUnits(hangar, false)) {
                 for (Person crew : unit.getCrew()) {

--- a/MekHQ/src/mekhq/gui/dialog/camOpsSalvage/SalvagePostScenarioPicker.java
+++ b/MekHQ/src/mekhq/gui/dialog/camOpsSalvage/SalvagePostScenarioPicker.java
@@ -72,7 +72,6 @@ import megamek.common.units.Tank;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Hangar;
 import mekhq.campaign.enums.CampaignTransportType;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.force.Formation;
@@ -353,7 +352,7 @@ public class SalvagePostScenarioPicker {
     private List<Integer> setSalvageUnits(Campaign campaign, Scenario scenario) {
         List<Integer> salvageFormations = new ArrayList<>();
         salvageUnits = new ArrayList<>();
-        Hangar hangar = campaign.getHangar();
+        mekhq.campaign.LocalHangar hangar = campaign.getHangar();
         for (Integer forceId : scenario.getSalvageFormations()) {
             salvageFormations.add(forceId);
 

--- a/MekHQ/src/mekhq/gui/menus/AssignPersonToUnitMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignPersonToUnitMenu.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2021-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -41,7 +41,6 @@ import javax.swing.JMenuItem;
 
 import megamek.common.units.*;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Hangar;
 import mekhq.campaign.base.AbstractBase;
 import mekhq.campaign.location.LocationUtils;
 import mekhq.campaign.personnel.Person;
@@ -190,7 +189,7 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
             // campaign hangar when in the main force. All selected persons must be co-located
             // (enforced above via the in-transit check and the unit co-location filter below).
             AbstractBase effectiveBase = LocationUtils.findEffectiveBase(people[0]);
-            Hangar sourceHangar = (effectiveBase != null)
+            mekhq.campaign.LocalHangar sourceHangar = (effectiveBase != null)
                   ? effectiveBase.getBaseHangar()
                   : campaign.getHangar();
             final List<Unit> units = HangarSorter.defaultSorting()

--- a/MekHQ/src/mekhq/gui/menus/AssignTechToUnitMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignTechToUnitMenu.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2021-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -41,7 +41,6 @@ import javax.swing.JMenuItem;
 import megamek.common.units.EntityWeightClass;
 import megamek.common.units.UnitType;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Hangar;
 import mekhq.campaign.base.AbstractBase;
 import mekhq.campaign.location.IPlace;
 import mekhq.campaign.location.LocationUtils;
@@ -92,7 +91,9 @@ public class AssignTechToUnitMenu extends JScrollableMenu {
         // 4) The unit can take a tech and the person can afford the time to maintain the unit
         IPlace personPlace = person.getPlace();
         AbstractBase effectiveBase = LocationUtils.findEffectiveBase(person);
-        Hangar sourceHangar = (effectiveBase != null) ? effectiveBase.getBaseHangar() : campaign.getHangar();
+        mekhq.campaign.LocalHangar sourceHangar = (effectiveBase != null) ?
+                                                          effectiveBase.getBaseHangar() :
+                                                          campaign.getHangar();
         final List<Unit> units = HangarSorter.defaultSorting()
                                        .sort(sourceHangar.getUnitsStream()
                                                    .filter(Unit::isAvailable)

--- a/MekHQ/src/mekhq/utilities/EntityUtilities.java
+++ b/MekHQ/src/mekhq/utilities/EntityUtilities.java
@@ -42,7 +42,7 @@ import megamek.common.options.OptionsConstants;
 import megamek.common.units.Entity;
 import megamek.common.units.UnitType;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Hangar;
+import mekhq.campaign.LocalHangar;
 import mekhq.campaign.unit.Unit;
 
 /**
@@ -56,13 +56,13 @@ public class EntityUtilities {
      * unit ID. If the unit exists, the method returns the associated {@link Entity}. If the unit does not exist or has
      * no associated entity, the method returns {@code null}.
      *
-     * @param hangar The {@link Hangar} instance from which to retrieve the {@link Unit}.
+     * @param hangar The {@link LocalHangar} instance from which to retrieve the {@link Unit}.
      * @param unitID The {@link UUID} of the unit for which the associated {@link Entity} is requested.
      *
      * @return The {@link Entity} associated with the specified unit ID, or {@code null} if the unit is not found or has
      *       no associated entity.
      */
-    public static @Nullable Entity getEntityFromUnitId(Hangar hangar, UUID unitID) {
+    public static @Nullable Entity getEntityFromUnitId(mekhq.campaign.LocalHangar hangar, UUID unitID) {
         Unit unit = hangar.getUnit(unitID);
 
         if (unit == null) {

--- a/MekHQ/unittests/mekhq/campaign/CampaignSummaryTest.java
+++ b/MekHQ/unittests/mekhq/campaign/CampaignSummaryTest.java
@@ -60,7 +60,7 @@ class CampaignSummaryTest {
 
     private static Campaign campaignWithEmptySummaryInputs() {
         Campaign campaign = mock(Campaign.class);
-        Hangar hangar = mock(Hangar.class);
+        LocalHangar hangar = mock(LocalHangar.class);
         CargoStatistics cargoStatistics = mock(CargoStatistics.class);
 
         when(campaign.getActivePersonnel(false, false)).thenReturn(List.of());

--- a/MekHQ/unittests/mekhq/campaign/CampaignTest.java
+++ b/MekHQ/unittests/mekhq/campaign/CampaignTest.java
@@ -200,13 +200,47 @@ public class CampaignTest {
 
         Campaign testCampaign = mock(Campaign.class);
         when(testCampaign.getTechs()).thenAnswer(inv ->
-              HumanResources.getTechsExpanded(testActivePersonList, noUnits, campaignOptions, false, today, false, false, false));
+                                                         ForceHumanResources.getTechsExpanded(testActivePersonList,
+                                                                 noUnits,
+                                                                 campaignOptions,
+                                                                 false,
+                                                                 today,
+                                                                 false,
+                                                                 false,
+                                                                 false));
         when(testCampaign.getTechs(anyBoolean())).thenAnswer(inv ->
-              HumanResources.getTechsExpanded(testActivePersonList, noUnits, campaignOptions, false, today, (boolean) inv.getArgument(0), false, false));
+                                                                     ForceHumanResources.getTechsExpanded(
+                                                                             testActivePersonList,
+                                                                             noUnits,
+                                                                             campaignOptions,
+                                                                             false,
+                                                                             today,
+                                                                             (boolean) inv.getArgument(0),
+                                                                             false,
+                                                                             false));
         when(testCampaign.getTechs(anyBoolean(), anyBoolean())).thenAnswer(inv ->
-              HumanResources.getTechsExpanded(testActivePersonList, noUnits, campaignOptions, false, today, (boolean) inv.getArgument(0), (boolean) inv.getArgument(1), false));
+                                                                                   ForceHumanResources.getTechsExpanded(
+                                                                                           testActivePersonList,
+                                                                                           noUnits,
+                                                                                           campaignOptions,
+                                                                                           false,
+                                                                                           today,
+                                                                                           (boolean) inv.getArgument(0),
+                                                                                           (boolean) inv.getArgument(1),
+                                                                                           false));
         when(testCampaign.getTechsExpanded(anyBoolean(), anyBoolean(), anyBoolean())).thenAnswer(inv ->
-              HumanResources.getTechsExpanded(testActivePersonList, noUnits, campaignOptions, false, today, (boolean) inv.getArgument(0), (boolean) inv.getArgument(1), (boolean) inv.getArgument(2)));
+                                                                                                         ForceHumanResources.getTechsExpanded(
+                                                                                                                 testActivePersonList,
+                                                                                                                 noUnits,
+                                                                                                                 campaignOptions,
+                                                                                                                 false,
+                                                                                                                 today,
+                                                                                                                 (boolean) inv.getArgument(
+                                                                                                                         0),
+                                                                                                                 (boolean) inv.getArgument(
+                                                                                                                         1),
+                                                                                                                 (boolean) inv.getArgument(
+                                                                                                                         2)));
 
         // Test just getting the list of active techs.
         List<Person> expected = new ArrayList<>(3);
@@ -303,7 +337,7 @@ public class CampaignTest {
         Person flaggedSecond = mock(Person.class);
         when(flaggedSecond.isSecondInCommand()).thenReturn(true);
 
-        Person[] result = HumanResources.findTopCommanders(
+        Person[] result = ForceHumanResources.findTopCommanders(
               List.of(flaggedCommander, flaggedSecond), opts, false, today);
 
         assertSame(flaggedCommander, result[0]);
@@ -324,7 +358,7 @@ public class CampaignTest {
         when(aPerson.outRanksUsingSkillTiebreaker(any(), anyBoolean(), any(), eq(bPerson))).thenReturn(true);
         when(bPerson.outRanksUsingSkillTiebreaker(any(), anyBoolean(), any(), eq(aPerson))).thenReturn(false);
 
-        Person[] result = HumanResources.findTopCommanders(
+        Person[] result = ForceHumanResources.findTopCommanders(
               List.of(flaggedCommander, bPerson, aPerson), opts, false, today);
 
         assertSame(flaggedCommander, result[0], "Flagged commander must remain commander");
@@ -344,7 +378,7 @@ public class CampaignTest {
 
         when(bPerson.outRanksUsingSkillTiebreaker(any(), anyBoolean(), any(), eq(aPerson))).thenReturn(true);
 
-        Person[] result = HumanResources.findTopCommanders(
+        Person[] result = ForceHumanResources.findTopCommanders(
               List.of(aPerson, flaggedSecond, bPerson), opts, false, today);
 
         assertSame(bPerson, result[0], "Commander should be the top-ranked among non-flagged-second personnel");
@@ -364,7 +398,7 @@ public class CampaignTest {
         when(person3.outRanksUsingSkillTiebreaker(any(), anyBoolean(), any(), eq(person2))).thenReturn(false);
         when(person3.outRanksUsingSkillTiebreaker(any(), anyBoolean(), any(), eq(person1))).thenReturn(true);
 
-        Person[] result = HumanResources.findTopCommanders(
+        Person[] result = ForceHumanResources.findTopCommanders(
               List.of(person1, person2, person3), opts, false, today);
 
         assertSame(person2, result[0], "Commander should be the best overall");
@@ -378,7 +412,7 @@ public class CampaignTest {
 
         Person only = mock(Person.class);
 
-        Person[] result = HumanResources.findTopCommanders(List.of(only), opts, false, today);
+        Person[] result = ForceHumanResources.findTopCommanders(List.of(only), opts, false, today);
 
         assertSame(only, result[0]);
         assertNull(result[1], "Second-in-command must be null when only one eligible person exists");

--- a/MekHQ/unittests/mekhq/campaign/HumanResourcesTest.java
+++ b/MekHQ/unittests/mekhq/campaign/HumanResourcesTest.java
@@ -98,7 +98,7 @@ public class HumanResourcesTest {
     }
 
     /**
-     * Tests for {@link HumanResources#getDoctors(Collection)}
+     * Tests for {@link ForceHumanResources#getDoctors(Collection)}
      */
     @Nested
     class GetDoctors {
@@ -109,7 +109,7 @@ public class HumanResourcesTest {
             List<Person> people = List.of();
 
             // Act
-            List<Person> result = HumanResources.getDoctors(people);
+            List<Person> result = ForceHumanResources.getDoctors(people);
 
             // Assert
             assertTrue(result.isEmpty());
@@ -122,7 +122,7 @@ public class HumanResourcesTest {
             when(doctor.isDoctor()).thenReturn(true);
 
             // Act
-            List<Person> result = HumanResources.getDoctors(List.of(doctor));
+            List<Person> result = ForceHumanResources.getDoctors(List.of(doctor));
 
             // Assert
             assertEquals(List.of(doctor), result);
@@ -135,7 +135,7 @@ public class HumanResourcesTest {
             when(nonDoctor.isDoctor()).thenReturn(false);
 
             // Act
-            List<Person> result = HumanResources.getDoctors(List.of(nonDoctor));
+            List<Person> result = ForceHumanResources.getDoctors(List.of(nonDoctor));
 
             // Assert
             assertTrue(result.isEmpty());
@@ -154,7 +154,7 @@ public class HumanResourcesTest {
             when(tech.isDoctor()).thenReturn(false);
 
             // Act
-            List<Person> result = HumanResources.getDoctors(List.of(doctor, mekwarrior, tech));
+            List<Person> result = ForceHumanResources.getDoctors(List.of(doctor, mekwarrior, tech));
 
             // Assert
             assertEquals(List.of(doctor), result);
@@ -162,7 +162,7 @@ public class HumanResourcesTest {
     }
 
     /**
-     * Tests for {@link HumanResources#getPatients(Collection)}
+     * Tests for {@link ForceHumanResources#getPatients(Collection)}
      */
     @Nested
     class GetPatients {
@@ -173,7 +173,7 @@ public class HumanResourcesTest {
             List<Person> people = List.of();
 
             // Act
-            List<Person> result = HumanResources.getPatients(people);
+            List<Person> result = ForceHumanResources.getPatients(people);
 
             // Assert
             assertTrue(result.isEmpty());
@@ -186,7 +186,7 @@ public class HumanResourcesTest {
             when(injured.needsFixing()).thenReturn(true);
 
             // Act
-            List<Person> result = HumanResources.getPatients(List.of(injured));
+            List<Person> result = ForceHumanResources.getPatients(List.of(injured));
 
             // Assert
             assertEquals(List.of(injured), result);
@@ -199,7 +199,7 @@ public class HumanResourcesTest {
             when(healthy.needsFixing()).thenReturn(false);
 
             // Act
-            List<Person> result = HumanResources.getPatients(List.of(healthy));
+            List<Person> result = ForceHumanResources.getPatients(List.of(healthy));
 
             // Assert
             assertTrue(result.isEmpty());
@@ -215,7 +215,7 @@ public class HumanResourcesTest {
             when(healthy.needsFixing()).thenReturn(false);
 
             // Act
-            List<Person> result = HumanResources.getPatients(List.of(injured, healthy));
+            List<Person> result = ForceHumanResources.getPatients(List.of(injured, healthy));
 
             // Assert
             assertEquals(List.of(injured), result);
@@ -223,7 +223,7 @@ public class HumanResourcesTest {
     }
 
     /**
-     * Tests for {@link HumanResources#getAdmins(Collection)}
+     * Tests for {@link ForceHumanResources#getAdmins(Collection)}
      */
     @Nested
     class GetAdmins {
@@ -234,7 +234,7 @@ public class HumanResourcesTest {
             List<Person> people = List.of();
 
             // Act
-            List<Person> result = HumanResources.getAdmins(people);
+            List<Person> result = ForceHumanResources.getAdmins(people);
 
             // Assert
             assertTrue(result.isEmpty());
@@ -247,7 +247,7 @@ public class HumanResourcesTest {
             when(admin.isAdministrator()).thenReturn(true);
 
             // Act
-            List<Person> result = HumanResources.getAdmins(List.of(admin));
+            List<Person> result = ForceHumanResources.getAdmins(List.of(admin));
 
             // Assert
             assertEquals(List.of(admin), result);
@@ -260,7 +260,7 @@ public class HumanResourcesTest {
             when(pilot.isAdministrator()).thenReturn(false);
 
             // Act
-            List<Person> result = HumanResources.getAdmins(List.of(pilot));
+            List<Person> result = ForceHumanResources.getAdmins(List.of(pilot));
 
             // Assert
             assertTrue(result.isEmpty());
@@ -279,7 +279,7 @@ public class HumanResourcesTest {
             when(tech.isAdministrator()).thenReturn(false);
 
             // Act
-            List<Person> result = HumanResources.getAdmins(List.of(admin, pilot, tech));
+            List<Person> result = ForceHumanResources.getAdmins(List.of(admin, pilot, tech));
 
             // Assert
             assertEquals(List.of(admin), result);
@@ -287,7 +287,7 @@ public class HumanResourcesTest {
     }
 
     /**
-     * Tests for {@link HumanResources#getActiveDependents(Collection)}
+     * Tests for {@link ForceHumanResources#getActiveDependents(Collection)}
      */
     @Nested
     class GetActiveDependents {
@@ -298,7 +298,7 @@ public class HumanResourcesTest {
             List<Person> people = List.of();
 
             // Act
-            List<Person> result = HumanResources.getActiveDependents(people);
+            List<Person> result = ForceHumanResources.getActiveDependents(people);
 
             // Assert
             assertTrue(result.isEmpty());
@@ -318,7 +318,7 @@ public class HumanResourcesTest {
             when(dependent.getStatus()).thenReturn(activeStatus);
 
             // Act
-            List<Person> result = HumanResources.getActiveDependents(List.of(dependent));
+            List<Person> result = ForceHumanResources.getActiveDependents(List.of(dependent));
 
             // Assert
             assertEquals(List.of(dependent), result);
@@ -338,7 +338,7 @@ public class HumanResourcesTest {
             when(dependent.getStatus()).thenReturn(retiredStatus);
 
             // Act
-            List<Person> result = HumanResources.getActiveDependents(List.of(dependent));
+            List<Person> result = ForceHumanResources.getActiveDependents(List.of(dependent));
 
             // Assert
             assertTrue(result.isEmpty());
@@ -358,7 +358,7 @@ public class HumanResourcesTest {
             when(pilot.getStatus()).thenReturn(activeStatus);
 
             // Act
-            List<Person> result = HumanResources.getActiveDependents(List.of(pilot));
+            List<Person> result = ForceHumanResources.getActiveDependents(List.of(pilot));
 
             // Assert
             assertTrue(result.isEmpty());
@@ -366,7 +366,7 @@ public class HumanResourcesTest {
     }
 
     /**
-     * Tests for {@link HumanResources#getCurrentPrisoners(Collection)}
+     * Tests for {@link ForceHumanResources#getCurrentPrisoners(Collection)}
      */
     @Nested
     class GetCurrentPrisoners {
@@ -377,7 +377,7 @@ public class HumanResourcesTest {
             List<Person> people = List.of();
 
             // Act
-            List<Person> result = HumanResources.getCurrentPrisoners(people);
+            List<Person> result = ForceHumanResources.getCurrentPrisoners(people);
 
             // Assert
             assertTrue(result.isEmpty());
@@ -390,7 +390,7 @@ public class HumanResourcesTest {
             when(prisoner.getPrisonerStatus()).thenReturn(PrisonerStatus.PRISONER);
 
             // Act
-            List<Person> result = HumanResources.getCurrentPrisoners(List.of(prisoner));
+            List<Person> result = ForceHumanResources.getCurrentPrisoners(List.of(prisoner));
 
             // Assert
             assertEquals(List.of(prisoner), result);
@@ -403,7 +403,7 @@ public class HumanResourcesTest {
             when(defector.getPrisonerStatus()).thenReturn(PrisonerStatus.PRISONER_DEFECTOR);
 
             // Act
-            List<Person> result = HumanResources.getCurrentPrisoners(List.of(defector));
+            List<Person> result = ForceHumanResources.getCurrentPrisoners(List.of(defector));
 
             // Assert
             assertEquals(List.of(defector), result);
@@ -416,7 +416,7 @@ public class HumanResourcesTest {
             when(freePerson.getPrisonerStatus()).thenReturn(PrisonerStatus.FREE);
 
             // Act
-            List<Person> result = HumanResources.getCurrentPrisoners(List.of(freePerson));
+            List<Person> result = ForceHumanResources.getCurrentPrisoners(List.of(freePerson));
 
             // Assert
             assertTrue(result.isEmpty());
@@ -432,7 +432,7 @@ public class HumanResourcesTest {
             when(freePerson.getPrisonerStatus()).thenReturn(PrisonerStatus.FREE);
 
             // Act
-            List<Person> result = HumanResources.getCurrentPrisoners(List.of(prisoner, freePerson));
+            List<Person> result = ForceHumanResources.getCurrentPrisoners(List.of(prisoner, freePerson));
 
             // Assert
             assertEquals(List.of(prisoner), result);
@@ -440,7 +440,7 @@ public class HumanResourcesTest {
     }
 
     /**
-     * Tests for {@link HumanResources#getSalaryEligiblePersonnel(Collection)}
+     * Tests for {@link ForceHumanResources#getSalaryEligiblePersonnel(Collection)}
      */
     @Nested
     class GetSalaryEligiblePersonnel {
@@ -451,7 +451,7 @@ public class HumanResourcesTest {
             List<Person> people = List.of();
 
             // Act
-            List<Person> result = HumanResources.getSalaryEligiblePersonnel(people);
+            List<Person> result = ForceHumanResources.getSalaryEligiblePersonnel(people);
 
             // Assert
             assertTrue(result.isEmpty());
@@ -467,7 +467,7 @@ public class HumanResourcesTest {
             when(activePerson.getStatus()).thenReturn(activeStatus);
 
             // Act
-            List<Person> result = HumanResources.getSalaryEligiblePersonnel(List.of(activePerson));
+            List<Person> result = ForceHumanResources.getSalaryEligiblePersonnel(List.of(activePerson));
 
             // Assert
             assertEquals(List.of(activePerson), result);
@@ -483,7 +483,7 @@ public class HumanResourcesTest {
             when(retiree.getStatus()).thenReturn(retiredStatus);
 
             // Act
-            List<Person> result = HumanResources.getSalaryEligiblePersonnel(List.of(retiree));
+            List<Person> result = ForceHumanResources.getSalaryEligiblePersonnel(List.of(retiree));
 
             // Assert
             assertTrue(result.isEmpty());
@@ -505,7 +505,7 @@ public class HumanResourcesTest {
             when(retired.getStatus()).thenReturn(retiredStatus);
 
             // Act
-            List<Person> result = HumanResources.getSalaryEligiblePersonnel(List.of(active, retired));
+            List<Person> result = ForceHumanResources.getSalaryEligiblePersonnel(List.of(active, retired));
 
             // Assert
             assertEquals(List.of(active), result);
@@ -514,7 +514,7 @@ public class HumanResourcesTest {
 
     /**
      * Tests for
-     * {@link HumanResources#getSeniorAdminPerson(Collection, AdministratorSpecialization, CampaignOptions, boolean,
+     * {@link ForceHumanResources#getSeniorAdminPerson(Collection, AdministratorSpecialization, CampaignOptions, boolean,
      * LocalDate)}
      */
     @Nested
@@ -526,7 +526,7 @@ public class HumanResourcesTest {
             List<Person> people = List.of();
 
             // Act
-            Person result = HumanResources.getSeniorAdminPerson(people,
+            Person result = ForceHumanResources.getSeniorAdminPerson(people,
                   AdministratorSpecialization.COMMAND, campaignOptions, false, today);
 
             // Assert
@@ -547,7 +547,7 @@ public class HumanResourcesTest {
             when(admin.getSecondaryRole()).thenReturn(none);
 
             // Act
-            Person result = HumanResources.getSeniorAdminPerson(List.of(admin),
+            Person result = ForceHumanResources.getSeniorAdminPerson(List.of(admin),
                   AdministratorSpecialization.COMMAND, campaignOptions, false, today);
 
             // Assert
@@ -574,7 +574,7 @@ public class HumanResourcesTest {
             when(senior.outRanksUsingSkillTiebreaker(any(), anyBoolean(), any(), any())).thenReturn(true);
 
             // Act
-            Person result = HumanResources.getSeniorAdminPerson(List.of(junior, senior),
+            Person result = ForceHumanResources.getSeniorAdminPerson(List.of(junior, senior),
                   AdministratorSpecialization.HR, campaignOptions, false, today);
 
             // Assert
@@ -596,7 +596,7 @@ public class HumanResourcesTest {
             when(logisticsAdmin.getSecondaryRole()).thenReturn(none);
 
             // Act
-            Person result = HumanResources.getSeniorAdminPerson(List.of(logisticsAdmin),
+            Person result = ForceHumanResources.getSeniorAdminPerson(List.of(logisticsAdmin),
                   AdministratorSpecialization.COMMAND, campaignOptions, false, today);
 
             // Assert
@@ -605,7 +605,7 @@ public class HumanResourcesTest {
     }
 
     /**
-     * Tests for {@link HumanResources#getSeniorPerson(Collection, CampaignOptions, boolean, LocalDate)}
+     * Tests for {@link ForceHumanResources#getSeniorPerson(Collection, CampaignOptions, boolean, LocalDate)}
      */
     @Nested
     class GetSeniorPerson {
@@ -616,7 +616,7 @@ public class HumanResourcesTest {
             List<Person> people = List.of();
 
             // Act
-            Person result = HumanResources.getSeniorPerson(people, campaignOptions, false, today);
+            Person result = ForceHumanResources.getSeniorPerson(people, campaignOptions, false, today);
 
             // Assert
             assertNull(result);
@@ -628,7 +628,7 @@ public class HumanResourcesTest {
             Person doctor = mock(Person.class);
 
             // Act
-            Person result = HumanResources.getSeniorPerson(List.of(doctor), campaignOptions, false, today);
+            Person result = ForceHumanResources.getSeniorPerson(List.of(doctor), campaignOptions, false, today);
 
             // Assert
             assertEquals(doctor, result);
@@ -644,7 +644,7 @@ public class HumanResourcesTest {
             when(senior.outRanksUsingSkillTiebreaker(any(), anyBoolean(), any(), any())).thenReturn(true);
 
             // Act
-            Person result = HumanResources.getSeniorPerson(List.of(junior, senior),
+            Person result = ForceHumanResources.getSeniorPerson(List.of(junior, senior),
                   campaignOptions, false, today);
 
             // Assert
@@ -653,7 +653,7 @@ public class HumanResourcesTest {
     }
 
     /**
-     * Tests for {@link HumanResources#findTopCommanders(Collection, CampaignOptions, boolean, LocalDate)}
+     * Tests for {@link ForceHumanResources#findTopCommanders(Collection, CampaignOptions, boolean, LocalDate)}
      */
     @Nested
     class FindTopCommanders {
@@ -664,7 +664,7 @@ public class HumanResourcesTest {
             List<Person> people = List.of();
 
             // Act
-            Person[] result = HumanResources.findTopCommanders(people, campaignOptions, false, today);
+            Person[] result = ForceHumanResources.findTopCommanders(people, campaignOptions, false, today);
 
             // Assert
             assertNotNull(result);
@@ -685,7 +685,7 @@ public class HumanResourcesTest {
             when(sic.isSecondInCommand()).thenReturn(true);
 
             // Act
-            Person[] result = HumanResources.findTopCommanders(List.of(sic, commander),
+            Person[] result = ForceHumanResources.findTopCommanders(List.of(sic, commander),
                   campaignOptions, false, today);
 
             // Assert
@@ -707,7 +707,7 @@ public class HumanResourcesTest {
             when(lowRanker.outRanksUsingSkillTiebreaker(any(), anyBoolean(), any(), any())).thenReturn(false);
 
             // Act
-            Person[] result = HumanResources.findTopCommanders(List.of(lowRanker, highRanker),
+            Person[] result = ForceHumanResources.findTopCommanders(List.of(lowRanker, highRanker),
                   campaignOptions, false, today);
 
             // Assert
@@ -723,7 +723,7 @@ public class HumanResourcesTest {
             when(only.isSecondInCommand()).thenReturn(false);
 
             // Act
-            Person[] result = HumanResources.findTopCommanders(List.of(only), campaignOptions, false, today);
+            Person[] result = ForceHumanResources.findTopCommanders(List.of(only), campaignOptions, false, today);
 
             // Assert
             assertEquals(only, result[0]);
@@ -732,7 +732,7 @@ public class HumanResourcesTest {
     }
 
     /**
-     * Tests for {@link HumanResources#findBestAtSkill(Collection, String, CampaignOptions, boolean, LocalDate)}
+     * Tests for {@link ForceHumanResources#findBestAtSkill(Collection, String, CampaignOptions, boolean, LocalDate)}
      */
     @Nested
     class FindBestAtSkill {
@@ -744,7 +744,7 @@ public class HumanResourcesTest {
             when(campaignOptions.isUseAgeEffects()).thenReturn(false);
 
             // Act
-            Person result = HumanResources.findBestAtSkill(people, "Negotiation", campaignOptions, false, today);
+            Person result = ForceHumanResources.findBestAtSkill(people, "Negotiation", campaignOptions, false, today);
 
             // Assert
             assertNull(result);
@@ -763,7 +763,7 @@ public class HumanResourcesTest {
             when(person.getSkillModifierData(anyBoolean(), anyBoolean(), any())).thenReturn(null);
 
             // Act
-            Person result = HumanResources.findBestAtSkill(List.of(person), "Negotiation",
+            Person result = ForceHumanResources.findBestAtSkill(List.of(person), "Negotiation",
                   campaignOptions, false, today);
 
             // Assert
@@ -779,7 +779,7 @@ public class HumanResourcesTest {
             when(person.getSkill(anyString())).thenReturn(null);
 
             // Act
-            Person result = HumanResources.findBestAtSkill(List.of(person), "Negotiation",
+            Person result = ForceHumanResources.findBestAtSkill(List.of(person), "Negotiation",
                   campaignOptions, false, today);
 
             // Assert
@@ -806,7 +806,7 @@ public class HumanResourcesTest {
             when(stronger.getSkillModifierData(anyBoolean(), anyBoolean(), any())).thenReturn(null);
 
             // Act
-            Person result = HumanResources.findBestAtSkill(List.of(weaker, stronger), "Negotiation",
+            Person result = ForceHumanResources.findBestAtSkill(List.of(weaker, stronger), "Negotiation",
                   campaignOptions, false, today);
 
             // Assert
@@ -816,7 +816,7 @@ public class HumanResourcesTest {
 
     /**
      * Tests for
-     * {@link HumanResources#findBestInRole(Collection, PersonnelRole, String, String, CampaignOptions, boolean,
+     * {@link ForceHumanResources#findBestInRole(Collection, PersonnelRole, String, String, CampaignOptions, boolean,
      * LocalDate)}
      */
     @Nested
@@ -829,7 +829,7 @@ public class HumanResourcesTest {
             List<Person> people = List.of();
 
             // Act
-            Person result = HumanResources.findBestInRole(people, PersonnelRole.DOCTOR,
+            Person result = ForceHumanResources.findBestInRole(people, PersonnelRole.DOCTOR,
                   "Surgery/Any", null, campaignOptions, false, today);
 
             // Assert
@@ -851,7 +851,7 @@ public class HumanResourcesTest {
             when(doctor.getSkillModifierData(anyBoolean(), anyBoolean(), any())).thenReturn(null);
 
             // Act
-            Person result = HumanResources.findBestInRole(List.of(doctor), PersonnelRole.DOCTOR,
+            Person result = ForceHumanResources.findBestInRole(List.of(doctor), PersonnelRole.DOCTOR,
                   "Surgery/Any", null, campaignOptions, false, today);
 
             // Assert
@@ -873,7 +873,7 @@ public class HumanResourcesTest {
             when(pilot.getSkillModifierData(anyBoolean(), anyBoolean(), any())).thenReturn(null);
 
             // Act
-            Person result = HumanResources.findBestInRole(List.of(pilot), PersonnelRole.DOCTOR,
+            Person result = ForceHumanResources.findBestInRole(List.of(pilot), PersonnelRole.DOCTOR,
                   "Surgery/Any", null, campaignOptions, false, today);
 
             // Assert
@@ -904,7 +904,7 @@ public class HumanResourcesTest {
             when(stronger.getSkillModifierData(anyBoolean(), anyBoolean(), any())).thenReturn(null);
 
             // Act
-            Person result = HumanResources.findBestInRole(List.of(weaker, stronger), PersonnelRole.DOCTOR,
+            Person result = ForceHumanResources.findBestInRole(List.of(weaker, stronger), PersonnelRole.DOCTOR,
                   "Surgery/Any", null, campaignOptions, false, today);
 
             // Assert
@@ -926,7 +926,7 @@ public class HumanResourcesTest {
             when(secondaryDoctor.getSkillModifierData(anyBoolean(), anyBoolean(), any())).thenReturn(null);
 
             // Act
-            Person result = HumanResources.findBestInRole(List.of(secondaryDoctor), PersonnelRole.DOCTOR,
+            Person result = ForceHumanResources.findBestInRole(List.of(secondaryDoctor), PersonnelRole.DOCTOR,
                   "Surgery/Any", null, campaignOptions, false, today);
 
             // Assert
@@ -935,7 +935,7 @@ public class HumanResourcesTest {
     }
 
     /**
-     * Tests for {@link HumanResources#getLogisticsPerson(Collection, CampaignOptions, boolean, LocalDate)}
+     * Tests for {@link ForceHumanResources#getLogisticsPerson(Collection, CampaignOptions, boolean, LocalDate)}
      */
     @Nested
     class GetLogisticsPerson {
@@ -948,7 +948,7 @@ public class HumanResourcesTest {
             Person admin = mock(Person.class);
 
             // Act
-            Person result = HumanResources.getLogisticsPerson(List.of(admin), campaignOptions, false, today);
+            Person result = ForceHumanResources.getLogisticsPerson(List.of(admin), campaignOptions, false, today);
 
             // Assert
             assertNull(result);
@@ -963,7 +963,7 @@ public class HumanResourcesTest {
             when(campaignOptions.isUseAgeEffects()).thenReturn(false);
 
             // Act
-            Person result = HumanResources.getLogisticsPerson(List.of(), campaignOptions, false, today);
+            Person result = ForceHumanResources.getLogisticsPerson(List.of(), campaignOptions, false, today);
 
             // Assert
             assertNull(result);
@@ -992,7 +992,7 @@ public class HumanResourcesTest {
             when(stronger.getSkillModifierData(anyBoolean(), anyBoolean(), any())).thenReturn(null);
 
             // Act
-            Person result = HumanResources.getLogisticsPerson(List.of(weaker, stronger),
+            Person result = ForceHumanResources.getLogisticsPerson(List.of(weaker, stronger),
                   campaignOptions, false, today);
 
             // Assert
@@ -1001,7 +1001,7 @@ public class HumanResourcesTest {
     }
 
     /**
-     * Tests for {@link HumanResources#writeToXML(PrintWriter, int, Campaign)}
+     * Tests for {@link ForceHumanResources#writeToXML(PrintWriter, int, Campaign)}
      */
     @Nested
     class WriteToXML {
@@ -1009,7 +1009,7 @@ public class HumanResourcesTest {
         @Test
         void outputWrapsContentInHumanResourcesTag() {
             // Arrange
-            HumanResources hr = campaign.getHumanResources();
+            ForceHumanResources hr = campaign.getHumanResources();
             StringWriter stringWriter = new StringWriter();
             PrintWriter writer = new PrintWriter(stringWriter);
 
@@ -1026,7 +1026,7 @@ public class HumanResourcesTest {
         @Test
         void poolValuesAreWritten() {
             // Arrange
-            HumanResources hr = campaign.getHumanResources();
+            ForceHumanResources hr = campaign.getHumanResources();
             hr.setAsTechPool(3);
             hr.setMedicPool(2);
 
@@ -1046,7 +1046,7 @@ public class HumanResourcesTest {
         @Test
         void personnelBlockIsNestedInsideHumanResources() {
             // Arrange
-            HumanResources hr = campaign.getHumanResources();
+            ForceHumanResources hr = campaign.getHumanResources();
             StringWriter stringWriter = new StringWriter();
             PrintWriter writer = new PrintWriter(stringWriter);
 
@@ -1067,7 +1067,7 @@ public class HumanResourcesTest {
     }
 
     /**
-     * Tests for {@link HumanResources#loadFromXML(Node, Campaign, Version)}
+     * Tests for {@link ForceHumanResources#loadFromXML(Node, Campaign, Version)}
      */
     @Nested
     class LoadFromXML {
@@ -1075,7 +1075,7 @@ public class HumanResourcesTest {
         @Test
         void roundTripPreservesAsTechPoolValue() throws Exception {
             // Arrange
-            HumanResources hr = campaign.getHumanResources();
+            ForceHumanResources hr = campaign.getHumanResources();
             hr.setAsTechPool(5);
 
             StringWriter stringWriter = new StringWriter();
@@ -1090,7 +1090,7 @@ public class HumanResourcesTest {
             Node hrNode = doc.getDocumentElement();
 
             // Act
-            HumanResources loaded = HumanResources.loadFromXML(hrNode, fresh, new Version());
+            ForceHumanResources loaded = ForceHumanResources.loadFromXML(hrNode, fresh, new Version());
 
             // Assert
             assertNotNull(loaded);
@@ -1100,7 +1100,7 @@ public class HumanResourcesTest {
         @Test
         void roundTripPreservesMedicPoolValue() throws Exception {
             // Arrange
-            HumanResources hr = campaign.getHumanResources();
+            ForceHumanResources hr = campaign.getHumanResources();
             hr.setMedicPool(4);
 
             StringWriter stringWriter = new StringWriter();
@@ -1115,7 +1115,7 @@ public class HumanResourcesTest {
             Node hrNode = doc.getDocumentElement();
 
             // Act
-            HumanResources loaded = HumanResources.loadFromXML(hrNode, fresh, new Version());
+            ForceHumanResources loaded = ForceHumanResources.loadFromXML(hrNode, fresh, new Version());
 
             // Assert
             assertNotNull(loaded);
@@ -1125,7 +1125,7 @@ public class HumanResourcesTest {
         @Test
         void roundTripPreservesPersonnelCount() throws Exception {
             // Arrange
-            HumanResources hr = campaign.getHumanResources();
+            ForceHumanResources hr = campaign.getHumanResources();
             Person mekwarrior = campaign.newPerson(PersonnelRole.MEKWARRIOR, PersonnelRole.NONE);
             Person doctor = campaign.newPerson(PersonnelRole.DOCTOR, PersonnelRole.NONE);
             hr.recruitPerson(campaign, mekwarrior);
@@ -1145,7 +1145,7 @@ public class HumanResourcesTest {
             Node hrNode = doc.getDocumentElement();
 
             // Act
-            HumanResources.loadFromXML(hrNode, fresh, new Version());
+            ForceHumanResources.loadFromXML(hrNode, fresh, new Version());
 
             // Assert
             assertEquals(originalCount, fresh.getHumanResources().getPersonnel().size(),
@@ -1154,7 +1154,7 @@ public class HumanResourcesTest {
     }
 
     /**
-     * Tests for the backward-compatibility path in {@link HumanResources#loadFromXML(Node, Campaign, Version)} that
+     * Tests for the backward-compatibility path in {@link ForceHumanResources#loadFromXML(Node, Campaign, Version)} that
      * handles the pre-{@code <humanResources>} save format where pool values and personnel appeared at the campaign
      * level.
      */
@@ -1179,7 +1179,7 @@ public class HumanResourcesTest {
             Node hrNode = doc.getDocumentElement();
 
             // Act
-            HumanResources loaded = HumanResources.loadFromXML(hrNode, fresh, new Version());
+            ForceHumanResources loaded = ForceHumanResources.loadFromXML(hrNode, fresh, new Version());
 
             // Assert
             assertNotNull(loaded);
@@ -1208,7 +1208,7 @@ public class HumanResourcesTest {
             Node hrNode = doc.getDocumentElement();
 
             // Act — must not throw
-            HumanResources loaded = HumanResources.loadFromXML(hrNode, fresh, new Version());
+            ForceHumanResources loaded = ForceHumanResources.loadFromXML(hrNode, fresh, new Version());
 
             // Assert
             assertNotNull(loaded, "Parser must return a valid HumanResources even with unknown elements");
@@ -1232,7 +1232,7 @@ public class HumanResourcesTest {
             Node hrNode = doc.getDocumentElement();
 
             // Act
-            HumanResources.loadFromXML(hrNode, fresh, new Version());
+            ForceHumanResources.loadFromXML(hrNode, fresh, new Version());
 
             // Assert
             assertTrue(fresh.getHumanResources().getPersonnel().isEmpty(),
@@ -1242,14 +1242,14 @@ public class HumanResourcesTest {
         @Test
         void usesExistingHRFromCampaign() throws Exception {
             Campaign mockCampaign = mock(Campaign.class);
-            HumanResources existingHr = new HumanResources();
+            ForceHumanResources existingHr = new ForceHumanResources();
             when(mockCampaign.getHumanResources()).thenReturn(existingHr);
 
             String xml = "<humanResources></humanResources>";
             DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
             Node node = db.parse(new ByteArrayInputStream(xml.getBytes())).getDocumentElement();
 
-            HumanResources result = HumanResources.loadFromXML(node, mockCampaign, new Version("0.50.00"));
+            ForceHumanResources result = ForceHumanResources.loadFromXML(node, mockCampaign, new Version("0.50.00"));
 
             assertSame(existingHr, result);
         }
@@ -1257,7 +1257,7 @@ public class HumanResourcesTest {
 
     /**
      * Tests for
-     * {@link HumanResources#getTechsExpanded(Collection, Collection, CampaignOptions, boolean, LocalDate, boolean,
+     * {@link ForceHumanResources#getTechsExpanded(Collection, Collection, CampaignOptions, boolean, LocalDate, boolean,
      * boolean, boolean)}
      */
     @Nested
@@ -1283,7 +1283,7 @@ public class HumanResourcesTest {
 
         @Test
         void emptyInputReturnsEmptyList() {
-            List<Person> result = HumanResources.getTechsExpanded(
+            List<Person> result = ForceHumanResources.getTechsExpanded(
                   List.of(), List.of(), campaignOptions, false, today, false, false, true);
 
             assertTrue(result.isEmpty());
@@ -1294,7 +1294,7 @@ public class HumanResourcesTest {
             Person nonTech = mock(Person.class);
             when(nonTech.isTechExpanded()).thenReturn(false);
 
-            List<Person> result = HumanResources.getTechsExpanded(
+            List<Person> result = ForceHumanResources.getTechsExpanded(
                   List.of(nonTech), List.of(), campaignOptions, false, today, false, false, true);
 
             assertTrue(result.isEmpty());
@@ -1305,7 +1305,7 @@ public class HumanResourcesTest {
             Person veteran = makeTech(SkillLevel.VETERAN, 480);
             Person regular = makeTech(SkillLevel.REGULAR, 480);
 
-            List<Person> result = HumanResources.getTechsExpanded(
+            List<Person> result = ForceHumanResources.getTechsExpanded(
                   List.of(regular, veteran), List.of(), campaignOptions, false, today,
                   false, true, true);
 
@@ -1318,7 +1318,7 @@ public class HumanResourcesTest {
             Person busy = makeTech(SkillLevel.REGULAR, 0);
             Person available = makeTech(SkillLevel.REGULAR, 480);
 
-            List<Person> result = HumanResources.getTechsExpanded(
+            List<Person> result = ForceHumanResources.getTechsExpanded(
                   List.of(busy, available), List.of(), campaignOptions, false, today,
                   true, false, true);
 
@@ -1336,7 +1336,7 @@ public class HumanResourcesTest {
             when(selfCrewedUnit.getEntity()).thenReturn(entity);
             when(selfCrewedUnit.getEngineer()).thenReturn(engineer);
 
-            List<Person> result = HumanResources.getTechsExpanded(
+            List<Person> result = ForceHumanResources.getTechsExpanded(
                   List.of(), List.of(selfCrewedUnit), campaignOptions, false, today,
                   false, false, true);
 

--- a/MekHQ/unittests/mekhq/campaign/LocalWarehouseTest.java
+++ b/MekHQ/unittests/mekhq/campaign/LocalWarehouseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -69,7 +69,7 @@ import mekhq.campaign.unit.Unit;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class WarehouseTest {
+public class LocalWarehouseTest {
 
     @BeforeAll
     static void beforeAll() {
@@ -78,7 +78,7 @@ public class WarehouseTest {
 
     @Test
     public void testWarehouseSimplePartActions() {
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
 
         // A new warehouse is empty
         assertTrue(warehouse.getParts().isEmpty());
@@ -119,7 +119,7 @@ public class WarehouseTest {
 
     @Test
     public void testWarehouseAddNewPart() {
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
 
         // Create a mock part without an ID
         Part mockPart = mock(Part.class, RETURNS_DEEP_STUBS);
@@ -161,7 +161,7 @@ public class WarehouseTest {
 
     @Test
     public void testWarehouseAddSecondNewPart() {
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
 
         // Create a mock part without an ID
         Part mockPart0 = mock(Part.class, RETURNS_DEEP_STUBS);
@@ -191,7 +191,7 @@ public class WarehouseTest {
 
     @Test
     public void testWarehouseAddPartEvent() {
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
 
         // Create a mock part
         int mockId = 10;
@@ -226,7 +226,7 @@ public class WarehouseTest {
 
     @Test
     public void testWarehouseRemovePart() {
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
 
         // Create a mock part
         int mockId = 10;
@@ -260,7 +260,7 @@ public class WarehouseTest {
 
     @Test
     public void testWarehouseRemoveChildParts() {
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
 
         // Add a parent part to the warehouse
         Part mockParentPart = createMockPart(1);
@@ -300,7 +300,7 @@ public class WarehouseTest {
 
     @Test
     public void testWarehouseRemoveRecursiveChildParts() {
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
 
         // Add a parent part to the warehouse
         Part mockParentPart = createMockPart(1);
@@ -344,7 +344,7 @@ public class WarehouseTest {
     @Test
     public void testAddSpareRegularPart() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
 
         // Add a spare part to the warehouse
         Part mockPart = spy(new MekLocation());
@@ -389,7 +389,7 @@ public class WarehouseTest {
     @Test
     public void testReturnSpareRegularPart() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
 
         // Add a spare part to the warehouse
         Part mockPart = spy(new MekLocation());
@@ -450,7 +450,7 @@ public class WarehouseTest {
     @Test
     public void testAddSpareArmorPart() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
 
         // Add some spare armor to the warehouse
         Armor mockArmor = createMockArmor(mockCampaign, EquipmentType.T_ARMOR_STANDARD, 16);
@@ -496,7 +496,7 @@ public class WarehouseTest {
     @Test
     public void testAddSpareAmmoStoragePart() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
 
         // Add some spare ammo to the warehouse
         AmmoStorage mockAmmoStorage = createMockAmmoStorage(mockCampaign, getAmmoType("ISAC5 Ammo"), 20);
@@ -542,7 +542,7 @@ public class WarehouseTest {
     @Test
     public void testAddSparePartWontMixWithRefitPart() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
 
         // Add a spare part to the warehouse reserved for a refit
         Part mockPart = spy(new MekLocation());
@@ -589,7 +589,7 @@ public class WarehouseTest {
     @Test
     public void testAddSparePartWontMixWithReplacementPart() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
 
         // Add a spare part to the warehouse reserved for
         // an overnight task on a unit
@@ -637,7 +637,7 @@ public class WarehouseTest {
     @Test
     public void testAddSparePartWontMixWithPartUnderRepair() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
 
         // Add a spare part under repair to the warehouse
         Part mockPart = spy(new MekLocation());
@@ -684,7 +684,7 @@ public class WarehouseTest {
     @Test
     public void testAddSpareArmorWontMixWithRefitArmor() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
 
         // Add a spare armor to the warehouse reserved for a refit
         Armor mockArmor = createMockArmor(mockCampaign, EquipmentType.T_ARMOR_STANDARD, 16);
@@ -729,7 +729,7 @@ public class WarehouseTest {
     @Test
     public void testAddSpareArmorWontMixWithReplacementArmor() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
 
         // Add a spare part to the warehouse reserved for
         // an overnight task on a unit
@@ -775,7 +775,7 @@ public class WarehouseTest {
     @Test
     public void testAddSpareAmmoStorageWonMixWithRefitAmmoStorage() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
 
         // Add some spare ammo to the warehouse reserved for a refit
         AmmoStorage mockAmmoStorage = createMockAmmoStorage(mockCampaign, getAmmoType("ISAC5 Ammo"), 20);
@@ -819,7 +819,7 @@ public class WarehouseTest {
     @Test
     public void testGetSpareParts() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
 
         // Spare
         Part mockSparePart = spy(new MekLocation());
@@ -887,7 +887,7 @@ public class WarehouseTest {
     @Test
     public void testForEachSpareParts() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
 
         // The warehouse is empty!
         warehouse.forEachSparePart(spare -> fail());
@@ -947,7 +947,7 @@ public class WarehouseTest {
     @Test
     public void testFindSparePart() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
 
         // The warehouse is empty!
         assertNull(warehouse.findSparePart(spare -> true));

--- a/MekHQ/unittests/mekhq/campaign/PersonnelTest.java
+++ b/MekHQ/unittests/mekhq/campaign/PersonnelTest.java
@@ -44,8 +44,8 @@ import java.util.UUID;
 
 import megamek.common.equipment.EquipmentType;
 import mekhq.campaign.personnel.Person;
-import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.personnel.enums.PersonnelRole;
+import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.utilities.MHQXMLUtility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -69,8 +69,8 @@ public class PersonnelTest {
     }
 
     /**
-     * Tests for {@link Personnel#writeToXML(PrintWriter, int, Campaign)} and
-     * {@link Personnel#loadFromXML(org.w3c.dom.Node, Campaign, megamek.common.Version)}
+     * Tests for {@link LocalPersonnel#writeToXML(PrintWriter, int, Campaign)} and
+     * {@link LocalPersonnel#loadFromXML(org.w3c.dom.Node, Campaign, megamek.common.Version)}
      */
     @Nested
     class WriteAndLoadFromXML {
@@ -78,7 +78,7 @@ public class PersonnelTest {
         @Test
         void emptyRosterWritesValidXmlWithNoPersonChildren() {
             // Arrange
-            Personnel personnel = new Personnel();
+            LocalPersonnel personnel = new LocalPersonnel();
             StringWriter stringWriter = new StringWriter();
             PrintWriter writer = new PrintWriter(stringWriter);
 
@@ -96,7 +96,7 @@ public class PersonnelTest {
         @Test
         void rosterWithPersonWritesPersonElement() {
             // Arrange
-            Personnel personnel = new Personnel();
+            LocalPersonnel personnel = new LocalPersonnel();
             Person person = new Person(campaign);
             UUID personId = person.getId();
             personnel.put(personId, person);
@@ -138,7 +138,7 @@ public class PersonnelTest {
     }
 
     /**
-     * Tests for {@link Personnel} as a {@link java.util.LinkedHashMap}
+     * Tests for {@link LocalPersonnel} as a {@link java.util.LinkedHashMap}
      */
     @Nested
     class MapBehavior {
@@ -146,7 +146,7 @@ public class PersonnelTest {
         @Test
         void newPersonnelIsEmpty() {
             // Arrange
-            Personnel personnel = new Personnel();
+            LocalPersonnel personnel = new LocalPersonnel();
 
             // Act — no act, testing initial state
 
@@ -158,7 +158,7 @@ public class PersonnelTest {
         @Test
         void putAndGetByUuid() {
             // Arrange
-            Personnel personnel = new Personnel();
+            LocalPersonnel personnel = new LocalPersonnel();
             Person person = mock(Person.class);
             UUID id = UUID.randomUUID();
 
@@ -173,7 +173,7 @@ public class PersonnelTest {
         @Test
         void removeByUuidLeavesMapEmpty() {
             // Arrange
-            Personnel personnel = new Personnel();
+            LocalPersonnel personnel = new LocalPersonnel();
             Person person = mock(Person.class);
             UUID id = UUID.randomUUID();
             personnel.put(id, person);
@@ -188,7 +188,7 @@ public class PersonnelTest {
         @Test
         void valuesCollectionReflectsInsertionOrder() {
             // Arrange
-            Personnel personnel = new Personnel();
+            LocalPersonnel personnel = new LocalPersonnel();
             Person first = mock(Person.class);
             Person second = mock(Person.class);
             Person third = mock(Person.class);
@@ -211,7 +211,7 @@ public class PersonnelTest {
         @Test
         void containsKeyReturnsTrueForInsertedId() {
             // Arrange
-            Personnel personnel = new Personnel();
+            LocalPersonnel personnel = new LocalPersonnel();
             UUID id = UUID.randomUUID();
             Person person = mock(Person.class);
             personnel.put(id, person);
@@ -226,7 +226,7 @@ public class PersonnelTest {
         @Test
         void containsKeyReturnsFalseForUnknownId() {
             // Arrange
-            Personnel personnel = new Personnel();
+            LocalPersonnel personnel = new LocalPersonnel();
             UUID knownId = UUID.randomUUID();
             Person person = mock(Person.class);
             personnel.put(knownId, person);
@@ -240,7 +240,7 @@ public class PersonnelTest {
     }
 
     /**
-     * Tests for {@link Personnel#loadFromXML(org.w3c.dom.Node, Campaign, megamek.common.Version)}
+     * Tests for {@link LocalPersonnel#loadFromXML(org.w3c.dom.Node, Campaign, megamek.common.Version)}
      * covering the XML parsing path directly.
      */
     @Nested
@@ -254,7 +254,7 @@ public class PersonnelTest {
 
             StringWriter stringWriter = new StringWriter();
             PrintWriter writer = new PrintWriter(stringWriter);
-            Personnel singlePerson = new Personnel();
+            LocalPersonnel singlePerson = new LocalPersonnel();
             singlePerson.put(original.getId(), original);
             singlePerson.writeToXML(writer, 0, campaign);
             writer.flush();
@@ -269,7 +269,7 @@ public class PersonnelTest {
                   .parse(new java.io.ByteArrayInputStream(xml.getBytes()));
             org.w3c.dom.Node personnelNode = doc.getDocumentElement();
             megamek.Version version = new megamek.Version();
-            Personnel.loadFromXML(personnelNode, fresh, version);
+            LocalPersonnel.loadFromXML(personnelNode, fresh, version);
 
             // Assert
             assertFalse(fresh.getHumanResources().getPersonnel().isEmpty(),

--- a/MekHQ/unittests/mekhq/campaign/QuartermasterTest.java
+++ b/MekHQ/unittests/mekhq/campaign/QuartermasterTest.java
@@ -78,9 +78,9 @@ public class QuartermasterTest {
     @Test
     public void addPartDoesntAddTestUnitParts() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         Part mockPart = mock(Part.class);
         TestUnit mockUnit = mock(TestUnit.class);
@@ -96,9 +96,9 @@ public class QuartermasterTest {
     @Test
     public void addPartDoesntAddSpareMissingParts() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         MissingPart mockPart = mock(MissingPart.class);
 
@@ -112,9 +112,9 @@ public class QuartermasterTest {
     @Test
     public void addPartTransitDaysNeverNegative() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         Part mockPart = mock(Part.class);
         doReturn(mockPart).when(mockWarehouse).addPart(eq(mockPart), eq(true));
@@ -131,9 +131,9 @@ public class QuartermasterTest {
     @Test
     public void addPartPlacesSparePartInWarehouse() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         Part mockPart = mock(Part.class);
         doReturn(mockPart).when(mockWarehouse).addPart(eq(mockPart), eq(true));
@@ -148,9 +148,9 @@ public class QuartermasterTest {
     @Test
     public void addPartPlacesUnitPartInWarehouse() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         Part mockPart = mock(Part.class);
         Unit mockUnit = mock(Unit.class);
@@ -167,9 +167,9 @@ public class QuartermasterTest {
     @Test
     public void addPartPlacesUnitMissingPartInWarehouse() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         MissingPart mockPart = mock(MissingPart.class);
         Unit mockUnit = mock(Unit.class);
@@ -185,9 +185,9 @@ public class QuartermasterTest {
     @Test
     public void arrivePartDoesNothingForUnitParts() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         Part mockPart = mock(Part.class);
         Unit mockUnit = mock(Unit.class);
@@ -203,9 +203,9 @@ public class QuartermasterTest {
     @Test
     public void arrivePartSetsDaysToArrivalToZero() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         Part mockPart = mock(Part.class);
         doReturn(mockPart).when(mockWarehouse).addPart(eq(mockPart), eq(true));
@@ -224,9 +224,9 @@ public class QuartermasterTest {
     @Test
     public void arrivePartPlacesPartInWarehouse() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         Part mockPart = mock(Part.class);
         doReturn(mockPart).when(mockWarehouse).addPart(eq(mockPart), eq(true));
@@ -241,9 +241,9 @@ public class QuartermasterTest {
     @Test
     public void arrivePartNotifiesPartArrival() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         Part mockPart = mock(Part.class);
         String arrivalReport = "Test Arrival Report";
@@ -267,7 +267,7 @@ public class QuartermasterTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockOptions);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // If we don't pay for units...
         when(mockOptions.isPayForUnits()).thenReturn(false);
@@ -289,7 +289,7 @@ public class QuartermasterTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockOptions);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // If we pay for units...
         when(mockOptions.isPayForUnits()).thenReturn(true);
@@ -314,7 +314,7 @@ public class QuartermasterTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockOptions);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // If we pay for units...
         when(mockOptions.isPayForUnits()).thenReturn(true);
@@ -346,7 +346,7 @@ public class QuartermasterTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockOptions);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // If we pay for units...
         when(mockOptions.isPayForUnits()).thenReturn(true);
@@ -378,7 +378,7 @@ public class QuartermasterTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockOptions);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // If we pay for units...
         when(mockOptions.isPayForUnits()).thenReturn(true);
@@ -415,7 +415,7 @@ public class QuartermasterTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockOptions);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // If we pay for units...
         when(mockOptions.isPayForUnits()).thenReturn(true);
@@ -452,7 +452,7 @@ public class QuartermasterTest {
         Campaign mockCampaign = mock(Campaign.class);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         Unit mockUnit = mock(Unit.class);
         when(mockUnit.getId()).thenReturn(UUID.randomUUID());
@@ -471,7 +471,7 @@ public class QuartermasterTest {
         Campaign mockCampaign = mock(Campaign.class);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         Unit mockUnit = mock(Unit.class);
         UUID mockId = UUID.randomUUID();
@@ -490,9 +490,9 @@ public class QuartermasterTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockOptions);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // If we don't pay for parts...
         when(mockOptions.isPayForParts()).thenReturn(false);
@@ -515,9 +515,9 @@ public class QuartermasterTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockOptions);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // If we don't pay for parts...
         when(mockOptions.isPayForParts()).thenReturn(false);
@@ -538,11 +538,11 @@ public class QuartermasterTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockOptions);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // If we pay for parts...
         when(mockOptions.isPayForParts()).thenReturn(true);
@@ -566,11 +566,11 @@ public class QuartermasterTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockOptions);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // If we pay for parts...
         when(mockOptions.isPayForParts()).thenReturn(true);
@@ -594,11 +594,11 @@ public class QuartermasterTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockOptions);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // If we pay for parts...
         when(mockOptions.isPayForParts()).thenReturn(true);
@@ -623,11 +623,11 @@ public class QuartermasterTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockOptions);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // If we pay for parts...
         when(mockOptions.isPayForParts()).thenReturn(true);
@@ -653,11 +653,11 @@ public class QuartermasterTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockOptions);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // If we pay for parts...
         when(mockOptions.isPayForParts()).thenReturn(true);
@@ -682,11 +682,11 @@ public class QuartermasterTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockOptions);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // If we pay for parts...
         when(mockOptions.isPayForParts()).thenReturn(true);
@@ -712,11 +712,11 @@ public class QuartermasterTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockOptions);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // If we pay for parts...
         when(mockOptions.isPayForParts()).thenReturn(true);
@@ -740,11 +740,11 @@ public class QuartermasterTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockOptions);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // If we pay for parts...
         when(mockOptions.isPayForParts()).thenReturn(true);
@@ -768,11 +768,11 @@ public class QuartermasterTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockOptions);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // If we don't pay for parts...
         when(mockOptions.isPayForParts()).thenReturn(false);
@@ -793,11 +793,11 @@ public class QuartermasterTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockOptions);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // If we pay for parts...
         when(mockOptions.isPayForParts()).thenReturn(true);
@@ -818,11 +818,11 @@ public class QuartermasterTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockOptions);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // If we pay for parts...
         when(mockOptions.isPayForParts()).thenReturn(true);
@@ -841,11 +841,11 @@ public class QuartermasterTest {
     @Test
     public void sellPartWontSellZeroParts() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         Part mockPart = mock(Part.class);
 
@@ -859,11 +859,11 @@ public class QuartermasterTest {
     @Test
     public void sellPartWontSellNegativeParts() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         Part mockPart = mock(Part.class);
 
@@ -877,11 +877,11 @@ public class QuartermasterTest {
     @Test
     public void sellPartWontSellMoreThanInStock() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // Zero parts on hand...
         Part mockPart = mock(Part.class);
@@ -898,11 +898,11 @@ public class QuartermasterTest {
     @Test
     public void sellPartCalculatesSalePrice() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // Two parts on hand worth 1 C-bill each...
         Part mockPart = mock(Part.class);
@@ -922,11 +922,11 @@ public class QuartermasterTest {
     @Test
     public void sellPartRemovesPartsFromWarehouse() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // Ten parts on hand worth 1 C-bill each...
         Part mockPart = mock(Part.class);
@@ -944,11 +944,11 @@ public class QuartermasterTest {
     @Test
     public void sellPartRemovesNoMorePartsFromWarehouseThanOnHand() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // Five parts on hand worth 1 C-bill each...
         Part mockPart = mock(Part.class);
@@ -967,11 +967,11 @@ public class QuartermasterTest {
     @Test
     public void sellPartCalculatesSalePriceWhenFewerPartsOnHand() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // Five parts on hand worth 1 C-bill each...
         Part mockPart = mock(Part.class);
@@ -992,11 +992,11 @@ public class QuartermasterTest {
     @Test
     public void sellAllPartsSellsNothingIfYouHaveNothing() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // Zero parts on hand...
         Part mockPart = mock(Part.class);
@@ -1013,11 +1013,11 @@ public class QuartermasterTest {
     @Test
     public void sellAllPartsRemovesPartsFromWarehouse() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // Ten parts on hand worth 1 C-bill each...
         Part mockPart = mock(Part.class);
@@ -1039,11 +1039,11 @@ public class QuartermasterTest {
     @Test
     public void sellAmmoWontSellZeroAmmo() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         AmmoStorage mockAmmo = mock(AmmoStorage.class);
 
@@ -1057,11 +1057,11 @@ public class QuartermasterTest {
     @Test
     public void sellAmmoWontSellNegativeAmmo() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         AmmoStorage mockAmmo = mock(AmmoStorage.class);
 
@@ -1075,11 +1075,11 @@ public class QuartermasterTest {
     @Test
     public void sellAmmoWontSellMoreThanInStock() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // Zero parts on hand...
         AmmoStorage mockAmmo = mock(AmmoStorage.class);
@@ -1096,11 +1096,11 @@ public class QuartermasterTest {
     @Test
     public void sellAmmoCalculatesSalePrice() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // One hundred rounds of ammo on hand worth 1 C-bill each...
         AmmoStorage mockAmmo = mock(AmmoStorage.class);
@@ -1120,11 +1120,11 @@ public class QuartermasterTest {
     @Test
     public void sellAmmoRemovesAmmoFromWarehouse() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // Ten rounds of ammo on hand worth 1 C-bill each...
         AmmoStorage mockAmmo = mock(AmmoStorage.class);
@@ -1142,11 +1142,11 @@ public class QuartermasterTest {
     @Test
     public void sellAmmoRemovesNoMoreAmmoFromWarehouseThanOnHand() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // Five rounds of ammo on hand worth 1 C-bill each...
         AmmoStorage mockAmmo = mock(AmmoStorage.class);
@@ -1165,11 +1165,11 @@ public class QuartermasterTest {
     @Test
     public void sellAmmoCalculatesSalePriceWhenFewerAmmoOnHand() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // Five rounds of ammo on hand worth 1 C-bill each...
         AmmoStorage mockAmmo = mock(AmmoStorage.class);
@@ -1192,11 +1192,11 @@ public class QuartermasterTest {
     @Test
     public void sellAllAmmoSellsNothingIfYouHaveNothing() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // Zero rounds of ammo on hand...
         AmmoStorage mockAmmo = mock(AmmoStorage.class);
@@ -1213,11 +1213,11 @@ public class QuartermasterTest {
     @Test
     public void sellAllAmmoRemovesAmmoFromWarehouse() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // One hundred rounds of ammo on hand worth 1 C-bill each...
         AmmoStorage mockAmmo = mock(AmmoStorage.class);
@@ -1239,11 +1239,11 @@ public class QuartermasterTest {
     @Test
     public void sellPartWithAmmoSellsAmmo() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // Ten rounds of ammo on hand worth 1 C-bill each...
         AmmoStorage mockAmmo = mock(AmmoStorage.class);
@@ -1265,11 +1265,11 @@ public class QuartermasterTest {
     @Test
     public void sellAllPartsWithAmmoSellsAllAmmo() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // One hundred rounds of ammo on hand worth 1 C-bill each...
         AmmoStorage mockAmmo = mock(AmmoStorage.class);
@@ -1291,11 +1291,11 @@ public class QuartermasterTest {
     @Test
     public void sellArmorWontSellZeroArmor() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         Armor mockArmor = mock(Armor.class);
 
@@ -1309,11 +1309,11 @@ public class QuartermasterTest {
     @Test
     public void sellArmorWontSellNegativeArmor() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         Armor mockArmor = mock(Armor.class);
 
@@ -1327,11 +1327,11 @@ public class QuartermasterTest {
     @Test
     public void sellArmorWontSellMoreThanInStock() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // Zero parts on hand...
         Armor mockArmor = mock(Armor.class);
@@ -1348,11 +1348,11 @@ public class QuartermasterTest {
     @Test
     public void sellArmorCalculatesSalePrice() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // One hundred points of armor on hand worth 1 C-bill each...
         Armor mockArmor = mock(Armor.class);
@@ -1372,11 +1372,11 @@ public class QuartermasterTest {
     @Test
     public void sellArmorRemovesArmorFromWarehouse() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // Ten points of armor on hand worth 1 C-bill each...
         Armor mockArmor = mock(Armor.class);
@@ -1394,11 +1394,11 @@ public class QuartermasterTest {
     @Test
     public void sellArmorRemovesNoMoreArmorFromWarehouseThanOnHand() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // Five points of armor on hand worth 1 C-bill each...
         Armor mockArmor = mock(Armor.class);
@@ -1417,11 +1417,11 @@ public class QuartermasterTest {
     @Test
     public void sellArmorCalculatesSalePriceWhenFewerArmorOnHand() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // Five points of armor on hand worth 1 C-bill each...
         Armor mockArmor = mock(Armor.class);
@@ -1444,11 +1444,11 @@ public class QuartermasterTest {
     @Test
     public void sellAllArmorSellsNothingIfYouHaveNothing() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // Zero points of armor on hand...
         Armor mockArmor = mock(Armor.class);
@@ -1465,11 +1465,11 @@ public class QuartermasterTest {
     @Test
     public void sellAllArmorRemovesArmorFromWarehouse() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // One hundred points of armor on hand worth 1 C-bill each...
         Armor mockArmor = mock(Armor.class);
@@ -1491,11 +1491,11 @@ public class QuartermasterTest {
     @Test
     public void sellPartWithArmorSellsArmor() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // Ten points of armor on hand worth 1 C-bill each...
         Armor mockArmor = mock(Armor.class);
@@ -1517,11 +1517,11 @@ public class QuartermasterTest {
     @Test
     public void sellAllPartsWithArmorSellsAllArmor() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Finances mockFinances = mock(Finances.class);
         when(mockCampaign.getFinances()).thenReturn(mockFinances);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // One hundred points of armor on hand worth 1 C-bill each...
         Armor mockArmor = mock(Armor.class);
@@ -1543,9 +1543,9 @@ public class QuartermasterTest {
     @Test
     public void remotePartFromPodOnlyDepodsOmniPoddedParts() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         Part mockOmniPart = mock(Part.class);
         when(mockOmniPart.isOmniPodded()).thenReturn(false);
@@ -1559,9 +1559,9 @@ public class QuartermasterTest {
     @Test
     public void depodPartDoesNotRemoteZeroPartsFromPod() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         Part mockOmniPart = mock(Part.class);
         when(mockOmniPart.isOmniPodded()).thenReturn(true);
@@ -1575,9 +1575,9 @@ public class QuartermasterTest {
     @Test
     public void depodPartDoesNotRemoteNegativePartsFromPod() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         Part mockOmniPart = mock(Part.class);
         when(mockOmniPart.isOmniPodded()).thenReturn(true);
@@ -1594,13 +1594,13 @@ public class QuartermasterTest {
         when(mockCampaignOptions.getCommonPartPriceMultiplier()).thenReturn(1d);
         when(mockCampaignOptions.getDamagedPartsValueMultiplier()).thenReturn(1d);
 
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
 
         Campaign mockCampaign = mock(Campaign.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
 
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // Create a spare omni-podded part...
         Part mockOmniPart = mock(Part.class);
@@ -1642,9 +1642,9 @@ public class QuartermasterTest {
     @Test
     public void remotePartAddsCorrectNumberOfPartFromPodAndOmniPod() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // Create a spare omni-podded part...
         Part mockOmniPart = mock(Part.class);
@@ -1672,9 +1672,9 @@ public class QuartermasterTest {
     @Test
     public void remotePartAddsCorrectNumberOfPartFromPodAndOmniPodIfLessOnHand() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // Create a spare omni-podded part...
         Part mockOmniPart = mock(Part.class);
@@ -1703,9 +1703,9 @@ public class QuartermasterTest {
     @Test
     public void depodAllPartsAddsCorrectNumberOfPartAndOmniPod() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // Create a spare omni-podded part...
         Part mockOmniPart = mock(Part.class);
@@ -1733,9 +1733,9 @@ public class QuartermasterTest {
     @Test
     public void remotePartFromPodRaisesChangedEventIfSomeRemain() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // Create a spare omni-podded part...
         Part mockOmniPart = mock(Part.class);
@@ -1755,9 +1755,9 @@ public class QuartermasterTest {
     @Test
     public void remotePartFromPodDoesNotRaiseChangedEventIfNoneRemain() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
 
         // Create a spare omni-podded part...
         Part mockOmniPart = mock(Part.class);
@@ -1792,11 +1792,11 @@ public class QuartermasterTest {
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
 
         // Set up an empty warehouse
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM4 Ammo");
@@ -1831,14 +1831,14 @@ public class QuartermasterTest {
         AmmoType ammoType = getAmmoType("ISSRM4 Ammo");
 
         // Set up a warehouse with ammo in transit
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         AmmoStorage inTransit = new AmmoStorage(0, ammoType, ammoType.getShots(), mockCampaign);
         inTransit.setDaysToArrival(10);
         warehouse.addPart(inTransit);
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Add shots to the Campaign when we don't have any spare ammo of that type present...
@@ -1874,14 +1874,14 @@ public class QuartermasterTest {
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
 
         // Set up a warehouse with ammo in transit
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         AmmoType otherAmmoType = getAmmoType("ISSRM4 Inferno Ammo");
         AmmoStorage otherAmmo = new AmmoStorage(0, otherAmmoType, otherAmmoType.getShots(), mockCampaign);
         warehouse.addPart(otherAmmo);
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM4 Ammo");
@@ -1922,7 +1922,7 @@ public class QuartermasterTest {
         AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
 
         // Set up a warehouse with ammo on hand
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         int originalShots = 1;
         AmmoStorage existing = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
         warehouse.addPart(existing);
@@ -1930,7 +1930,7 @@ public class QuartermasterTest {
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Add shots to the Campaign when we have spare ammo of that type present...
@@ -1962,7 +1962,7 @@ public class QuartermasterTest {
         AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
 
         // Set up a warehouse with ammo on hand plus other junk
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         int originalShots = 1;
         AmmoStorage existingInTransit = new AmmoStorage(0, ammoType, originalShots + 5, mockCampaign);
         existingInTransit.setDaysToArrival(10);
@@ -1975,7 +1975,7 @@ public class QuartermasterTest {
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Add shots to the Campaign when we have spare ammo of that type present...
@@ -2008,14 +2008,14 @@ public class QuartermasterTest {
         AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
 
         // Set up a warehouse with ammo in transit
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         int originalShots = 1;
         AmmoStorage existing = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
         warehouse.addPart(existing);
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Add nothing to the Campaign when we have spare ammo of that type present...
@@ -2046,14 +2046,14 @@ public class QuartermasterTest {
         AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
 
         // Set up a warehouse with ammo in transit
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         int originalShots = 1;
         AmmoStorage existing = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
         warehouse.addPart(existing);
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Add less than nothing to the Campaign when we have spare ammo of that type present...
@@ -2082,11 +2082,11 @@ public class QuartermasterTest {
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
 
         // Set up an empty warehouse
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM4 Ammo");
@@ -2109,7 +2109,7 @@ public class QuartermasterTest {
         AmmoType ammoType = getAmmoType("ISSRM4 Ammo");
 
         // Set up a warehouse with ammo in transit
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         int originalShots = 100;
         AmmoStorage inTransit = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
         inTransit.setDaysToArrival(10);
@@ -2117,7 +2117,7 @@ public class QuartermasterTest {
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Try to remove shots from the Campaign when we don't have any spare ammo of that type present...
@@ -2151,14 +2151,14 @@ public class QuartermasterTest {
         AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
 
         // Set up a warehouse with ammo in transit
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         int originalShots = 100;
         AmmoStorage existing = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
         warehouse.addPart(existing);
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Remove shots from the Campaign when we have spare ammo of that type present...
@@ -2193,14 +2193,14 @@ public class QuartermasterTest {
         AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
 
         // Set up a warehouse with ammo in transit
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         int originalShots = 100;
         AmmoStorage existing = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
         warehouse.addPart(existing);
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Remove nothing.
@@ -2231,14 +2231,14 @@ public class QuartermasterTest {
         AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
 
         // Set up a warehouse with ammo in transit
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         int originalShots = 100;
         AmmoStorage existing = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
         warehouse.addPart(existing);
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Remove all the shots from the Campaign when we have spare ammo of that type present...
@@ -2260,7 +2260,7 @@ public class QuartermasterTest {
         AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
 
         // Set up a warehouse with ammo in transit and available
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         int originalShots = 100;
         AmmoStorage inTransit = new AmmoStorage(0, ammoType, originalShots + 1, mockCampaign);
         inTransit.setDaysToArrival(10);
@@ -2270,7 +2270,7 @@ public class QuartermasterTest {
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Remove way more than the number shots from the Campaign when we have
@@ -2297,7 +2297,7 @@ public class QuartermasterTest {
         AmmoType compatibleAmmoType = getAmmoType("ISSRM2 Inferno Ammo");
 
         // Set up a warehouse with compatible ammo types
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // We only have one ton of the ammo we want.
@@ -2311,7 +2311,7 @@ public class QuartermasterTest {
         warehouse.addPart(compatible);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Ask for two tons of ammo (double what we have on hand)
@@ -2357,7 +2357,7 @@ public class QuartermasterTest {
         AmmoType compatibleAmmoType = getAmmoType("ISSRM2 Inferno Ammo");
 
         // Set up a warehouse with compatible ammo types
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // We have JUST enough compatible ammo
@@ -2366,7 +2366,7 @@ public class QuartermasterTest {
         warehouse.addPart(compatible);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Ask for one ton of ammo (exactly what we have on hand in a compatible ammo type)
@@ -2396,7 +2396,7 @@ public class QuartermasterTest {
         AmmoType compatibleAmmoType = getAmmoType("ISLRM20 Ammo");
 
         // Set up a warehouse with compatible ammo types
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // We have JUST enough compatible ammo
@@ -2405,7 +2405,7 @@ public class QuartermasterTest {
         warehouse.addPart(compatible);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Ask for one ton of ammo (exactly what we have on hand in a compatible ammo type)
@@ -2436,7 +2436,7 @@ public class QuartermasterTest {
         AmmoType incompatibleAmmoType = getAmmoType("ISSRM2 Ammo");
 
         // Set up a warehouse with compatible ammo types
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // We only have one ton of the ammo we want.
@@ -2454,7 +2454,7 @@ public class QuartermasterTest {
         warehouse.addPart(compatible);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Ask for two tons of ammo (double what we have on hand)
@@ -2501,7 +2501,7 @@ public class QuartermasterTest {
         AmmoType compatibleAmmoType = getAmmoType("ISSRM2 Inferno Ammo");
 
         // Set up a warehouse with compatible ammo types
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // We only have one ton of the ammo we want.
@@ -2515,7 +2515,7 @@ public class QuartermasterTest {
         warehouse.addPart(compatible);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Ask for two tons of ammo (double what we have on hand)
@@ -2553,7 +2553,7 @@ public class QuartermasterTest {
         AmmoType compatibleAmmoType = getAmmoType("ISLRM20 Ammo");
 
         // Set up a warehouse with compatible ammo types
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // We have enough compatible ammo
@@ -2562,7 +2562,7 @@ public class QuartermasterTest {
         warehouse.addPart(compatible);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Ask for one round of ammo
@@ -2595,7 +2595,7 @@ public class QuartermasterTest {
         AmmoType compatibleAmmoType = getAmmoType("ISLRM5 Ammo");
 
         // Set up a warehouse with compatible ammo types
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // We have JUST enough compatible ammo
@@ -2604,7 +2604,7 @@ public class QuartermasterTest {
         warehouse.addPart(compatible);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Ask for one shot of ammo
@@ -2632,11 +2632,11 @@ public class QuartermasterTest {
         Campaign mockCampaign = mock(Campaign.class);
 
         // Set up an empty warehouse
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
@@ -2673,7 +2673,7 @@ public class QuartermasterTest {
         InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
 
         // Set up a warehouse with ammo in transit
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         InfantryAmmoStorage inTransit = new InfantryAmmoStorage(0,
               ammoType,
               ammoType.getShots(),
@@ -2684,7 +2684,7 @@ public class QuartermasterTest {
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Add shots to the Campaign when we don't have any spare ammo of that type present...
@@ -2720,7 +2720,7 @@ public class QuartermasterTest {
         Campaign mockCampaign = mock(Campaign.class);
 
         // Set up a warehouse with ammo in transit
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
         InfantryWeapon otherWeaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_TAG);
         InfantryAmmoStorage otherAmmo = new InfantryAmmoStorage(0,
@@ -2732,7 +2732,7 @@ public class QuartermasterTest {
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
@@ -2776,7 +2776,7 @@ public class QuartermasterTest {
         InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
 
         // Set up a warehouse with ammo in transit
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         int originalShots = 1;
         InfantryAmmoStorage existing = new InfantryAmmoStorage(0, ammoType, originalShots, weaponType, mockCampaign);
         existing.setBrandNew(false);
@@ -2784,7 +2784,7 @@ public class QuartermasterTest {
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Add shots to the Campaign when we have spare ammo of that type present...
@@ -2816,11 +2816,11 @@ public class QuartermasterTest {
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
 
         // Set up an empty warehouse
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
@@ -2845,7 +2845,7 @@ public class QuartermasterTest {
         InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
 
         // Set up a warehouse with ammo in transit
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         int originalShots = 100;
         InfantryAmmoStorage inTransit = new InfantryAmmoStorage(0, ammoType, originalShots, weaponType, mockCampaign);
         inTransit.setDaysToArrival(10);
@@ -2853,7 +2853,7 @@ public class QuartermasterTest {
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Try to remove shots from the Campaign when we don't have any spare ammo of that type present...
@@ -2889,14 +2889,14 @@ public class QuartermasterTest {
         InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
 
         // Set up a warehouse with ammo in transit
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         int originalShots = 100;
         InfantryAmmoStorage existing = new InfantryAmmoStorage(0, ammoType, originalShots, weaponType, mockCampaign);
         warehouse.addPart(existing);
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Remove shots from the Campaign when we have spare ammo of that type present...
@@ -2932,14 +2932,14 @@ public class QuartermasterTest {
         InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
 
         // Set up a warehouse with ammo in transit
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         int originalShots = 100;
         InfantryAmmoStorage existing = new InfantryAmmoStorage(0, ammoType, originalShots, weaponType, mockCampaign);
         warehouse.addPart(existing);
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Remove all the shots from the Campaign when we have spare ammo of that type present...
@@ -2962,14 +2962,14 @@ public class QuartermasterTest {
         InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
 
         // Set up a warehouse with ammo in transit
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         int originalShots = 100;
         InfantryAmmoStorage existing = new InfantryAmmoStorage(0, ammoType, originalShots, weaponType, mockCampaign);
         warehouse.addPart(existing);
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
         // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Remove way more than the number shots from the Campaign when we have
@@ -2992,43 +2992,43 @@ public class QuartermasterTest {
         AmmoType lrm20 = getAmmoType("ISLRM20 Ammo");
 
         // 1 shot
-        assertEquals(1, Quartermaster.convertShots(lrm5, 1, lrm5));
-        assertEquals(3, Quartermaster.convertShots(lrm15, 1, lrm5));
-        assertEquals(4, Quartermaster.convertShots(lrm20, 1, lrm5));
+        assertEquals(1, ForceQuartermaster.convertShots(lrm5, 1, lrm5));
+        assertEquals(3, ForceQuartermaster.convertShots(lrm15, 1, lrm5));
+        assertEquals(4, ForceQuartermaster.convertShots(lrm20, 1, lrm5));
 
-        assertEquals(0, Quartermaster.convertShots(lrm5, 1, lrm15));
-        assertEquals(1, Quartermaster.convertShots(lrm15, 1, lrm15));
-        assertEquals(1, Quartermaster.convertShots(lrm20, 1, lrm15));
+        assertEquals(0, ForceQuartermaster.convertShots(lrm5, 1, lrm15));
+        assertEquals(1, ForceQuartermaster.convertShots(lrm15, 1, lrm15));
+        assertEquals(1, ForceQuartermaster.convertShots(lrm20, 1, lrm15));
 
-        assertEquals(0, Quartermaster.convertShots(lrm5, 1, lrm20));
-        assertEquals(0, Quartermaster.convertShots(lrm15, 1, lrm20));
-        assertEquals(1, Quartermaster.convertShots(lrm20, 1, lrm20));
+        assertEquals(0, ForceQuartermaster.convertShots(lrm5, 1, lrm20));
+        assertEquals(0, ForceQuartermaster.convertShots(lrm15, 1, lrm20));
+        assertEquals(1, ForceQuartermaster.convertShots(lrm20, 1, lrm20));
 
         // 3 shots
-        assertEquals(3, Quartermaster.convertShots(lrm5, 3, lrm5));
-        assertEquals(9, Quartermaster.convertShots(lrm15, 3, lrm5));
-        assertEquals(12, Quartermaster.convertShots(lrm20, 3, lrm5));
+        assertEquals(3, ForceQuartermaster.convertShots(lrm5, 3, lrm5));
+        assertEquals(9, ForceQuartermaster.convertShots(lrm15, 3, lrm5));
+        assertEquals(12, ForceQuartermaster.convertShots(lrm20, 3, lrm5));
 
-        assertEquals(1, Quartermaster.convertShots(lrm5, 3, lrm15));
-        assertEquals(3, Quartermaster.convertShots(lrm15, 3, lrm15));
-        assertEquals(4, Quartermaster.convertShots(lrm20, 3, lrm15));
+        assertEquals(1, ForceQuartermaster.convertShots(lrm5, 3, lrm15));
+        assertEquals(3, ForceQuartermaster.convertShots(lrm15, 3, lrm15));
+        assertEquals(4, ForceQuartermaster.convertShots(lrm20, 3, lrm15));
 
-        assertEquals(0, Quartermaster.convertShots(lrm5, 3, lrm20));
-        assertEquals(2, Quartermaster.convertShots(lrm15, 3, lrm20));
-        assertEquals(3, Quartermaster.convertShots(lrm20, 3, lrm20));
+        assertEquals(0, ForceQuartermaster.convertShots(lrm5, 3, lrm20));
+        assertEquals(2, ForceQuartermaster.convertShots(lrm15, 3, lrm20));
+        assertEquals(3, ForceQuartermaster.convertShots(lrm20, 3, lrm20));
 
         // 100 shots
-        assertEquals(100, Quartermaster.convertShots(lrm5, 100, lrm5));
-        assertEquals(300, Quartermaster.convertShots(lrm15, 100, lrm5));
-        assertEquals(400, Quartermaster.convertShots(lrm20, 100, lrm5));
+        assertEquals(100, ForceQuartermaster.convertShots(lrm5, 100, lrm5));
+        assertEquals(300, ForceQuartermaster.convertShots(lrm15, 100, lrm5));
+        assertEquals(400, ForceQuartermaster.convertShots(lrm20, 100, lrm5));
 
-        assertEquals(33, Quartermaster.convertShots(lrm5, 100, lrm15));
-        assertEquals(100, Quartermaster.convertShots(lrm15, 100, lrm15));
-        assertEquals(133, Quartermaster.convertShots(lrm20, 100, lrm15));
+        assertEquals(33, ForceQuartermaster.convertShots(lrm5, 100, lrm15));
+        assertEquals(100, ForceQuartermaster.convertShots(lrm15, 100, lrm15));
+        assertEquals(133, ForceQuartermaster.convertShots(lrm20, 100, lrm15));
 
-        assertEquals(25, Quartermaster.convertShots(lrm5, 100, lrm20));
-        assertEquals(75, Quartermaster.convertShots(lrm15, 100, lrm20));
-        assertEquals(100, Quartermaster.convertShots(lrm20, 100, lrm20));
+        assertEquals(25, ForceQuartermaster.convertShots(lrm5, 100, lrm20));
+        assertEquals(75, ForceQuartermaster.convertShots(lrm15, 100, lrm20));
+        assertEquals(100, ForceQuartermaster.convertShots(lrm20, 100, lrm20));
     }
 
     @Test
@@ -3038,43 +3038,43 @@ public class QuartermasterTest {
         AmmoType lrm20 = getAmmoType("ISLRM20 Ammo");
 
         // 1 shot
-        assertEquals(1, Quartermaster.convertShotsNeeded(lrm5, 1, lrm5));
-        assertEquals(3, Quartermaster.convertShotsNeeded(lrm15, 1, lrm5));
-        assertEquals(4, Quartermaster.convertShotsNeeded(lrm20, 1, lrm5));
+        assertEquals(1, ForceQuartermaster.convertShotsNeeded(lrm5, 1, lrm5));
+        assertEquals(3, ForceQuartermaster.convertShotsNeeded(lrm15, 1, lrm5));
+        assertEquals(4, ForceQuartermaster.convertShotsNeeded(lrm20, 1, lrm5));
 
-        assertEquals(1, Quartermaster.convertShotsNeeded(lrm5, 1, lrm15));
-        assertEquals(1, Quartermaster.convertShotsNeeded(lrm15, 1, lrm15));
-        assertEquals(2, Quartermaster.convertShotsNeeded(lrm20, 1, lrm15));
+        assertEquals(1, ForceQuartermaster.convertShotsNeeded(lrm5, 1, lrm15));
+        assertEquals(1, ForceQuartermaster.convertShotsNeeded(lrm15, 1, lrm15));
+        assertEquals(2, ForceQuartermaster.convertShotsNeeded(lrm20, 1, lrm15));
 
-        assertEquals(1, Quartermaster.convertShotsNeeded(lrm5, 1, lrm20));
-        assertEquals(1, Quartermaster.convertShotsNeeded(lrm15, 1, lrm20));
-        assertEquals(1, Quartermaster.convertShotsNeeded(lrm20, 1, lrm20));
+        assertEquals(1, ForceQuartermaster.convertShotsNeeded(lrm5, 1, lrm20));
+        assertEquals(1, ForceQuartermaster.convertShotsNeeded(lrm15, 1, lrm20));
+        assertEquals(1, ForceQuartermaster.convertShotsNeeded(lrm20, 1, lrm20));
 
         // 3 shots
-        assertEquals(3, Quartermaster.convertShotsNeeded(lrm5, 3, lrm5));
-        assertEquals(9, Quartermaster.convertShotsNeeded(lrm15, 3, lrm5));
-        assertEquals(12, Quartermaster.convertShotsNeeded(lrm20, 3, lrm5));
+        assertEquals(3, ForceQuartermaster.convertShotsNeeded(lrm5, 3, lrm5));
+        assertEquals(9, ForceQuartermaster.convertShotsNeeded(lrm15, 3, lrm5));
+        assertEquals(12, ForceQuartermaster.convertShotsNeeded(lrm20, 3, lrm5));
 
-        assertEquals(1, Quartermaster.convertShotsNeeded(lrm5, 3, lrm15));
-        assertEquals(3, Quartermaster.convertShotsNeeded(lrm15, 3, lrm15));
-        assertEquals(4, Quartermaster.convertShotsNeeded(lrm20, 3, lrm15));
+        assertEquals(1, ForceQuartermaster.convertShotsNeeded(lrm5, 3, lrm15));
+        assertEquals(3, ForceQuartermaster.convertShotsNeeded(lrm15, 3, lrm15));
+        assertEquals(4, ForceQuartermaster.convertShotsNeeded(lrm20, 3, lrm15));
 
-        assertEquals(1, Quartermaster.convertShotsNeeded(lrm5, 3, lrm20));
-        assertEquals(3, Quartermaster.convertShotsNeeded(lrm15, 3, lrm20));
-        assertEquals(3, Quartermaster.convertShotsNeeded(lrm20, 3, lrm20));
+        assertEquals(1, ForceQuartermaster.convertShotsNeeded(lrm5, 3, lrm20));
+        assertEquals(3, ForceQuartermaster.convertShotsNeeded(lrm15, 3, lrm20));
+        assertEquals(3, ForceQuartermaster.convertShotsNeeded(lrm20, 3, lrm20));
 
         // 100 shots
-        assertEquals(100, Quartermaster.convertShotsNeeded(lrm5, 100, lrm5));
-        assertEquals(300, Quartermaster.convertShotsNeeded(lrm15, 100, lrm5));
-        assertEquals(400, Quartermaster.convertShotsNeeded(lrm20, 100, lrm5));
+        assertEquals(100, ForceQuartermaster.convertShotsNeeded(lrm5, 100, lrm5));
+        assertEquals(300, ForceQuartermaster.convertShotsNeeded(lrm15, 100, lrm5));
+        assertEquals(400, ForceQuartermaster.convertShotsNeeded(lrm20, 100, lrm5));
 
-        assertEquals(34, Quartermaster.convertShotsNeeded(lrm5, 100, lrm15));
-        assertEquals(100, Quartermaster.convertShotsNeeded(lrm15, 100, lrm15));
-        assertEquals(134, Quartermaster.convertShotsNeeded(lrm20, 100, lrm15));
+        assertEquals(34, ForceQuartermaster.convertShotsNeeded(lrm5, 100, lrm15));
+        assertEquals(100, ForceQuartermaster.convertShotsNeeded(lrm15, 100, lrm15));
+        assertEquals(134, ForceQuartermaster.convertShotsNeeded(lrm20, 100, lrm15));
 
-        assertEquals(25, Quartermaster.convertShotsNeeded(lrm5, 100, lrm20));
-        assertEquals(75, Quartermaster.convertShotsNeeded(lrm15, 100, lrm20));
-        assertEquals(100, Quartermaster.convertShotsNeeded(lrm20, 100, lrm20));
+        assertEquals(25, ForceQuartermaster.convertShotsNeeded(lrm5, 100, lrm20));
+        assertEquals(75, ForceQuartermaster.convertShotsNeeded(lrm15, 100, lrm20));
+        assertEquals(100, ForceQuartermaster.convertShotsNeeded(lrm20, 100, lrm20));
     }
 
     /**
@@ -3090,12 +3090,12 @@ public class QuartermasterTest {
         AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
 
         // Set up a warehouse with a 0-shot AmmoStorage (the buggy state)
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         AmmoStorage emptyAmmo = new AmmoStorage(0, ammoType, 0, mockCampaign);
         warehouse.addPart(emptyAmmo);
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
 
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        ForceQuartermaster quartermaster = new ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Try to remove ammo — this should clean up the 0-shot entry

--- a/MekHQ/unittests/mekhq/campaign/SkillCheckRulesTest.java
+++ b/MekHQ/unittests/mekhq/campaign/SkillCheckRulesTest.java
@@ -42,12 +42,13 @@ import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Field;
+
 import megamek.common.TechConstants;
 import megamek.common.enums.TechBase;
 import megamek.common.rolls.TargetRoll;
 import mekhq.campaign.campaignOptions.AcquisitionsType;
 import mekhq.campaign.campaignOptions.CampaignOptions;
-import mekhq.campaign.market.ShoppingList;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.skills.ActionCheck;
 import mekhq.campaign.personnel.skills.SkillCheck;
@@ -59,8 +60,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-
-import java.lang.reflect.Field;
 
 
 public class SkillCheckRulesTest {
@@ -80,7 +79,7 @@ public class SkillCheckRulesTest {
             Faction faction = new Faction();
             when(campaign.getCampaignOptions()).thenReturn(options);
             when(campaign.getFaction()).thenReturn(faction);
-            ShoppingList shoppingList = mock(ShoppingList.class);
+            mekhq.campaign.market.ForceShoppingList shoppingList = mock(mekhq.campaign.market.ForceShoppingList.class);
             when(campaign.getShoppingList()).thenReturn(shoppingList);
             return campaign;
         }
@@ -155,7 +154,7 @@ public class SkillCheckRulesTest {
             CampaignOptions options = mock(CampaignOptions.class);
             Campaign campaign = createCampaignMock(options);
             IAcquisitionWork acquisition = mock(IAcquisitionWork.class);
-            ShoppingList shoppingList = mock(ShoppingList.class);
+            mekhq.campaign.market.ForceShoppingList shoppingList = mock(mekhq.campaign.market.ForceShoppingList.class);
             when(campaign.getShoppingList()).thenReturn(shoppingList);
             when(options.getAcquisitionType()).thenReturn(AcquisitionsType.ADMINISTRATION);
             when(shoppingList.getShoppingItem(any())).thenReturn(mock(IAcquisitionWork.class));

--- a/MekHQ/unittests/mekhq/campaign/autoResolve/ResolverTest.java
+++ b/MekHQ/unittests/mekhq/campaign/autoResolve/ResolverTest.java
@@ -72,7 +72,6 @@ import megamek.common.units.CrewType;
 import megamek.common.units.Entity;
 import megamek.common.util.BoardUtilities;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.camOpsReputation.ReputationController;
 import mekhq.campaign.force.Formation;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.AtBDynamicScenario;
@@ -232,7 +231,7 @@ public class ResolverTest {
     Campaign createCampaign() {
         var campaign = MHQTestUtilities.getTestCampaign();
         campaign.setName("Test Player");
-        var reputationController = mock(ReputationController.class);
+        var reputationController = mock(mekhq.campaign.camOpsReputation.ForceReputationController.class);
         when(reputationController.getAverageSkillLevel()).thenReturn(SkillLevel.REGULAR);
 
         campaign.setReputation(reputationController);

--- a/MekHQ/unittests/mekhq/campaign/autoResolve/ScenarioSetupForcesTest.java
+++ b/MekHQ/unittests/mekhq/campaign/autoResolve/ScenarioSetupForcesTest.java
@@ -51,16 +51,15 @@ import megamek.common.autoResolve.converter.FlattenForces;
 import megamek.common.board.Board;
 import megamek.common.enums.Gender;
 import megamek.common.enums.SkillLevel;
+import megamek.common.equipment.EquipmentType;
 import megamek.common.icons.Camouflage;
+import megamek.common.loaders.MapSettings;
 import megamek.common.planetaryConditions.PlanetaryConditions;
 import megamek.common.units.Crew;
 import megamek.common.units.CrewType;
 import megamek.common.units.Entity;
-import megamek.common.equipment.EquipmentType;
-import megamek.common.loaders.MapSettings;
 import megamek.common.util.BoardUtilities;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.camOpsReputation.ReputationController;
 import mekhq.campaign.force.Formation;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.AtBDynamicScenario;
@@ -169,7 +168,7 @@ class ScenarioSetupForcesTest {
     private Campaign createCampaign() {
         var campaign = MHQTestUtilities.getTestCampaign();
         campaign.setName("Test Player");
-        var reputationController = mock(ReputationController.class);
+        var reputationController = mock(mekhq.campaign.camOpsReputation.ForceReputationController.class);
         when(reputationController.getAverageSkillLevel()).thenReturn(SkillLevel.REGULAR);
         campaign.setReputation(reputationController);
         campaign.addFormation(new Formation("Heroes"), campaign.getFormation(0));

--- a/MekHQ/unittests/mekhq/campaign/base/AbstractBaseTest.java
+++ b/MekHQ/unittests/mekhq/campaign/base/AbstractBaseTest.java
@@ -43,9 +43,8 @@ import java.util.List;
 import java.util.UUID;
 
 import mekhq.campaign.FixedLocation;
-import mekhq.campaign.Hangar;
-import mekhq.campaign.Personnel;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalPersonnel;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.parts.Armor;
 import mekhq.campaign.parts.PartInventory;
 import mekhq.campaign.parts.meks.MekSensor;
@@ -84,21 +83,21 @@ public class AbstractBaseTest {
     class ResourceOwnership {
         @Test
         void getWarehouse_returnsBaseWarehouse() {
-            Warehouse wh = base.getWarehouse();
+            LocalWarehouse wh = base.getWarehouse();
             assertNotNull(wh);
             assertSame(wh, base.getBaseWarehouse());
         }
 
         @Test
         void getHangar_returnsBaseHangar() {
-            Hangar h = base.getHangar();
+            mekhq.campaign.LocalHangar h = base.getHangar();
             assertNotNull(h);
             assertSame(h, base.getBaseHangar());
         }
 
         @Test
         void getPersonnel_returnsBasePersonnel() {
-            Personnel p = base.getPersonnel();
+            LocalPersonnel p = base.getPersonnel();
             assertNotNull(p);
             assertSame(p, base.getBasePersonnel());
         }

--- a/MekHQ/unittests/mekhq/campaign/camOpsReputation/AverageExperienceRatingTest.java
+++ b/MekHQ/unittests/mekhq/campaign/camOpsReputation/AverageExperienceRatingTest.java
@@ -47,7 +47,6 @@ import megamek.common.units.Entity;
 import megamek.common.units.Jumpship;
 import megamek.common.units.SmallCraft;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Hangar;
 import mekhq.campaign.force.CombatTeam;
 import mekhq.campaign.force.Formation;
 import mekhq.campaign.personnel.Person;
@@ -63,7 +62,7 @@ class AverageExperienceRatingTest {
     @Test
     void returnsNoCampaignExperience_whenNoCombatTeams() throws Exception {
         Campaign campaign = mock(Campaign.class);
-        when(campaign.getAllHangar()).thenReturn(mock(Hangar.class));
+        when(campaign.getAllHangar()).thenReturn(mock(mekhq.campaign.LocalHangar.class));
         when(campaign.getCombatTeamsAsList()).thenReturn(new ArrayList<>());
 
         assertEquals(7, invokeCalculateAverageExperienceRating(campaign, false));
@@ -73,7 +72,7 @@ class AverageExperienceRatingTest {
     @Test
     void returnsNoCampaignExperience_whenAllCombatTeamsReturnNullForce() throws Exception {
         Campaign campaign = mock(Campaign.class);
-        Hangar hangar = mock(Hangar.class);
+        mekhq.campaign.LocalHangar hangar = mock(mekhq.campaign.LocalHangar.class);
         when(campaign.getAllHangar()).thenReturn(hangar);
 
         CombatTeam team = mock(CombatTeam.class);
@@ -88,7 +87,7 @@ class AverageExperienceRatingTest {
     @Test
     void returnsNoCampaignExperience_whenAllForcesAreTraining() throws Exception {
         Campaign campaign = mock(Campaign.class);
-        Hangar hangar = mock(Hangar.class);
+        mekhq.campaign.LocalHangar hangar = mock(mekhq.campaign.LocalHangar.class);
         when(campaign.getAllHangar()).thenReturn(hangar);
 
         Formation trainingFormation = mock(Formation.class, RETURNS_DEEP_STUBS);
@@ -105,7 +104,7 @@ class AverageExperienceRatingTest {
     @Test
     void returnsNoCampaignExperience_whenUnitsAreUncrewed() throws Exception {
         Campaign campaign = mock(Campaign.class);
-        Hangar hangar = mock(Hangar.class);
+        mekhq.campaign.LocalHangar hangar = mock(mekhq.campaign.LocalHangar.class);
         when(campaign.getAllHangar()).thenReturn(hangar);
 
         Entity entity = mock(Entity.class);
@@ -128,7 +127,7 @@ class AverageExperienceRatingTest {
     @Test
     void ignoresJumpships_entirely() throws Exception {
         Campaign campaign = mock(Campaign.class);
-        Hangar hangar = mock(Hangar.class);
+        mekhq.campaign.LocalHangar hangar = mock(mekhq.campaign.LocalHangar.class);
         when(campaign.getAllHangar()).thenReturn(hangar);
 
         Jumpship jumpship = mock(Jumpship.class); // instanceof Jumpship => must be skipped
@@ -152,7 +151,7 @@ class AverageExperienceRatingTest {
         // One unit: piloting=4, gunnery=3 => totalExperience=7
         // unitCount=1 => divisor=2 => rawAverage=3.5 => fractional==0.5 => round DOWN => 3
         Campaign campaign = mock(Campaign.class);
-        Hangar hangar = mock(Hangar.class);
+        mekhq.campaign.LocalHangar hangar = mock(mekhq.campaign.LocalHangar.class);
         when(campaign.getAllHangar()).thenReturn(hangar);
 
         Entity entity = mock(Entity.class);
@@ -196,7 +195,7 @@ class AverageExperienceRatingTest {
         // Unit B: piloting=3, gunnery=5 => 8
         // totalExperience=15, units=2 => divisor=4 => rawAverage=3.75 => fractional>0.5 => ceil => 4
         Campaign campaign = mock(Campaign.class);
-        Hangar hangar = mock(Hangar.class);
+        mekhq.campaign.LocalHangar hangar = mock(mekhq.campaign.LocalHangar.class);
         when(campaign.getAllHangar()).thenReturn(hangar);
 
         Entity entityA = mock(Entity.class);
@@ -255,7 +254,7 @@ class AverageExperienceRatingTest {
         // If the person lacks the skill, code uses SkillType.getType(skillName).getTarget() + 1
         // Set target=5 => returns 6 for driving and 6 for gunnery => total=12 => divisor=2 => avg=6
         Campaign campaign = mock(Campaign.class);
-        Hangar hangar = mock(Hangar.class);
+        mekhq.campaign.LocalHangar hangar = mock(mekhq.campaign.LocalHangar.class);
         when(campaign.getAllHangar()).thenReturn(hangar);
 
         Entity entity = mock(Entity.class);
@@ -301,7 +300,7 @@ class AverageExperienceRatingTest {
         // Gunners (2): 3 and 3 => avg=3.0 => round => 3
         // totalExperience=8 => divisor=2 => avg=4
         Campaign campaign = mock(Campaign.class);
-        Hangar hangar = mock(Hangar.class);
+        mekhq.campaign.LocalHangar hangar = mock(mekhq.campaign.LocalHangar.class);
         when(campaign.getAllHangar()).thenReturn(hangar);
 
         SmallCraft smallCraft = mock(SmallCraft.class);
@@ -361,7 +360,7 @@ class AverageExperienceRatingTest {
         // In the SmallCraft branch, hasAtLeastOneCrew is only set true when a role has > 1 person.
         // So (1 driver, 1 gunner) leaves hasAtLeastOneCrew false and should return NO_CAMPAIGN_EXPERIENCE.
         Campaign campaign = mock(Campaign.class);
-        Hangar hangar = mock(Hangar.class);
+        mekhq.campaign.LocalHangar hangar = mock(mekhq.campaign.LocalHangar.class);
         when(campaign.getAllHangar()).thenReturn(hangar);
 
         SmallCraft smallCraft = mock(SmallCraft.class);
@@ -405,7 +404,7 @@ class AverageExperienceRatingTest {
     @Test
     void logFlag_doesNotChangeComputedResult() throws Exception {
         Campaign campaign = mock(Campaign.class);
-        Hangar hangar = mock(Hangar.class);
+        mekhq.campaign.LocalHangar hangar = mock(mekhq.campaign.LocalHangar.class);
         when(campaign.getAllHangar()).thenReturn(hangar);
 
         Entity entity = mock(Entity.class);

--- a/MekHQ/unittests/mekhq/campaign/camOpsReputation/ForceReputationControllerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/camOpsReputation/ForceReputationControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2024-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -50,8 +50,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-class ReputationControllerTest {
-    private ReputationController reputation;
+class ForceReputationControllerTest {
+    private ForceReputationController reputation;
     private Campaign campaign;
     private MockedStatic<AverageExperienceRating> averageExperienceRating;
     private MockedStatic<CommandRating> commandRating;
@@ -64,7 +64,7 @@ class ReputationControllerTest {
 
     @BeforeEach
     void setUp() {
-        reputation = new ReputationController();
+        reputation = new ForceReputationController();
         campaign = mock(Campaign.class);
         when(campaign.getCommander()).thenReturn(null);
         when(campaign.getFinances()).thenReturn(null);

--- a/MekHQ/unittests/mekhq/campaign/finances/AccountantTest.java
+++ b/MekHQ/unittests/mekhq/campaign/finances/AccountantTest.java
@@ -59,8 +59,7 @@ import megamek.common.equipment.Engine;
 import megamek.common.units.Entity;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CurrentLocation;
-import mekhq.campaign.Hangar;
-import mekhq.campaign.HumanResources;
+import mekhq.campaign.LocalHangar;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.force.Formation;
 import mekhq.campaign.force.FormationType;
@@ -920,7 +919,7 @@ public class AccountantTest {
     @Nested
     class TestGetPayrollSummary {
         Campaign mockCampaign;
-        HumanResources mockHumanResources;
+        mekhq.campaign.ForceHumanResources mockHumanResources;
         CampaignOptions campaignOptions;
         Accountant accountant;
         final int EXPECTEDPAY = 100;
@@ -930,7 +929,7 @@ public class AccountantTest {
         @BeforeEach
         void beforeEach() {
             mockCampaign = mock(Campaign.class);
-            mockHumanResources = mock(HumanResources.class);
+            mockHumanResources = mock(mekhq.campaign.ForceHumanResources.class);
             campaignOptions = new CampaignOptions();
             accountant = new Accountant(mockCampaign);
             when(mockCampaign.isClanCampaign()).thenReturn(false);
@@ -1220,13 +1219,13 @@ public class AccountantTest {
 
     /**
      * tests
-     * {@link Accountant#getPeacetimeOperatingCosts(java.util.Collection, Hangar, CampaignOptions, boolean, LocalDate,
+     * {@link Accountant#getPeacetimeOperatingCosts(java.util.Collection, LocalHangar, CampaignOptions, boolean, LocalDate,
      * int, int, java.util.Map, boolean)}
      */
     @Nested
     class TestGetPeacetimeOperatingCosts {
         CampaignOptions campaignOptions;
-        Hangar mockHangar;
+        LocalHangar mockHangar;
         final LocalDate TODAY = LocalDate.of(3025, 1, 1);
 
         @BeforeEach
@@ -1235,7 +1234,7 @@ public class AccountantTest {
             // getRoleBaseSalaries() - consulted internally while totaling temporary crew pay - resolve to
             // real, non-null values instead of requiring exhaustive stubbing.
             campaignOptions = new CampaignOptions();
-            mockHangar = mock(Hangar.class);
+            mockHangar = mock(LocalHangar.class);
         }
 
         @Test
@@ -1406,7 +1405,7 @@ public class AccountantTest {
      * These tests confirm that, for a campaign where every hangar unit is assigned somewhere in the TO&E and every
      * salary-eligible person crews one of those units (i.e. the common case today), routing
      * {@link Accountant#getPeacetimeCost(boolean)} through the new formation-based
-     * {@link Accountant#getPeacetimeOperatingCosts(java.util.Collection, Hangar, CampaignOptions, boolean, LocalDate,
+     * {@link Accountant#getPeacetimeOperatingCosts(java.util.Collection, LocalHangar, CampaignOptions, boolean, LocalDate,
      * int, int, java.util.Map, boolean)} produces the exact same total that the old whole-campaign calculation used to
      * produce.
      */
@@ -1414,7 +1413,7 @@ public class AccountantTest {
     class TestPeacetimeCostMatchesLegacyBehavior {
         Campaign mockCampaign;
         CampaignOptions mockCampaignOptions;
-        Hangar mockHangar;
+        LocalHangar mockHangar;
         Accountant accountant;
         final LocalDate TODAY = LocalDate.of(3025, 1, 1);
 
@@ -1430,14 +1429,14 @@ public class AccountantTest {
             // getRoleBaseSalaries() - consulted internally while totaling temporary crew pay - resolve to
             // real, non-null values instead of requiring exhaustive stubbing.
             mockCampaignOptions = new CampaignOptions();
-            mockHangar = mock(Hangar.class);
+            mockHangar = mock(LocalHangar.class);
             accountant = new Accountant(mockCampaign);
 
             when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
             when(mockCampaign.getAllHangar()).thenReturn(mockHangar);
             when(mockCampaign.isClanCampaign()).thenReturn(false);
             when(mockCampaign.getLocalDate()).thenReturn(TODAY);
-            when(mockCampaign.getHumanResources()).thenReturn(mock(HumanResources.class));
+            when(mockCampaign.getHumanResources()).thenReturn(mock(mekhq.campaign.ForceHumanResources.class));
             mockCampaignOptions.setPayForSalaries(true);
             mockCampaignOptions.setUseInfantryDontCount(false);
 
@@ -1825,18 +1824,18 @@ public class AccountantTest {
 
     /**
      * tests
-     * {@link Accountant#getForceValue(java.util.Collection, Hangar, Faction, CampaignOptions, boolean, boolean, double,
+     * {@link Accountant#getForceValue(java.util.Collection, LocalHangar, Faction, CampaignOptions, boolean, boolean, double,
      * double, double, boolean)}
      */
     @Nested
     class TestGetForceValueStatic {
-        Hangar mockHangar;
+        LocalHangar mockHangar;
         CampaignOptions campaignOptions;
         Faction faction;
 
         @BeforeEach
         void beforeEach() {
-            mockHangar = mock(Hangar.class);
+            mockHangar = mock(LocalHangar.class);
             // A mock is used (rather than a real CampaignOptions) because the real setters clamp contract
             // percentages to small real-game maximums (e.g. 5% for combat equipment), which would get in the
             // way of asserting simple round-number totals here.
@@ -2174,7 +2173,7 @@ public class AccountantTest {
 
     /**
      * tests
-     * {@link Accountant#getContractBase(CampaignOptions, Faction, LocalDate, Hangar, java.util.List, int, int,
+     * {@link Accountant#getContractBase(CampaignOptions, Faction, LocalDate, LocalHangar, java.util.List, int, int,
      * java.util.Map, java.util.List)}
      */
     @Nested
@@ -2195,7 +2194,7 @@ public class AccountantTest {
             when(person.getPrimaryRole()).thenReturn(MEKWARRIOR);
             when(person.getSalary(campaignOptions, false, TODAY)).thenReturn(Money.of(1000));
 
-            Hangar mockHangar = mock(Hangar.class);
+            LocalHangar mockHangar = mock(LocalHangar.class);
 
             Money actual = getContractBase(campaignOptions, faction, TODAY, mockHangar, List.of(person), 0, 0,
                   Map.of(), List.of());
@@ -2217,7 +2216,7 @@ public class AccountantTest {
             when(unit.getBuyCost()).thenReturn(Money.of(2000));
             when(unit.isConventionalInfantry()).thenReturn(false);
 
-            Hangar mockHangar = mock(Hangar.class);
+            LocalHangar mockHangar = mock(LocalHangar.class);
             when(mockHangar.getUnit(unitId)).thenReturn(unit);
 
             Formation formation = mock(Formation.class);
@@ -2239,7 +2238,7 @@ public class AccountantTest {
             when(person.getPrimaryRole()).thenReturn(MEKWARRIOR);
             when(person.getSalary(campaignOptions, false, TODAY)).thenReturn(Money.of(1000));
 
-            Hangar mockHangar = mock(Hangar.class);
+            LocalHangar mockHangar = mock(LocalHangar.class);
 
             Money actual = getContractBase(campaignOptions, faction, TODAY, mockHangar, List.of(person), 0, 0,
                   Map.of(), List.of());
@@ -2263,7 +2262,7 @@ public class AccountantTest {
             Unit unit = mock(Unit.class);
             when(unit.getEntity()).thenReturn(entity);
 
-            Hangar mockHangar = mock(Hangar.class);
+            LocalHangar mockHangar = mock(LocalHangar.class);
             when(mockHangar.getUnit(unitId)).thenReturn(unit);
 
             Formation formation = mock(Formation.class);
@@ -2291,7 +2290,7 @@ public class AccountantTest {
             Unit unit = mock(Unit.class);
             when(unit.getEntity()).thenReturn(entity);
 
-            Hangar mockHangar = mock(Hangar.class);
+            LocalHangar mockHangar = mock(LocalHangar.class);
             when(mockHangar.getUnit(unitId)).thenReturn(unit);
 
             Formation formation = mock(Formation.class);
@@ -2319,7 +2318,7 @@ public class AccountantTest {
             when(unit.getAmmoCost()).thenReturn(Money.of(5));
             when(unit.getFuelCost(anyInt())).thenReturn(Money.zero());
 
-            Hangar mockHangar = mock(Hangar.class);
+            LocalHangar mockHangar = mock(LocalHangar.class);
             when(mockHangar.getUnit(unitId)).thenReturn(unit);
 
             Formation formation = mock(Formation.class);
@@ -2390,7 +2389,7 @@ public class AccountantTest {
     class TestInstanceMethodDelegation {
         Campaign mockCampaign;
         CampaignOptions campaignOptions;
-        Hangar mockHangar;
+        LocalHangar mockHangar;
         Accountant accountant;
         final LocalDate TODAY = LocalDate.of(3025, 1, 1);
 
@@ -2398,14 +2397,14 @@ public class AccountantTest {
         void beforeEach() {
             mockCampaign = mock(Campaign.class);
             campaignOptions = new CampaignOptions();
-            mockHangar = mock(Hangar.class);
+            mockHangar = mock(LocalHangar.class);
             accountant = new Accountant(mockCampaign);
 
             when(mockCampaign.getCampaignOptions()).thenReturn(campaignOptions);
             when(mockCampaign.getAllHangar()).thenReturn(mockHangar);
             when(mockCampaign.isClanCampaign()).thenReturn(false);
             when(mockCampaign.getLocalDate()).thenReturn(TODAY);
-            when(mockCampaign.getHumanResources()).thenReturn(mock(HumanResources.class));
+            when(mockCampaign.getHumanResources()).thenReturn(mock(mekhq.campaign.ForceHumanResources.class));
         }
 
         @Test

--- a/MekHQ/unittests/mekhq/campaign/market/ContractMarketAtBGenerationTests.java
+++ b/MekHQ/unittests/mekhq/campaign/market/ContractMarketAtBGenerationTests.java
@@ -54,9 +54,8 @@ import java.util.Vector;
 
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CurrentLocation;
-import mekhq.campaign.Hangar;
 import mekhq.campaign.JumpPath;
-import mekhq.campaign.camOpsReputation.ReputationController;
+import mekhq.campaign.LocalHangar;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.enums.DragoonRating;
 import mekhq.campaign.finances.Accountant;
@@ -102,7 +101,7 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
-        ReputationController camOpsReputation = mock(ReputationController.class);
+        mekhq.campaign.camOpsReputation.ForceReputationController camOpsReputation = mock(mekhq.campaign.camOpsReputation.ForceReputationController.class);
         when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
         when(campaign.getReputation()).thenReturn(camOpsReputation);
 
@@ -121,7 +120,7 @@ public class ContractMarketAtBGenerationTests {
         when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
         when(campaign.getAccountant()).thenReturn(accountant);
 
-        Hangar hangar = mock(Hangar.class);
+        LocalHangar hangar = mock(LocalHangar.class);
         doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
         when(campaign.getAllHangar()).thenReturn(hangar);
 
@@ -207,7 +206,7 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
-        ReputationController camOpsReputation = mock(ReputationController.class);
+        mekhq.campaign.camOpsReputation.ForceReputationController camOpsReputation = mock(mekhq.campaign.camOpsReputation.ForceReputationController.class);
         when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
         when(campaign.getReputation()).thenReturn(camOpsReputation);
 
@@ -226,7 +225,7 @@ public class ContractMarketAtBGenerationTests {
         when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
         when(campaign.getAccountant()).thenReturn(accountant);
 
-        Hangar hangar = mock(Hangar.class);
+        LocalHangar hangar = mock(LocalHangar.class);
         doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
         when(campaign.getAllHangar()).thenReturn(hangar);
 
@@ -315,7 +314,7 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
-        ReputationController camOpsReputation = mock(ReputationController.class);
+        mekhq.campaign.camOpsReputation.ForceReputationController camOpsReputation = mock(mekhq.campaign.camOpsReputation.ForceReputationController.class);
         when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
         when(campaign.getReputation()).thenReturn(camOpsReputation);
 
@@ -334,7 +333,7 @@ public class ContractMarketAtBGenerationTests {
         when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
         when(campaign.getAccountant()).thenReturn(accountant);
 
-        Hangar hangar = mock(Hangar.class);
+        LocalHangar hangar = mock(LocalHangar.class);
         doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
         when(campaign.getAllHangar()).thenReturn(hangar);
 
@@ -423,7 +422,7 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
-        ReputationController camOpsReputation = mock(ReputationController.class);
+        mekhq.campaign.camOpsReputation.ForceReputationController camOpsReputation = mock(mekhq.campaign.camOpsReputation.ForceReputationController.class);
         when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
         when(campaign.getReputation()).thenReturn(camOpsReputation);
 
@@ -442,7 +441,7 @@ public class ContractMarketAtBGenerationTests {
         when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
         when(campaign.getAccountant()).thenReturn(accountant);
 
-        Hangar hangar = mock(Hangar.class);
+        LocalHangar hangar = mock(LocalHangar.class);
         doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
         when(campaign.getAllHangar()).thenReturn(hangar);
 
@@ -540,7 +539,7 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
-        ReputationController camOpsReputation = mock(ReputationController.class);
+        mekhq.campaign.camOpsReputation.ForceReputationController camOpsReputation = mock(mekhq.campaign.camOpsReputation.ForceReputationController.class);
         when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
         when(campaign.getReputation()).thenReturn(camOpsReputation);
 
@@ -559,7 +558,7 @@ public class ContractMarketAtBGenerationTests {
         when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
         when(campaign.getAccountant()).thenReturn(accountant);
 
-        Hangar hangar = mock(Hangar.class);
+        LocalHangar hangar = mock(LocalHangar.class);
         doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
         when(campaign.getAllHangar()).thenReturn(hangar);
 
@@ -653,7 +652,7 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
-        ReputationController camOpsReputation = mock(ReputationController.class);
+        mekhq.campaign.camOpsReputation.ForceReputationController camOpsReputation = mock(mekhq.campaign.camOpsReputation.ForceReputationController.class);
         when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
         when(campaign.getReputation()).thenReturn(camOpsReputation);
 
@@ -692,7 +691,7 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
-        ReputationController camOpsReputation = mock(ReputationController.class);
+        mekhq.campaign.camOpsReputation.ForceReputationController camOpsReputation = mock(mekhq.campaign.camOpsReputation.ForceReputationController.class);
         when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
         when(campaign.getReputation()).thenReturn(camOpsReputation);
 
@@ -711,7 +710,7 @@ public class ContractMarketAtBGenerationTests {
         when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
         when(campaign.getAccountant()).thenReturn(accountant);
 
-        Hangar hangar = mock(Hangar.class);
+        LocalHangar hangar = mock(LocalHangar.class);
         doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
         when(campaign.getAllHangar()).thenReturn(hangar);
 
@@ -800,7 +799,7 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
-        ReputationController camOpsReputation = mock(ReputationController.class);
+        mekhq.campaign.camOpsReputation.ForceReputationController camOpsReputation = mock(mekhq.campaign.camOpsReputation.ForceReputationController.class);
         when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
         when(campaign.getReputation()).thenReturn(camOpsReputation);
 
@@ -819,7 +818,7 @@ public class ContractMarketAtBGenerationTests {
         when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
         when(campaign.getAccountant()).thenReturn(accountant);
 
-        Hangar hangar = mock(Hangar.class);
+        LocalHangar hangar = mock(LocalHangar.class);
         doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
         when(campaign.getAllHangar()).thenReturn(hangar);
 
@@ -900,7 +899,7 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
-        ReputationController camOpsReputation = mock(ReputationController.class);
+        mekhq.campaign.camOpsReputation.ForceReputationController camOpsReputation = mock(mekhq.campaign.camOpsReputation.ForceReputationController.class);
         when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
         when(campaign.getReputation()).thenReturn(camOpsReputation);
 
@@ -919,7 +918,7 @@ public class ContractMarketAtBGenerationTests {
         when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
         when(campaign.getAccountant()).thenReturn(accountant);
 
-        Hangar hangar = mock(Hangar.class);
+        LocalHangar hangar = mock(LocalHangar.class);
         doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
         when(campaign.getAllHangar()).thenReturn(hangar);
 
@@ -1008,7 +1007,7 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
-        ReputationController camOpsReputation = mock(ReputationController.class);
+        mekhq.campaign.camOpsReputation.ForceReputationController camOpsReputation = mock(mekhq.campaign.camOpsReputation.ForceReputationController.class);
         when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
         when(campaign.getReputation()).thenReturn(camOpsReputation);
 
@@ -1027,7 +1026,7 @@ public class ContractMarketAtBGenerationTests {
         when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
         when(campaign.getAccountant()).thenReturn(accountant);
 
-        Hangar hangar = mock(Hangar.class);
+        LocalHangar hangar = mock(LocalHangar.class);
         doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
         when(campaign.getAllHangar()).thenReturn(hangar);
 
@@ -1112,7 +1111,7 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
-        ReputationController camOpsReputation = mock(ReputationController.class);
+        mekhq.campaign.camOpsReputation.ForceReputationController camOpsReputation = mock(mekhq.campaign.camOpsReputation.ForceReputationController.class);
         when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
         when(campaign.getReputation()).thenReturn(camOpsReputation);
 
@@ -1131,7 +1130,7 @@ public class ContractMarketAtBGenerationTests {
         when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
         when(campaign.getAccountant()).thenReturn(accountant);
 
-        Hangar hangar = mock(Hangar.class);
+        LocalHangar hangar = mock(LocalHangar.class);
         doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
         when(campaign.getAllHangar()).thenReturn(hangar);
 
@@ -1220,7 +1219,7 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
-        ReputationController camOpsReputation = mock(ReputationController.class);
+        mekhq.campaign.camOpsReputation.ForceReputationController camOpsReputation = mock(mekhq.campaign.camOpsReputation.ForceReputationController.class);
         when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
         when(campaign.getReputation()).thenReturn(camOpsReputation);
 
@@ -1239,7 +1238,7 @@ public class ContractMarketAtBGenerationTests {
         when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
         when(campaign.getAccountant()).thenReturn(accountant);
 
-        Hangar hangar = mock(Hangar.class);
+        LocalHangar hangar = mock(LocalHangar.class);
         doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
         when(campaign.getAllHangar()).thenReturn(hangar);
 
@@ -1328,7 +1327,7 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
-        ReputationController camOpsReputation = mock(ReputationController.class);
+        mekhq.campaign.camOpsReputation.ForceReputationController camOpsReputation = mock(mekhq.campaign.camOpsReputation.ForceReputationController.class);
         when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
         when(campaign.getReputation()).thenReturn(camOpsReputation);
 
@@ -1347,7 +1346,7 @@ public class ContractMarketAtBGenerationTests {
         when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
         when(campaign.getAccountant()).thenReturn(accountant);
 
-        Hangar hangar = mock(Hangar.class);
+        LocalHangar hangar = mock(LocalHangar.class);
         doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
         when(campaign.getAllHangar()).thenReturn(hangar);
 
@@ -1436,7 +1435,7 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
-        ReputationController camOpsReputation = mock(ReputationController.class);
+        mekhq.campaign.camOpsReputation.ForceReputationController camOpsReputation = mock(mekhq.campaign.camOpsReputation.ForceReputationController.class);
         when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
         when(campaign.getReputation()).thenReturn(camOpsReputation);
 
@@ -1455,7 +1454,7 @@ public class ContractMarketAtBGenerationTests {
         when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
         when(campaign.getAccountant()).thenReturn(accountant);
 
-        Hangar hangar = mock(Hangar.class);
+        LocalHangar hangar = mock(LocalHangar.class);
         doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
         when(campaign.getAllHangar()).thenReturn(hangar);
 
@@ -1542,7 +1541,7 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
-        ReputationController camOpsReputation = mock(ReputationController.class);
+        mekhq.campaign.camOpsReputation.ForceReputationController camOpsReputation = mock(mekhq.campaign.camOpsReputation.ForceReputationController.class);
         when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
         when(campaign.getReputation()).thenReturn(camOpsReputation);
 
@@ -1562,7 +1561,7 @@ public class ContractMarketAtBGenerationTests {
         when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
         when(campaign.getAccountant()).thenReturn(accountant);
 
-        Hangar hangar = mock(Hangar.class);
+        LocalHangar hangar = mock(LocalHangar.class);
         doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
         when(campaign.getAllHangar()).thenReturn(hangar);
 
@@ -1651,7 +1650,7 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
-        ReputationController camOpsReputation = mock(ReputationController.class);
+        mekhq.campaign.camOpsReputation.ForceReputationController camOpsReputation = mock(mekhq.campaign.camOpsReputation.ForceReputationController.class);
         when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
         when(campaign.getReputation()).thenReturn(camOpsReputation);
 
@@ -1671,7 +1670,7 @@ public class ContractMarketAtBGenerationTests {
         when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
         when(campaign.getAccountant()).thenReturn(accountant);
 
-        Hangar hangar = mock(Hangar.class);
+        LocalHangar hangar = mock(LocalHangar.class);
         doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
         when(campaign.getAllHangar()).thenReturn(hangar);
 
@@ -1759,7 +1758,7 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
-        ReputationController camOpsReputation = mock(ReputationController.class);
+        mekhq.campaign.camOpsReputation.ForceReputationController camOpsReputation = mock(mekhq.campaign.camOpsReputation.ForceReputationController.class);
         when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
         when(campaign.getReputation()).thenReturn(camOpsReputation);
 
@@ -1779,7 +1778,7 @@ public class ContractMarketAtBGenerationTests {
         when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
         when(campaign.getAccountant()).thenReturn(accountant);
 
-        Hangar hangar = mock(Hangar.class);
+        LocalHangar hangar = mock(LocalHangar.class);
         doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
         when(campaign.getAllHangar()).thenReturn(hangar);
 
@@ -1868,7 +1867,7 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
-        ReputationController camOpsReputation = mock(ReputationController.class);
+        mekhq.campaign.camOpsReputation.ForceReputationController camOpsReputation = mock(mekhq.campaign.camOpsReputation.ForceReputationController.class);
         when(camOpsReputation.getReputationFactor()).thenReturn(0.0);
         when(campaign.getReputation()).thenReturn(camOpsReputation);
 
@@ -1888,7 +1887,7 @@ public class ContractMarketAtBGenerationTests {
         when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
         when(campaign.getAccountant()).thenReturn(accountant);
 
-        Hangar hangar = mock(Hangar.class);
+        LocalHangar hangar = mock(LocalHangar.class);
         doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
         when(campaign.getAllHangar()).thenReturn(hangar);
 

--- a/MekHQ/unittests/mekhq/campaign/market/contractMarket/AlternatePaymentModelValuesTest.java
+++ b/MekHQ/unittests/mekhq/campaign/market/contractMarket/AlternatePaymentModelValuesTest.java
@@ -59,7 +59,6 @@ import megamek.common.units.Entity;
 import megamek.common.units.EntityMovementMode;
 import megamek.common.units.Infantry;
 import megamek.common.units.LandAirMek;
-import mekhq.campaign.Hangar;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.force.CombatTeam;
 import mekhq.campaign.force.Formation;
@@ -67,9 +66,9 @@ import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Faction;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.MockedStatic;
 
 class AlternatePaymentModelValuesTest {
     @Test
@@ -79,13 +78,24 @@ class AlternatePaymentModelValuesTest {
         assertEquals(Money.of(50_000_000), AlternatePaymentModelValues.LARGE_CRAFT.getValue());
     }
 
+    private static Formation mockForce(boolean isStandard, boolean isCombatRole, List<Unit> units) {
+        Formation formation = mock(Formation.class, RETURNS_DEEP_STUBS);
+
+        when(formation.getFormationType().isStandard()).thenReturn(isStandard);
+        when(formation.getCombatRoleInMemory().isCombatRole()).thenReturn(isCombatRole);
+
+        when(formation.getUnitsAsUnits(any(mekhq.campaign.LocalHangar.class))).thenReturn(units);
+
+        return formation;
+    }
+
     @Test
     void getForceValue_skipsNonStandardForces() {
         Formation nonStandard = mockForce(false, true, List.of(mockUnitWithEntity(mock(Entity.class))));
         Money total = AlternatePaymentModelValues.getForceValue(
               dummyFaction(),
               List.of(nonStandard),
-              mock(Hangar.class),
+              mock(mekhq.campaign.LocalHangar.class),
               false,
               false,
               100, 100, 100, 100
@@ -99,7 +109,7 @@ class AlternatePaymentModelValuesTest {
         Money total = AlternatePaymentModelValues.getForceValue(
               dummyFaction(),
               List.of(nonCombat),
-              mock(Hangar.class),
+              mock(mekhq.campaign.LocalHangar.class),
               false,
               false,
               100, 100, 100, 100
@@ -121,7 +131,7 @@ class AlternatePaymentModelValuesTest {
         Money total = AlternatePaymentModelValues.getForceValue(
               dummyFaction(),
               List.of(formation),
-              mock(Hangar.class),
+              mock(mekhq.campaign.LocalHangar.class),
               false,
               false,
               100, 100, 100, 100
@@ -133,7 +143,7 @@ class AlternatePaymentModelValuesTest {
     @Test
     void getForceValue_doesNotUseDiminishingReturnsWhenDisabled_evenIfUnitCountExceedsStart() {
         Faction faction = dummyFaction();
-        Hangar hangar = mock(Hangar.class);
+        mekhq.campaign.LocalHangar hangar = mock(mekhq.campaign.LocalHangar.class);
 
         // 3 ProtoMeks @ 100% combat multiplier => raw total = 3,000,000
         Formation formation = mockForce(true, true, List.of(
@@ -164,7 +174,7 @@ class AlternatePaymentModelValuesTest {
     @Test
     void getForceValue_usesDiminishingReturnsOnlyWhenEnabled_andUnitCountExceedsStart() {
         Faction faction = dummyFaction();
-        Hangar hangar = mock(Hangar.class);
+        mekhq.campaign.LocalHangar hangar = mock(mekhq.campaign.LocalHangar.class);
 
         // 3 ProtoMeks @ 100% combat multiplier => raw total = 3,000,000
         Formation formation = mockForce(true, true, List.of(
@@ -199,27 +209,6 @@ class AlternatePaymentModelValuesTest {
             assertEquals(diminishedExpected, actual,
                   "When enabled and unit count exceeds start, total must be the diminished-returns sum");
         }
-    }
-
-    @Test
-    void getForceValue_appliesPercentMultipliersByDividingBy100_usingProtoMekBranch() {
-        Entity protoMek = mock(Entity.class);
-        when(protoMek.isProtoMek()).thenReturn(true);
-
-        Unit unit = mockUnitWithEntity(protoMek);
-        Formation formation = mockForce(true, true, List.of(unit));
-
-        // 50% combat multiplier => PROTOMEK(1_000_000) * 0.5 = 500_000
-        Money total = AlternatePaymentModelValues.getForceValue(
-              dummyFaction(),
-              List.of(formation),
-              mock(Hangar.class),
-              false,
-              false,
-              50, 0, 0, 0
-        );
-
-        assertEquals(Money.of(500_000), total);
     }
 
     @Nested
@@ -468,15 +457,25 @@ class AlternatePaymentModelValuesTest {
         }
     }
 
-    private static Formation mockForce(boolean isStandard, boolean isCombatRole, List<Unit> units) {
-        Formation formation = mock(Formation.class, RETURNS_DEEP_STUBS);
+    @Test
+    void getForceValue_appliesPercentMultipliersByDividingBy100_usingProtoMekBranch() {
+        Entity protoMek = mock(Entity.class);
+        when(protoMek.isProtoMek()).thenReturn(true);
 
-        when(formation.getFormationType().isStandard()).thenReturn(isStandard);
-        when(formation.getCombatRoleInMemory().isCombatRole()).thenReturn(isCombatRole);
+        Unit unit = mockUnitWithEntity(protoMek);
+        Formation formation = mockForce(true, true, List.of(unit));
 
-        when(formation.getUnitsAsUnits(any(Hangar.class))).thenReturn(units);
+        // 50% combat multiplier => PROTOMEK(1_000_000) * 0.5 = 500_000
+        Money total = AlternatePaymentModelValues.getForceValue(
+              dummyFaction(),
+              List.of(formation),
+              mock(mekhq.campaign.LocalHangar.class),
+              false,
+              false,
+              50, 0, 0, 0
+        );
 
-        return formation;
+        assertEquals(Money.of(500_000), total);
     }
 
     private static Unit mockUnitWithEntity(Entity entity) {

--- a/MekHQ/unittests/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarketTest.java
+++ b/MekHQ/unittests/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarketTest.java
@@ -53,9 +53,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Hangar;
 import mekhq.campaign.JumpPath;
-import mekhq.campaign.camOpsReputation.ReputationController;
+import mekhq.campaign.LocalHangar;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.enums.DragoonRating;
 import mekhq.campaign.finances.Accountant;
@@ -146,7 +145,7 @@ class AtbMonthlyContractMarketTest {
             CampaignOptions campaignOptions = mock(CampaignOptions.class);
             when(campaignOptions.getContractMaxSalvagePercentage()).thenReturn(100);
 
-            ReputationController reputation = mock(ReputationController.class);
+            mekhq.campaign.camOpsReputation.ForceReputationController reputation = mock(mekhq.campaign.camOpsReputation.ForceReputationController.class);
             when(reputation.getReputationFactor()).thenReturn(1.0);
             when(reputation.getAverageSkillLevel()).thenReturn(REGULAR);
 
@@ -155,7 +154,7 @@ class AtbMonthlyContractMarketTest {
             when(accountant.getOverheadExpenses()).thenReturn(Money.of(1));
             when(accountant.getPeacetimeCost()).thenReturn(Money.of(1));
 
-            Hangar hangar = mock(Hangar.class);
+            LocalHangar hangar = mock(LocalHangar.class);
             doReturn(Money.of(1)).when(hangar).getUnitCosts(any(), any());
 
             when(campaign.getFaction()).thenReturn(employerFaction);

--- a/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
@@ -55,7 +55,6 @@ import megamek.common.equipment.EquipmentType;
 import megamek.common.units.Entity;
 import megamek.common.units.UnitType;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Hangar;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.force.CombatTeam;
 import mekhq.campaign.force.Formation;
@@ -271,7 +270,7 @@ public class AtBContractTest {
         Faction mockFaction;
         Campaign mockCampaign;
 
-        Hangar hangar;
+        mekhq.campaign.LocalHangar hangar;
 
         public static Stream<Arguments> getFormationSizesForTests() {
             return Stream.of(
@@ -285,7 +284,7 @@ public class AtBContractTest {
         @BeforeEach
         void beforeEach() {
             nextForceId = 0;
-            hangar = new Hangar();
+            hangar = new mekhq.campaign.LocalHangar();
 
             mockFaction = mock(Faction.class);
             mockCampaign = mock(Campaign.class);

--- a/MekHQ/unittests/mekhq/campaign/parts/ArmorTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/ArmorTest.java
@@ -44,7 +44,6 @@ import megamek.common.enums.TechRating;
 import megamek.common.equipment.EquipmentType;
 import megamek.common.units.Entity;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Warehouse;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.parts.enums.PartQuality;
 import mekhq.campaign.parts.protomeks.ProtoMekArmor;
@@ -66,7 +65,7 @@ public class ArmorTest {
 
     static Campaign mockCampaign;
     static CampaignOptions mockCampaignOptions;
-    Warehouse warehouse;
+    mekhq.campaign.LocalWarehouse warehouse;
 
     @BeforeAll
     static void beforeAll() {
@@ -90,7 +89,7 @@ public class ArmorTest {
 
     @BeforeEach
     public void beforeEach() {
-        warehouse = new Warehouse();
+        warehouse = new mekhq.campaign.LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
     }
 

--- a/MekHQ/unittests/mekhq/campaign/parts/MekLocationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/MekLocationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -70,8 +70,7 @@ import megamek.common.units.Entity;
 import megamek.common.units.LandAirMek;
 import megamek.common.units.Mek;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Quartermaster;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.parts.enums.PartRepairType;
 import mekhq.campaign.parts.equipment.EquipmentPart;
@@ -1468,9 +1467,9 @@ class MekLocationTest {
     @Test
     void removeSimpleTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
         Unit unit = mock(Unit.class);
         doAnswer(inv -> {
@@ -1510,9 +1509,9 @@ class MekLocationTest {
     @Test
     void removeHeadWithoutComponentsTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
         Unit unit = mock(Unit.class);
         doAnswer(inv -> {
@@ -1541,9 +1540,9 @@ class MekLocationTest {
     @Test
     void removeHeadWithSensorComponentTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
         Unit unit = mock(Unit.class);
         doAnswer(inv -> {
@@ -1578,9 +1577,9 @@ class MekLocationTest {
     @Test
     void removeHeadWithLifeSupportComponentTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
         Unit unit = mock(Unit.class);
         doAnswer(inv -> {
@@ -1615,9 +1614,9 @@ class MekLocationTest {
     @Test
     void removeHeadWithComponentsTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
         Unit unit = mock(Unit.class);
         doAnswer(inv -> {
@@ -1654,9 +1653,9 @@ class MekLocationTest {
     @Test
     void removeCenterTorsoDoesntAddMissingPartTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
         Unit unit = mock(Unit.class);
         doAnswer(inv -> {
@@ -1685,9 +1684,9 @@ class MekLocationTest {
     @Test
     void updateConditionFromEntityNoInternalsRemovesLocationTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster mockQuartermaster = mock(Quartermaster.class);
+        mekhq.campaign.ForceQuartermaster mockQuartermaster = mock(mekhq.campaign.ForceQuartermaster.class);
         when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
         Unit unit = mock(Unit.class);
         Entity entity = mock(Entity.class);
@@ -1721,9 +1720,9 @@ class MekLocationTest {
     @Test
     void salvageSimpleTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
         Unit unit = mock(Unit.class);
         doAnswer(inv -> {
@@ -1767,9 +1766,9 @@ class MekLocationTest {
     @Test
     void salvageCenterTorsoDoesntAddMissingPartTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
         Unit unit = mock(Unit.class);
         doAnswer(inv -> {

--- a/MekHQ/unittests/mekhq/campaign/parts/MissingPartTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/MissingPartTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -46,8 +46,7 @@ import java.util.UUID;
 import megamek.common.equipment.EquipmentType;
 import megamek.common.units.Mek;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Quartermaster;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.parts.meks.MekLocation;
 import mekhq.campaign.parts.missing.MissingMekLocation;
 import mekhq.campaign.parts.missing.MissingPart;
@@ -59,9 +58,9 @@ public class MissingPartTest {
     @Test
     public void reservePartDoesNothingWithoutTheRightPart() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Add a not-suitable parts to the warehouse
@@ -89,9 +88,9 @@ public class MissingPartTest {
     @Test
     public void reservePartDoesNothingWithoutATech() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Add a suitable parts to the warehouse
@@ -113,9 +112,9 @@ public class MissingPartTest {
     @Test
     public void reservePartFindsTheRightPart() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Add a suitable parts to the warehouse
@@ -151,9 +150,9 @@ public class MissingPartTest {
     @Test
     public void reservePartTakesJustOne() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Add a few suitable parts to the warehouse
@@ -198,9 +197,9 @@ public class MissingPartTest {
     @Test
     public void cancelReservationReturnsThePart() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Add a suitable parts to the warehouse
@@ -240,9 +239,9 @@ public class MissingPartTest {
     @Test
     public void cancelReservationReturnsJustOnePart() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Add a few suitable parts to the warehouse
@@ -292,9 +291,9 @@ public class MissingPartTest {
     @Test
     public void cancelReservationReturnsNothingIfReplacementUsed() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Add a few suitable parts to the warehouse

--- a/MekHQ/unittests/mekhq/campaign/parts/PartTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/PartTest.java
@@ -51,7 +51,7 @@ import megamek.common.units.Entity;
 import megamek.common.units.Mek;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.FixedLocation;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.base.PlayerBase;
 import mekhq.campaign.location.LocationNode;
 import mekhq.campaign.parts.meks.MekLocation;
@@ -152,7 +152,7 @@ public class PartTest {
     @Test
     public void decrementQuantity() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Part part = new MekLocation();
         part.setCampaign(mockCampaign);
@@ -179,7 +179,7 @@ public class PartTest {
     @Test
     public void decrementQuantityDoesNotGoNegative() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Part part = new MekLocation();
         part.setCampaign(mockCampaign);
@@ -200,7 +200,7 @@ public class PartTest {
     @Test
     public void decrementQuantityZeroRemovesChildParts() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Part part = new MekLocation();
         part.setCampaign(mockCampaign);
@@ -228,7 +228,7 @@ public class PartTest {
     @Test
     public void setQuantity() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Part part = new MekLocation();
         part.setCampaign(mockCampaign);
@@ -250,7 +250,7 @@ public class PartTest {
     @Test
     public void setNegativeQuantity() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Part part = new MekLocation();
         part.setCampaign(mockCampaign);
@@ -272,7 +272,7 @@ public class PartTest {
     @Test
     public void setQuantityZeroRemovesChildParts() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Part part = new MekLocation();
         part.setCampaign(mockCampaign);
@@ -461,7 +461,7 @@ public class PartTest {
         @Test
         void getWarehouse_sparePartInCampaignWarehouse_returnsCampaignWarehouse() {
             Campaign mockCampaign = mock(Campaign.class);
-            Warehouse campaignWarehouse = new Warehouse();
+            LocalWarehouse campaignWarehouse = new LocalWarehouse();
             when(mockCampaign.getWarehouse()).thenReturn(campaignWarehouse);
 
             Part part = new MekSensor();
@@ -474,7 +474,7 @@ public class PartTest {
         @Test
         void getWarehouse_sparePartInBaseWarehouse_returnsBaseWarehouse() {
             Campaign mockCampaign = mock(Campaign.class);
-            Warehouse campaignWarehouse = new Warehouse();
+            LocalWarehouse campaignWarehouse = new LocalWarehouse();
             when(mockCampaign.getWarehouse()).thenReturn(campaignWarehouse);
 
             PlayerBase base = new PlayerBase(new FixedLocation(mock(PlanetarySystem.class)));
@@ -489,7 +489,7 @@ public class PartTest {
         @Test
         void getWarehouse_partOnUnitAtBase_returnsBaseWarehouse() {
             Campaign mockCampaign = mock(Campaign.class);
-            Warehouse campaignWarehouse = new Warehouse();
+            LocalWarehouse campaignWarehouse = new LocalWarehouse();
             when(mockCampaign.getWarehouse()).thenReturn(campaignWarehouse);
 
             PlayerBase base = new PlayerBase(new FixedLocation(mock(PlanetarySystem.class)));
@@ -514,7 +514,7 @@ public class PartTest {
         @Test
         void getWarehouse_partOnMainForceUnit_returnsCampaignWarehouse() {
             Campaign mockCampaign = mock(Campaign.class);
-            Warehouse campaignWarehouse = new Warehouse();
+            LocalWarehouse campaignWarehouse = new LocalWarehouse();
             when(mockCampaign.getWarehouse()).thenReturn(campaignWarehouse);
 
             // Unit with a locationNode that has no IPlace ancestor.

--- a/MekHQ/unittests/mekhq/campaign/parts/RefitTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/RefitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -64,12 +64,11 @@ import megamek.common.options.GameOptions;
 import megamek.common.options.OptionsConstants;
 import megamek.common.units.Entity;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Hangar;
-import mekhq.campaign.Quartermaster;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalHangar;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.finances.Money;
-import mekhq.campaign.market.ShoppingList;
+import mekhq.campaign.market.ForceShoppingList;
 import mekhq.campaign.parts.equipment.AmmoBin;
 import mekhq.campaign.parts.equipment.EquipmentPart;
 import mekhq.campaign.parts.equipment.MissingEquipmentPart;
@@ -109,10 +108,10 @@ public class RefitTest {
     private Board mockBoard;
 
     @Mock
-    private Quartermaster mockQuartermaster;
+    private mekhq.campaign.ForceQuartermaster mockQuartermaster;
 
     @Mock
-    private Warehouse mockWarehouse;
+    private LocalWarehouse mockWarehouse;
 
     @BeforeAll
     static void before() {
@@ -788,9 +787,9 @@ public class RefitTest {
     @MockitoSettings(strictness = Strictness.LENIENT)
     // Allegedly unnecessary stubbing for the mockHanger & mockShoppingList
     public void heavyTrackedApcMgToStandard() throws EntityLoadingException, IOException {
-        final Hangar mockHangar = mock(Hangar.class);
+        final LocalHangar mockHangar = mock(LocalHangar.class);
         when(mockCampaign.getHangar()).thenReturn(mockHangar);
-        final ShoppingList mockShoppingList = mock(ShoppingList.class);
+        final ForceShoppingList mockShoppingList = mock(ForceShoppingList.class);
         when(mockCampaign.getShoppingList()).thenReturn(mockShoppingList);
 
         // Create the original entity backing the unit

--- a/MekHQ/unittests/mekhq/campaign/parts/TotalBuyCostTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/TotalBuyCostTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -46,7 +46,6 @@ import megamek.common.units.Mek;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.finances.Money;
-import mekhq.campaign.market.ShoppingList;
 import mekhq.campaign.parts.meks.MekCockpit;
 import mekhq.campaign.parts.meks.MekSensor;
 import mekhq.campaign.work.IAcquisitionWork;
@@ -85,7 +84,7 @@ public class TotalBuyCostTest {
 
     @Test
     public void emptyShoppingList() {
-        ShoppingList testShoppingList = new ShoppingList();
+        mekhq.campaign.market.ForceShoppingList testShoppingList = new mekhq.campaign.market.ForceShoppingList();
         Money totalBuyValue = testShoppingList.getTotalBuyCost();
         assertTrue(testShoppingList.getPartList().isEmpty());
         assertTrue(totalBuyValue.isZero());
@@ -93,7 +92,7 @@ public class TotalBuyCostTest {
 
     @Test
     public void onePartInShoppingList() {
-        ShoppingList testShoppingList = new ShoppingList();
+        mekhq.campaign.market.ForceShoppingList testShoppingList = new mekhq.campaign.market.ForceShoppingList();
         mockCampaign.setShoppingList(testShoppingList);
         Part part = new MekSensor(1, mockCampaign);
         IAcquisitionWork shoppingListItem = part.getAcquisitionWork();
@@ -105,7 +104,7 @@ public class TotalBuyCostTest {
 
     @Test
     public void incrementPartInShoppingList() {
-        ShoppingList testShoppingList = new ShoppingList();
+        mekhq.campaign.market.ForceShoppingList testShoppingList = new mekhq.campaign.market.ForceShoppingList();
         mockCampaign.setShoppingList(testShoppingList);
         Part part = new MekSensor(1, mockCampaign);
         IAcquisitionWork shoppingListItem = part.getAcquisitionWork();
@@ -122,7 +121,7 @@ public class TotalBuyCostTest {
 
     @Test
     public void decrementPartInShoppingList() {
-        ShoppingList testShoppingList = new ShoppingList();
+        mekhq.campaign.market.ForceShoppingList testShoppingList = new mekhq.campaign.market.ForceShoppingList();
         mockCampaign.setShoppingList(testShoppingList);
         Part part = new MekSensor(1, mockCampaign);
         IAcquisitionWork shoppingListItem = part.getAcquisitionWork();
@@ -144,7 +143,7 @@ public class TotalBuyCostTest {
 
     @Test
     public void addDifferentPartsInShoppingList() {
-        ShoppingList testShoppingList = new ShoppingList();
+        mekhq.campaign.market.ForceShoppingList testShoppingList = new mekhq.campaign.market.ForceShoppingList();
         mockCampaign.setShoppingList(testShoppingList);
         Part partA = new MekSensor(1, mockCampaign);
         Part partB = new MekCockpit(2, Mek.COCKPIT_SMALL, false, mockCampaign);

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/AmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/AmmoBinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -58,15 +58,13 @@ import javax.xml.parsers.ParserConfigurationException;
 import megamek.Version;
 import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.AmmoType;
-import megamek.common.equipment.EquipmentType;
 import megamek.common.equipment.Mounted;
 import megamek.common.equipment.WeaponMounted;
 import megamek.common.equipment.WeaponType;
 import megamek.common.units.Entity;
 import megamek.common.units.ProtoMek;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Quartermaster;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.parts.AmmoStorage;
 import mekhq.campaign.parts.Part;
@@ -706,9 +704,9 @@ public class AmmoBinTest {
     @Test
     public void unloadEmptyBinTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
@@ -727,9 +725,9 @@ public class AmmoBinTest {
     @Test
     public void unloadFullBinTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
@@ -757,9 +755,9 @@ public class AmmoBinTest {
     @Test
     public void unloadPartialBinTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
@@ -789,9 +787,9 @@ public class AmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
@@ -813,9 +811,9 @@ public class AmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
@@ -846,9 +844,9 @@ public class AmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
@@ -877,9 +875,9 @@ public class AmmoBinTest {
     @Test
     public void loadBinWithoutUnitDoesNothing() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
@@ -900,9 +898,9 @@ public class AmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
@@ -935,9 +933,9 @@ public class AmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
@@ -977,9 +975,9 @@ public class AmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
@@ -1018,9 +1016,9 @@ public class AmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
@@ -1060,9 +1058,9 @@ public class AmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
@@ -1123,9 +1121,9 @@ public class AmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
@@ -1185,9 +1183,9 @@ public class AmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("IS Ammo RL-10");
@@ -1237,9 +1235,9 @@ public class AmmoBinTest {
     @Test
     public void fixBinWithoutUnitDoesNothing() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
@@ -1260,9 +1258,9 @@ public class AmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
@@ -1295,9 +1293,9 @@ public class AmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
@@ -1337,9 +1335,9 @@ public class AmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
@@ -1378,9 +1376,9 @@ public class AmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
@@ -1420,9 +1418,9 @@ public class AmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
@@ -1483,9 +1481,9 @@ public class AmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM6 Ammo");

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/BattleArmorAmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/BattleArmorAmmoBinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -52,13 +52,12 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
 
 import megamek.Version;
-import megamek.common.equipment.AmmoType;
 import megamek.common.battleArmor.BattleArmor;
-import megamek.common.equipment.Mounted;
 import megamek.common.equipment.AmmoMounted;
+import megamek.common.equipment.AmmoType;
+import megamek.common.equipment.Mounted;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Quartermaster;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.unit.Unit;
@@ -312,8 +311,8 @@ public class BattleArmorAmmoBinTest {
 
         Campaign mockCampaign;
         CampaignOptions mockCampaignOptions;
-        Warehouse warehouse;
-        Quartermaster quartermaster;
+        LocalWarehouse warehouse;
+        mekhq.campaign.ForceQuartermaster quartermaster;
         Unit mockUnit;
         BattleArmor mockEntity;
         AmmoMounted mockMounted;
@@ -323,9 +322,9 @@ public class BattleArmorAmmoBinTest {
             mockCampaign = mock(Campaign.class);
             mockCampaignOptions = mock(CampaignOptions.class);
             when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-            warehouse = new Warehouse();
+            warehouse = new LocalWarehouse();
             when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-            quartermaster = new Quartermaster(mockCampaign);
+            quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
             when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
             mockUnit = mock(Unit.class);

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/EquipmentPartTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/EquipmentPartTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -69,8 +69,7 @@ import megamek.common.units.Mek;
 import megamek.common.units.SmallCraft;
 import megamek.common.weapons.bayWeapons.BayWeapon;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Quartermaster;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.unit.Unit;
@@ -537,9 +536,9 @@ public class EquipmentPartTest {
     @Test
     public void removeTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         Unit unit = mock(Unit.class);
@@ -602,9 +601,9 @@ public class EquipmentPartTest {
     @Test
     public void salvageTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         Unit unit = mock(Unit.class);
@@ -1126,9 +1125,9 @@ public class EquipmentPartTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions campaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(campaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         Unit unit = mock(Unit.class);
@@ -1221,9 +1220,9 @@ public class EquipmentPartTest {
     @Test
     public void updateConditionFromEntityMissingTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         Unit unit = mock(Unit.class);
@@ -1449,9 +1448,9 @@ public class EquipmentPartTest {
     @Test
     public void checkWeaponBayOnlyWeaponRemovedTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         Unit unit = mock(Unit.class);
@@ -1531,9 +1530,9 @@ public class EquipmentPartTest {
     @Test
     public void checkWeaponBayWeaponRemovedOthersOkayTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         Unit unit = mock(Unit.class);
@@ -1619,9 +1618,9 @@ public class EquipmentPartTest {
     @Test
     public void checkWeaponBayWeaponRemovedOthersDestroyedTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         Unit unit = mock(Unit.class);
@@ -1708,9 +1707,9 @@ public class EquipmentPartTest {
     @Test
     public void checkWeaponBayUpdateConditionFromPartGoodWeaponTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         Unit unit = mock(Unit.class);

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/InfantryAmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/InfantryAmmoBinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -58,17 +58,16 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
 
 import megamek.Version;
-import megamek.common.equipment.AmmoType;
-import megamek.common.units.Entity;
-import megamek.common.equipment.EquipmentTypeLookup;
-import megamek.common.units.Infantry;
-import megamek.common.equipment.Mounted;
-import megamek.common.units.SupportTank;
 import megamek.common.equipment.AmmoMounted;
+import megamek.common.equipment.AmmoType;
+import megamek.common.equipment.EquipmentTypeLookup;
+import megamek.common.equipment.Mounted;
+import megamek.common.units.Entity;
+import megamek.common.units.Infantry;
+import megamek.common.units.SupportTank;
 import megamek.common.weapons.infantry.InfantryWeapon;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Quartermaster;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.parts.InfantryAmmoStorage;
 import mekhq.campaign.parts.Part;
@@ -592,9 +591,9 @@ public class InfantryAmmoBinTest {
     @Test
     public void unloadEmptyBinTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
@@ -623,9 +622,9 @@ public class InfantryAmmoBinTest {
     @Test
     public void unloadFullBinTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
@@ -663,9 +662,9 @@ public class InfantryAmmoBinTest {
     @Test
     public void unloadPartialBinTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
@@ -704,9 +703,9 @@ public class InfantryAmmoBinTest {
     @Test
     public void salvageEmptyBinTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
@@ -736,9 +735,9 @@ public class InfantryAmmoBinTest {
     @Test
     public void salvageFullBinTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
@@ -777,9 +776,9 @@ public class InfantryAmmoBinTest {
     @Test
     public void salvagePartialBinTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
@@ -817,9 +816,9 @@ public class InfantryAmmoBinTest {
     @Test
     public void loadBinWithoutUnitDoesNothing() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
@@ -849,9 +848,9 @@ public class InfantryAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
@@ -893,9 +892,9 @@ public class InfantryAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
@@ -944,9 +943,9 @@ public class InfantryAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
@@ -994,9 +993,9 @@ public class InfantryAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
@@ -1045,9 +1044,9 @@ public class InfantryAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
@@ -1118,9 +1117,9 @@ public class InfantryAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
@@ -1188,9 +1187,9 @@ public class InfantryAmmoBinTest {
     @Test
     public void fixBinWithoutUnitDoesNothing() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
@@ -1220,9 +1219,9 @@ public class InfantryAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
@@ -1264,9 +1263,9 @@ public class InfantryAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
@@ -1315,9 +1314,9 @@ public class InfantryAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
@@ -1365,9 +1364,9 @@ public class InfantryAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
@@ -1416,9 +1415,9 @@ public class InfantryAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
@@ -1488,9 +1487,9 @@ public class InfantryAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
@@ -1676,9 +1675,9 @@ public class InfantryAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/LargeCraftAmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/LargeCraftAmmoBinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -58,14 +58,13 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
 
 import megamek.Version;
-import megamek.common.equipment.AmmoType;
-import megamek.common.units.Entity;
-import megamek.common.equipment.Mounted;
 import megamek.common.equipment.AmmoMounted;
+import megamek.common.equipment.AmmoType;
+import megamek.common.equipment.Mounted;
 import megamek.common.equipment.WeaponMounted;
+import megamek.common.units.Entity;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Quartermaster;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.parts.AmmoStorage;
 import mekhq.campaign.parts.Part;
@@ -553,9 +552,9 @@ public class LargeCraftAmmoBinTest {
     @Test
     public void unloadEmptyBinTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
@@ -576,9 +575,9 @@ public class LargeCraftAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
@@ -608,9 +607,9 @@ public class LargeCraftAmmoBinTest {
     @Test
     public void unloadPartialBinTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
@@ -640,9 +639,9 @@ public class LargeCraftAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
@@ -664,9 +663,9 @@ public class LargeCraftAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
@@ -698,9 +697,9 @@ public class LargeCraftAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
@@ -730,9 +729,9 @@ public class LargeCraftAmmoBinTest {
     @Test
     public void unloadSingleTonEmptyBinTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
@@ -770,9 +769,9 @@ public class LargeCraftAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
@@ -822,9 +821,9 @@ public class LargeCraftAmmoBinTest {
     @Test
     public void unloadSingleTonPartialBinTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
@@ -875,9 +874,9 @@ public class LargeCraftAmmoBinTest {
     @Test
     public void loadBinWithoutUnitDoesNothing() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
@@ -899,9 +898,9 @@ public class LargeCraftAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
@@ -940,9 +939,9 @@ public class LargeCraftAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
@@ -988,9 +987,9 @@ public class LargeCraftAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
@@ -1035,9 +1034,9 @@ public class LargeCraftAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
@@ -1081,9 +1080,9 @@ public class LargeCraftAmmoBinTest {
     @Test
     public void loadBinSingleTonWithoutUnitDoesNothing() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
@@ -1105,9 +1104,9 @@ public class LargeCraftAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
@@ -1146,9 +1145,9 @@ public class LargeCraftAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
@@ -1194,9 +1193,9 @@ public class LargeCraftAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
@@ -1241,9 +1240,9 @@ public class LargeCraftAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
@@ -1287,9 +1286,9 @@ public class LargeCraftAmmoBinTest {
     @Test
     public void needsFixingEmptyBinTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
@@ -1324,9 +1323,9 @@ public class LargeCraftAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
@@ -1359,9 +1358,9 @@ public class LargeCraftAmmoBinTest {
     @Test
     public void needsFixingPartialBinTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
@@ -1394,9 +1393,9 @@ public class LargeCraftAmmoBinTest {
     @Test
     public void needsFixingOverflowingBinTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
@@ -1429,9 +1428,9 @@ public class LargeCraftAmmoBinTest {
     @Test
     public void fixBinWithoutUnitDoesNothing() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
@@ -1453,9 +1452,9 @@ public class LargeCraftAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
@@ -1494,9 +1493,9 @@ public class LargeCraftAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
@@ -1542,9 +1541,9 @@ public class LargeCraftAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
@@ -1589,9 +1588,9 @@ public class LargeCraftAmmoBinTest {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISLRM20 Ammo");

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingAmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingAmmoBinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -55,8 +55,7 @@ import megamek.common.equipment.AmmoType;
 import megamek.common.equipment.Mounted;
 import megamek.common.units.Entity;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Quartermaster;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.enums.PartRepairType;
 import mekhq.campaign.parts.meks.MekLocation;
@@ -286,9 +285,9 @@ public class MissingAmmoBinTest {
     @Test
     public void fixFindsAcceptableReplacementTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
@@ -337,9 +336,9 @@ public class MissingAmmoBinTest {
     @Test
     public void fixFindsAcceptableOneShotReplacementTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingEquipmentPartTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingEquipmentPartTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -60,8 +60,7 @@ import megamek.common.units.Aero;
 import megamek.common.units.Entity;
 import megamek.common.units.Mek;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Quartermaster;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
@@ -612,9 +611,9 @@ public class MissingEquipmentPartTest {
     @Test
     public void removeTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         Unit unit = mock(Unit.class);
@@ -666,9 +665,9 @@ public class MissingEquipmentPartTest {
     @Test
     public void salvageTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         Unit unit = mock(Unit.class);
@@ -909,9 +908,9 @@ public class MissingEquipmentPartTest {
     @Test
     public void fixWithoutSparePartsTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         Unit unit = mock(Unit.class);
@@ -959,9 +958,9 @@ public class MissingEquipmentPartTest {
     @Test
     public void fixWithOneSparePartTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         Unit unit = mock(Unit.class);
@@ -1036,9 +1035,9 @@ public class MissingEquipmentPartTest {
     @Test
     public void fixWithManySparePartsTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         Unit unit = mock(Unit.class);

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingHeatSinkTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingHeatSinkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -48,8 +48,7 @@ import megamek.common.equipment.EquipmentType;
 import megamek.common.units.Aero;
 import megamek.common.units.Mek;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Quartermaster;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.parts.AeroHeatSink;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.unit.Unit;
@@ -66,9 +65,9 @@ public class MissingHeatSinkTest {
     @Test
     public void missingHeatSinkSelectsCorrectPartDuringRepair() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
         Unit unit = mock(Unit.class);
         doAnswer(inv -> {

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingInfantryAmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingInfantryAmmoBinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -58,8 +58,7 @@ import megamek.common.equipment.Mounted;
 import megamek.common.units.Entity;
 import megamek.common.weapons.infantry.InfantryWeapon;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Quartermaster;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.enums.PartRepairType;
 import mekhq.campaign.parts.meks.MekLocation;
@@ -351,9 +350,9 @@ public class MissingInfantryAmmoBinTest {
     @Test
     public void fixFindsAcceptableReplacementTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingLargeCraftAmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingLargeCraftAmmoBinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -59,8 +59,7 @@ import megamek.common.equipment.Mounted;
 import megamek.common.equipment.WeaponMounted;
 import megamek.common.units.Entity;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Quartermaster;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.enums.PartRepairType;
 import mekhq.campaign.parts.meks.MekLocation;
@@ -211,9 +210,9 @@ public class MissingLargeCraftAmmoBinTest {
     @Test
     public void fixFindsAcceptableReplacementTest() {
         Campaign mockCampaign = mock(Campaign.class);
-        Warehouse warehouse = new Warehouse();
+        LocalWarehouse warehouse = new LocalWarehouse();
         when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        mekhq.campaign.ForceQuartermaster quartermaster = new mekhq.campaign.ForceQuartermaster(mockCampaign);
         when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
 
         AmmoType ammoType = getAmmoType("ISSRM6 Ammo");

--- a/MekHQ/unittests/mekhq/campaign/personnel/BloodmarkTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/BloodmarkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -44,8 +44,7 @@ import java.util.List;
 
 import megamek.common.compute.Compute;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Hangar;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.personnel.enums.BloodmarkLevel;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
@@ -67,8 +66,8 @@ class BloodmarkTest {
         campaign = mock(Campaign.class);
         campaignOptions = mock(CampaignOptions.class);
         Faction campaignFaction = mock(Faction.class);
-        Hangar campaignHangar = mock(Hangar.class);
-        Warehouse campaignWarehouse = mock(Warehouse.class);
+        mekhq.campaign.LocalHangar campaignHangar = mock(mekhq.campaign.LocalHangar.class);
+        LocalWarehouse campaignWarehouse = mock(LocalWarehouse.class);
 
         when(campaign.getCampaignOptions()).thenReturn(campaignOptions);
         when(campaign.getFaction()).thenReturn(campaignFaction);

--- a/MekHQ/unittests/mekhq/campaign/personnel/PersonTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/PersonTest.java
@@ -69,8 +69,7 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignLocationManager;
 import mekhq.campaign.CurrentLocation;
 import mekhq.campaign.FixedLocation;
-import mekhq.campaign.Hangar;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.enums.DailyReportType;
 import mekhq.campaign.events.persons.PersonStatusChangedEvent;
@@ -690,8 +689,8 @@ public class PersonTest {
         Campaign mockCampaign = mock(Campaign.class);
         Faction mockFaction = mock(Faction.class);
         LocalDate currentDate = LocalDate.of(3151, 1, 1);
-        Hangar mockHangar = mock(Hangar.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        mekhq.campaign.LocalHangar mockHangar = mock(mekhq.campaign.LocalHangar.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getFaction()).thenReturn(mockFaction);
         when(mockFaction.getShortName()).thenReturn("MERC");
@@ -715,8 +714,8 @@ public class PersonTest {
         Campaign mockCampaign = mock(Campaign.class);
         Faction mockFaction = mock(Faction.class);
         LocalDate currentDate = LocalDate.of(3151, 1, 1);
-        Hangar mockHangar = mock(Hangar.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        mekhq.campaign.LocalHangar mockHangar = mock(mekhq.campaign.LocalHangar.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getFaction()).thenReturn(mockFaction);
         when(mockFaction.getShortName()).thenReturn("MERC");
@@ -802,8 +801,8 @@ public class PersonTest {
         Campaign mockCampaign = mock(Campaign.class);
         Faction mockFaction = mock(Faction.class);
         LocalDate currentDate = LocalDate.of(3151, 1, 1);
-        Hangar mockHangar = mock(Hangar.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        mekhq.campaign.LocalHangar mockHangar = mock(mekhq.campaign.LocalHangar.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getFaction()).thenReturn(mockFaction);
         when(mockFaction.getShortName()).thenReturn("MERC");
@@ -826,8 +825,8 @@ public class PersonTest {
         Campaign mockCampaign = mock(Campaign.class);
         Faction mockFaction = mock(Faction.class);
         LocalDate currentDate = LocalDate.of(3151, 1, 1);
-        Hangar mockHangar = mock(Hangar.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        mekhq.campaign.LocalHangar mockHangar = mock(mekhq.campaign.LocalHangar.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getFaction()).thenReturn(mockFaction);
         when(mockFaction.getShortName()).thenReturn("MERC");
@@ -1056,8 +1055,8 @@ public class PersonTest {
         Campaign mockCampaign = mock(Campaign.class);
         Faction mockFaction = mock(Faction.class);
         LocalDate currentDate = LocalDate.of(3151, 1, 1);
-        Hangar mockHangar = mock(Hangar.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        mekhq.campaign.LocalHangar mockHangar = mock(mekhq.campaign.LocalHangar.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
 
         when(mockCampaign.getFaction()).thenReturn(mockFaction);
@@ -1081,8 +1080,8 @@ public class PersonTest {
         Campaign mockCampaign = mock(Campaign.class);
         Faction mockFaction = mock(Faction.class);
         LocalDate currentDate = LocalDate.of(3151, 1, 1);
-        Hangar mockHangar = mock(Hangar.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        mekhq.campaign.LocalHangar mockHangar = mock(mekhq.campaign.LocalHangar.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
 
         when(mockCampaign.getFaction()).thenReturn(mockFaction);
@@ -1168,8 +1167,8 @@ public class PersonTest {
         Campaign mockCampaign = mock(Campaign.class);
         Faction mockFaction = mock(Faction.class);
         LocalDate currentDate = LocalDate.of(3151, 1, 1);
-        Hangar mockHangar = mock(Hangar.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        mekhq.campaign.LocalHangar mockHangar = mock(mekhq.campaign.LocalHangar.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getFaction()).thenReturn(mockFaction);
         when(mockFaction.getShortName()).thenReturn("MERC");
@@ -1192,8 +1191,8 @@ public class PersonTest {
         Campaign mockCampaign = mock(Campaign.class);
         Faction mockFaction = mock(Faction.class);
         LocalDate currentDate = LocalDate.of(3151, 1, 1);
-        Hangar mockHangar = mock(Hangar.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        mekhq.campaign.LocalHangar mockHangar = mock(mekhq.campaign.LocalHangar.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getFaction()).thenReturn(mockFaction);
         when(mockFaction.getShortName()).thenReturn("MERC");
@@ -1278,8 +1277,8 @@ public class PersonTest {
         Campaign mockCampaign = mock(Campaign.class);
         Faction mockFaction = mock(Faction.class);
         LocalDate currentDate = LocalDate.of(3151, 1, 1);
-        Hangar mockHangar = mock(Hangar.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        mekhq.campaign.LocalHangar mockHangar = mock(mekhq.campaign.LocalHangar.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getFaction()).thenReturn(mockFaction);
         when(mockFaction.getShortName()).thenReturn("MERC");
@@ -1302,8 +1301,8 @@ public class PersonTest {
         Campaign mockCampaign = mock(Campaign.class);
         Faction mockFaction = mock(Faction.class);
         LocalDate currentDate = LocalDate.of(3151, 1, 1);
-        Hangar mockHangar = mock(Hangar.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        mekhq.campaign.LocalHangar mockHangar = mock(mekhq.campaign.LocalHangar.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getFaction()).thenReturn(mockFaction);
         when(mockFaction.getShortName()).thenReturn("MERC");
@@ -1413,8 +1412,8 @@ public class PersonTest {
         Campaign mockCampaign = Mockito.mock(Campaign.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(new CampaignOptions());
         // Couple prereqs for removeAllTechJobs this test doesn't otherwise exercise
-        when(mockCampaign.getAllHangar()).thenReturn(new Hangar());
-        when(mockCampaign.getAllWarehouse()).thenReturn(new Warehouse());
+        when(mockCampaign.getAllHangar()).thenReturn(new mekhq.campaign.LocalHangar());
+        when(mockCampaign.getAllWarehouse()).thenReturn(new LocalWarehouse());
 
         Faction mockFaction = mock(Faction.class);
         when(mockCampaign.getFaction()).thenReturn(mockFaction);
@@ -1458,8 +1457,8 @@ public class PersonTest {
         Campaign mockCampaign = Mockito.mock(Campaign.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(new CampaignOptions());
         // Couple prereqs for removeAllTechJobs this test doesn't otherwise exercise
-        when(mockCampaign.getAllHangar()).thenReturn(new Hangar());
-        when(mockCampaign.getAllWarehouse()).thenReturn(new Warehouse());
+        when(mockCampaign.getAllHangar()).thenReturn(new mekhq.campaign.LocalHangar());
+        when(mockCampaign.getAllWarehouse()).thenReturn(new LocalWarehouse());
 
         Faction mockFaction = mock(Faction.class);
         when(mockCampaign.getFaction()).thenReturn(mockFaction);
@@ -1609,10 +1608,10 @@ public class PersonTest {
                 when(options.getNaturalHealingWaitingPeriod()).thenReturn(0);
                 when(campaign.getCampaignOptions()).thenReturn(options);
 
-                Hangar hangar = mock(Hangar.class);
+                mekhq.campaign.LocalHangar hangar = mock(mekhq.campaign.LocalHangar.class);
                 when(campaign.getAllHangar()).thenReturn(hangar);
 
-                Warehouse warehouse = mock(Warehouse.class);
+                LocalWarehouse warehouse = mock(LocalWarehouse.class);
                 when(warehouse.getParts()).thenReturn(Collections.emptyList());
                 when(campaign.getAllWarehouse()).thenReturn(warehouse);
 
@@ -1693,10 +1692,10 @@ public class PersonTest {
                 when(options.getNaturalHealingWaitingPeriod()).thenReturn(0);
                 when(campaign.getCampaignOptions()).thenReturn(options);
 
-                Hangar hangar = mock(Hangar.class);
+                mekhq.campaign.LocalHangar hangar = mock(mekhq.campaign.LocalHangar.class);
                 when(campaign.getAllHangar()).thenReturn(hangar);
 
-                Warehouse warehouse = mock(Warehouse.class);
+                LocalWarehouse warehouse = mock(LocalWarehouse.class);
                 when(warehouse.getParts()).thenReturn(Collections.emptyList());
                 when(campaign.getAllWarehouse()).thenReturn(warehouse);
 

--- a/MekHQ/unittests/mekhq/campaign/personnel/RandomDependentsTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/RandomDependentsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -46,8 +46,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Hangar;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
 import mekhq.campaign.universe.Faction;
@@ -61,8 +60,8 @@ class RandomDependentsTest {
 
         // Setup
         Campaign mockCampaign = mock(Campaign.class);
-        Hangar mockHangar = mock(Hangar.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        mekhq.campaign.LocalHangar mockHangar = mock(mekhq.campaign.LocalHangar.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         Faction campaignFaction = mock(Faction.class);
         when(mockCampaign.getHangar()).thenReturn(mockHangar);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);

--- a/MekHQ/unittests/mekhq/campaign/personnel/education/EducationControllerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/education/EducationControllerTest.java
@@ -50,9 +50,8 @@ import java.util.List;
 
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignLocationManager;
-import mekhq.campaign.Hangar;
 import mekhq.campaign.JumpPath;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.force.Detachment;
 import mekhq.campaign.force.PlayerForce;
@@ -102,10 +101,10 @@ class EducationControllerTest {
         when(options.getNaturalHealingWaitingPeriod()).thenReturn(0);
         when(campaign.getCampaignOptions()).thenReturn(options);
 
-        Hangar hangar = mock(Hangar.class);
+        mekhq.campaign.LocalHangar hangar = mock(mekhq.campaign.LocalHangar.class);
         when(campaign.getAllHangar()).thenReturn(hangar);
 
-        Warehouse warehouse = mock(Warehouse.class);
+        LocalWarehouse warehouse = mock(LocalWarehouse.class);
         when(warehouse.getParts()).thenReturn(Collections.emptyList());
         when(campaign.getAllWarehouse()).thenReturn(warehouse);
 

--- a/MekHQ/unittests/mekhq/campaign/randomEvents/prisoners/EventEffectsManagerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/randomEvents/prisoners/EventEffectsManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -60,8 +60,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Hangar;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.personnel.Person;
@@ -407,9 +406,9 @@ class EventEffectsManagerTest {
         when(mockCampaignOptions.isUseFatigue()).thenReturn(true);
         when(mockCampaignOptions.getFatigueRate()).thenReturn(1);
 
-        Hangar mockHangar = mock(Hangar.class);
+        mekhq.campaign.LocalHangar mockHangar = mock(mekhq.campaign.LocalHangar.class);
         when(mockCampaign.getHangar()).thenReturn(mockHangar);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
 
         EventResult eventResult = new EventResult(FATIGUE_ONE, false, MAGNITUDE, "");
@@ -434,9 +433,9 @@ class EventEffectsManagerTest {
         when(mockCampaignOptions.isUseFatigue()).thenReturn(true);
         when(mockCampaignOptions.getFatigueRate()).thenReturn(1);
 
-        Hangar mockHangar = mock(Hangar.class);
+        mekhq.campaign.LocalHangar mockHangar = mock(mekhq.campaign.LocalHangar.class);
         when(mockCampaign.getHangar()).thenReturn(mockHangar);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
 
         EventResult eventResult = new EventResult(FATIGUE_ALL, false, MAGNITUDE, "");
@@ -575,9 +574,9 @@ class EventEffectsManagerTest {
         when(mockCampaignOptions.isUseFatigue()).thenReturn(true);
         when(mockCampaignOptions.getFatigueRate()).thenReturn(1);
 
-        Hangar mockHangar = mock(Hangar.class);
+        mekhq.campaign.LocalHangar mockHangar = mock(mekhq.campaign.LocalHangar.class);
         when(mockCampaign.getHangar()).thenReturn(mockHangar);
-        Warehouse mockWarehouse = mock(Warehouse.class);
+        LocalWarehouse mockWarehouse = mock(LocalWarehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
 
         EventResult eventResult = new EventResult(UNIQUE, false, MAGNITUDE, "");

--- a/MekHQ/unittests/mekhq/campaign/stratCon/StratConRulesManagerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/stratCon/StratConRulesManagerTest.java
@@ -62,7 +62,6 @@ import megamek.common.units.Entity;
 import megamek.common.units.UnitType;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CurrentLocation;
-import mekhq.campaign.Hangar;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.force.CombatTeam;
 import mekhq.campaign.force.Formation;
@@ -290,7 +289,7 @@ class StratConRulesManagerTest {
 
         // processForceDeployment needs LocalDate and Hangar
         when(campaign.getLocalDate()).thenReturn(LocalDate.of(3025, 1, 15));
-        when(campaign.getAllHangar()).thenReturn(mock(Hangar.class));
+        when(campaign.getAllHangar()).thenReturn(mock(mekhq.campaign.LocalHangar.class));
 
         // Track setup for processForceDeployment
         when(track.getAssignedCoordForces()).thenReturn(new HashMap<>());
@@ -880,7 +879,9 @@ class StratConRulesManagerTest {
         @Test
         void testBuildScoutMap_NullFormation() {
             List<ScoutRecord> scouts =
-                  StratConRulesManager.buildScoutMap(null, mock(Hangar.class), mock(Campaign.class));
+                  StratConRulesManager.buildScoutMap(null,
+                        mock(mekhq.campaign.LocalHangar.class),
+                        mock(Campaign.class));
             assertNotNull(scouts);
             assertTrue(scouts.isEmpty());
         }
@@ -998,7 +999,7 @@ class StratConRulesManagerTest {
         @Test
         void testBuildScoutMap_EmptyCrewSkipsUnit() {
             Formation formation = mock(Formation.class);
-            Hangar hangar = mock(Hangar.class);
+            mekhq.campaign.LocalHangar hangar = mock(mekhq.campaign.LocalHangar.class);
             Unit unit = mock(Unit.class);
 
             when(formation.getAllUnitsAsUnits(hangar, false)).thenReturn(Collections.singletonList(unit));
@@ -1042,7 +1043,7 @@ class StratConRulesManagerTest {
         private ScoutRecord getBestScoutForUnit(List<Person> crew, double unitWeight, int unitSpeed,
               boolean hasImprovedSensors, boolean hasActiveProbe, boolean useAgingEffects, boolean isClanCampaign) {
             Formation formation = mock(Formation.class);
-            Hangar hangar = mock(Hangar.class);
+            mekhq.campaign.LocalHangar hangar = mock(mekhq.campaign.LocalHangar.class);
             Unit unit = mock(Unit.class);
             Entity entity = mock(Entity.class);
 
@@ -1072,7 +1073,7 @@ class StratConRulesManagerTest {
         private List<ScoutRecord> getBestScoutsForUnits(List<Person> crews,
               boolean hasImprovedSensors, boolean hasActiveProbe) {
             Formation formation = mock(Formation.class);
-            Hangar hangar = mock(Hangar.class);
+            mekhq.campaign.LocalHangar hangar = mock(mekhq.campaign.LocalHangar.class);
 
             try (MockedStatic<AtBDynamicScenarioFactory> scenarioFactory = mockStatic(AtBDynamicScenarioFactory.class);
                   MockedStatic<EntityUtilities> entityUtils = mockStatic(EntityUtilities.class);

--- a/MekHQ/unittests/mekhq/campaign/unit/LocalHangarStatisticsTest.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/LocalHangarStatisticsTest.java
@@ -39,11 +39,11 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 
 import megamek.common.units.Entity;
-import mekhq.campaign.Hangar;
+import mekhq.campaign.LocalHangar;
 import org.junit.jupiter.api.Test;
 
-class HangarStatisticsTest {
-    private final Hangar hangar = mock(Hangar.class);
+class LocalHangarStatisticsTest {
+    private final LocalHangar hangar = mock(LocalHangar.class);
     private final HangarStatistics hangarStatistics = new HangarStatistics(hangar);
 
     @Test

--- a/MekHQ/unittests/mekhq/campaign/unit/actions/AdjustLargeCraftAmmoActionTest.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/actions/AdjustLargeCraftAmmoActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -53,7 +53,6 @@ import megamek.common.equipment.AmmoType;
 import megamek.common.equipment.WeaponMounted;
 import megamek.common.units.Entity;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Quartermaster;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.equipment.AmmoBin;
 import mekhq.campaign.parts.equipment.LargeCraftAmmoBin;
@@ -65,7 +64,7 @@ public class AdjustLargeCraftAmmoActionTest {
     @Test
     public void onlyAcceptsEntitiesUsingBayWeapons() {
         Campaign campaign = mock(Campaign.class);
-        Quartermaster quartermaster = mock(Quartermaster.class);
+        mekhq.campaign.ForceQuartermaster quartermaster = mock(mekhq.campaign.ForceQuartermaster.class);
         when(campaign.getQuartermaster()).thenReturn(quartermaster);
         Unit unit = mock(Unit.class);
         when(unit.getCampaign()).thenReturn(campaign);
@@ -84,7 +83,7 @@ public class AdjustLargeCraftAmmoActionTest {
     @Test
     public void doesNothingWithNoAmmoBays() {
         Campaign campaign = mock(Campaign.class);
-        Quartermaster quartermaster = mock(Quartermaster.class);
+        mekhq.campaign.ForceQuartermaster quartermaster = mock(mekhq.campaign.ForceQuartermaster.class);
         when(campaign.getQuartermaster()).thenReturn(quartermaster);
         Unit unit = mock(Unit.class);
         when(unit.getCampaign()).thenReturn(campaign);
@@ -104,7 +103,7 @@ public class AdjustLargeCraftAmmoActionTest {
     @Test
     public void addsMissingBins() {
         Campaign campaign = mock(Campaign.class);
-        Quartermaster quartermaster = mock(Quartermaster.class);
+        mekhq.campaign.ForceQuartermaster quartermaster = mock(mekhq.campaign.ForceQuartermaster.class);
         when(campaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Put together a unit with 1 bay, with 1 ammo type
@@ -162,7 +161,7 @@ public class AdjustLargeCraftAmmoActionTest {
     @Test
     public void updatesExistingBayToMatchType() {
         Campaign campaign = mock(Campaign.class);
-        Quartermaster quartermaster = mock(Quartermaster.class);
+        mekhq.campaign.ForceQuartermaster quartermaster = mock(mekhq.campaign.ForceQuartermaster.class);
         when(campaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Put together a unit with 1 bay, 1 ammo type, and 1 bin on the unit already
@@ -199,7 +198,7 @@ public class AdjustLargeCraftAmmoActionTest {
     @Test
     public void addsMissingBinsSkipsNonLargeCraftBins() {
         Campaign campaign = mock(Campaign.class);
-        Quartermaster quartermaster = mock(Quartermaster.class);
+        mekhq.campaign.ForceQuartermaster quartermaster = mock(mekhq.campaign.ForceQuartermaster.class);
         when(campaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Put together a unit with 1 bay, with 1 ammo type
@@ -259,7 +258,7 @@ public class AdjustLargeCraftAmmoActionTest {
     @Test
     public void updatesExistingBayToMatchTypeSkipsNonLargeCraftBins() {
         Campaign campaign = mock(Campaign.class);
-        Quartermaster quartermaster = mock(Quartermaster.class);
+        mekhq.campaign.ForceQuartermaster quartermaster = mock(mekhq.campaign.ForceQuartermaster.class);
         when(campaign.getQuartermaster()).thenReturn(quartermaster);
 
         // Put together a unit with 1 bay, 1 ammo type, and 1 bin on the unit already

--- a/MekHQ/unittests/mekhq/campaign/unit/actions/RestoreUnitActionTest.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/actions/RestoreUnitActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -48,7 +48,6 @@ import megamek.common.Player;
 import megamek.common.game.Game;
 import megamek.common.units.Entity;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Quartermaster;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.equipment.EquipmentPart;
 import mekhq.campaign.parts.equipment.MissingEquipmentPart;
@@ -65,7 +64,7 @@ public class RestoreUnitActionTest {
         when(mockCampaign.getGame()).thenReturn(mockGame);
         Player mockPlayer = new Player(1, "Player");
         when(mockCampaign.getPlayer()).thenReturn(mockPlayer);
-        Quartermaster mockQuartermaster = mock(Quartermaster.class);
+        mekhq.campaign.ForceQuartermaster mockQuartermaster = mock(mekhq.campaign.ForceQuartermaster.class);
         when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
 
         int entityId = 42;
@@ -113,7 +112,7 @@ public class RestoreUnitActionTest {
     public void restoreUnitUsingOldStrategy() {
         IEntityCopyFactory mockEntityCopyFactory = mock(IEntityCopyFactory.class);
         Campaign mockCampaign = mock(Campaign.class);
-        Quartermaster mockQuartermaster = mock(Quartermaster.class);
+        mekhq.campaign.ForceQuartermaster mockQuartermaster = mock(mekhq.campaign.ForceQuartermaster.class);
         when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
         Entity mockEntity = mock(Entity.class);
         when(mockEntity.getShortNameRaw()).thenReturn("Test Mek TST-01X");

--- a/MekHQ/unittests/mekhq/campaign/utilities/AutomatedPersonnelCleanUpTest.java
+++ b/MekHQ/unittests/mekhq/campaign/utilities/AutomatedPersonnelCleanUpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -37,7 +37,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.time.LocalDate;
 
 import mekhq.campaign.Campaign;
-import mekhq.campaign.HumanResources;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.FamilialRelationshipType;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
@@ -58,7 +57,7 @@ class AutomatedPersonnelCleanUpTest {
     @Test
     void testGetPersonnelToCleanUp_NoExemptions_NoDepartedPersons() {
         // Setup
-        HumanResources humanResources = testCampaign.getHumanResources();
+        mekhq.campaign.ForceHumanResources humanResources = testCampaign.getHumanResources();
         for (int i = 0; i < 10; i++) {
             Person ineligiblePerson = new Person(testCampaign);
             ineligiblePerson.setStatus(PersonnelStatus.ACTIVE);
@@ -79,7 +78,7 @@ class AutomatedPersonnelCleanUpTest {
     @Test
     void testGetPersonnelToCleanUp_NoExemptions_DeadPersonsButBeforeDate() {
         // Setup
-        HumanResources humanResources = testCampaign.getHumanResources();
+        mekhq.campaign.ForceHumanResources humanResources = testCampaign.getHumanResources();
         for (int i = 0; i < 10; i++) {
             Person ineligibleDeadPerson = new Person(testCampaign);
             ineligibleDeadPerson.setStatus(PersonnelStatus.DISEASE);
@@ -101,7 +100,7 @@ class AutomatedPersonnelCleanUpTest {
     @Test
     void testGetPersonnelToCleanUp_NoExemptions_DeadPersonsAfterDate() {
         // Setup
-        HumanResources humanResources = testCampaign.getHumanResources();
+        mekhq.campaign.ForceHumanResources humanResources = testCampaign.getHumanResources();
         for (int i = 0; i < 10; i++) {
             Person eligibleDeadPerson = new Person(testCampaign);
             eligibleDeadPerson.setStatus(PersonnelStatus.DISEASE);
@@ -123,7 +122,7 @@ class AutomatedPersonnelCleanUpTest {
     @Test
     void testGetPersonnelToCleanUp_RelatedExemption_DeadPersonsAfterDate() {
         // Setup
-        HumanResources humanResources = testCampaign.getHumanResources();
+        mekhq.campaign.ForceHumanResources humanResources = testCampaign.getHumanResources();
         for (int i = 0; i < 10; i++) {
             Person eligibleDeadPerson = new Person(testCampaign);
             eligibleDeadPerson.setStatus(PersonnelStatus.DISEASE);
@@ -145,7 +144,7 @@ class AutomatedPersonnelCleanUpTest {
     @Test
     void testGetPersonnelToCleanUp_UnrelatedExemption_DeadPersonsAfterDate() {
         // Setup
-        HumanResources humanResources = testCampaign.getHumanResources();
+        mekhq.campaign.ForceHumanResources humanResources = testCampaign.getHumanResources();
         for (int i = 0; i < 10; i++) {
             Person eligibleDeadPerson = new Person(testCampaign);
             eligibleDeadPerson.setStatus(PersonnelStatus.DISEASE);
@@ -167,7 +166,7 @@ class AutomatedPersonnelCleanUpTest {
     @Test
     void testGetPersonnelToCleanUp_NoExemptions_DeadPersonsAfterDateActiveGenealogy() {
         // Setup
-        HumanResources humanResources = testCampaign.getHumanResources();
+        mekhq.campaign.ForceHumanResources humanResources = testCampaign.getHumanResources();
         for (int i = 0; i < 10; i++) {
             Person personWhoDiedAfterThresholdButActiveGenealogy = new Person(testCampaign);
             personWhoDiedAfterThresholdButActiveGenealogy.setStatus(PersonnelStatus.DISEASE);
@@ -195,7 +194,7 @@ class AutomatedPersonnelCleanUpTest {
     @Test
     void testGetPersonnelToCleanUp_NoExemptions_DeadPersonsAfterDateInactiveGenealogy() {
         // Setup
-        HumanResources humanResources = testCampaign.getHumanResources();
+        mekhq.campaign.ForceHumanResources humanResources = testCampaign.getHumanResources();
         for (int i = 0; i < 10; i++) {
             Person personWhoDiedAfterThresholdAndInactiveGenealogy = new Person(testCampaign);
             personWhoDiedAfterThresholdAndInactiveGenealogy.setStatus(PersonnelStatus.DISEASE);
@@ -223,7 +222,7 @@ class AutomatedPersonnelCleanUpTest {
     @Test
     void testGetPersonnelToCleanUp_NoExemptions_RetiredPersonsButBeforeDate() {
         // Setup
-        HumanResources humanResources = testCampaign.getHumanResources();
+        mekhq.campaign.ForceHumanResources humanResources = testCampaign.getHumanResources();
         for (int i = 0; i < 10; i++) {
             Person ineligibleRetiredPerson = new Person(testCampaign);
             ineligibleRetiredPerson.setStatus(PersonnelStatus.RETIRED);
@@ -245,7 +244,7 @@ class AutomatedPersonnelCleanUpTest {
     @Test
     void testGetPersonnelToCleanUp_NoExemptions_DepartedPersonsAfterDateButNotRetired() {
         // Setup
-        HumanResources humanResources = testCampaign.getHumanResources();
+        mekhq.campaign.ForceHumanResources humanResources = testCampaign.getHumanResources();
         for (int i = 0; i < 10; i++) {
             Person eligibleRetiredPerson = new Person(testCampaign);
             eligibleRetiredPerson.setStatus(PersonnelStatus.LEFT);
@@ -267,7 +266,7 @@ class AutomatedPersonnelCleanUpTest {
     @Test
     void testGetPersonnelToCleanUp_NoExemptions_RetiredPersonsAfterDate() {
         // Setup
-        HumanResources humanResources = testCampaign.getHumanResources();
+        mekhq.campaign.ForceHumanResources humanResources = testCampaign.getHumanResources();
         for (int i = 0; i < 10; i++) {
             Person eligibleRetiredPerson = new Person(testCampaign);
             eligibleRetiredPerson.setStatus(PersonnelStatus.LEFT);
@@ -289,7 +288,7 @@ class AutomatedPersonnelCleanUpTest {
     @Test
     void testGetPersonnelToCleanUp_RelatedExemption_RetiredPersonsAfterDate() {
         // Setup
-        HumanResources humanResources = testCampaign.getHumanResources();
+        mekhq.campaign.ForceHumanResources humanResources = testCampaign.getHumanResources();
         for (int i = 0; i < 10; i++) {
             Person eligibleRetiredPerson = new Person(testCampaign);
             eligibleRetiredPerson.setStatus(PersonnelStatus.RETIRED);
@@ -311,7 +310,7 @@ class AutomatedPersonnelCleanUpTest {
     @Test
     void testGetPersonnelToCleanUp_UnrelatedExemption_RetiredPersonsAfterDate() {
         // Setup
-        HumanResources humanResources = testCampaign.getHumanResources();
+        mekhq.campaign.ForceHumanResources humanResources = testCampaign.getHumanResources();
         for (int i = 0; i < 10; i++) {
             Person eligibleRetiredPerson = new Person(testCampaign);
             eligibleRetiredPerson.setStatus(PersonnelStatus.RETIRED);
@@ -333,7 +332,7 @@ class AutomatedPersonnelCleanUpTest {
     @Test
     void testGetPersonnelToCleanUp_NoExemptions_RetiredPersonsAfterDateActiveGenealogy() {
         // Setup
-        HumanResources humanResources = testCampaign.getHumanResources();
+        mekhq.campaign.ForceHumanResources humanResources = testCampaign.getHumanResources();
         for (int i = 0; i < 10; i++) {
             Person personWhoRetiredAfterThresholdButActiveGenealogy = new Person(testCampaign);
             personWhoRetiredAfterThresholdButActiveGenealogy.setStatus(PersonnelStatus.RETIRED);
@@ -361,7 +360,7 @@ class AutomatedPersonnelCleanUpTest {
     @Test
     void testGetPersonnelToCleanUp_NoExemptions_RetiredPersonsAfterDateInactiveGenealogy() {
         // Setup
-        HumanResources humanResources = testCampaign.getHumanResources();
+        mekhq.campaign.ForceHumanResources humanResources = testCampaign.getHumanResources();
         for (int i = 0; i < 10; i++) {
             Person personWhoRetiredAfterThresholdWithInActiveGenealogy = new Person(testCampaign);
             personWhoRetiredAfterThresholdWithInActiveGenealogy.setStatus(PersonnelStatus.RETIRED);
@@ -388,7 +387,7 @@ class AutomatedPersonnelCleanUpTest {
 
     @Test
     void testGetPersonnelToCleanUp_NoExemptions_BackgroundPersonsAfterDate() {
-        HumanResources humanResources = testCampaign.getHumanResources();
+        mekhq.campaign.ForceHumanResources humanResources = testCampaign.getHumanResources();
         for (int i = 0; i < 10; i++) {
             Person eligibleDeadPerson = new Person(testCampaign);
             eligibleDeadPerson.setStatus(PersonnelStatus.BACKGROUND_CHARACTER);
@@ -408,7 +407,7 @@ class AutomatedPersonnelCleanUpTest {
     @Test
     void testGetPersonnelToCleanUp_NoExemptions_BackgroundPersonsAfterDateActiveGenealogy() {
         // Setup
-        HumanResources humanResources = testCampaign.getHumanResources();
+        mekhq.campaign.ForceHumanResources humanResources = testCampaign.getHumanResources();
         for (int i = 0; i < 10; i++) {
             Person personWhoRetiredAfterThresholdButActiveGenealogy = new Person(testCampaign);
             personWhoRetiredAfterThresholdButActiveGenealogy.setStatus(PersonnelStatus.BACKGROUND_CHARACTER);

--- a/MekHQ/unittests/mekhq/gui/dialog/nagDialogs/nagLogic/UnableToAffordExpensesNagLogicTest.java
+++ b/MekHQ/unittests/mekhq/gui/dialog/nagDialogs/nagLogic/UnableToAffordExpensesNagLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2024-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -38,8 +38,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Hangar;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.finances.Finances;
 import mekhq.campaign.finances.FinancialReport;
@@ -73,10 +72,10 @@ class UnableToAffordExpensesNagLogicTest {
         Finances finances = mock(Finances.class);
 
         Unit unit = mock(Unit.class);
-        Hangar hangar = mock(Hangar.class);
+        mekhq.campaign.LocalHangar hangar = mock(mekhq.campaign.LocalHangar.class);
         hangar.addUnit(unit);
 
-        Warehouse warehouse = mock(Warehouse.class);
+        LocalWarehouse warehouse = mock(LocalWarehouse.class);
 
         report = mock(FinancialReport.class);
 

--- a/MekHQ/unittests/mekhq/gui/dialog/nagDialogs/nagLogic/UnableToAffordForceShoppingListNagLogicTest.java
+++ b/MekHQ/unittests/mekhq/gui/dialog/nagDialogs/nagLogic/UnableToAffordForceShoppingListNagLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import mekhq.campaign.finances.Money;
 import org.junit.jupiter.api.Test;
 
-public class UnableToAffordShoppingListNagLogicTest {
+public class UnableToAffordForceShoppingListNagLogicTest {
 
     @Test
     void canAfford() {

--- a/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
+++ b/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
@@ -52,7 +52,7 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.CurrentLocation;
 import mekhq.campaign.FixedLocation;
 import mekhq.campaign.JumpPath;
-import mekhq.campaign.Personnel;
+import mekhq.campaign.LocalPersonnel;
 import mekhq.campaign.base.PlayerBase;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.location.AcademyCampusLocation;
@@ -160,11 +160,11 @@ public class PersonnelTableModelColumnTest {
         private static final LocalDate TODAY = LocalDate.of(3025, 1, 1);
         private static final String CAMPAIGN_NAME = "Test Mercs";
 
-        private Personnel mainForce;
+        private LocalPersonnel mainForce;
 
         @BeforeEach
         void setUp() {
-            mainForce = new Personnel();
+            mainForce = new LocalPersonnel();
         }
 
         private PlanetarySystem mockSystem(String sysName, String planetName) {

--- a/MekHQ/unittests/mekhq/service/mrms/MRMSServiceTest.java
+++ b/MekHQ/unittests/mekhq/service/mrms/MRMSServiceTest.java
@@ -54,14 +54,11 @@ import megamek.common.compute.Compute;
 import megamek.common.enums.SkillLevel;
 import megamek.common.equipment.EquipmentType;
 import megamek.common.rolls.TargetRoll;
-import megamek.common.units.Aero;
 import megamek.common.units.Entity;
 import megamek.common.units.Mek;
-import megamek.common.units.ProtoMek;
-import megamek.common.units.Tank;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Quartermaster;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.ForceQuartermaster;
+import mekhq.campaign.LocalWarehouse;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.parts.Armor;
 import mekhq.campaign.parts.Part;
@@ -98,8 +95,8 @@ public class MRMSServiceTest {
 
     Campaign mockCampaign;
     CampaignOptions mockCampaignOptions;
-    Warehouse warehouse;
-    Quartermaster mockQuartermaster;
+    LocalWarehouse warehouse;
+    ForceQuartermaster mockQuartermaster;
     PartInventory mockPartInventory;
     MRMSConfiguredOptions configuredOptions;
 
@@ -129,9 +126,9 @@ public class MRMSServiceTest {
         mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaignOptions.getMRMSOptions()).thenReturn(new ArrayList<>());
 
-        warehouse = new Warehouse();
+        warehouse = new LocalWarehouse();
 
-        mockQuartermaster = mock(Quartermaster.class);
+        mockQuartermaster = mock(ForceQuartermaster.class);
 
         mockPartInventory = mock(PartInventory.class);
         when(mockPartInventory.getTransitOrderedDetails()).thenReturn("");


### PR DESCRIPTION
`Quartermaster` -> `ForceQuartermaster`
`HumanResources` -> `ForceHumanResources`
`ShoppingList` -> `ForceShoppingList`
`ReputationController` -> `ForceReputationController`
`Hangar` -> `LocalHangar`
`Personnel` -> `LocalPersonnel`
`Warehouse` -> `LocalWarehouse`
