### PR TITLE
Fix campaign preset user-folder handling

### DIFF
--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -34,8 +34,8 @@
 # Campaign Class
 acquireEquipment.bulkOrder.format=(bulk order of {0})
 # CampaignPreset Class
-CampaignPresetSaveFailure.title=Campaign Preset Creation Failure
-CampaignPresetSaveFailure.text=Oh no! The program was unable to correctly export your campaign options. We know this \nis annoying and apologize. Please help us out and submit a bug with the \nmekhq.log file from this game so we can prevent this from happening in the future.
+CampaignPresetSaveFailure.title=Campaign Preset Save Failed
+CampaignPresetSaveFailure.text=<html>MekHQ could not save the campaign preset.<br><br>Check that the selected User Files Directory exists and is writable, then try again.<br>See mekhq.log for details.</html>
 ## Enums
 # PlanetaryAcquisitionFactionLimit Enum
 PlanetaryAcquisitionFactionLimit.ALL.text=All Factions

--- a/MekHQ/src/mekhq/CampaignPreset.java
+++ b/MekHQ/src/mekhq/CampaignPreset.java
@@ -39,6 +39,7 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -420,9 +421,9 @@ public class CampaignPreset {
     }
 
     // region File I/O
-    public void writeToFile(final JFrame frame, @Nullable File file) {
+    public boolean writeToFile(final @Nullable JFrame frame, @Nullable File file) {
         if (file == null) {
-            return;
+            return false;
         }
 
         String path = file.getPath();
@@ -436,14 +437,21 @@ public class CampaignPreset {
               OutputStreamWriter osw = new OutputStreamWriter(bos, StandardCharsets.UTF_8);
               PrintWriter pw = new PrintWriter(osw)) {
             writeToXML(pw, 0);
+            if (pw.checkError()) {
+                throw new IOException("Failed to write campaign preset to " + file);
+            }
+            return true;
         } catch (Exception ex) {
             LOGGER.error("writeToFile() Exception", ex);
-            final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Campaign",
-                  MekHQ.getMHQOptions().getLocale());
-            JOptionPane.showMessageDialog(frame,
-                  resources.getString("CampaignPresetSaveFailure.text"),
-                  resources.getString("CampaignPresetSaveFailure.title"),
-                  JOptionPane.ERROR_MESSAGE);
+            if (frame != null) {
+                final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Campaign",
+                      MekHQ.getMHQOptions().getLocale());
+                JOptionPane.showMessageDialog(frame,
+                      resources.getString("CampaignPresetSaveFailure.text"),
+                      resources.getString("CampaignPresetSaveFailure.title"),
+                      JOptionPane.ERROR_MESSAGE);
+            }
+            return false;
         }
     }
 

--- a/MekHQ/src/mekhq/CampaignPreset.java
+++ b/MekHQ/src/mekhq/CampaignPreset.java
@@ -34,6 +34,7 @@ package mekhq;
 
 import static megamek.SuiteConstants.LAST_MILESTONE;
 import static mekhq.MHQConstants.CAMPAIGN_PRESET_DIRECTORY;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -52,7 +53,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.ResourceBundle;
 import java.util.stream.Collectors;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
