### PR TITLE
Close #9644: Updated Training Formation Glossary Entry; Added Class Size Limitations

### DIFF
--- a/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
+++ b/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
@@ -1978,35 +1978,37 @@ TURNING_POINTS.definition=Turning Points are scenarios of significant strategic 
 TRAINING_COMBAT_TEAMS.title=Training Combat Teams
 TRAINING_COMBAT_TEAMS.definition=Training <a href='GLOSSARY:COMBAT_TEAMS'>Combat Teams</a> are essential for \
   improving the skills of your personnel and ensuring they remain combat-ready.\
-  <p>While deployed, each Monday the commander of each formation in a training combat team will attempt to use their \
-  Training skills to improve the skills of the personnel under their command. If the commander is in a multi-crewed \
-  unit, all personnel in the unit will contribute their skills to assist. Collectively, these characters (and the \
-  commander) are referred to as the formation 'Educators.'</p>\
-  <p>There are some restrictions on what can be taught. Only profession and scouting skills can be taught. New skills\
-  \ cannot be trained, so the character must at least possess the skill before it can be improved. Furthermore, the \
-  maximum that a skill can be improved to is to Regular, or the highest experience milestone an educator has in that \
-  skill minus 1, whichever is lowest.</p>\
-  <p>It's important to note that while educator skill level factors in all relevant modifiers, trainee skill level \
-  (the level improved) only factors in the raw level of the skill (ignoring all modifiers). This represents all \
-  characters receiving the same level of education regardless of individual talents.</p>\
-  <p>Training occurs each Monday. For training to take place, the combat team must be deployed to the AO (unless \
-  StratCon Mapless mode is enabled). The efficacy of training is determined by the Training skill of the formation \
-  commander. The skills Margin of Success determines how quickly trainees improve:</p>\
-  <blockquote><b>Spectacular:</b> x2.0\
-  <br><b>Extraordinary:</b> x1.75\
-  <br><b>Good:</b> x1.5\
-  <br><b>It Will Do:</b> x1.25\
-  <br><b>Barely Made It:</b> x1.0\
-  <br><b>Almost...:</b> x0.75\
-  <br><b>Bad:</b> x0.5\
-  <br><b>Terrible:</b> x0.25\
-  <br><b>Disastrous:</b> No Improvement</blockquote>\
-  <p>The number of days it takes to improve a skill is based on the target skill level. It takes 35 days to go from \
-  level 0 to 1; an additional 70 days for 1 to 2; and another 105 days for 2 to 3. Each week spent in training \
-  increases the <a href='GLOSSARY:FATIGUE'>Fatigue</a> of all personnel in the formation by 1 (if Fatigue is enabled in \
-  campaign options).</p>\
-  <p>Progression is at a rate of 7 days/week multiplied by the training efficacy determined above. If the ability for\
-  \ Talent to affect XP costs is enabled in campaign options, a character's Talent score also impacts progression.</p>
+  <p>While deployed to the <a href='GLOSSARY:AREA_OF_OPERATIONS'>Area of Operations</a>, each Monday the commander of\
+  \ a formation assigned to the Training <a href='GLOSSARY:COMBAT_ROLES'>Combat Role</a> will attempt to use their \
+  <b>Training</b> skill to train the <b>other</b> units in the formation.</p>\
+  <p>First, all personnel in the commander's unit pool their skills. Only skills related to the command of the unit \
+  the commander is in will be trained. Alongside the unit's best <a href='GLOSSARY:ADVANCED_SCOUTING'>Scouting \
+  Skill</a>. For example, a commander in a 'Mek will only train the two 'Mek skills and potentially one Scouting \
+  Skill. This is known as the training formation's curriculum.</p>\
+  <p><a href='GLOSSARY:INFANTRY_GUNNERY_SKILLS'>Infantry Gunnery Skills</a> work similarly to Scouting Skills in that\
+  \ only the best in the command unit will be trained.</p>\
+  <p>It is important to note that a trainer can only train skills to be one level below their current level in that \
+  skill, minus 1. This includes all relevant modifiers, such as SPAs, and injuries.</p>\
+  <p>While all personnel in the commander's unit assist in the training exercises, only the commander uses their \
+  <b>Training</b> skill to determine the success of the exercises.</p>\
+  <p>When training takes place (on each Monday), the commander will perform their Training check, the success of \
+  which dictates how much XP each trainee receives in the lowest skill among those featured in the curriculum. \
+  Progress is equal to the roll's Margin of Success (minimum 1 XP). Failed Training skill checks result in no XP \
+  being taught for that week.</p>\
+  <p>All XP earned from Training Formations is pre-spent on the skill being trained. That means if a character \
+  learned 5 XP towards the Communications/Any skill, the cost of improving that skill will go down by 5. If a \
+  character ends up with sufficient progress to improve their skill to the next level, they will.</p>\
+  <p>While a Training Formation is deployed, they will suffer Fatigue damage, each week. The amount of Fatigue gained\
+  \ is equal to the Fatigue Scale in campaign options (default 1).</p>\
+  <p>Remember: you can right click on a training formation and specify who commands it. This is useful if the \
+  formation commander is of lower rank than one of their trainees.</p>\
+  <p><b>Class Sizes:</b> Training Formations receive a penalty if the 'class' size gets too large. This penalty is \
+  applied to the Training skill roll. Generally, Inner Sphere training formations consist of a commander and 3 \
+  trainees. Clan training formations consist of a commander and 4 trainees. ComStar/Word of Blake training formations\
+  \ consist of a commander and 5 trainees. For each trainee over this allowance there is a -1 penalty. Some factions,\
+  \ such as the Marians, break this trend which is tracked by MekHQ. There is no differentiation between types of \
+  unit. Even for factions that normally field more vehicles in a lance than they would 'Meks. This is largely due to \
+  code restrictions.</p>
 TURNOVER.title=Turnover
 TURNOVER.definition=Turnover is the system that determines when and why personnel might leave your campaign. It simulates\
   \ the natural flow of people in and out of your unit, adding depth and realism.\

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -429,6 +429,7 @@ public class Person implements ILocatable {
     private boolean immortal;
     private boolean quickTrainIgnore;
     private boolean salvageSupervisor;
+    private boolean trainer;
     private boolean underProtection;
     private boolean neverAssignMaintenanceAutomatically;
     private boolean coverIllicitMedicalExpenses;
@@ -3340,6 +3341,14 @@ public class Person implements ILocatable {
         this.salvageSupervisor = salvageSupervisor;
     }
 
+    public boolean isTrainer() {
+        return trainer;
+    }
+
+    public void setTrainer(final boolean trainer) {
+        this.trainer = trainer;
+    }
+
     public boolean isUnderProtection() {
         return underProtection;
     }
@@ -3973,6 +3982,7 @@ public class Person implements ILocatable {
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "immortal", immortal);
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "quickTrainIgnore", quickTrainIgnore);
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "salvageSupervisor", salvageSupervisor);
+            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "trainer", trainer);
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "underProtection", underProtection);
             MHQXMLUtility.writeSimpleXMLTag(pw,
                   indent,
@@ -4611,6 +4621,8 @@ public class Person implements ILocatable {
                     person.setQuickTrainIgnore(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (nodeName.equalsIgnoreCase("salvageSupervisor")) {
                     person.setSalvageSupervisor(Boolean.parseBoolean(wn2.getTextContent().trim()));
+                } else if (nodeName.equalsIgnoreCase("trainer")) {
+                    person.setTrainer(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (nodeName.equalsIgnoreCase("underProtection")) {
                     person.setUnderProtection(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (nodeName.equalsIgnoreCase("neverAssignMaintenanceAutomatically")) {

--- a/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
@@ -206,7 +206,11 @@ public class TrainingCombatTeams {
         // Then build a set of their skills
         Map<String, Integer> educatorSkills = createSkillsList(campaign, educators);
 
-        ActionCheckResult actionCheckResult = performTrainingSkillCheck(campaign, commander);
+        int formationSize = formation.getUnits().size();
+        int standardLanceSize = campaign.getPlayerForce().getFaction().getFormationBaseSize();
+        int classSizeModifier = max(0, standardLanceSize - formationSize);
+
+        ActionCheckResult actionCheckResult = performTrainingSkillCheck(campaign, commander, classSizeModifier);
 
         performTraining(campaign, formation, commander, educatorSkills, actionCheckResult);
     }
@@ -548,13 +552,15 @@ public class TrainingCombatTeams {
         return !actionCheckResult.isSuccess() || isNothingBeingTrained;
     }
 
-    private static ActionCheckResult performTrainingSkillCheck(Campaign campaign, Person educator) {
+    private static ActionCheckResult performTrainingSkillCheck(Campaign campaign, Person educator,
+          int classSizeModifier) {
         final CampaignOptions campaignOptions = campaign.getCampaignOptions();
         boolean isUseEdge = campaignOptions.isUseEdge();
         isUseEdge = isUseEdge && educator.getOptions().booleanOption(EDGE_TRAINING);
 
         ActionCheckResult actionCheckResult =
               educator.checkSkill(S_TRAINING, campaign)
+                    .withMiscModifier(classSizeModifier)
                     .resolve(isUseEdge, getTextAt(RESOURCE_BUNDLE, "trainingCombatTeam.skillCheck"));
         campaign.addReport(SKILL_CHECKS, actionCheckResult.getReport(true));
 


### PR DESCRIPTION
Close #9644

Glossary entry for Training Formations had fallen out of date. Now, it's in date again. I also took the opportunity to add 'class size' limitations, so players would stop putting an entire battalion on the shoulders of a single trainer.