### PR TITLE
Fix Campaign Options visual issues

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -79,13 +79,13 @@ generalPanel.border="War has been described as an art, as a science, as an exten
   \ competing in a wide-open market, the mercenary leader does not have this advantage, and it\
   \ behooves him to run his firm wisely, efficiently, and economically."\
   <br><i>From "The Soldier's Balance Sheet" by Colonel David "Bear" Tarquin</i>
-legend.customSystem=Custom system unique to <i>MekHQ</i>.
-legend.documented=Documentation included in <i>MekHQ/docs</i>.
+legend.customSystem=Custom system unique to MekHQ.
+legend.documented=Documentation included in MekHQ/docs.
 legend.important=Tooltip contains important information.
 legend.recommended=Tooltip contains a recommendation.
 legend.unimplemented=Feature is shown but not yet implemented.
-legend.development=Added since the last <b>Development</b> release.
-legend.milestone=Added since the last <b>Milestone</b> release.
+legend.development=Added since the last Development release.
+legend.milestone=Added since the last Milestone release.
 lblGeneralCampaignBasicsPanel.text=Campaign Basics
 lblGeneralCampaignBasicsPanel.summary=Start date, unit name, and faction identity.
 lblGeneralIdentityArtworkPanel.text=Unit Identity
@@ -1117,7 +1117,7 @@ lblFactionNames.text=Fixed Faction
 lblFactionNames.tooltip=All names will be generated based on the selected faction.
 lblAssignPortraitOnRoleChange.text=Reassign Portrait on Role Change
 lblAssignPortraitOnRoleChange.tooltip=With this enabled, a person without a portrait will\
-  \ automatically gain a random portrait when their primary role is changed switched.
+  \ automatically gain a random portrait when their primary role changes.
 lblAllowDuplicatePortraits.text=Allow Duplicate Portraits
 lblAllowDuplicatePortraits.tooltip=With this enabled, random portraits are no longer unique\
   \ and several different people can have the same portrait.
@@ -1813,7 +1813,7 @@ lblRequireSupportForceTransportation.text=Require Transportation for Non-Combat 
 lblRequireSupportForceTransportation.tooltip=Campaign Operations is ambiguous about the need for transportation for \
   non-combat forces. If this option is enabled, non-combat forces without transport bays will penalize your force's \
   Reputation, in the same way as untransported combat forces.
-lblClampReputationPayMultiplier.text=Clamp Reputation Pay Multiplier 
+lblClampReputationPayMultiplier.text=Clamp Reputation Pay Multiplier
 lblClampReputationPayMultiplier.tooltip=When using CamOps Reputation your unit's reputation score\
   \ affects contract pay. This option clamps the reputation-based multiplier between 50 and 200%.\
   <br>\

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/MedicalPage.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/MedicalPage.java
@@ -151,7 +151,8 @@ class MedicalPage {
               "UseAlternativeAdvancedMedicalFewerPermanentInjuries"));
 
         lblAlternativeAdvancedMedicalHealingTimeMultiplier = new CampaignOptionsLabel(
-              "AlternativeAdvancedMedicalHealingTimeMultiplier");
+              "AlternativeAdvancedMedicalHealingTimeMultiplier",
+              getMetadata(new Version(0, 51, 1), CampaignOptionFlag.IMPORTANT));
         lblAlternativeAdvancedMedicalHealingTimeMultiplier.addMouseListener(createTipPanelUpdater(
               "AlternativeAdvancedMedicalHealingTimeMultiplier"));
         spnAlternativeAdvancedMedicalHealingTimeMultiplier = new CampaignOptionsSpinner(
@@ -159,8 +160,7 @@ class MedicalPage {
               1.0,
               0.01,
               10,
-              0.01,
-              getMetadata(new Version(0, 51, 1), CampaignOptionFlag.IMPORTANT));
+              0.01);
         spnAlternativeAdvancedMedicalHealingTimeMultiplier.addMouseListener(createTipPanelUpdater(
               "AlternativeAdvancedMedicalHealingTimeMultiplier"));
 

--- a/MekHQ/unittests/mekhq/gui/campaignOptions/contents/CampaignOptionsVisualRegressionTest.java
+++ b/MekHQ/unittests/mekhq/gui/campaignOptions/contents/CampaignOptionsVisualRegressionTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.campaignOptions.contents;
+
+import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.campaignOptionsLegendEntries;
+import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.getCampaignOptionsResourceBundle;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+
+import megamek.client.ui.settings.SettingsBadge;
+import megamek.common.preference.PreferenceManager;
+import mekhq.gui.campaignOptions.CampaignOptionFlag;
+import mekhq.gui.campaignOptions.components.CampaignOptionsLabel;
+import mekhq.gui.campaignOptions.components.CampaignOptionsSpinner;
+import org.junit.jupiter.api.Test;
+
+class CampaignOptionsVisualRegressionTest {
+    @Test
+    void legendDescriptionsArePlainText() {
+        for (SettingsBadge badge : campaignOptionsLegendEntries()) {
+            assertFalse(badge.description().matches("(?s).*<[^>]+>.*"), badge.description());
+        }
+    }
+
+    @Test
+    void advancedMedicalMultiplierBadgesBelongToLabel() throws ReflectiveOperationException {
+        var clientPreferences = PreferenceManager.getClientPreferences();
+        String userDirectory = clientPreferences.getUserDir();
+        MedicalPage page = new MedicalPage();
+        try {
+            clientPreferences.setUserDir("");
+            page.createPanel(null);
+        } finally {
+            clientPreferences.setUserDir(userDirectory);
+        }
+
+        CampaignOptionsLabel label = getField(page,
+              "lblAlternativeAdvancedMedicalHealingTimeMultiplier",
+              CampaignOptionsLabel.class);
+        CampaignOptionsSpinner spinner = getField(page,
+              "spnAlternativeAdvancedMedicalHealingTimeMultiplier",
+              CampaignOptionsSpinner.class);
+
+        assertTrue(label.getText().contains(CampaignOptionFlag.IMPORTANT.getSymbol()));
+        assertFalse(spinner.getSettingsHelpText().contains("Material Symbols Rounded"));
+    }
+
+    @Test
+    void portraitRoleChangeTooltipUsesOneVerb() {
+        assertEquals(
+              "With this enabled, a person without a portrait will automatically gain a random portrait when their "
+                    + "primary role changes.",
+              getTextAt(getCampaignOptionsResourceBundle(), "lblAssignPortraitOnRoleChange.tooltip"));
+    }
+
+    private static <T> T getField(Object target, String fieldName, Class<T> fieldType)
+          throws ReflectiveOperationException {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return fieldType.cast(field.get(target));
+    }
+}


### PR DESCRIPTION
## Summary

- use plain text in the Campaign Options icon legend so formatting tags are not displayed literally
- render the advanced medical multiplier's metadata badges beside its label instead of appending symbols to spinner help
- correct the duplicated verb in the portrait reassignment description
- add focused regression coverage for all three reported presentation issues

## Verification

- `:MekHQ:test --tests "mekhq.gui.campaignOptions.contents.CampaignOptionsVisualRegressionTest"`
- `:MekHQ:compileJava :MekHQ:processResources`
- `:MekHQ:checkstyleMain :MekHQ:checkstyleTest`
- manual review of all three Campaign Options locations

Closes #9745

Companion startup-hardening fix: MegaMek/megamek#8696 closes MegaMek/megamek#8695, which was discovered while manually verifying this change.