### PR TITLE
Fix MekHQ#9594 Destroyed BA Suits cannot be replaced

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6473,10 +6473,6 @@ public class Campaign implements ITechManager {
         }
 
         final int minutes = Math.min(partWork.getTimeLeft(), techTime);
-        if (!(partWork instanceof Refit) && minutes <= 0) {
-            LOGGER.error("Attempting to get the target number for a part with zero time left.");
-            return new TargetRoll(TargetRoll.AUTOMATIC_FAIL, "No part repair time remaining.");
-        }
 
         int helpMod;
         if ((partWork.getUnit() != null) && partWork.getUnit().isSelfCrewed()) {


### PR DESCRIPTION
Fix #9594

Campaign.getTargetFor includes a check for if a technician has 0 repair time left || a part takes 0 minutes to repair, and automatically fails if either condition is true. 

This comes after a check that auto fails if the tech has 0 repair minutes remaining, so all it's doing is automatically failing to repair parts that take 0 minutes to repair.

This was changed at some point in the past from an automatic success to an automatic fail, but I don't believe either is necessary, so this PR removes the check.