@@ -108,6 +108,7 @@ public class CampaignPreset {
      */
     private static final Version LAST_COMPATIBLE_VERSION = LAST_MILESTONE;
 
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.Campaign";
     private static final MMLogger LOGGER = MMLogger.create(CampaignPreset.class);
 
     /**
@@ -444,11 +445,9 @@ public class CampaignPreset {
         } catch (Exception ex) {
             LOGGER.error("writeToFile() Exception", ex);
             if (frame != null) {
-                final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Campaign",
-                      MekHQ.getMHQOptions().getLocale());
                 JOptionPane.showMessageDialog(frame,
-                      resources.getString("CampaignPresetSaveFailure.text"),
-                      resources.getString("CampaignPresetSaveFailure.title"),
+                      getTextAt(RESOURCE_BUNDLE, "CampaignPresetSaveFailure.text"),
+                      getTextAt(RESOURCE_BUNDLE, "CampaignPresetSaveFailure.title"),
                       JOptionPane.ERROR_MESSAGE);
             }
             return false;

--- a/MekHQ/src/mekhq/CampaignPreset.java
+++ b/MekHQ/src/mekhq/CampaignPreset.java
@@ -334,6 +334,19 @@ public class CampaignPreset {
     // endregion Getters/Setters
 
     /**
+     * Returns the directory where user-created campaign presets should be saved. If a custom user directory is
+     * configured, presets are stored beneath it; otherwise the legacy MekHQ user-data directory is used.
+     *
+     * @return the writable campaign preset directory
+     */
+    public static File getUserCampaignPresetDirectory() {
+        final File configuredDirectory = getConfiguredUserCampaignPresetDirectory();
+        return configuredDirectory == null
+              ? new File(MHQConstants.USER_CAMPAIGN_PRESET_DIRECTORY)
+              : configuredDirectory;
+    }
+
+    /**
      * Retrieves a combined list of all campaign presets from the default directory, the old user data directory, and
      * the modern (user-defined) user data directory. The campaign presets are sourced, merged, and sorted in natural
      * order before being returned.
@@ -358,9 +371,10 @@ public class CampaignPreset {
         presets.addAll(loadCampaignPresetsFromDirectory(new File(MHQConstants.USER_CAMPAIGN_PRESET_DIRECTORY)));
 
         // Modern user data directory
-        String userDirectory = PreferenceManager.getClientPreferences().getUserDir();
-        File presetUserDirectory = new File(userDirectory + '/' + CAMPAIGN_PRESET_DIRECTORY);
-        presets.addAll(loadCampaignPresetsFromDirectory(presetUserDirectory));
+        final File configuredDirectory = getConfiguredUserCampaignPresetDirectory();
+        if (configuredDirectory != null) {
+            presets.addAll(loadCampaignPresetsFromDirectory(configuredDirectory));
+        }
 
         final NaturalOrderComparator naturalOrderComparator = new NaturalOrderComparator();
 
@@ -388,15 +402,21 @@ public class CampaignPreset {
         presets.addAll(loadCampaignPresetsMetadataFromDirectory(new File(MHQConstants.USER_CAMPAIGN_PRESET_DIRECTORY)));
 
         // Modern user data directory
-        String userDirectory = PreferenceManager.getClientPreferences().getUserDir();
-        File presetUserDirectory = new File(userDirectory + '/' + CAMPAIGN_PRESET_DIRECTORY);
-        presets.addAll(loadCampaignPresetsMetadataFromDirectory(presetUserDirectory));
+        final File configuredDirectory = getConfiguredUserCampaignPresetDirectory();
+        if (configuredDirectory != null) {
+            presets.addAll(loadCampaignPresetsMetadataFromDirectory(configuredDirectory));
+        }
 
         final NaturalOrderComparator naturalOrderComparator = new NaturalOrderComparator();
 
         presets.sort((p0, p1) -> naturalOrderComparator.compare(p0.toString(), p1.toString()));
 
         return presets;
+    }
+
+    private static @Nullable File getConfiguredUserCampaignPresetDirectory() {
+        final String userDirectory = PreferenceManager.getClientPreferences().getUserDir();
+        return userDirectory.isBlank() ? null : new File(userDirectory, CAMPAIGN_PRESET_DIRECTORY);
     }
 
     // region File I/O

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsDialog.java
@@ -62,7 +62,6 @@ import megamek.client.ui.settings.SettingsIconLegend;
 import megamek.client.ui.util.UIUtil;
 import megamek.logging.MMLogger;
 import mekhq.CampaignPreset;
-import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.campaignOptions.CampaignOptions;
@@ -318,7 +317,7 @@ public class CampaignOptionsDialog extends AbstractButtonDialog {
      * @return the file the preset should be written to
      */
     private File resolveUserPresetFile(final CampaignPreset preset) {
-        final File presetDirectory = new File(MHQConstants.USER_CAMPAIGN_PRESET_DIRECTORY);
+        final File presetDirectory = CampaignPreset.getUserCampaignPresetDirectory();
         if (!presetDirectory.exists() && !presetDirectory.mkdirs()) {
             LOGGER.error("Failed to create campaign preset directory: {}", presetDirectory);
         }

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsDialog.java
@@ -301,7 +301,9 @@ public class CampaignOptionsDialog extends AbstractButtonDialog {
             }
 
             campaignOptionsPane.applyCampaignOptionsToCampaign(preset, mode, true);
-            preset.writeToFile(getFrame(), presetFile);
+            if (!preset.writeToFile(getFrame(), presetFile)) {
+                return;
+            }
             showSavePresetSuccessDialog(preset, presetFile.getParentFile(), presetFile);
             return;
         }

--- a/MekHQ/unittests/mekhq/CampaignPresetTest.java
+++ b/MekHQ/unittests/mekhq/CampaignPresetTest.java
@@ -33,6 +33,7 @@
 package mekhq;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -94,5 +95,23 @@ class CampaignPresetTest {
         assertTrue(CampaignPreset.getCampaignPresetsMetadata()
                          .stream()
                          .anyMatch(preset -> presetFile.toFile().equals(preset.getPresetFile())));
+    }
+
+    @Test
+    void writeToFileReportsFailureForInvalidDestination(final @TempDir Path temporaryDirectory) throws IOException {
+        final Path parentFile = temporaryDirectory.resolve("not-a-directory");
+        Files.writeString(parentFile, "blocking file", StandardCharsets.UTF_8);
+        final Path presetFile = parentFile.resolve("Campaign Preset.xml");
+
+        assertFalse(new CampaignPreset().writeToFile(null, presetFile.toFile()));
+        assertFalse(Files.exists(presetFile));
+    }
+
+    @Test
+    void writeToFileReportsSuccess(final @TempDir Path temporaryDirectory) {
+        final Path presetFile = temporaryDirectory.resolve("Campaign Preset.xml");
+
+        assertTrue(new CampaignPreset().writeToFile(null, presetFile.toFile()));
+        assertTrue(Files.isRegularFile(presetFile));
     }
 }

