### PR TITLE
Exclude subunits from the faction choosers (requires MegaMek #8679)

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/Faction.java
+++ b/MekHQ/src/mekhq/campaign/universe/Faction.java
@@ -390,6 +390,20 @@ public boolean isAresConventionsSignatory(int year) {
         return is(FactionTag.PLAYABLE);
     }
 
+    /**
+     * Returns whether this is a subordinate formation declared inside another command's file - an individual regiment
+     * of the Davion Brigade of Guards, say - rather than a command in its own right.
+     *
+     * <p>Subunits are loaded as full factions so that they stay selectable and generatable, which means they arrive in
+     * {@link Factions#getFactions()} alongside everything else. Anywhere the player is offered a choice of factions
+     * should leave them out, or a single faction's list grows by every regiment of every command it owns.</p>
+     *
+     * @return {@code true} when this faction came from another command's subunit declaration
+     */
+    public boolean isSubunit() {
+        return (faction2 != null) && faction2.isSubunit();
+    }
+
     public boolean isMercenary() {
         return is(FactionTag.MERC);
     }

--- a/MekHQ/src/mekhq/gui/dialog/PlanetarySystemEditorDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PlanetarySystemEditorDialog.java
@@ -2011,6 +2011,8 @@ public class PlanetarySystemEditorDialog extends AbstractMHQDialogBasic {
                      .filter(Objects::nonNull)
                      .filter(faction -> blankToNull(faction.getShortName()) != null)
                      .filter(faction -> !faction.isAggregate())
+                     // A planet is owned by a faction or a command, never by an individual regiment of one.
+                     .filter(faction -> !faction.isSubunit())
                      .map(faction -> new FactionChoice(faction.getShortName(), factionDisplayName(faction, year),
                            faction.getStartYear(), faction.getEndYear()))
                      .sorted(Comparator.comparing(choice -> choice.displayName().toLowerCase(Locale.ROOT)))

--- a/MekHQ/src/mekhq/gui/displayWrappers/FactionDisplay.java
+++ b/MekHQ/src/mekhq/gui/displayWrappers/FactionDisplay.java
@@ -65,10 +65,23 @@ public class FactionDisplay {
     }
     //endregion Getters/Setters
 
+    /**
+     * Builds the display list for a faction chooser, dropping factions not valid on the given date and any subordinate
+     * formation declared inside another command's file.
+     *
+     * <p>Subunits are excluded because these lists offer whole commands: including every regiment of every command
+     * would add thousands of entries a player has no use for choosing between here.</p>
+     *
+     * @param factions the factions to offer
+     * @param today    the date the list is being shown for
+     *
+     * @return the sorted display list
+     */
     public static List<FactionDisplay> getSortedValidFactionDisplays(
           final Collection<Faction> factions, final LocalDate today) {
         return getSortedFactionDisplays(factions.stream()
                                               .filter(faction -> faction.validIn(today))
+                                              .filter(faction -> !faction.isSubunit())
                                               .collect(Collectors.toList()), today);
     }
 

--- a/MekHQ/src/mekhq/gui/utilities/OriginFactionPickerHelper.java
+++ b/MekHQ/src/mekhq/gui/utilities/OriginFactionPickerHelper.java
@@ -102,9 +102,12 @@ public final class OriginFactionPickerHelper {
      */
     public static DefaultComboBoxModel<Faction> buildModel(Person person, int currentYear,
           LocalDate endDate, boolean showAllFactions) {
+        // Subordinate formations declared inside another command's file are left out: a person's origin is a faction
+        // or a command, never an individual regiment of one.
         List<Faction> orderedFactions = Factions.getInstance()
                                               .getFactions()
                                               .stream()
+                                              .filter(faction -> !faction.isSubunit())
                                               .sorted((a, b) -> a.getFullName(currentYear)
                                                                       .compareToIgnoreCase(b.getFullName(currentYear)))
                                               .toList();

--- a/MekHQ/src/mekhq/gui/utilities/OriginFactionPickerHelper.java
+++ b/MekHQ/src/mekhq/gui/utilities/OriginFactionPickerHelper.java
@@ -102,12 +102,9 @@ public final class OriginFactionPickerHelper {
      */
     public static DefaultComboBoxModel<Faction> buildModel(Person person, int currentYear,
           LocalDate endDate, boolean showAllFactions) {
-        // Subordinate formations declared inside another command's file are left out: a person's origin is a faction
-        // or a command, never an individual regiment of one.
         List<Faction> orderedFactions = Factions.getInstance()
                                               .getFactions()
                                               .stream()
-                                              .filter(faction -> !faction.isSubunit())
                                               .sorted((a, b) -> a.getFullName(currentYear)
                                                                       .compareToIgnoreCase(b.getFullName(currentYear)))
                                               .toList();
@@ -120,6 +117,12 @@ public final class OriginFactionPickerHelper {
                 continue;
             }
             if (faction.is(FactionTag.HIDDEN) || faction.is(FactionTag.SPECIAL)) {
+                continue;
+            }
+            // A person's origin is a faction or a command, never an individual regiment of one.
+            // Checked after the origin test above so that a character who somehow already has a
+            // subunit origin keeps it, rather than silently losing the assignment on edit.
+            if (faction.isSubunit()) {
                 continue;
             }
             if (showAllFactions) {

--- a/MekHQ/unittests/mekhq/campaign/universe/FactionSubunitTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/FactionSubunitTest.java
@@ -36,8 +36,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
+import javax.swing.DefaultComboBoxModel;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -47,8 +49,11 @@ import java.util.TreeMap;
 
 import megamek.common.universe.Faction2;
 import megamek.common.universe.HonorRating;
+import mekhq.campaign.personnel.Person;
 import mekhq.gui.displayWrappers.FactionDisplay;
+import mekhq.gui.utilities.OriginFactionPickerHelper;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 /**
  * Verifies that subordinate formations - the individual regiments declared inside a command's file - are recognised as
@@ -95,6 +100,29 @@ class FactionSubunitTest {
         Faction legacyFaction = new Faction("FS", "Federated Suns");
 
         assertFalse(legacyFaction.isSubunit());
+    }
+
+    @Test
+    void anExistingSubunitOriginIsKeptSoEditingDoesNotLoseIt() {
+        // buildModel documents that a person's current origin is always offered, so that editing a
+        // character whose origin would otherwise be filtered out does not silently drop it. The
+        // subunit exclusion has to respect that, or hand-edited data loses the assignment.
+        Faction subunitOrigin = factionFrom("FS.DaviBrig.Heav", "Davion Heavy Guards", true);
+        Person person = mock(Person.class);
+        when(person.getOriginFaction()).thenReturn(subunitOrigin);
+        when(person.getDateOfBirth()).thenReturn(LocalDate.of(3000, 1, 1));
+
+        try (MockedStatic<Factions> factionsStatic = mockStatic(Factions.class)) {
+            Factions factions = mock(Factions.class);
+            when(factions.getFactions()).thenReturn(List.of(subunitOrigin));
+            factionsStatic.when(Factions::getInstance).thenReturn(factions);
+
+            DefaultComboBoxModel<Faction> model =
+                  OriginFactionPickerHelper.buildModel(person, 3025, null, true);
+
+            assertEquals(1, model.getSize(), "The person's existing origin must still be offered");
+            assertEquals(subunitOrigin, model.getElementAt(0));
+        }
     }
 
     @Test

--- a/MekHQ/unittests/mekhq/campaign/universe/FactionSubunitTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/FactionSubunitTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.universe;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.TreeMap;
+
+import megamek.common.universe.Faction2;
+import megamek.common.universe.HonorRating;
+import mekhq.gui.displayWrappers.FactionDisplay;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that subordinate formations - the individual regiments declared inside a command's file - are recognised as
+ * such and left out of the lists that offer the player a choice of faction.
+ */
+class FactionSubunitTest {
+
+    /**
+     * Builds a Faction from a stubbed Faction2. Every collection the constructor walks is stubbed explicitly rather
+     * than left to Mockito's defaults, because it dereferences several of them directly.
+     */
+    private static Faction factionFrom(String key, String name, boolean isSubunit) {
+        Faction2 faction2 = mock(Faction2.class);
+        when(faction2.getKey()).thenReturn(key);
+        when(faction2.getName()).thenReturn(name);
+        when(faction2.isSubunit()).thenReturn(isSubunit);
+        when(faction2.getTags()).thenReturn(new HashSet<>());
+        when(faction2.getFallBackFactions()).thenReturn(new LinkedHashSet<>());
+        when(faction2.getYearsActive()).thenReturn(new ArrayList<>());
+        when(faction2.getNameChanges()).thenReturn(new TreeMap<>());
+        when(faction2.getCapitalChanges()).thenReturn(new TreeMap<>());
+        when(faction2.getPreInvasionHonorRating()).thenReturn(HonorRating.NONE);
+        when(faction2.getPostInvasionHonorRating()).thenReturn(HonorRating.NONE);
+        return new Faction(faction2);
+    }
+
+    @Test
+    void aCommandIsNotASubunit() {
+        Faction command = factionFrom("FS.DaviBrig", "Davion Brigade of Guards", false);
+
+        assertFalse(command.isSubunit());
+    }
+
+    @Test
+    void aRegimentDeclaredInsideACommandIsASubunit() {
+        Faction regiment = factionFrom("FS.DaviBrig.Heav", "Davion Heavy Guards", true);
+
+        assertTrue(regiment.isSubunit());
+    }
+
+    @Test
+    void aFactionBuiltWithoutFaction2IsNotASubunit() {
+        // Factions built the old way carry no Faction2, and must not blow up on the question.
+        Faction legacyFaction = new Faction("FS", "Federated Suns");
+
+        assertFalse(legacyFaction.isSubunit());
+    }
+
+    @Test
+    void factionChoosersLeaveSubunitsOut() {
+        Faction command = factionFrom("FS.DaviBrig", "Davion Brigade of Guards", false);
+        Faction regiment = factionFrom("FS.DaviBrig.Heav", "Davion Heavy Guards", true);
+
+        List<FactionDisplay> offered = FactionDisplay.getSortedValidFactionDisplays(
+              List.of(command, regiment), LocalDate.of(3025, 1, 1));
+
+        assertEquals(1, offered.size(), "Only the command should be offered, not its regiment");
+        assertEquals(command, offered.get(0).getFaction());
+    }
+}


### PR DESCRIPTION
> **Depends on MegaMek PR #8679** (`faction2-subunits`). This will not compile until that is
> merged, because it calls `Faction2.isSubunit()`, which #8679 introduces. MekHQ builds against
> the MegaMek source via `includeBuild('../megamek')`, so the sibling checkout needs #8679 in it
> as well. **Please hold this until #8679 is in.**

## Summary

Keeps subordinate formations out of the lists that offer the player a choice of faction.

MegaMek PR #8679 lets a command declare its regiments inline, and registers each one as a full
faction so it stays selectable and generatable. That is the right runtime model, but it means
they arrive in `Factions.getFactions()` alongside everything else - and MekHQ builds its entire
faction map from exactly that call:

```java
Factions2.getInstance(isForTesting).getFactions().stream()
      .map(Faction::new)
      .forEach(f -> factionsObject.factions.put(f.getShortName(), f));
```

Once the nested command data ships, that is roughly 5,400 extra entries. Most of MekHQ is already
protected - `getActiveFactions(...)` filters on `!getShortName().contains(".")`, and no caller
asks for commands - but a handful of choosers read the map directly and would grow by every
regiment of every command.

## Changes

1. `Faction` - `isSubunit()`, delegating to the `Faction2` it already holds. No new state: a
   `Faction` built the old way has no `Faction2` and answers `false`.
2. `FactionDisplay.getSortedValidFactionDisplays(...)` - excludes subunits. This is the shared
   entry point for the bot force, GM tools and campaign faction choosers, so one filter covers
   three dialogs.
3. `OriginFactionPickerHelper.buildModel(...)` - excludes subunits. A person's origin is a
   faction or a command, never an individual regiment of one.
4. `PlanetarySystemEditorDialog.loadFactionChoices()` - excludes subunits. A planet is owned by a
   faction or a command.

## Files Changed

- `MekHQ/src/mekhq/campaign/universe/Faction.java` - `isSubunit()`
- `MekHQ/src/mekhq/gui/displayWrappers/FactionDisplay.java` - filter, covering three dialogs
- `MekHQ/src/mekhq/gui/utilities/OriginFactionPickerHelper.java` - filter
- `MekHQ/src/mekhq/gui/dialog/PlanetarySystemEditorDialog.java` - filter
- `MekHQ/unittests/mekhq/campaign/universe/FactionSubunitTest.java` - new; 4 tests

## Deliberately left alone

`InterstellarMapPanel` also reads `getFactions()` directly, but only to build a
faction-to-capital lookup map - nothing is shown to the player, and a subunit simply has no
capital. Filtering it would add noise without changing behaviour.

## Testing

Four unit tests: a command is not a subunit, a regiment declared inside one is, a `Faction`
built without a `Faction2` answers `false` rather than throwing, and the shared chooser returns
the command but not its regiment.

## What is NOT proven yet

- **Not compiled or run.** `Faction2.isSubunit()` does not exist until #8679 merges, and the
  MegaMek checkout this builds against is on another branch, so I could not build or execute the
  tests. Everything here is written against the current sources by reading them. The test stubs
  every collection the `Faction(Faction2)` constructor dereferences, and the stub return types
  were checked against `Faction2`'s real signatures, but that is inspection rather than a green
  run. **Please treat the test as unverified until CI has had it.**
- **Not seen in a running client.** No dropdown has been observed with subunits present, because
  no shipped data declares any yet.
- The count of affected choosers comes from searching for direct `getFactions()` callers. A
  chooser that reaches the faction list another way would not have been found.
