### PR TITLE
Version the build with MegaMek's optional fourth version component

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,16 @@ subprojects {
     versionProperties.load(rootProject.file("../megamek/megamek/resources/Version.properties").newDataInputStream())
     def processedVersion = String.format("%d.%02d.%02d", Integer.parseInt(versionProperties.getProperty("major")), Integer.parseInt(versionProperties.getProperty("minor")), Integer.parseInt(versionProperties.getProperty("patch")))
 
+    // Optional fourth component, present only for a special point release such as 0.51.0.1. See the comment in
+    // MegaMek's megamek/resources/Version.properties, which is the file read above.
+    def revisionProperty = versionProperties.getProperty("revision")
+    if (revisionProperty != null && !revisionProperty.trim().isEmpty()) {
+        def parsedRevision = Integer.parseInt(revisionProperty.trim())
+        if (parsedRevision > 0) {
+            processedVersion = String.format("%s.%d", processedVersion, parsedRevision)
+        }
+    }
+
     if (project.hasProperty("extraVersion")) {
         processedVersion = String.format("%s-%s", processedVersion, project.getProperty('extraVersion'))
     }


### PR DESCRIPTION
## What this changes for you

Nothing, until someone cuts a special point release. This is the MekHQ half of a three-repo change.

MegaMek can now be given a version number like **0.51.0.1** for a point release that ships on top of an existing patch release (MegaMek/megamek#8690). The number lives in `megamek/resources/Version.properties` — and **MekHQ's build reads that exact file**, from the sibling checkout, to version itself (`build.gradle:19`).

So without this change, a point release would have produced a `MekHQ-0.51.01.tar.gz` sitting next to a `MegaMek-0.51.01.1.tar.gz`, and MekHQ's own dependency line (`implementation "org.megamek:megamek:${version}"`) would have asked for a MegaMek version string that no longer existed.

Ten lines in `build.gradle` appends the fourth component when it is present. Most releases will not have one, and when it is absent the computed version is unchanged.

| | revision absent | `revision=1` set in MegaMek |
|---|---|---|
| MekHQ artifact | `0.51.01` | `0.51.01.1` |

## Why there is no Java change

Two things already handle it, which is worth stating because "add a fourth version digit" sounds like it should need code:

**MekHQ inherits the version object.** `MHQConstants extends SuiteConstants`, so `MHQConstants.VERSION` *is* MegaMek's `Version`, which now understands the optional component. And MekHQ builds with `includeBuild('../megamek')`, compiling against local MegaMek source rather than a published jar.

**MekHQ stores its version as a single string.** Campaign saves, presets, rank systems and story arcs all write `version="0.51.01"` as one attribute and read it back with `new Version(text)`. Since `toString()` now emits the fourth digit and the parser now reads it, they round-trip a point release for free. (MegaMek needed a reader fix precisely because it stores its version as separate `<major>`/`<minor>`/`<patch>` elements instead.)

I checked for component-wise version handling across `MekHQ/src` and there is none.

## Changes

1. `build.gradle` - appends MegaMek's optional revision component to the computed project version, when present.

## Files Changed

- `build.gradle` - artifact version

## Testing

Verified against the real build rather than by inspection. With no revision set, `:MekHQ:properties` reports `version: 0.51.01` — unchanged. With `revision=1` set in MegaMek's `Version.properties`, it reports `version: 0.51.01.1`. Reverted and re-checked: back to `0.51.01`.

`:MekHQ:compileJava` is green against a MegaMek with a four-part version set, so the composite build and the `org.megamek:megamek:${version}` dependency both resolve.

I also checked the one MekHQ feature that could be sensitive to version *format* — the campaign milestone-upgrade gate (`CampaignPreset:644`, `CampaignOptionsMetadata:147`, and the glossary "added since last milestone" tags). Every one uses `Version` comparison methods rather than string matching, so a four-part version orders correctly through all of them.

## What is NOT proven yet

- **MekHQ was not launched, and no campaign was saved and reloaded carrying a four-part version.** The round-trip is inferred from reading `CampaignXmlParser:2018` and `Campaign:5367`, not observed.
- **No tests added.** There is no MekHQ Java change to regress here; the behaviour lives in MegaMek's `Version` and is covered by 26 tests in `VersionTest` on that PR.
- **Setting a revision versions the whole suite**, since all three projects read the one file. For a MegaMek-only release, it should be set on the release branch rather than main — otherwise MekHQ nightlies built from that checkout will also report the point-release number.

## Companion PRs

- MegaMek: MegaMek/megamek#8690 (the actual implementation — **merge first**)
- MegaMekLab: MegaMek/megameklab — same branch name

All three branches share a name so CI resolves them against each other.
