### PR TITLE
Carry the bot combat posture through campaign saves (Requires megamek #8659)

### DIFF
--- a/MekHQ/resources/mekhq/resources/CustomizeBotForceDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CustomizeBotForceDialog.properties
@@ -40,6 +40,7 @@ lblCowardice.text=Cowardice:
 lblSelfPreservation.text=Self-Preservation:
 lblAggression.text=Aggression:
 lblHerdMentality.text=Herd Mentality:
+lblPosture.text=Combat Posture:
 lblPilotingRisk.text=Piloting Risk:
 lblForcedWithdrawal.text=Forced Withdrawal:
 lblAutoFlee.text=Auto Flee:

--- a/MekHQ/src/mekhq/campaign/mission/BotForce.java
+++ b/MekHQ/src/mekhq/campaign/mission/BotForce.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2018-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -169,6 +169,7 @@ public class BotForce implements IPlayerSettings {
         copy.getBehaviorSettings().setHyperAggressionIndex(this.getBehaviorSettings().getHyperAggressionIndex());
         copy.getBehaviorSettings().setSelfPreservationIndex(this.getBehaviorSettings().getSelfPreservationIndex());
         copy.getBehaviorSettings().setHerdMentalityIndex(this.getBehaviorSettings().getHerdMentalityIndex());
+        copy.getBehaviorSettings().setCombatPosture(this.getBehaviorSettings().getCombatPosture());
         // this bit of trickery seems to work to make a proper copy of the entity list
         copy.fixedEntityList = new ArrayList<>(this.getFixedEntityListDirect());
 
@@ -532,6 +533,7 @@ public class BotForce implements IPlayerSettings {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "retreatEdge", behaviorSettings.getRetreatEdge().ordinal());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "herdMentalityIndex", behaviorSettings.getHerdMentalityIndex());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "braveryIndex", behaviorSettings.getBraveryIndex());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "combatPosture", behaviorSettings.getCombatPosture().name());
         MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "behaviorSettings");
         MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "botForce");
     }
@@ -611,6 +613,10 @@ public class BotForce implements IPlayerSettings {
                             behaviorSettings.setHerdMentalityIndex(Integer.parseInt(wn3.getTextContent()));
                         } else if (wn3.getNodeName().equalsIgnoreCase("braveryIndex")) {
                             behaviorSettings.setBraveryIndex(Integer.parseInt(wn3.getTextContent()));
+                        } else if (wn3.getNodeName().equalsIgnoreCase("combatPosture")) {
+                            // The string setter parses case-insensitively and falls back to AUTO,
+                            // so campaigns saved before this tag existed load unchanged.
+                            behaviorSettings.setCombatPosture(wn3.getTextContent());
                         }
                     }
                 }

--- a/MekHQ/src/mekhq/gui/dialog/CustomizeBotForceDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizeBotForceDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2024-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -99,6 +99,7 @@ public class CustomizeBotForceDialog extends JDialog {
     private JLabel lblSelfPreservation;
     private JLabel lblAggression;
     private JLabel lblHerdMentality;
+    private JLabel lblPosture;
     private JLabel lblPilotingRisk;
     private JLabel lblForcedWithdrawal;
     private JLabel lblAutoFlee;
@@ -313,6 +314,7 @@ public class CustomizeBotForceDialog extends JDialog {
         lblSelfPreservation = new JLabel(Integer.toString(behavior.getSelfPreservationIndex()));
         lblAggression = new JLabel(Integer.toString(behavior.getHyperAggressionIndex()));
         lblHerdMentality = new JLabel(Integer.toString(behavior.getHerdMentalityIndex()));
+        lblPosture = new JLabel(behavior.getCombatPosture().toString());
         lblPilotingRisk = new JLabel(Integer.toString(behavior.getFallShameIndex()));
         lblForcedWithdrawal = new JLabel(getForcedWithdrawalDescription(behavior));
         lblAutoFlee = new JLabel(getAutoFleeDescription(behavior));
@@ -331,6 +333,10 @@ public class CustomizeBotForceDialog extends JDialog {
         gbcRight.gridy++;
         panBehavior.add(new JLabel(resourceMap.getString("lblHerdMentality.text")), gbcLeft);
         panBehavior.add(lblHerdMentality, gbcRight);
+        gbcLeft.gridy++;
+        gbcRight.gridy++;
+        panBehavior.add(new JLabel(resourceMap.getString("lblPosture.text")), gbcLeft);
+        panBehavior.add(lblPosture, gbcRight);
         gbcLeft.gridy++;
         gbcRight.gridy++;
         panBehavior.add(new JLabel(resourceMap.getString("lblPilotingRisk.text")), gbcLeft);
@@ -567,6 +573,7 @@ public class CustomizeBotForceDialog extends JDialog {
             lblSelfPreservation.setText(Integer.toString(behavior.getSelfPreservationIndex()));
             lblAggression.setText(Integer.toString(behavior.getHyperAggressionIndex()));
             lblHerdMentality.setText(Integer.toString(behavior.getHerdMentalityIndex()));
+            lblPosture.setText(behavior.getCombatPosture().toString());
             lblPilotingRisk.setText(Integer.toString(behavior.getFallShameIndex()));
             lblForcedWithdrawal.setText(getForcedWithdrawalDescription(behavior));
             lblAutoFlee.setText(getAutoFleeDescription(behavior));


### PR DESCRIPTION
> **Do not merge before megamek #8659.** This PR uses the `CombatPosture` class that PR adds; MekHQ's build against megamek main stays red until it lands.

## Summary

MegaMek's bots gained a combat posture setting - Attack, Defend, or Auto (megamek #8659): a defender holds its side of deep water and fights the enemy in the crossing. MekHQ already launches scenario bots with the whole `BehaviorSettings` object, so the posture reaches them with no launch changes. What was missing was persistence and visibility.

## Changes Made

- **BotForce** writes a `combatPosture` tag into the campaign save and reads it back. Campaigns saved before the tag existed load as AUTO - the string setter parses case-insensitively and falls back. The copy used by scenario generation carries it.
- **The bot force dialog** shows a read-only Combat Posture row. Editing already goes through MegaMek's bot config dialog, which owns the control.

## Files Changed

- `MekHQ/src/mekhq/campaign/mission/BotForce.java` - save tag, load branch, copy
- `MekHQ/src/mekhq/gui/dialog/CustomizeBotForceDialog.java` - display row
- `MekHQ/resources/mekhq/resources/CustomizeBotForceDialog.properties` - its label

## Testing

- `compileJava` clean against the megamek water branch.
- Manual: campaign save round-trip with a posture set; a pre-tag campaign loads as AUTO.

## Out of scope

- StratCon setting a mission tone per scenario template - tracked in #9733 with the rest of the campaign bot-type work.