### PR TITLE
Resolve retired faction codes through their aliases (CEI, SE)

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/Factions.java
+++ b/MekHQ/src/mekhq/campaign/universe/Factions.java
@@ -50,6 +50,7 @@ import javax.swing.ImageIcon;
 import megamek.client.ratgenerator.FactionRecord;
 import megamek.client.ratgenerator.RATGenerator;
 import megamek.common.annotations.Nullable;
+import megamek.common.universe.Faction2;
 import megamek.common.universe.Factions2;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
@@ -148,9 +149,39 @@ public class Factions {
         return new ArrayList<>(factions.keySet());
     }
 
-    public Faction getFaction(String name) {
-        Faction defaultFaction = new Faction();
-        return factions.getOrDefault(name, defaultFaction);
+    /**
+     * Returns the faction for the given faction code.
+     * <p>
+     * A code that is not a current faction key is then resolved through the historical faction-code aliases (see
+     * {@link Faction2#getAliases()}). When a faction consolidation retires a code, the surviving faction keeps the old
+     * code as an alias - for example {@code CEI} (Escorpion Imperio) and {@code SE} (Scorpion Empire) are both retired
+     * into {@code CGS} - so that campaign saves, planetary ownership, universe data and RAT availability tables that
+     * still use the retired code keep resolving to the surviving faction rather than to the placeholder faction.
+     *
+     * @param name the faction code, either a current faction key or a retired alias
+     *
+     * @return the matching faction, or a placeholder faction when the code matches neither a key nor an alias
+     */
+    public Faction getFaction(@Nullable String name) {
+        Faction faction = factions.get(name);
+        if (faction == null) {
+            faction = factions.get(canonicalKeyForAlias(name));
+        }
+        return (faction != null) ? faction : new Faction();
+    }
+
+    /**
+     * Resolves a possibly retired faction code to the key of the faction that kept it as an alias.
+     *
+     * @param factionCode the faction code to resolve, which may be {@code null}
+     *
+     * @return the surviving faction's key, or {@code null} when the code is not a known alias
+     */
+    private @Nullable String canonicalKeyForAlias(@Nullable String factionCode) {
+        return Factions2.getInstance()
+                     .getFaction(factionCode)
+                     .map(Faction2::getKey)
+                     .orElse(null);
     }
 
     public @Nullable Faction getFactionFromFullNameAndYear(final String factionName, final int year) {

--- a/MekHQ/testresources/data/universe/factions/CC_test.yml
+++ b/MekHQ/testresources/data/universe/factions/CC_test.yml
@@ -17,6 +17,10 @@
 
 key: CC
 name: Capellan Confederation
+# Synthetic retired faction code, present only so that alias resolution has something to exercise in
+# tests. Mirrors the real CGS faction, which keeps the retired CEI and SE codes as aliases.
+aliases:
+  2367: CAPCON
 capital: Sian
 yearsActive:
   - start: 2367

--- a/MekHQ/unittests/mekhq/campaign/universe/FactionsIntegrationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/FactionsIntegrationTest.java
@@ -34,7 +34,9 @@ package mekhq.campaign.universe;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDate;
@@ -42,6 +44,7 @@ import java.util.List;
 
 import megamek.common.universe.FactionTag;
 import megamek.common.universe.Factions2;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.DOMException;
@@ -56,6 +59,20 @@ public class FactionsIntegrationTest {
         // previously executed test class happened to load into the singleton.
         Factions2.setInstance(testFactions2);
         Factions.setInstance(Factions.loadDefault(true));
+    }
+
+    /**
+     * Clears the faction singletons this class published, so that a later test class in the same JVM does not silently
+     * inherit the small test faction set. Clearing rather than restoring a captured instance is deliberate: there is no
+     * way to read the singletons without creating them, so capturing in {@link #setUp()} would force the full
+     * production faction data to load just to have something to put back. A null instance simply means "not yet
+     * loaded", which is the state the next caller expects to handle.
+     */
+    @AfterAll
+    public static void tearDown() {
+        Factions.setInstance(null);
+        Factions2.setInstance(null);
+        testFactions2 = null;
     }
 
     @Test
@@ -112,8 +129,13 @@ public class FactionsIntegrationTest {
         Faction byCurrentKey = factions.getFaction("CC");
         Faction byRetiredAlias = factions.getFaction("CAPCON");
 
-        assertEquals(byCurrentKey.getShortName(), byRetiredAlias.getShortName(),
-              "A retired faction code kept as an alias must resolve to the surviving faction");
+        // Pin down the current key first. Comparing the two lookups alone would also pass if the test faction data
+        // failed to load and both calls returned the placeholder faction.
+        assertEquals("CC", byCurrentKey.getShortName(), "Test faction data did not load");
+        assertNotEquals(Faction.DEFAULT_CODE, byRetiredAlias.getShortName(),
+              "A retired faction code must not fall back to the placeholder faction");
+        assertSame(byCurrentKey, byRetiredAlias,
+              "A retired faction code kept as an alias must resolve to the surviving faction entry itself");
     }
 
     /**

--- a/MekHQ/unittests/mekhq/campaign/universe/FactionsIntegrationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/FactionsIntegrationTest.java
@@ -52,6 +52,9 @@ public class FactionsIntegrationTest {
     @BeforeAll
     public static void setUp() {
         testFactions2 = new Factions2("testresources/data/universe/factions");
+        // The instance has to be published, otherwise these tests run against whichever faction data a
+        // previously executed test class happened to load into the singleton.
+        Factions2.setInstance(testFactions2);
         Factions.setInstance(Factions.loadDefault(true));
     }
 
@@ -94,5 +97,36 @@ public class FactionsIntegrationTest {
         assertEquals("Alshain", ghostBear.getStartingPlanet(LocalDate.of(3067, 1, 1)));
         assertTrue(ghostBear.is(FactionTag.CLAN));
         assertTrue(ghostBear.is(FactionTag.MAJOR));
+    }
+
+    /**
+     * A faction consolidation retires a faction code and keeps it on the surviving faction as an alias, so universe
+     * data and campaign saves still referring to the retired code must keep resolving. Regression coverage for the
+     * live case where {@code CEI} (retired into {@code CGS}) resolved to the placeholder faction instead, which made
+     * the faction diplomacy loader drop every Escorpion Imperio containment entry.
+     */
+    @Test
+    public void getFactionResolvesRetiredCodeThroughAlias() {
+        Factions factions = Factions.getInstance();
+
+        Faction byCurrentKey = factions.getFaction("CC");
+        Faction byRetiredAlias = factions.getFaction("CAPCON");
+
+        assertEquals(byCurrentKey.getShortName(), byRetiredAlias.getShortName(),
+              "A retired faction code kept as an alias must resolve to the surviving faction");
+    }
+
+    /**
+     * The alias fallback must not turn genuinely unknown codes into real factions - they still have to come back as
+     * the placeholder faction so callers can detect and report bad data.
+     */
+    @Test
+    public void getFactionReturnsPlaceholderForUnknownCode() {
+        Factions factions = Factions.getInstance();
+
+        Faction unknown = factions.getFaction("NOT_A_REAL_FACTION_CODE");
+
+        assertEquals(Faction.DEFAULT_CODE, unknown.getShortName(),
+              "An unrecognised faction code must resolve to the placeholder faction");
     }
 }


### PR DESCRIPTION
## What this fixes

MekHQ never resolved a retired faction code. If a faction's code changed - because two faction files
were consolidated into one - anything still referring to the old code silently resolved to the
placeholder "no such faction" entry instead of to the faction that actually survived.

The visible symptom was a constant stream of errors in `megamek.log`:

```
Invalid faction code in factionhints.xml: CEI
Invalid faction code in factionhints.xml: CEI/CGS
Invalid faction code in factionhints.xml: CEI/NC
Invalid faction code in factionhints.xml: CEI/UC
Invalid faction code in factionhints.xml: CEI/HL
```

The quieter and more damaging half: the faction diplomacy loader resolves faction codes through the same
lookup, so every one of those Escorpion Imperio relationships was **dropped from the loaded data**, with
nothing but a log line to say so.

## Why this is not a data problem

`CGS.yml` is the consolidation of the former Escorpion Imperio and Scorpion Empire faction files, and it
deliberately keeps both retired codes:

```yaml
aliases:
  3080: CEI
  3141: SE
```

The file's own comment explains the intent: the codes are kept "so that existing campaign saves,
planetary ownership and RAT availability tables that still reference CEI or SE resolve to CGS."

MegaMek honours that. `Factions2` builds an alias-to-canonical map in `registerAliases()`, and
`Factions2.getFaction()` falls back to it when a code is not a current key.

MekHQ did not. `Factions.getFaction()` was a flat map lookup:

```java
public Faction getFaction(String name) {
    Faction defaultFaction = new Faction();
    return factions.getOrDefault(name, defaultFaction);
}
```

and that map is keyed only on each faction's current short name. So MekHQ built its faction list *from*
`Factions2` and then threw the alias information away. `CGS` is currently the only faction with aliases,
which is why this only ever showed up as a Scorpion problem.

## Changes

- `Factions.getFaction()` now falls back to alias resolution on a miss, by asking `Factions2` for the
  surviving faction's key. It reuses the one existing alias source rather than keeping a second copy of
  the table in MekHQ.
- An unrecognised code still returns the placeholder faction, so genuinely bad data is still reported
  rather than being quietly mapped onto something real.
- `FactionsIntegrationTest` gains two tests: one that a retired code resolves to the surviving faction,
  one that an unknown code still does not.
- No test faction had aliases, so `CC_test.yml` gains a synthetic retired code for the fallback to
  exercise.
- That test class also now publishes its `Factions2` instance. The field was assigned and never used,
  which meant the tests ran against whichever faction data a previously executed test class happened to
  have loaded into the singleton. Two other test classes already do this.

## Files Changed

- `MekHQ/src/mekhq/campaign/universe/Factions.java`
- `MekHQ/unittests/mekhq/campaign/universe/FactionsIntegrationTest.java`
- `MekHQ/testresources/data/universe/factions/CC_test.yml`

## Testing

- `FactionsIntegrationTest`: 3 tests, 0 failures, 0 skipped - confirmed from the test report that the two
  new tests actually ran rather than being filtered out.
- **Confirmed the regression test really catches the bug**: with the fix stashed,
  `getFactionResolvesRetiredCodeThroughAlias` fails; with it applied, it passes.
- `checkstyleMain` clean.

**Playtested.** Started MekHQ and the faction diplomacy data loads with no faction errors at all:

```
[FactionDiplomacy] Loading faction diplomacy data from data\universe\factionDiplomacy
[FactionDiplomacy] Loaded 94 files from data\universe\factionDiplomacy (0 failed)
```

Both families of error are gone from `logs/mekhq.log` - the `factionhints.xml: CEI/CGS` lines from the
original report, and the `[FactionDiplomacy] Invalid faction code CEI in ...` lines that the YAML loader
was producing. The remaining ERROR/WARN lines in that log are unrelated and pre-existing (a missing
optional `randomDeathCauses.xml`, some MRMS repair-option type IDs, two campaign-options entries).

## Relationship to mm-data #507

MegaMek/mm-data#507 removes the Escorpion Imperio entries that still used the retired `CEI` code, one of
which was independently wrong (it made Clan Goliath Scorpion contained within itself).

**The two are independent and can merge in either order.** This PR is the general fix - it makes retired
codes resolve everywhere, including in campaign saves, planetary ownership and RAT availability tables
that no data PR can reach. #507 is the specific data cleanup. Neither blocks the other.

## What is NOT proven yet

- **The playtest does not separate this fix from the data fix.** It was run with MegaMek/mm-data#507
  applied as well, and either change alone would have silenced those log errors. What isolates *this*
  change is the unit test: with the fix stashed, `getFactionResolvesRetiredCodeThroughAlias` fails.
- **The unit tests were run against a MegaMek feature branch, not `main`.** MekHQ builds against the
  local MegaMek working tree, which was on an unrelated feature branch at the time. Nothing in that
  branch touches the faction classes this change depends on, but it should get one confirming run
  against `main`.
- **Only the alias path is tested, not every consumer of it.** Making retired codes resolve is a
  behaviour change for anything that previously received the placeholder faction. That is the intended
  fix, but the knock-on effects on planetary ownership and RAT lookups have not been exercised.
- **No before/after measurement of contract generation.** The employer-weighting consequence described
  in #507 was traced by reading `RandomFactionGenerator`, not measured; confirming it would need many
  contract generations and a tally.
