### PR TITLE
Keep the speaker's gender when a faction leader has none recorded

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionAccoladeEvent.java
+++ b/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionAccoladeEvent.java
@@ -47,6 +47,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import megamek.common.annotations.Nullable;
 import megamek.common.enums.Gender;
 import megamek.common.loaders.EntityLoadingException;
 import megamek.common.loaders.MekFileParser;
@@ -303,15 +304,34 @@ public class FactionAccoladeEvent {
                 speaker.setSecondaryRole(PersonnelRole.MILITARY_PROMOTER);
             } else if (isLetterFromHeadOfState) {
                 FactionLeaderData leaderData = accoladingFaction.getLeaderForYear(campaign.getGameYear());
-                if (leaderData != null) {
-                    String name = leaderData.getFullTitle(true);
-                    speaker.setGivenName(name);
-                    speaker.setSurname("");
-                    speaker.setGender(leaderData.gender());
-                }
+                applyLeaderIdentity(speaker, leaderData);
             }
         }
         return speaker;
+    }
+
+    /**
+     * Gives the speaker the name and gender of the faction leader who signed the letter.
+     *
+     * <p>The leader's gender is only applied when one is recorded. Command files carry commanding officers whose
+     * sourcebooks never state a gender, so {@link FactionLeaderData#gender()} can be {@code null}; the speaker was
+     * already created with a generated gender, and that is kept rather than cleared.</p>
+     *
+     * @param speaker    the person who will deliver the letter
+     * @param leaderData the leader in power in the current year, or {@code null} if the faction records none
+     */
+    static void applyLeaderIdentity(final Person speaker, final @Nullable FactionLeaderData leaderData) {
+        if (leaderData == null) {
+            return;
+        }
+
+        speaker.setGivenName(leaderData.getFullTitle(true));
+        speaker.setSurname("");
+
+        Gender leaderGender = leaderData.gender();
+        if (leaderGender != null) {
+            speaker.setGender(leaderGender);
+        }
     }
 
     /**

--- a/MekHQ/unittests/mekhq/campaign/universe/factionStanding/FactionAccoladeLeaderIdentityTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/factionStanding/FactionAccoladeLeaderIdentityTest.java
@@ -73,7 +73,11 @@ class FactionAccoladeLeaderIdentityTest {
         FactionAccoladeEvent.applyLeaderIdentity(speaker, leaderWithGender(null));
 
         verify(speaker, never()).setGender(any());
+        // The full title goes into the given name, so the generated surname must still be cleared.
+        // Otherwise the letter is signed by "Colonel Natasha Kerensky" followed by a surname that
+        // was never theirs.
         verify(speaker).setGivenName("Colonel Natasha Kerensky");
+        verify(speaker).setSurname("");
     }
 
     @Test

--- a/MekHQ/unittests/mekhq/campaign/universe/factionStanding/FactionAccoladeLeaderIdentityTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/factionStanding/FactionAccoladeLeaderIdentityTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.universe.factionStanding;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import megamek.common.enums.Gender;
+import megamek.common.universe.FactionLeaderData;
+import mekhq.campaign.personnel.Person;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies how the signatory of a head-of-state letter is named and gendered.
+ *
+ * <p>Faction leaders come from the universe data, where the gender is optional: the command files carry commanding
+ * officers whose sourcebooks never state one. Applying such a leader must not clear the gender the speaker was
+ * already generated with, because a person without a gender goes on to break anything that reads it.</p>
+ */
+class FactionAccoladeLeaderIdentityTest {
+
+    private static FactionLeaderData leaderWithGender(Gender gender) {
+        return new FactionLeaderData("Colonel", "Natasha", "Kerensky", null, gender, 3020, 3050);
+    }
+
+    @Test
+    void genderIsAppliedWhenTheLeaderRecordsOne() {
+        Person speaker = mock(Person.class);
+
+        FactionAccoladeEvent.applyLeaderIdentity(speaker, leaderWithGender(Gender.FEMALE));
+
+        verify(speaker).setGender(Gender.FEMALE);
+        verify(speaker).setGivenName("Colonel Natasha Kerensky");
+        verify(speaker).setSurname("");
+    }
+
+    @Test
+    void generatedGenderIsKeptWhenTheLeaderRecordsNone() {
+        Person speaker = mock(Person.class);
+
+        FactionAccoladeEvent.applyLeaderIdentity(speaker, leaderWithGender(null));
+
+        verify(speaker, never()).setGender(any());
+        verify(speaker).setGivenName("Colonel Natasha Kerensky");
+    }
+
+    @Test
+    void nothingIsAppliedWhenTheFactionHasNoLeaderForTheYear() {
+        Person speaker = mock(Person.class);
+
+        FactionAccoladeEvent.applyLeaderIdentity(speaker, null);
+
+        verify(speaker, never()).setGender(any());
+        verify(speaker, never()).setGivenName(any());
+        verify(speaker, never()).setSurname(any());
+    }
+}


### PR DESCRIPTION
## What goes wrong

When a faction sends the player a letter from its head of state, the speaker who delivers it takes
the leader's name and gender. The gender was applied unconditionally:

```java
speaker.setGender(leaderData.gender());
```

That was safe only because every faction leader in the universe data happens to have a gender
recorded. [mm-data #508](https://github.com/MegaMek/mm-data/pull/508) breaks that assumption: it
adds 2,660 commanding officers to the command files, drawn from the sourcebooks, and **1,837 of them
have no gender stated anywhere**.

The loader accepts a leader with the field left out and hands it over as `null` - I verified that
against a live load - so that `null` would be written straight onto the speaker. A person with no
gender then breaks the next time anything reads it: `person.getGender().isFemale()` in the marriage
and death routines, or `getGender().name()` when the campaign is saved.

This is reachable in ordinary play. `FactionStandings` walks every faction the campaign has standing
with, and commands are factions like any other, so the Davion Brigade of Guards can be the one
sending the letter.

## The fix

The speaker is already created with a generated gender a few lines above:

```java
speaker = ... .newPerson(campaign, personnelRole, factionCode1, Gender.RANDOMIZE);
```

So when the leader's gender is unknown, the right answer is to keep the one the speaker already has
rather than overwrite it with nothing. The name is still applied either way.

I moved it into `applyLeaderIdentity(Person, FactionLeaderData)` so the behaviour can be tested -
`getSpeaker` is private, static, and needs a whole `Campaign` to call. That also makes the method it
came out of shorter rather than longer.

## Files Changed

- `MekHQ/src/mekhq/campaign/universe/factionStanding/FactionAccoladeEvent.java` - apply the leader's
  gender only when one is recorded, in a named helper
- `MekHQ/unittests/mekhq/campaign/universe/factionStanding/FactionAccoladeLeaderIdentityTest.java` -
  new, 3 tests

## Testing

Three tests, all passing:

- a leader with a gender has it applied
- a leader without one leaves the speaker's generated gender alone
- a faction with no leader for the year changes nothing at all

## What is NOT proven yet

- **Not exercised in a running campaign.** No accolade letter has actually been triggered in a
  client; the tests cover the helper directly.
- **This does not need mm-data #508 to be merged first**, and is worth having either way - the guard
  is correct regardless of which data is loaded. It does need to be in before that data lands.
- **Other consumers of leader data were checked and need nothing.** `getFullTitle` and
  `getFullName` do not touch the gender, and this is the only place a leader's gender is read.
