### PR TITLE
Fix duplicate execution of setInitialEducationLevel and further boosted doctor to have higher levels of education

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -75,6 +75,7 @@ import mekhq.campaign.CurrentLocation;
 import mekhq.campaign.JumpPath;
 import mekhq.campaign.LocalPersonnel;
 import mekhq.campaign.base.PlayerBase;
+import mekhq.campaign.campaignOptions.CampaignOption;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.events.persons.PersonChangedEvent;
 import mekhq.campaign.finances.Money;
@@ -2349,7 +2350,7 @@ public class EducationController {
 
         // We base passRate on US averages
         int passRate = 60 - (Reasoning.values().length / 2);
-        final int reasoningModifier = campaign.getCampaignOptions().isUseRandomPersonalities() ?
+        final int reasoningModifier = campaign.getCampaignOptions().get(CampaignOption.USE_RANDOM_PERSONALITIES) ?
                                             person.getReasoning().getReasoningScore() :
                                             Reasoning.values().length / 2;
         passRate += reasoningModifier;
@@ -2362,7 +2363,7 @@ public class EducationController {
             educationLevel = getCombatEducationLevel(experienceLevel, flunked, passRate);
         } else {
             // Calculate effective experience level (boost for doctors)
-            final int effectiveExperienceLevel = isDoctor ? max(experienceLevel, EXP_VETERAN) : experienceLevel;
+            final int effectiveExperienceLevel = isDoctor ? experienceLevel + EXP_VETERAN : experienceLevel;
             // Determine education levels for non-combat roles
             educationLevel = getNonCombatEducationLevel(effectiveExperienceLevel, flunked, passRate);
         }

--- a/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
+++ b/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
@@ -34,7 +34,6 @@ package mekhq.campaign.personnel.procreation;
 
 import static mekhq.campaign.enums.DailyReportType.PERSONNEL;
 import static mekhq.campaign.personnel.PersonnelOptions.UNOFFICIAL_DOBROWSKI_SYNDROME;
-import static mekhq.campaign.personnel.education.EducationController.setInitialEducationLevel;
 import static mekhq.campaign.personnel.enums.BloodGroup.getInheritedBloodGroup;
 import static mekhq.campaign.personnel.enums.BloodGroup.getRandomBloodGroup;
 import static mekhq.campaign.personnel.medical.BodyLocation.GENERIC;
@@ -639,9 +638,6 @@ public abstract class AbstractProcreation {
             }
 
             baby.setLoyalty(Compute.d6(3) + 2);
-
-            // set education based on age
-            setInitialEducationLevel(campaign, baby);
 
             // Create reports and log the birth
             logAndUpdateFamily(campaign, today, mother, baby, father);

--- a/MekHQ/src/mekhq/campaign/universe/generators/companyGenerators/AbstractCompanyGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/generators/companyGenerators/AbstractCompanyGenerator.java
@@ -33,7 +33,6 @@
 package mekhq.campaign.universe.generators.companyGenerators;
 
 import static mekhq.campaign.enums.DailyReportType.FINANCES;
-import static mekhq.campaign.personnel.education.EducationController.setInitialEducationLevel;
 import static mekhq.campaign.personnel.skills.SkillType.S_LEADER;
 import static mekhq.campaign.personnel.skills.SkillType.S_STRATEGY;
 import static mekhq.campaign.personnel.skills.SkillType.S_TACTICS;
@@ -732,10 +731,6 @@ public abstract class AbstractCompanyGenerator {
 
         // Now that they are recruited, we can simulate backwards a few years and
         // generate marriages and children
-        for (final CompanyGenerationPersonTracker tracker : trackers) {
-            Person person = tracker.getPerson();
-            setInitialEducationLevel(campaign, person);
-        }
 
         if (getOptions().isRunStartingSimulation()) {
             LocalDate date = campaign.getLocalDate().minusYears(getOptions().getSimulationDuration()).minusWeeks(1);


### PR DESCRIPTION
This fixes a non-critical issue where personnel could be generated with the prenominal "Dr" while having a highest education level of "Post-Graduate".

The issue was caused by `setInitialEducationLevel` being executed twice during campaign generation. The second execution could occasionally roll a lower education level, overwriting the previously assigned doctorate level. However, the prenominal "Dr" was already set during the first execution and was never removed, resulting in inconsistent personnel data.

I discovered the issue by adding additional logging:

```java
@@ -2372,6 +2379,7 @@ public class EducationController {
         if (educationLevel.isDoctorate()) {
             person.setPreNominal("Dr");
         }
+        LOGGER.info("Person {} highest level {} is doctor {} prenominal {}", person.getFullName(), educationLevel, educationLevel.isDoctorate(), person.getPreNominal());
 }
 
example logs: 
```
18:14:34,362 INFO  [mekhq.campaign.personnel.education.EducationController] {AWT-EventQueue-0}
mekhq.campaign.personnel.education.EducationController.setInitialEducationLevel(EducationController.java:2382) - Person Dr Ben Rodríguez highest level Doctorate is doctor true prenominal Dr

18:14:34,529 INFO  [mekhq.campaign.personnel.education.EducationController] {AWT-EventQueue-0}
mekhq.campaign.personnel.education.EducationController.setInitialEducationLevel(EducationController.java:2382) - Person Dr Ben Rodríguez highest level Post-Graduate is doctor false prenominal Dr
```
