### PR TITLE
Fix Campaign Operations campaign dates

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -119,7 +119,7 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
     private final boolean isInAppNewCampaign;
     private final Consumer<Campaign> completionHandler;
 
-    private final LocalDate DEFAULT_START_DATE = LocalDate.of(3051, 1, 1);
+    private static final LocalDate DEFAULT_START_DATE = LocalDate.of(3151, 1, 1);
 
     // endregion Variable Declarations
 

--- a/MekHQ/src/mekhq/gui/dialog/DateChooser.java
+++ b/MekHQ/src/mekhq/gui/dialog/DateChooser.java
@@ -759,7 +759,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
             }
             case 3 -> {
                 turningPoints = List.of("OperationFreedom");
-                turningPointDates = List.of(LocalDate.of(2866, 1, 1));
+                turningPointDates = List.of(LocalDate.of(2913, 2, 1));
                 eraLogo = new ImageIcon(LOGO_DIRECTORY + "era_sw" + LOGO_FILE_TYPE);
             }
             case 4 -> {


### PR DESCRIPTION
## Summary
- default new Campaign Operations campaigns to 3151 instead of 3051, as requested by CGL
- correct the Operation FREEDOM turning point from 2866 to February 2913 so it falls within the displayed Late Succession War era

## Validation
- `./gradlew :MekHQ:compileJava`
- `./gradlew :MekHQ:compileTestJava :MekHQ:checkstyleMain`

Fixes #9697