--- a/MekHQ/unittests/mekhq/CampaignPresetTest.java
+++ b/MekHQ/unittests/mekhq/CampaignPresetTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import megamek.common.preference.PreferenceManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CampaignPresetTest {
+    private String originalUserDirectory;
+
+    @BeforeEach
+    void rememberUserDirectory() {
+        originalUserDirectory = PreferenceManager.getClientPreferences().getUserDir();
+    }
+
+    @AfterEach
+    void restoreUserDirectory() {
+        PreferenceManager.getClientPreferences().setUserDir(originalUserDirectory == null ? "" : originalUserDirectory);
+    }
+
+    @Test
+    void userCampaignPresetDirectoryFallsBackToLegacyDirectory() {
+        PreferenceManager.getClientPreferences().setUserDir("");
+
+        assertEquals(Path.of(MHQConstants.USER_CAMPAIGN_PRESET_DIRECTORY).normalize(),
+              CampaignPreset.getUserCampaignPresetDirectory().toPath().normalize());
+    }
+
+    @Test
+    void userCampaignPresetDirectoryUsesConfiguredUserDirectory(final @TempDir Path temporaryDirectory) {
+        final Path userDirectory = temporaryDirectory.resolve("Custom Files (BattleTech)");
+        PreferenceManager.getClientPreferences().setUserDir(userDirectory.toString());
+
+        assertEquals(userDirectory.resolve(MHQConstants.CAMPAIGN_PRESET_DIRECTORY).normalize(),
+              CampaignPreset.getUserCampaignPresetDirectory().toPath().normalize());
+    }
+
+    @Test
+    void presetPickerFindsMetadataInConfiguredUserDirectory(final @TempDir Path temporaryDirectory) throws IOException {
+        final Path userDirectory = temporaryDirectory.resolve("Custom Files (BattleTech)");
+        final Path presetDirectory = userDirectory.resolve(MHQConstants.CAMPAIGN_PRESET_DIRECTORY);
+        final Path presetFile = presetDirectory.resolve("Custom User Preset.xml");
+        Files.createDirectories(presetDirectory);
+        Files.writeString(presetFile, """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <campaignPreset version="0.50.10">
+                  <title>Custom User Preset</title>
+                  <description>Loaded from the configured user directory.</description>
+              </campaignPreset>
+              """, StandardCharsets.UTF_8);
+        PreferenceManager.getClientPreferences().setUserDir(userDirectory.toString());
+
+        assertTrue(CampaignPreset.getCampaignPresetsMetadata()
+                         .stream()
+                         .anyMatch(preset -> presetFile.toFile().equals(preset.getPresetFile())));
+    }
+}


### PR DESCRIPTION
## Summary
- save user-created campaign presets under the configured User Files Directory, with the legacy `userdata` location as the fallback
- use the same configured preset directory for full and metadata loading, while avoiding a filesystem-root lookup when no user directory is configured
- report write failures explicitly and suppress the false success dialog after a failed save
- add focused coverage for default and configured paths, custom-folder discovery, and successful/failed writes

## Validation
- `./gradlew :MekHQ:test --tests "mekhq.CampaignPresetTest"`
- `./gradlew :MekHQ:compileJava :MekHQ:compileTestJava :MekHQ:checkstyleMain :MekHQ:checkstyleTest`
- manually verified default-folder saves, configured custom-folder saves and loading, and an unwritable-folder failure
- verified the preset attached to #7996 is discovered from `{userDir}/data/campaignPresets`

Closes #8617
Closes #7996