### PR TITLE
Fix graded rank serialization

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/ranks/Rank.java
+++ b/MekHQ/src/mekhq/campaign/personnel/ranks/Rank.java
@@ -170,7 +170,7 @@ public class Rank {
             String name = getRankNames().get(profession);
             name = (name == null) ? "-" : name;
             if (getRankLevels().containsKey(profession) && (getRankLevels().get(profession) > 1)) {
-                joiner.add(name + getRankLevels().get(profession));
+                joiner.add(name + ":" + getRankLevels().get(profession));
             } else {
                 joiner.add(name);
             }

--- a/MekHQ/unittests/mekhq/campaign/personnel/ranks/RankTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/ranks/RankTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.personnel.ranks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+
+import mekhq.campaign.personnel.enums.Profession;
+import org.junit.jupiter.api.Test;
+
+public class RankTest {
+    @Test
+    public void testGetRankNamesAsStringPreservesRankLevel() {
+        final String[] rankNames = new String[Profession.values().length];
+        Arrays.fill(rankNames, "-");
+        rankNames[Profession.MEKWARRIOR.ordinal()] = "Collective:3";
+        final Rank rank = new Rank(rankNames, false, 1.0);
+
+        final String[] serializedNames = rank.getRankNamesAsString(",").split(",", -1);
+
+        assertEquals("Collective:3", serializedNames[Profession.MEKWARRIOR.ordinal()]);
+    }
+}


### PR DESCRIPTION
## Summary
- preserve the colon between a rank name and its grade when serializing rank systems
- add a regression test covering graded rank-name serialization

Fixes #9699

## Testing
- `./gradlew :MekHQ:compileJava :MekHQ:compileTestJava :MekHQ:checkstyleMain :MekHQ:checkstyleTest`
- `./gradlew :MekHQ:test --tests "mekhq.campaign.personnel.ranks.RankTest"`