### PR TITLE
Let automatic Quick Train skip training formations

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -1159,6 +1159,9 @@ chkNewDayAutomaticallyAssignUnmaintainedUnits.toolTipText=Automatically assign t
   personnel you want this system to ignore.
 chkNewMonthQuickTrain.text=Quick Train on First Day of Each Month.
 chkNewMonthQuickTrain.toolTipText=On the first day of a new month, automatically run Quick Training on all characters.
+chkQuickTrainIgnoreTrainingFormations.text=Exclude Training Formations
+chkQuickTrainIgnoreTrainingFormations.toolTipText=When monthly Quick Train runs automatically, skip personnel assigned \
+  to Training Formations and their sub-formations. Manual Quick Train remains available.
 lblQuickTrainTarget.text=Quick Train Target
 lblQuickTrainTarget.toolTipText=If 'Quick Train on First Day of Each Month', this is the highest skill level Quick \
   Train will increase skills to. Has no effect when Quick Train is manually run from the Personnel tab.

--- a/MekHQ/src/mekhq/MHQConstants.java
+++ b/MekHQ/src/mekhq/MHQConstants.java
@@ -202,6 +202,8 @@ public final class MHQConstants extends SuiteConstants {
     public static final String NEW_DAY_OPTIMIZE_MEDICAL_ASSIGNMENTS = "NewDayOptimizeMedicalAssignments";
     public static final String NEW_DAY_AUTOMATE_MAINTENANCE_ASSIGNMENTS = "NewDayAutomateMaintenanceAssignments";
     public static final String NEW_DAY_QUICK_TRAIN = "NewDayQuickTrain";
+    public static final String NEW_DAY_QUICK_TRAIN_IGNORE_TRAINING_FORMATIONS =
+          "NewDayQuickTrainIgnoreTrainingFormations";
     public static final String NEW_DAY_QUICK_TRAIN_TARGET = "QuickTrainTarget";
     public static final String NEW_DAY_ARTILLERY = "NewDayArtillery";
     public static final String NEW_DAY_SCOUTING = "NewDayScouting";

--- a/MekHQ/src/mekhq/MHQOptions.java
+++ b/MekHQ/src/mekhq/MHQOptions.java
@@ -1149,6 +1149,16 @@ public final class MHQOptions extends SuiteOptions {
               .putBoolean(MHQConstants.NEW_DAY_QUICK_TRAIN, value);
     }
 
+    public boolean getQuickTrainIgnoreTrainingFormations() {
+        return userPreferences.node(MHQConstants.NEW_DAY_NODE)
+              .getBoolean(MHQConstants.NEW_DAY_QUICK_TRAIN_IGNORE_TRAINING_FORMATIONS, false);
+    }
+
+    public void setQuickTrainIgnoreTrainingFormations(final boolean value) {
+        userPreferences.node(MHQConstants.NEW_DAY_NODE)
+              .putBoolean(MHQConstants.NEW_DAY_QUICK_TRAIN_IGNORE_TRAINING_FORMATIONS, value);
+    }
+
     public int getQuickTrainTarget() {
         return userPreferences.node(MHQConstants.NEW_DAY_NODE).getInt(MHQConstants.NEW_DAY_QUICK_TRAIN_TARGET, 5);
     }

--- a/MekHQ/src/mekhq/campaign/personnel/skills/QuickTrain.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/QuickTrain.java
@@ -52,6 +52,7 @@ import megamek.logging.MMLogger;
 import mekhq.MHQOptions;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.campaignOptions.CampaignOptions;
+import mekhq.campaign.force.Formation;
 import mekhq.campaign.log.PerformanceLogger;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRole;
@@ -135,6 +136,9 @@ public class QuickTrain {
             if (status.isDepartedUnit() || status.isStudent()) {
                 continue;
             }
+            if (options.ignoreTrainingFormations() && isInTrainingFormation(person, campaign)) {
+                continue;
+            }
 
             List<String> targetSkills = new ArrayList<>();
 
@@ -162,6 +166,18 @@ public class QuickTrain {
             // Do this last so we're not spamming person update events
             campaign.getPlayerForce().getHumanResources().personUpdated(campaign, person);
         }
+    }
+
+    static boolean isInTrainingFormation(Person person, Campaign campaign) {
+        Formation formation = campaign.getPlayerForce().getFormationFor(person.getUnit());
+        if (formation == null) {
+            return false;
+        }
+        if (formation.getCombatRoleInMemory().isTraining()) {
+            return true;
+        }
+        return formation.getAllParents().stream()
+              .anyMatch(parent -> parent.getCombatRoleInMemory().isTraining());
     }
 
     /**
@@ -481,8 +497,16 @@ public class QuickTrain {
           boolean isLevelEscapeSkills,
           boolean isLevelLeadership,
           boolean isLevelTraining,
-          boolean isLevelOtherCommandSkills
+            boolean isLevelOtherCommandSkills,
+            boolean ignoreTrainingFormations
     ) {
+              public QuickTrainOptions(boolean isLevelArtillery, boolean isLevelScoutingSkills,
+                  boolean isLevelEscapeSkills, boolean isLevelLeadership, boolean isLevelTraining,
+                  boolean isLevelOtherCommandSkills) {
+                this(isLevelArtillery, isLevelScoutingSkills, isLevelEscapeSkills, isLevelLeadership, isLevelTraining,
+                    isLevelOtherCommandSkills, false);
+              }
+
         // Additional logic to provide defaults for missing properties
         public static QuickTrainOptions buildQuickTrainOptions(CampaignOptions campaignOptions) {
             boolean isLevelArtillery = campaignOptions.isUseArtillery();
@@ -503,7 +527,8 @@ public class QuickTrain {
                   isLevelEscapeSkills,
                   isLevelLeadership,
                   isLevelTraining,
-                  isLevelOtherCommandSkills);
+                  isLevelOtherCommandSkills,
+                  false);
         }
 
         public static QuickTrain.@NonNull QuickTrainOptions getQuickTrainOptionsForNewDay(MHQOptions mekhqOptions) {
@@ -513,13 +538,15 @@ public class QuickTrain {
             final boolean isLevelLeadership = mekhqOptions.getLevelLeadership();
             final boolean isLevelTraining = mekhqOptions.getLevelTraining();
             final boolean isLevelOtherCommandSkills = mekhqOptions.getLevelOtherCommand();
+            final boolean ignoreTrainingFormations = mekhqOptions.getQuickTrainIgnoreTrainingFormations();
 
             return new QuickTrainOptions(isLevelArtillery,
                   isLevelScoutingSkills,
                   isLevelEscapeSkills,
                   isLevelLeadership,
                   isLevelTraining,
-                  isLevelOtherCommandSkills);
+                  isLevelOtherCommandSkills,
+                ignoreTrainingFormations);
         }
     }
 }

--- a/MekHQ/src/mekhq/campaign/personnel/skills/QuickTrain.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/QuickTrain.java
@@ -497,15 +497,15 @@ public class QuickTrain {
           boolean isLevelEscapeSkills,
           boolean isLevelLeadership,
           boolean isLevelTraining,
-            boolean isLevelOtherCommandSkills,
-            boolean ignoreTrainingFormations
+                    boolean isLevelOtherCommandSkills,
+                    boolean ignoreTrainingFormations
     ) {
-              public QuickTrainOptions(boolean isLevelArtillery, boolean isLevelScoutingSkills,
-                  boolean isLevelEscapeSkills, boolean isLevelLeadership, boolean isLevelTraining,
-                  boolean isLevelOtherCommandSkills) {
-                this(isLevelArtillery, isLevelScoutingSkills, isLevelEscapeSkills, isLevelLeadership, isLevelTraining,
-                    isLevelOtherCommandSkills, false);
-              }
+                public QuickTrainOptions(boolean isLevelArtillery, boolean isLevelScoutingSkills,
+                            boolean isLevelEscapeSkills, boolean isLevelLeadership, boolean isLevelTraining,
+                            boolean isLevelOtherCommandSkills) {
+                        this(isLevelArtillery, isLevelScoutingSkills, isLevelEscapeSkills, isLevelLeadership, isLevelTraining,
+                                    isLevelOtherCommandSkills, false);
+                }
 
         // Additional logic to provide defaults for missing properties
         public static QuickTrainOptions buildQuickTrainOptions(CampaignOptions campaignOptions) {
@@ -546,7 +546,7 @@ public class QuickTrain {
                   isLevelLeadership,
                   isLevelTraining,
                   isLevelOtherCommandSkills,
-                ignoreTrainingFormations);
+                                    ignoreTrainingFormations);
         }
     }
 }

--- a/MekHQ/src/mekhq/campaign/personnel/skills/QuickTrain.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/QuickTrain.java
@@ -497,15 +497,15 @@ public class QuickTrain {
           boolean isLevelEscapeSkills,
           boolean isLevelLeadership,
           boolean isLevelTraining,
-                    boolean isLevelOtherCommandSkills,
-                    boolean ignoreTrainingFormations
+          boolean isLevelOtherCommandSkills,
+          boolean ignoreTrainingFormations
     ) {
-                public QuickTrainOptions(boolean isLevelArtillery, boolean isLevelScoutingSkills,
-                            boolean isLevelEscapeSkills, boolean isLevelLeadership, boolean isLevelTraining,
-                            boolean isLevelOtherCommandSkills) {
-                        this(isLevelArtillery, isLevelScoutingSkills, isLevelEscapeSkills, isLevelLeadership, isLevelTraining,
-                                    isLevelOtherCommandSkills, false);
-                }
+        public QuickTrainOptions(boolean isLevelArtillery, boolean isLevelScoutingSkills,
+              boolean isLevelEscapeSkills, boolean isLevelLeadership, boolean isLevelTraining,
+              boolean isLevelOtherCommandSkills) {
+            this(isLevelArtillery, isLevelScoutingSkills, isLevelEscapeSkills, isLevelLeadership, isLevelTraining,
+                  isLevelOtherCommandSkills, false);
+        }
 
         // Additional logic to provide defaults for missing properties
         public static QuickTrainOptions buildQuickTrainOptions(CampaignOptions campaignOptions) {
@@ -546,7 +546,7 @@ public class QuickTrain {
                   isLevelLeadership,
                   isLevelTraining,
                   isLevelOtherCommandSkills,
-                                    ignoreTrainingFormations);
+                  ignoreTrainingFormations);
         }
     }
 }

--- a/MekHQ/src/mekhq/gui/clientOptions/MHQNewDayPage.java
+++ b/MekHQ/src/mekhq/gui/clientOptions/MHQNewDayPage.java
@@ -157,10 +157,10 @@ class MHQNewDayPage extends MHQOptionsPage {
 
     private JPanel createNewDayTrainingSection() {
         chkNewMonthQuickTrain = checkBox("chkNewMonthQuickTrain", model.newMonthQuickTrain);
-                        chkQuickTrainIgnoreTrainingFormations = checkBox("chkQuickTrainIgnoreTrainingFormations",
-                                          model.quickTrainIgnoreTrainingFormations);
+            chkQuickTrainIgnoreTrainingFormations = checkBox("chkQuickTrainIgnoreTrainingFormations",
+                    model.quickTrainIgnoreTrainingFormations);
 
-      SettingsLabel labelQuickTrainTarget = new SettingsLabel(TEXT_PROVIDER, "lblQuickTrainTarget");
+            SettingsLabel labelQuickTrainTarget = new SettingsLabel(TEXT_PROVIDER, "lblQuickTrainTarget");
         spinnerQuickTrainTarget =
               new SettingsSpinner(TEXT_PROVIDER, "lblQuickTrainTarget", 5, 1, 10, 1);
         spinnerQuickTrainTarget.setValue(model.quickTrainTarget);
@@ -172,9 +172,9 @@ class MHQNewDayPage extends MHQOptionsPage {
         chkLevelTraining = checkBox("chkLevelTraining", model.levelTraining);
         chkLevelOtherCommandSkills = checkBox("chkLevelOtherCommandSkills", model.levelOtherCommand);
 
-      SettingsFormPanel panel = new SettingsFormPanel("MHQNewDayTrainingContent", FORM_LABEL_WIDTH,
+                        SettingsFormPanel panel = new SettingsFormPanel("MHQNewDayTrainingContent", FORM_LABEL_WIDTH,
               FORM_CONTROL_WIDTH);
-            panel.addCheckBoxGrid(2, chkNewMonthQuickTrain, chkQuickTrainIgnoreTrainingFormations);
+                        panel.addCheckBoxGrid(2, chkNewMonthQuickTrain, chkQuickTrainIgnoreTrainingFormations);
         panel.addRow(labelQuickTrainTarget, spinnerQuickTrainTarget);
         panel.addCheckBoxGrid(2, chkLevelArtillery, chkLevelScoutingSkills, chkLevelEscapeSkills, chkLevelLeadership,
               chkLevelTraining, chkLevelOtherCommandSkills);

--- a/MekHQ/src/mekhq/gui/clientOptions/MHQNewDayPage.java
+++ b/MekHQ/src/mekhq/gui/clientOptions/MHQNewDayPage.java
@@ -77,7 +77,7 @@ class MHQNewDayPage extends MHQOptionsPage {
 
     // New Day - Training
       private SettingsCheckBox chkNewMonthQuickTrain;
-                  private SettingsCheckBox chkQuickTrainIgnoreTrainingFormations;
+      private SettingsCheckBox chkQuickTrainIgnoreTrainingFormations;
       private SettingsSpinner spinnerQuickTrainTarget;
       private SettingsCheckBox chkLevelArtillery;
       private SettingsCheckBox chkLevelScoutingSkills;
@@ -157,10 +157,10 @@ class MHQNewDayPage extends MHQOptionsPage {
 
     private JPanel createNewDayTrainingSection() {
         chkNewMonthQuickTrain = checkBox("chkNewMonthQuickTrain", model.newMonthQuickTrain);
-            chkQuickTrainIgnoreTrainingFormations = checkBox("chkQuickTrainIgnoreTrainingFormations",
-                    model.quickTrainIgnoreTrainingFormations);
+        chkQuickTrainIgnoreTrainingFormations = checkBox("chkQuickTrainIgnoreTrainingFormations",
+              model.quickTrainIgnoreTrainingFormations);
 
-            SettingsLabel labelQuickTrainTarget = new SettingsLabel(TEXT_PROVIDER, "lblQuickTrainTarget");
+      SettingsLabel labelQuickTrainTarget = new SettingsLabel(TEXT_PROVIDER, "lblQuickTrainTarget");
         spinnerQuickTrainTarget =
               new SettingsSpinner(TEXT_PROVIDER, "lblQuickTrainTarget", 5, 1, 10, 1);
         spinnerQuickTrainTarget.setValue(model.quickTrainTarget);
@@ -172,9 +172,9 @@ class MHQNewDayPage extends MHQOptionsPage {
         chkLevelTraining = checkBox("chkLevelTraining", model.levelTraining);
         chkLevelOtherCommandSkills = checkBox("chkLevelOtherCommandSkills", model.levelOtherCommand);
 
-                        SettingsFormPanel panel = new SettingsFormPanel("MHQNewDayTrainingContent", FORM_LABEL_WIDTH,
+      SettingsFormPanel panel = new SettingsFormPanel("MHQNewDayTrainingContent", FORM_LABEL_WIDTH,
               FORM_CONTROL_WIDTH);
-                        panel.addCheckBoxGrid(2, chkNewMonthQuickTrain, chkQuickTrainIgnoreTrainingFormations);
+        panel.addCheckBoxGrid(2, chkNewMonthQuickTrain, chkQuickTrainIgnoreTrainingFormations);
         panel.addRow(labelQuickTrainTarget, spinnerQuickTrainTarget);
         panel.addCheckBoxGrid(2, chkLevelArtillery, chkLevelScoutingSkills, chkLevelEscapeSkills, chkLevelLeadership,
               chkLevelTraining, chkLevelOtherCommandSkills);
@@ -283,7 +283,7 @@ class MHQNewDayPage extends MHQOptionsPage {
         model.selfCorrectMaintenance = chkSelfCorrectMaintenance.isSelected();
 
         model.newMonthQuickTrain = chkNewMonthQuickTrain.isSelected();
-      model.quickTrainIgnoreTrainingFormations = chkQuickTrainIgnoreTrainingFormations.isSelected();
+        model.quickTrainIgnoreTrainingFormations = chkQuickTrainIgnoreTrainingFormations.isSelected();
         model.quickTrainTarget = (int) spinnerQuickTrainTarget.getValue();
         model.levelArtillery = chkLevelArtillery.isSelected();
         model.levelScouting = chkLevelScoutingSkills.isSelected();

--- a/MekHQ/src/mekhq/gui/clientOptions/MHQNewDayPage.java
+++ b/MekHQ/src/mekhq/gui/clientOptions/MHQNewDayPage.java
@@ -77,6 +77,7 @@ class MHQNewDayPage extends MHQOptionsPage {
 
     // New Day - Training
       private SettingsCheckBox chkNewMonthQuickTrain;
+                  private SettingsCheckBox chkQuickTrainIgnoreTrainingFormations;
       private SettingsSpinner spinnerQuickTrainTarget;
       private SettingsCheckBox chkLevelArtillery;
       private SettingsCheckBox chkLevelScoutingSkills;
@@ -156,6 +157,8 @@ class MHQNewDayPage extends MHQOptionsPage {
 
     private JPanel createNewDayTrainingSection() {
         chkNewMonthQuickTrain = checkBox("chkNewMonthQuickTrain", model.newMonthQuickTrain);
+                        chkQuickTrainIgnoreTrainingFormations = checkBox("chkQuickTrainIgnoreTrainingFormations",
+                                          model.quickTrainIgnoreTrainingFormations);
 
       SettingsLabel labelQuickTrainTarget = new SettingsLabel(TEXT_PROVIDER, "lblQuickTrainTarget");
         spinnerQuickTrainTarget =
@@ -171,7 +174,7 @@ class MHQNewDayPage extends MHQOptionsPage {
 
       SettingsFormPanel panel = new SettingsFormPanel("MHQNewDayTrainingContent", FORM_LABEL_WIDTH,
               FORM_CONTROL_WIDTH);
-        panel.addCheckBox(chkNewMonthQuickTrain);
+            panel.addCheckBoxGrid(2, chkNewMonthQuickTrain, chkQuickTrainIgnoreTrainingFormations);
         panel.addRow(labelQuickTrainTarget, spinnerQuickTrainTarget);
         panel.addCheckBoxGrid(2, chkLevelArtillery, chkLevelScoutingSkills, chkLevelEscapeSkills, chkLevelLeadership,
               chkLevelTraining, chkLevelOtherCommandSkills);
@@ -280,6 +283,7 @@ class MHQNewDayPage extends MHQOptionsPage {
         model.selfCorrectMaintenance = chkSelfCorrectMaintenance.isSelected();
 
         model.newMonthQuickTrain = chkNewMonthQuickTrain.isSelected();
+      model.quickTrainIgnoreTrainingFormations = chkQuickTrainIgnoreTrainingFormations.isSelected();
         model.quickTrainTarget = (int) spinnerQuickTrainTarget.getValue();
         model.levelArtillery = chkLevelArtillery.isSelected();
         model.levelScouting = chkLevelScoutingSkills.isSelected();

--- a/MekHQ/src/mekhq/gui/clientOptions/MHQOptionsModel.java
+++ b/MekHQ/src/mekhq/gui/clientOptions/MHQOptionsModel.java
@@ -159,6 +159,7 @@ class MHQOptionsModel {
 
     // region New Day - Training
     boolean newMonthQuickTrain;
+    boolean quickTrainIgnoreTrainingFormations;
     int quickTrainTarget;
     boolean levelArtillery;
     boolean levelScouting;
@@ -318,6 +319,7 @@ class MHQOptionsModel {
 
         // New Day - Training
         newMonthQuickTrain = options.getNewMonthQuickTrain();
+        quickTrainIgnoreTrainingFormations = options.getQuickTrainIgnoreTrainingFormations();
         quickTrainTarget = options.getQuickTrainTarget();
         levelArtillery = options.getLevelArtillery();
         levelScouting = options.getLevelScouting();
@@ -487,6 +489,7 @@ class MHQOptionsModel {
 
         // New Day - Training
         options.setNewMonthQuickTrain(newMonthQuickTrain);
+        options.setQuickTrainIgnoreTrainingFormations(quickTrainIgnoreTrainingFormations);
         options.setQuickTrainTarget(quickTrainTarget);
         options.setLevelArtillery(levelArtillery);
         options.setLevelScouting(levelScouting);

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/QuickTrainTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/QuickTrainTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.personnel.skills;
+
+import static mekhq.campaign.personnel.enums.PersonnelStatus.ACTIVE;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import mekhq.MHQOptions;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.campaignOptions.CampaignOptions;
+import mekhq.campaign.force.Formation;
+import mekhq.campaign.force.PlayerForce;
+import mekhq.campaign.mission.enums.CombatRole;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.enums.PersonnelRole;
+import mekhq.campaign.unit.Unit;
+import org.junit.jupiter.api.Test;
+
+class QuickTrainTest {
+
+    @Test
+    void detectsDirectTrainingFormation() {
+        Person person = activePerson();
+        Formation formation = formation(CombatRole.TRAINING, List.of());
+
+        assertTrue(QuickTrain.isInTrainingFormation(person, campaign(person, formation)));
+    }
+
+    @Test
+    void detectsParentTrainingFormation() {
+        Person person = activePerson();
+        Formation parent = formation(CombatRole.TRAINING, List.of());
+        Formation formation = formation(CombatRole.FRONTLINE, List.of(parent));
+
+        assertTrue(QuickTrain.isInTrainingFormation(person, campaign(person, formation)));
+    }
+
+    @Test
+    void doesNotTreatNormalFormationAsTraining() {
+        Person person = activePerson();
+        Formation formation = formation(CombatRole.FRONTLINE, List.of());
+
+        assertFalse(QuickTrain.isInTrainingFormation(person, campaign(person, formation)));
+    }
+
+    @Test
+    void doesNotTreatUnassignedPersonAsTraining() {
+        Person person = activePerson();
+        when(person.getUnit()).thenReturn(null);
+
+        assertFalse(QuickTrain.isInTrainingFormation(person, campaign(person, null)));
+    }
+
+    @Test
+    void doesNotTreatFormationTechnicianAsTrainee() {
+        Person person = activePerson();
+        when(person.getUnit()).thenReturn(null);
+        Campaign campaign = campaign(person, null);
+          Formation trainingFormation = formation(CombatRole.TRAINING, List.of());
+          when(campaign.getPlayerForce().getFormationFor(person)).thenReturn(trainingFormation);
+
+        assertFalse(QuickTrain.isInTrainingFormation(person, campaign));
+    }
+
+    @Test
+    void monthlyOptionsIncludeTrainingFormationPreference() {
+        MHQOptions options = mock(MHQOptions.class);
+        when(options.getQuickTrainIgnoreTrainingFormations()).thenReturn(true);
+
+        QuickTrain.QuickTrainOptions quickTrainOptions =
+              QuickTrain.QuickTrainOptions.getQuickTrainOptionsForNewDay(options);
+
+        assertTrue(quickTrainOptions.ignoreTrainingFormations());
+    }
+
+    @Test
+    void manualOptionsDoNotIgnoreTrainingFormations() {
+        QuickTrain.QuickTrainOptions quickTrainOptions =
+              QuickTrain.QuickTrainOptions.buildQuickTrainOptions(mock(CampaignOptions.class));
+
+        assertFalse(quickTrainOptions.ignoreTrainingFormations());
+    }
+
+    @Test
+    void enabledOptionSkipsSkillProcessingForTrainee() {
+        Person person = processablePerson();
+        Campaign campaign = processCampaign(person, formation(CombatRole.TRAINING, List.of()));
+
+        QuickTrain.processQuickTraining(List.of(person), 5, campaign, options(true), true);
+
+        verify(person, never()).getSkills();
+    }
+
+    @Test
+    void disabledOptionRetainsSkillProcessingForTrainee() {
+        Person person = processablePerson();
+        Campaign campaign = processCampaign(person, formation(CombatRole.TRAINING, List.of()));
+
+        QuickTrain.processQuickTraining(List.of(person), 5, campaign, options(false), true);
+
+        verify(person).getSkills();
+    }
+
+    private static Person activePerson() {
+        Person person = mock(Person.class);
+        when(person.getStatus()).thenReturn(ACTIVE);
+        when(person.getUnit()).thenReturn(mock(Unit.class));
+        return person;
+    }
+
+    private static Person processablePerson() {
+        Person person = activePerson();
+        LocalDate today = LocalDate.of(3151, 1, 1);
+        when(person.getSkillModifierData(false, false, today, true)).thenReturn(mock(SkillModifierData.class));
+        when(person.getSkills()).thenReturn(mock(Skills.class));
+        when(person.getPrimaryRole()).thenReturn(PersonnelRole.NONE);
+        when(person.getSecondaryRole()).thenReturn(PersonnelRole.NONE);
+        return person;
+    }
+
+    private static Formation formation(CombatRole role, List<Formation> parents) {
+        Formation formation = mock(Formation.class);
+        when(formation.getCombatRoleInMemory()).thenReturn(role);
+        when(formation.getAllParents()).thenReturn(parents);
+        return formation;
+    }
+
+    private static Campaign campaign(Person person, Formation formation) {
+        Campaign campaign = mock(Campaign.class);
+        PlayerForce playerForce = mock(PlayerForce.class);
+        when(campaign.getPlayerForce()).thenReturn(playerForce);
+        Unit unit = person.getUnit();
+        if (unit != null) {
+            when(playerForce.getFormationFor(unit)).thenReturn(formation);
+        }
+        return campaign;
+    }
+
+    private static Campaign processCampaign(Person person, Formation formation) {
+        Campaign campaign = campaign(person, formation);
+        when(campaign.getCampaignOptions()).thenReturn(mock(CampaignOptions.class));
+        when(campaign.getLocalDate()).thenReturn(LocalDate.of(3151, 1, 1));
+        return campaign;
+    }
+
+    private static QuickTrain.QuickTrainOptions options(boolean ignoreTrainingFormations) {
+        return new QuickTrain.QuickTrainOptions(false, false, false, false, false, false,
+              ignoreTrainingFormations);
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/QuickTrainTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/QuickTrainTest.java
@@ -94,8 +94,8 @@ class QuickTrainTest {
         Person person = activePerson();
         when(person.getUnit()).thenReturn(null);
         Campaign campaign = campaign(person, null);
-          Formation trainingFormation = formation(CombatRole.TRAINING, List.of());
-          when(campaign.getPlayerForce().getFormationFor(person)).thenReturn(trainingFormation);
+                Formation trainingFormation = formation(CombatRole.TRAINING, List.of());
+                when(campaign.getPlayerForce().getFormationFor(person)).thenReturn(trainingFormation);
 
         assertFalse(QuickTrain.isInTrainingFormation(person, campaign));
     }

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/QuickTrainTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/QuickTrainTest.java
@@ -94,10 +94,12 @@ class QuickTrainTest {
         Person person = activePerson();
         when(person.getUnit()).thenReturn(null);
         Campaign campaign = campaign(person, null);
-                Formation trainingFormation = formation(CombatRole.TRAINING, List.of());
-                when(campaign.getPlayerForce().getFormationFor(person)).thenReturn(trainingFormation);
+        PlayerForce playerForce = campaign.getPlayerForce();
+        Formation trainingFormation = formation(CombatRole.TRAINING, List.of());
+        when(playerForce.getFormationFor(person)).thenReturn(trainingFormation);
 
         assertFalse(QuickTrain.isInTrainingFormation(person, campaign));
+        verify(playerForce, never()).getFormationFor(person);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add an opt-in MekHQ Client Option to exclude Training Formations from automatic monthly Quick Train
- skip personnel whose assigned unit is in a Training Formation or any descendant formation
- keep manual Quick Train, manual XP allocation, Training Formation progression, and formation technicians unchanged
- preserve existing behavior by defaulting the preference to disabled

## Screenshot
<img width="2722" height="1582" alt="image" src="https://github.com/user-attachments/assets/231c29d7-3297-4715-957e-7095ab26ee45" />

Fixes #9666