### PR TITLE
Allow relationship disinterest chance to be disabled

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/ProcreationPage.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/ProcreationPage.java
@@ -304,7 +304,7 @@ class ProcreationPage {
                 getMetadata(MILESTONE_BEFORE_METADATA, CampaignOptionFlag.IMPORTANT));
         lblNoInterestInRelationshipsDiceSize.addMouseListener(createTipPanelUpdater("NoInterestInRelationshipsDiceSize"));
         spnNoInterestInRelationshipsDiceSize = new CampaignOptionsSpinner("NoInterestInRelationshipsDiceSize",
-                10, 1, 100000, 1);
+                10, 0, 100000, 1);
         spnNoInterestInRelationshipsDiceSize.addMouseListener(createTipPanelUpdater("NoInterestInRelationshipsDiceSize"));
 
         lblPrefersSameSexDiceSize = new CampaignOptionsLabel("PrefersSameSexDiceSize",

--- a/MekHQ/unittests/mekhq/gui/campaignOptions/contents/CampaignOptionsVisualRegressionTest.java
+++ b/MekHQ/unittests/mekhq/gui/campaignOptions/contents/CampaignOptionsVisualRegressionTest.java
@@ -40,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Field;
+import javax.swing.SpinnerNumberModel;
 
 import megamek.client.ui.settings.SettingsBadge;
 import megamek.common.preference.PreferenceManager;
@@ -86,6 +87,19 @@ class CampaignOptionsVisualRegressionTest {
                     + "primary role changes.",
               getTextAt(getCampaignOptionsResourceBundle(), "lblAssignPortraitOnRoleChange.tooltip"));
     }
+
+        @Test
+        void noInterestInRelationshipsChanceCanReachZero() throws ReflectiveOperationException {
+          ProcreationPage page = new ProcreationPage();
+          page.createPanel(null);
+
+          CampaignOptionsSpinner spinner = getField(page,
+              "spnNoInterestInRelationshipsDiceSize",
+              CampaignOptionsSpinner.class);
+          spinner.setValue(1);
+
+          assertEquals(0, ((SpinnerNumberModel) spinner.getModel()).getPreviousValue());
+        }
 
     private static <T> T getField(Object target, String fieldName, Class<T> fieldType)
           throws ReflectiveOperationException {


### PR DESCRIPTION
## Summary
- allow the No Interest in Relationships chance to be set to `0`, matching the tooltip and existing runtime semantics for disabling the result
- add regression coverage confirming the spinner can decrement from `1` to `0`

## Testing
- `./gradlew.bat :MekHQ:compileJava :MekHQ:compileTestJava :MekHQ:checkstyleMain :MekHQ:checkstyleTest`
- `CampaignOptionsVisualRegressionTest` (5 tests passed)
- mutation check against the previous minimum of `1`

Fixes #9488