### PR TITLE
Fix bot crew generation changing name faction

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -2915,7 +2915,6 @@ public class AtBDynamicScenarioFactory {
         entity.setGame(campaign.getGame());
 
         RandomNameGenerator nameGenerator = RandomNameGenerator.getInstance();
-        nameGenerator.setChosenFaction(faction.getNameGenerator());
 
         Gender gender;
         int nonBinaryDiceSize = campaign.getCampaignOptions().getNonBinaryDiceSize();
@@ -2928,7 +2927,7 @@ public class AtBDynamicScenarioFactory {
 
         String[] crewNameArray = nameGenerator.generateGivenNameSurnameSplit(gender,
               faction.isClan(),
-              faction.getShortName());
+              faction.getNameGenerator());
         String crewName = crewNameArray[0];
         crewName += !StringUtility.isNullOrBlank(crewNameArray[1]) ? ' ' + crewNameArray[1] : "";
 

--- a/MekHQ/src/mekhq/campaign/mission/BotForceRandomizer.java
+++ b/MekHQ/src/mekhq/campaign/mission/BotForceRandomizer.java
@@ -459,7 +459,6 @@ public class BotForceRandomizer {
         en.setGame(campaign.getGame());
 
         RandomNameGenerator rng = RandomNameGenerator.getInstance();
-        rng.setChosenFaction(faction.getNameGenerator());
 
         Gender gender;
         int nonBinaryDiceSize = campaign.getCampaignOptions().getNonBinaryDiceSize();
@@ -470,7 +469,7 @@ public class BotForceRandomizer {
             gender = RandomGenderGenerator.generate();
         }
 
-        String[] crewNameArray = rng.generateGivenNameSurnameSplit(gender, faction.isClan(), faction.getShortName());
+        String[] crewNameArray = rng.generateGivenNameSurnameSplit(gender, faction.isClan(), faction.getNameGenerator());
         String crewName = crewNameArray[0];
         crewName += !StringUtility.isNullOrBlank(crewNameArray[1]) ? ' ' + crewNameArray[1] : "";
 

--- a/MekHQ/unittests/mekhq/campaign/mission/AtBDynamicScenarioFactoryTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/AtBDynamicScenarioFactoryTest.java
@@ -51,6 +51,7 @@ import static testUtilities.MHQTestUtilities.mockCampaign;
 
 import java.util.List;
 
+import megamek.client.generator.RandomNameGenerator;
 import megamek.common.Player;
 import megamek.common.enums.SkillLevel;
 import megamek.common.equipment.EquipmentType;
@@ -117,6 +118,24 @@ class AtBDynamicScenarioFactoryTest {
         createEntityWithCrew(faction, skill, campaign, entity, true);
 
         assertTrue(entity.getCrew().getNickname(0).isEmpty());
+    }
+
+    @Test
+    void createEntityWithCrewPreservesConfiguredNameFaction() {
+        RandomNameGenerator nameGenerator = RandomNameGenerator.getInstance();
+        String previousFaction = nameGenerator.getChosenFaction();
+        Faction capellanFaction = mock(Faction.class);
+        when(capellanFaction.getNameGenerator()).thenReturn("CC");
+        when(capellanFaction.getShortName()).thenReturn("CC");
+
+        try {
+            nameGenerator.setChosenFaction("FS");
+            createEntityWithCrew(capellanFaction, SkillLevel.VETERAN, campaign, getShadowHawk(), true);
+
+            assertEquals("FS", nameGenerator.getChosenFaction());
+        } finally {
+            nameGenerator.setChosenFaction(previousFaction);
+        }
     }
 
     private static Entity getShadowHawk() {

--- a/MekHQ/unittests/mekhq/campaign/mission/BotForceRandomizerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/BotForceRandomizerTest.java
@@ -33,6 +33,7 @@
 package mekhq.campaign.mission;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -41,10 +42,12 @@ import static testUtilities.MHQTestUtilities.mockCampaign;
 import java.io.File;
 import java.util.List;
 
+import megamek.client.generator.RandomNameGenerator;
 import megamek.common.Player;
 import megamek.common.equipment.EquipmentType;
 import megamek.common.loaders.MekSummary;
 import megamek.common.units.Entity;
+import megamek.common.units.EntityWeightClass;
 import megamek.common.units.UnitType;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.campaignOptions.CampaignOptions;
@@ -123,5 +126,24 @@ public class BotForceRandomizerTest {
         // There should be two units generated, as the player units score 1449BV, the same as the
         // Sparky.
         assertEquals(2, generated.size());
+    }
+
+    @Test
+    void testCrewGenerationPreservesConfiguredNameFaction() {
+        initializeTest();
+        RandomNameGenerator nameGenerator = RandomNameGenerator.getInstance();
+        String previousFaction = nameGenerator.getChosenFaction();
+        BotForceRandomizer randomizer = new BotForceRandomizer();
+        randomizer.setFactionCode("CC");
+
+        try {
+            nameGenerator.setChosenFaction("FS");
+            Entity generated = randomizer.getEntity(UnitType.MEK, EntityWeightClass.WEIGHT_MEDIUM, mockCampaign);
+
+            assertNotNull(generated);
+            assertEquals("FS", nameGenerator.getChosenFaction());
+        } finally {
+            nameGenerator.setChosenFaction(previousFaction);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- prevent dynamic scenario and randomized bot crew generation from overwriting the campaign's configured fixed name faction
- pass each bot faction's configured name-generator key directly when creating crew names
- add regression coverage for both bot crew generation paths using a Capellan faction while preserving a Federated Suns campaign setting

## Root cause
Bot crew generation called `RandomNameGenerator.setChosenFaction(...)` on the shared singleton before generating a name. Generating a Capellan bot therefore changed the Campaign Options fixed faction to `CC`, which affected later personnel name generation and was persisted with the campaign.

## Testing
- `./gradlew :MekHQ:test --tests "mekhq.campaign.mission.AtBDynamicScenarioFactoryTest" --tests "mekhq.campaign.mission.BotForceRandomizerTest"`
- `./gradlew :MekHQ:checkstyleTest`