### PR TITLE
Fix #5924: Fixed MekHQ & MegaMek's Independent Game Options Instances Becoming Desync'd

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7338,6 +7338,11 @@ public class Campaign implements ITechManager {
 
     public void setGameOptions(final GameOptions gameOptions) {
         this.gameOptions = gameOptions;
+        // Keep the Game's reference in sync: MegaMek code (e.g. TeamLoadOutGenerator during scenario setup) reads
+        // options through campaign.getGame().getOptions(). Without this, replacing the campaign's options (e.g. when
+        // applying a campaign preset) leaves the Game holding a stale GameOptions object, so later updates such as
+        // the ALLOWED_YEAR sync are never seen there and bot forces get munitions from the wrong era.
+        game.setOptions(gameOptions);
     }
 
     public void setGameOptions(final Vector<IBasicOption> options) {

--- a/MekHQ/unittests/mekhq/campaign/CampaignTest.java
+++ b/MekHQ/unittests/mekhq/campaign/CampaignTest.java
@@ -67,6 +67,8 @@ import megamek.common.enums.SkillLevel;
 import megamek.common.equipment.EquipmentType;
 import megamek.common.equipment.Mounted;
 import megamek.common.icons.Portrait;
+import megamek.common.options.GameOptions;
+import megamek.common.options.OptionsConstants;
 import megamek.common.units.Crew;
 import megamek.common.units.Dropship;
 import megamek.common.units.EntityMovementMode;
@@ -133,6 +135,31 @@ public class CampaignTest {
         assertEquals(6, travelTime);
     }
 
+    /**
+     * Regression test: replacing the campaign's GameOptions (as happens when applying a campaign preset) must also
+     * update the Game's options reference. MegaMek code such as TeamLoadOutGenerator reads options through
+     * campaign.getGame().getOptions(); if the two references diverge, later updates like the ALLOWED_YEAR sync during
+     * scenario setup are applied to one object while the loadout generator reads the other, and bot forces are equipped
+     * with munitions from the wrong era.
+     */
+    @Test
+    void testSetGameOptionsKeepsGameInSync() {
+        Campaign campaign = MHQTestUtilities.getTestCampaign();
+
+        // Sanity check: the constructor wires the same object into both places
+        assertSame(campaign.getGameOptions(), campaign.getGame().getOptions());
+
+        // Replace the options wholesale, as preset application does
+        GameOptions replacementOptions = new GameOptions();
+        campaign.setGameOptions(replacementOptions);
+        assertSame(replacementOptions, campaign.getGame().getOptions());
+
+        // A year written through the campaign accessor (e.g. the pre-scenario ALLOWED_YEAR sync in BriefingTab)
+        // must be visible to code reading through the game, like TeamLoadOutGenerator
+        campaign.getGameOptions().getOption(OptionsConstants.ALLOWED_YEAR).setValue(3019);
+        assertEquals(3019, campaign.getGame().getOptions().intOption(OptionsConstants.ALLOWED_YEAR));
+    }
+
     @Test
     void testGetTechs() {
         List<Person> testPersonList = new ArrayList<>(5);
@@ -144,7 +171,11 @@ public class CampaignTest {
         when(mockTechActive.getSecondaryRole()).thenReturn(PersonnelRole.NONE);
         doReturn(PersonnelStatus.ACTIVE).when(mockTechActive).getStatus();
         when(mockTechActive.getMinutesLeft()).thenReturn(240);
-        when(mockTechActive.getSkillLevel(any(), anyBoolean(), any(), anyBoolean(), anyBoolean())).thenReturn(SkillLevel.REGULAR);
+        when(mockTechActive.getSkillLevel(any(),
+              anyBoolean(),
+              any(),
+              anyBoolean(),
+              anyBoolean())).thenReturn(SkillLevel.REGULAR);
         when(mockTechActive.getDailyAvailableTechTime(anyBoolean())).thenReturn(240);
         testPersonList.add(mockTechActive);
         testActivePersonList.add(mockTechActive);
@@ -155,7 +186,8 @@ public class CampaignTest {
         when(mockTechActiveTwo.getSecondaryRole()).thenReturn(PersonnelRole.NONE);
         doReturn(PersonnelStatus.ACTIVE).when(mockTechActiveTwo).getStatus();
         when(mockTechActiveTwo.getMinutesLeft()).thenReturn(1);
-        when(mockTechActiveTwo.getSkillLevel(any(), anyBoolean(), any(), anyBoolean(), anyBoolean())).thenReturn(SkillLevel.REGULAR);
+        when(mockTechActiveTwo.getSkillLevel(any(), anyBoolean(), any(), anyBoolean(), anyBoolean())).thenReturn(
+              SkillLevel.REGULAR);
         when(mockTechActiveTwo.getDailyAvailableTechTime(anyBoolean())).thenReturn(1);
         testPersonList.add(mockTechActiveTwo);
         testActivePersonList.add(mockTechActiveTwo);
@@ -174,7 +206,11 @@ public class CampaignTest {
         when(mockTechNoTime.getSecondaryRole()).thenReturn(PersonnelRole.NONE);
         doReturn(PersonnelStatus.ACTIVE).when(mockTechNoTime).getStatus();
         when(mockTechNoTime.getMinutesLeft()).thenReturn(0);
-        when(mockTechNoTime.getSkillLevel(any(), anyBoolean(), any(), anyBoolean(), anyBoolean())).thenReturn(SkillLevel.REGULAR);
+        when(mockTechNoTime.getSkillLevel(any(),
+              anyBoolean(),
+              any(),
+              anyBoolean(),
+              anyBoolean())).thenReturn(SkillLevel.REGULAR);
         when(mockTechNoTime.getDailyAvailableTechTime(anyBoolean())).thenReturn(0);
         testPersonList.add(mockTechNoTime);
         testActivePersonList.add(mockTechNoTime);
@@ -209,14 +245,15 @@ public class CampaignTest {
                          ArgumentMatchers.any(),
                          ArgumentMatchers.anyBoolean(),
                          ArgumentMatchers.any())).thenAnswer(inv ->
-                                                         ForceHumanResources.getTechsExpanded(testActivePersonList,
-                                                                 noUnits,
-                                                                 campaignOptions,
-                                                                 false,
-                                                                 today,
-                                                                 false,
-                                                                 false,
-                                                                 false));
+                                                                   ForceHumanResources.getTechsExpanded(
+                                                                         testActivePersonList,
+                                                                         noUnits,
+                                                                         campaignOptions,
+                                                                         false,
+                                                                         today,
+                                                                         false,
+                                                                         false,
+                                                                         false));
         when(testCampaign.getPlayerForce()
                    .getHumanResources()
                    .getTechs(ArgumentMatchers.any(),
@@ -224,15 +261,15 @@ public class CampaignTest {
                          ArgumentMatchers.anyBoolean(),
                          ArgumentMatchers.any(),
                          ArgumentMatchers.anyBoolean())).thenAnswer(inv ->
-                                                                     ForceHumanResources.getTechsExpanded(
-                                                                             testActivePersonList,
-                                                                             noUnits,
-                                                                             campaignOptions,
-                                                                             false,
-                                                                             today,
-                                                                           (boolean) inv.getArgument(4),
-                                                                             false,
-                                                                             false));
+                                                                          ForceHumanResources.getTechsExpanded(
+                                                                                testActivePersonList,
+                                                                                noUnits,
+                                                                                campaignOptions,
+                                                                                false,
+                                                                                today,
+                                                                                (boolean) inv.getArgument(4),
+                                                                                false,
+                                                                                false));
         when(testCampaign.getPlayerForce()
                    .getHumanResources()
                    .getTechs(ArgumentMatchers.any(),
@@ -241,15 +278,15 @@ public class CampaignTest {
                          ArgumentMatchers.any(),
                          ArgumentMatchers.anyBoolean(),
                          ArgumentMatchers.anyBoolean())).thenAnswer(inv ->
-                                                                                   ForceHumanResources.getTechsExpanded(
-                                                                                           testActivePersonList,
-                                                                                           noUnits,
-                                                                                           campaignOptions,
-                                                                                           false,
-                                                                                           today,
-                                                                                         (boolean) inv.getArgument(4),
-                                                                                         (boolean) inv.getArgument(5),
-                                                                                           false));
+                                                                          ForceHumanResources.getTechsExpanded(
+                                                                                testActivePersonList,
+                                                                                noUnits,
+                                                                                campaignOptions,
+                                                                                false,
+                                                                                today,
+                                                                                (boolean) inv.getArgument(4),
+                                                                                (boolean) inv.getArgument(5),
+                                                                                false));
         when(testCampaign.getPlayerForce()
                    .getHumanResources()
                    .getTechsExpanded(ArgumentMatchers.any(),
@@ -259,18 +296,18 @@ public class CampaignTest {
                          ArgumentMatchers.anyBoolean(),
                          ArgumentMatchers.anyBoolean(),
                          ArgumentMatchers.anyBoolean())).thenAnswer(inv ->
-                                                                                                         ForceHumanResources.getTechsExpanded(
-                                                                                                                 testActivePersonList,
-                                                                                                                 noUnits,
-                                                                                                                 campaignOptions,
-                                                                                                                 false,
-                                                                                                                 today,
-                                                                                                               (boolean) inv.getArgument(
-                                                                                                                     4),
-                                                                                                               (boolean) inv.getArgument(
-                                                                                                                     5),
-                                                                                                               (boolean) inv.getArgument(
-                                                                                                                     6)));
+                                                                          ForceHumanResources.getTechsExpanded(
+                                                                                testActivePersonList,
+                                                                                noUnits,
+                                                                                campaignOptions,
+                                                                                false,
+                                                                                today,
+                                                                                (boolean) inv.getArgument(
+                                                                                      4),
+                                                                                (boolean) inv.getArgument(
+                                                                                      5),
+                                                                                (boolean) inv.getArgument(
+                                                                                      6)));
 
         // Test just getting the list of active techs.
         List<Person> expected = new ArrayList<>(3);


### PR DESCRIPTION
Fix #5924

Here's a fun one:

- `Campaign` has a copy of `GameOptions`
- `Game` has a copy of `GameOptions`

Both `GameOptions` objects share the same instance. Hurray

_Except_ if we apply a campaign preset. At that point we correctly replace `Campaign`'s `GameOptions` instance, but we don't hand the new one to `Game`. Why is this a problem? Generally it's not, except there is one tinsy winsy little issue: every update from that point on only lands on `Campaign`'s copy. Including the "sync the allowed year to the campaign date" step that runs when you pick your start date and again before every scenario.

That means the date in `Campaign` changes to match and so does `Campaign`'s `GameOptions` reference. But `Game` is still clutching the stale object it was constructed with, frozen at the default year (3067). So `Game` thinks the Jihad is about to kick off while `Campaign` (and the player) know they're in [insert year] (3019, in my case).

Thus resulting in my 3019 game being littered with future munitions, because most systems were checking against `Campaign`'s year. But autoammo was checking against Game's incorrect year. Whoops!

Now `setGameOptions` points `Game` at the new instance too, so the two can't diverge again. There's also a regression test to make sure we don't backslide.

This bug has been in the game since at least 2020.

Contains AI tests.