### PR TITLE
Document Essential Scenarios in the glossary

### DIFF
--- a/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
+++ b/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
@@ -678,6 +678,14 @@ EMPTY_SYSTEMS.definition=Empty or abandoned systems are only visible if the 'Emp
  \ stranded in one of these systems could be disastrous.\
  <p>Currently, MekHQ doesn't model the dangers of traversing empty systems. However, that will not always be the case\
  \ and players are advised to avoid these systems when possible.</p>
+ESSENTIAL_SCENARIOS.title=Essential Scenarios
+ESSENTIAL_SCENARIOS.definition=Essential Scenarios are <a href='GLOSSARY:STRATCON'>StratCon</a> scenarios tied to a\
+ \ specific <a href='GLOSSARY:STRATEGIC_OBJECTIVES'>Strategic Objective</a>. The Briefing Room marks them as\
+ \ <b>(Essential)</b> when they appear.\
+ <p>Winning an Essential Scenario completes its associated objective. Any other result fails that objective.</p>\
+ <p>The Essential label identifies a required contract objective. It is separate from\
+ \ <a href='GLOSSARY:TURNING_POINTS'>Turning Point</a> and <a href='GLOSSARY:CRISIS_SCENARIO'>Crisis</a> labels, which\
+ \ describe effects on <a href='GLOSSARY:CONTRACT_VICTORY_POINTS'>Contract Victory Points (CVP)</a>.</p>
 EXPERIENCE_COSTS.title=Experience Costs
 EXPERIENCE_COSTS.definition=Both the New and Veteran Player presets model their xp costs on <i>A Time of War</i>. These\
   \ costs can be higher than expected if you've played MeKHQ for a long time.\
@@ -1934,7 +1942,8 @@ STRATEGIC_OBJECTIVES.definition=In <a href='GLOSSARY:STRATCON'>StratCon</a> you 
  \ several Strategic Objectives. This is usually ensuring you end the contract with a positive\
  \ <a href='GLOSSARY:CONTRACT_VICTORY_POINTS'>Contract Victory Point (CVP)</a> score, but might also include\
  \ destroying or retaining control of a specific <a href='GLOSSARY:STRATCON_FACILITIES'>Facility</a>. Sometimes there\
- \ are specific, hidden, scenarios that you must find and complete.\
+ \ are specific, hidden, scenarios that you must find and complete. These are shown as\
+ \ <a href='GLOSSARY:ESSENTIAL_SCENARIOS'>Essential Scenarios</a> in the Briefing Room.\
  <p>When completing a contract, you should select 'Partial Success' if you have not completed all Strategic\
  \ Objectives.</p>
 STRIPPING_AND_REPAIRING.title=Stripping & Repairing a Unit

--- a/MekHQ/src/mekhq/campaign/utilities/glossary/GlossaryEntry.java
+++ b/MekHQ/src/mekhq/campaign/utilities/glossary/GlossaryEntry.java
@@ -86,6 +86,7 @@ public enum GlossaryEntry {
     EDGE("EDGE", new Version("0.50.06")),
     EDUCATION("EDUCATION", new Version("0.50.06")),
     EMPTY_SYSTEMS("EMPTY_SYSTEMS", new Version("0.50.06")),
+    ESSENTIAL_SCENARIOS("ESSENTIAL_SCENARIOS", new Version("0.51.01")),
     EXPERIENCE_COSTS("EXPERIENCE_COSTS", new Version("0.50.06")),
     EXPERIENCE_RATING("EXPERIENCE_RATING", new Version("0.50.06")),
     EXTRA_INCOME("EXTRA_INCOME", new Version("0.50.10")),


### PR DESCRIPTION
## Summary
- add an Essential Scenarios glossary entry explaining the Briefing Room label
- distinguish Essential scenarios from Turning Point and Crisis scenarios
- cross-link Essential Scenarios and Strategic Objectives

## Investigation
The campaign attached to #9722 was loaded against current `main`. Both affected strategic scenarios retained their objective flags and rendered `(Essential)` through `ScenarioTableModel`. The relevant lookup and rendering logic is unchanged from v0.51.0, so this PR limits the change to the confirmed documentation gap.

## Testing
- `GlossaryEntryTest` (258 tests passed)
- `./gradlew :MekHQ:compileJava :MekHQ:compileTestJava :MekHQ:checkstyleMain`

## Screenshots
<img width="2170" height="1835" alt="image" src="https://github.com/user-attachments/assets/05b4c2d2-7d4b-46ec-834a-63f9b23aa3c1" />
<img width="2977" height="1220" alt="image" src="https://github.com/user-attachments/assets/22c64c5f-9ea7-43d5-832f-a939b5d4ba1a" />

Closes #9722