### PR TITLE
Rename automatic rank assigner

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -214,7 +214,7 @@ import mekhq.campaign.personnel.enums.SplittingSurnameStyle;
 import mekhq.campaign.personnel.generator.AbstractPersonnelGenerator;
 import mekhq.campaign.personnel.marriage.AbstractMarriage;
 import mekhq.campaign.personnel.procreation.AbstractProcreation;
-import mekhq.campaign.personnel.ranks.AutoAssignRankForCompanyGenerator;
+import mekhq.campaign.personnel.ranks.AutomaticRankAssigner;
 import mekhq.campaign.personnel.ranks.RankSystem;
 import mekhq.campaign.personnel.skills.ActionCheckResult;
 import mekhq.campaign.personnel.skills.Appraisal;
@@ -4403,7 +4403,7 @@ public class Campaign implements ITechManager {
             final String factionCode = chosenFaction.getShortName();
             Person speaker = getPlayerForce().getHumanResources().newPerson(this, role, factionCode, Gender.RANDOMIZE);
 
-            AutoAssignRankForCompanyGenerator.assignRankSystemFromFaction(speaker, RO_MIN);
+            AutomaticRankAssigner.assignRankSystemFromFaction(speaker, RO_MIN);
 
             new FactionJudgmentDialog(this, speaker, getPlayerForce().getHumanResources()
                                                            .getCommander(getCampaignOptions(),

--- a/MekHQ/src/mekhq/campaign/mission/AbstractMissionTransition.java
+++ b/MekHQ/src/mekhq/campaign/mission/AbstractMissionTransition.java
@@ -83,7 +83,7 @@ import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.backgrounds.BackgroundsController;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.enums.Phenotype;
-import mekhq.campaign.personnel.ranks.AutoAssignRankForCompanyGenerator;
+import mekhq.campaign.personnel.ranks.AutomaticRankAssigner;
 import mekhq.campaign.personnel.ranks.RankSystem;
 import mekhq.campaign.personnel.ranks.RankValidator;
 import mekhq.campaign.personnel.ranks.Ranks;
@@ -443,7 +443,7 @@ public abstract class AbstractMissionTransition {
                                  .getHumanResources()
                                  .newPerson(campaign, PersonnelRole.MILITARY_LIAISON, factionCode, Gender.RANDOMIZE));
 
-        AutoAssignRankForCompanyGenerator.assignRankSystemFromFaction(getEmployerLiaison(), RO_MIN);
+    AutomaticRankAssigner.assignRankSystemFromFaction(getEmployerLiaison(), RO_MIN);
     }
 
     public int getAllyQuality() {
@@ -627,7 +627,7 @@ public abstract class AbstractMissionTransition {
             getClanOpponent().setBloodname(bloodname.getName());
         }
 
-        AutoAssignRankForCompanyGenerator.assignAscendingRank(getClanOpponent(), RO_MIN);
+        AutomaticRankAssigner.assignAscendingRank(getClanOpponent(), RO_MIN);
 
         final RankSystem rankSystem = Ranks.getRankSystemFromCode("CLAN");
 
@@ -639,7 +639,7 @@ public abstract class AbstractMissionTransition {
         getClanOpponent().setRankSystem(rankValidator, rankSystem);
 
         int targetClanRank = 38;
-        AutoAssignRankForCompanyGenerator.assignAscendingRank(getClanOpponent(), targetClanRank);
+        AutomaticRankAssigner.assignAscendingRank(getClanOpponent(), targetClanRank);
     }
 
     public boolean isBatchallAccepted() {

--- a/MekHQ/src/mekhq/campaign/mission/AbstractMissionTransition.java
+++ b/MekHQ/src/mekhq/campaign/mission/AbstractMissionTransition.java
@@ -443,7 +443,7 @@ public abstract class AbstractMissionTransition {
                                  .getHumanResources()
                                  .newPerson(campaign, PersonnelRole.MILITARY_LIAISON, factionCode, Gender.RANDOMIZE));
 
-    AutomaticRankAssigner.assignRankSystemFromFaction(getEmployerLiaison(), RO_MIN);
+        AutomaticRankAssigner.assignRankSystemFromFaction(getEmployerLiaison(), RO_MIN);
     }
 
     public int getAllyQuality() {

--- a/MekHQ/src/mekhq/campaign/mission/newContract/contractGeneration/EmployerLiaison.java
+++ b/MekHQ/src/mekhq/campaign/mission/newContract/contractGeneration/EmployerLiaison.java
@@ -45,7 +45,7 @@ import megamek.common.enums.Gender;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRole;
-import mekhq.campaign.personnel.ranks.AutoAssignRankForCompanyGenerator;
+import mekhq.campaign.personnel.ranks.AutomaticRankAssigner;
 
 public class EmployerLiaison {
     private final static PersonnelRole PIRATE_LIAISON_ROLE = BROKER;
@@ -88,6 +88,6 @@ public class EmployerLiaison {
             return;
         }
 
-        AutoAssignRankForCompanyGenerator.assignRankSystemFromFaction(negotiator, RO_MIN);
+        AutomaticRankAssigner.assignRankSystemFromFaction(negotiator, RO_MIN);
     }
 }

--- a/MekHQ/src/mekhq/campaign/mission/newContract/contractGeneration/EmployerNegotiator.java
+++ b/MekHQ/src/mekhq/campaign/mission/newContract/contractGeneration/EmployerNegotiator.java
@@ -50,7 +50,7 @@ import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonUtility;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.generator.SingleSpecialAbilityGenerator;
-import mekhq.campaign.personnel.ranks.AutoAssignRankForCompanyGenerator;
+import mekhq.campaign.personnel.ranks.AutomaticRankAssigner;
 import mekhq.campaign.personnel.skills.Skill;
 import mekhq.campaign.personnel.skills.enums.SkillAttribute;
 import mekhq.campaign.universe.Faction;
@@ -189,6 +189,6 @@ public class EmployerNegotiator {
             return;
         }
 
-        AutoAssignRankForCompanyGenerator.assignRankSystemFromFaction(negotiator, RO_MIN);
+        AutomaticRankAssigner.assignRankSystemFromFaction(negotiator, RO_MIN);
     }
 }

--- a/MekHQ/src/mekhq/campaign/personnel/ranks/AutomaticRankAssigner.java
+++ b/MekHQ/src/mekhq/campaign/personnel/ranks/AutomaticRankAssigner.java
@@ -51,21 +51,21 @@ import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Faction;
 
 /**
- * Utility class responsible for automatically assigning ranks to the crew of a given {@link Unit} based on faction
- * rules, unit type, and individual experience levels.
+ * Utility class responsible for automatically assigning ranks to personnel. It can apply a faction's rank system and
+ * select a valid rank for an individual, or assign missing ranks across a {@link Unit}'s crew.
  *
- * <p>Rank assignment follows a hierarchy: the unit commander receives the highest
+ * <p>When assigning a unit's crew, rank assignment follows a hierarchy: the unit commander receives the highest
  * rank index, squad leaders (if applicable) receive an intermediate rank, and remaining crew members are assigned the
  * next available rank below the leaders. Clan and ComStar/Word of Blake factions use simplified, flat rank assignments
  * rather than the standard graduated system.</p>
  *
- * <p>Only personnel who do not already hold a rank are affected; existing ranks
+ * <p>Only crew members who do not already hold a rank are affected; existing ranks
  * are always preserved.</p>
  *
  * @author Illiani
  * @since 0.51.0
  */
-public final class AutoAssignRankForCompanyGenerator {
+public final class AutomaticRankAssigner {
     private static final String NO_RANK = "None";
     private static final String MISSING_RANK = "-";
 
@@ -317,6 +317,6 @@ public final class AutoAssignRankForCompanyGenerator {
         }
         person.setRankSystem(rankValidator, rankSystem);
 
-        AutoAssignRankForCompanyGenerator.assignAscendingRank(person, rankLevel);
+        AutomaticRankAssigner.assignAscendingRank(person, rankLevel);
     }
 }

--- a/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionAccoladeEvent.java
+++ b/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionAccoladeEvent.java
@@ -65,7 +65,7 @@ import mekhq.campaign.force.CombatTeam;
 import mekhq.campaign.force.FormationLevel;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRole;
-import mekhq.campaign.personnel.ranks.AutoAssignRankForCompanyGenerator;
+import mekhq.campaign.personnel.ranks.AutomaticRankAssigner;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.IUnitGenerator;
@@ -185,7 +185,7 @@ public class FactionAccoladeEvent {
             Person speaker = getSpeaker(campaign, accoladingFaction, accoladeLevel);
 
             if (speaker != null) {
-                AutoAssignRankForCompanyGenerator.assignRankSystemFromFaction(speaker, RO_MIN);
+                AutomaticRankAssigner.assignRankSystemFromFaction(speaker, RO_MIN);
                 if (isCashReward &&
                           accoladingFaction.getShortName().equals(PIRACY_SUCCESS_INDEX_FACTION_CODE)) {
                     speaker = null;

--- a/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionCensureEvent.java
+++ b/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionCensureEvent.java
@@ -68,7 +68,7 @@ import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
 import mekhq.campaign.personnel.medical.advancedMedical.InjuryUtil;
-import mekhq.campaign.personnel.ranks.AutoAssignRankForCompanyGenerator;
+import mekhq.campaign.personnel.ranks.AutomaticRankAssigner;
 import mekhq.campaign.universe.Faction;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogWidth;
@@ -178,7 +178,7 @@ public class FactionCensureEvent {
                     Person speaker = campaign.getPlayerForce()
                                            .getHumanResources()
                                            .newPerson(campaign, role, factionCode, Gender.RANDOMIZE);
-                    AutoAssignRankForCompanyGenerator.assignRankSystemFromFaction(speaker, RO_MIN);
+                    AutomaticRankAssigner.assignRankSystemFromFaction(speaker, RO_MIN);
 
                     ImmersiveDialogWidth dialogWidth;
                     if (censureAction.equals(FINE) || censureAction.equals(FORMAL_WARNING)) {

--- a/MekHQ/src/mekhq/campaign/universe/factionStanding/GoingRogue.java
+++ b/MekHQ/src/mekhq/campaign/universe/factionStanding/GoingRogue.java
@@ -54,7 +54,7 @@ import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
 import mekhq.campaign.personnel.familyTree.Genealogy;
-import mekhq.campaign.personnel.ranks.AutoAssignRankForCompanyGenerator;
+import mekhq.campaign.personnel.ranks.AutomaticRankAssigner;
 import mekhq.campaign.universe.Faction;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogWidth;
 import mekhq.gui.dialog.factionStanding.factionJudgment.FactionCensureGoingRogueDialog;
@@ -214,7 +214,7 @@ public class GoingRogue {
                                          role,
                                          chosenFactionCode,
                                          megamek.common.enums.Gender.RANDOMIZE);
-            AutoAssignRankForCompanyGenerator.assignRankSystemFromFaction(speaker, RO_MIN);
+            AutomaticRankAssigner.assignRankSystemFromFaction(speaker, RO_MIN);
             new FactionJudgmentDialog(campaign, speaker, commander, DEFECTION_GREETING_LOOKUP, newFaction,
                   FactionStandingJudgmentType.WELCOME, ImmersiveDialogWidth.MEDIUM, null, null);
         }

--- a/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/FatigueTrackingCampaignOptionsChangedConfirmationDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/FatigueTrackingCampaignOptionsChangedConfirmationDialog.java
@@ -66,7 +66,7 @@ import megamek.common.loaders.MekSummaryCache;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.parts.enums.PartQuality;
-import mekhq.campaign.personnel.ranks.AutoAssignRankForCompanyGenerator;
+import mekhq.campaign.personnel.ranks.AutomaticRankAssigner;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.UnitOrder;
 import mekhq.campaign.universe.Faction;
@@ -213,7 +213,7 @@ public class FatigueTrackingCampaignOptionsChangedConfirmationDialog extends JDi
             Unit unit = campaign.addNewUnit(mekSummary.loadEntity(), true, 0, quality);
             if (unit != null) {
                 if (isAutomaticallyAssignRanks) {
-                    AutoAssignRankForCompanyGenerator.assignRanks(campaign, unit, faction);
+                    AutomaticRankAssigner.assignRanks(campaign, unit, faction);
                 }
                 units.add(unit);
             }

--- a/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/MASHTheaterTrackingCampaignOptionsChangedConfirmationDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/MASHTheaterTrackingCampaignOptionsChangedConfirmationDialog.java
@@ -66,7 +66,7 @@ import megamek.common.loaders.MekSummaryCache;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.parts.enums.PartQuality;
-import mekhq.campaign.personnel.ranks.AutoAssignRankForCompanyGenerator;
+import mekhq.campaign.personnel.ranks.AutomaticRankAssigner;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.UnitOrder;
 import mekhq.campaign.universe.Faction;
@@ -214,7 +214,7 @@ public class MASHTheaterTrackingCampaignOptionsChangedConfirmationDialog extends
 
             if (unit != null) {
                 if (isAutomaticallyAssignRanks) {
-                    AutoAssignRankForCompanyGenerator.assignRanks(campaign, unit, faction);
+                    AutomaticRankAssigner.assignRanks(campaign, unit, faction);
                 }
                 units.add(unit);
             }

--- a/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/PrisonerTrackingCampaignOptionsChangedConfirmationDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/PrisonerTrackingCampaignOptionsChangedConfirmationDialog.java
@@ -66,7 +66,7 @@ import megamek.common.loaders.MekSummaryCache;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.parts.enums.PartQuality;
-import mekhq.campaign.personnel.ranks.AutoAssignRankForCompanyGenerator;
+import mekhq.campaign.personnel.ranks.AutomaticRankAssigner;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.UnitOrder;
 import mekhq.campaign.universe.Faction;
@@ -220,7 +220,7 @@ public class PrisonerTrackingCampaignOptionsChangedConfirmationDialog extends JD
             Unit unit = campaign.addNewUnit(mekSummary.loadEntity(), true, 0, quality);
             if (unit != null) {
                 if (automaticallyAssignRanks) {
-                    AutoAssignRankForCompanyGenerator.assignRanks(campaign, unit, faction);
+                    AutomaticRankAssigner.assignRanks(campaign, unit, faction);
                 }
                 units.add(unit);
             }

--- a/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/SalvageCampaignOptionsChangedConfirmationDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/SalvageCampaignOptionsChangedConfirmationDialog.java
@@ -66,7 +66,7 @@ import megamek.common.loaders.MekSummaryCache;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.parts.enums.PartQuality;
-import mekhq.campaign.personnel.ranks.AutoAssignRankForCompanyGenerator;
+import mekhq.campaign.personnel.ranks.AutomaticRankAssigner;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.UnitOrder;
 import mekhq.campaign.universe.Faction;
@@ -222,7 +222,7 @@ public class SalvageCampaignOptionsChangedConfirmationDialog extends JDialog {
                 Unit unit = campaign.addNewUnit(mekSummary.loadEntity(), true, 0, quality);
                 if (unit != null) {
                     if (isAutomaticallyAssignRanks) {
-                        AutoAssignRankForCompanyGenerator.assignRanks(campaign, unit, faction);
+                        AutomaticRankAssigner.assignRanks(campaign, unit, faction);
                     }
                     units.add(unit);
                 }

--- a/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/StratConConvoyCampaignOptionsChangedConfirmationDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/StratConConvoyCampaignOptionsChangedConfirmationDialog.java
@@ -66,7 +66,7 @@ import megamek.common.loaders.MekSummaryCache;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.parts.enums.PartQuality;
-import mekhq.campaign.personnel.ranks.AutoAssignRankForCompanyGenerator;
+import mekhq.campaign.personnel.ranks.AutomaticRankAssigner;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.UnitOrder;
 import mekhq.campaign.universe.Faction;
@@ -220,7 +220,7 @@ public class StratConConvoyCampaignOptionsChangedConfirmationDialog extends JDia
 
                 if (unit != null) {
                     if (isAutomaticallyAssignRanks) {
-                        AutoAssignRankForCompanyGenerator.assignRanks(campaign, unit, faction);
+                        AutomaticRankAssigner.assignRanks(campaign, unit, faction);
                     }
                     units.add(unit);
                 }

--- a/MekHQ/src/mekhq/gui/dialog/CompanyGenerationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CompanyGenerationDialog.java
@@ -63,7 +63,7 @@ import mekhq.campaign.parts.Part;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.autoAwards.AutoAwardsController;
 import mekhq.campaign.personnel.enums.PersonnelRole;
-import mekhq.campaign.personnel.ranks.AutoAssignRankForCompanyGenerator;
+import mekhq.campaign.personnel.ranks.AutomaticRankAssigner;
 import mekhq.campaign.reputation.camOpsReputation.ForceReputationController;
 import mekhq.campaign.reputation.chaosReputation.ChaosReputation;
 import mekhq.campaign.unit.Unit;
@@ -185,7 +185,7 @@ public class CompanyGenerationDialog extends AbstractMHQValidationButtonDialog {
         Person speaker = campaign.getPlayerForce()
                                .getHumanResources()
                                .newPerson(campaign, role, campaignFactionCode, Gender.RANDOMIZE);
-        AutoAssignRankForCompanyGenerator.assignRankSystemFromFaction(speaker, RO_MIN);
+        AutomaticRankAssigner.assignRankSystemFromFaction(speaker, RO_MIN);
         new FactionJudgmentDialog(campaign, speaker, campaign.getPlayerForce().getHumanResources()
                                                            .getCommander(campaign.getCampaignOptions(),
                                                                  campaign.isClanCampaign(),


### PR DESCRIPTION
## Summary
- rename `AutoAssignRankForCompanyGenerator` to `AutomaticRankAssigner` as the original name is confusing
- update all production callers and the class documentation to reflect that rank assignment is also used for generated NPCs and existing crews outside company generation

## Testing
- `./gradlew :MekHQ:compileJava :MekHQ:compileTestJava :MekHQ:checkstyleMain :MekHQ:test --tests "mekhq.campaign.mission.AtBContractTest.createEmployerLiaisonAssignsEmployerFactionRankSystem"`

Follow-up to #9772.