### PR TITLE
Add early victory status to CVP meter

### DIFF
--- a/MekHQ/resources/mekhq/resources/ContractViewPanel.properties
+++ b/MekHQ/resources/mekhq/resources/ContractViewPanel.properties
@@ -52,11 +52,28 @@ lblScore.text=<html><nobr><b>Victory Points:</b></nobr></html>
 lblSupportPoints.text=<html><nobr><b>Support Points:</b></nobr></html>
 lblNoEarlyEnd.text=This contract must run its full term
 contractScoreBar.title.text=<html><nobr><b>Victory Points</b></nobr></html>
-contractScoreBar.title.cannotEndEarly.text=<html><nobr><b>Victory Points</b> (full term)</nobr></html>
+contractScoreBar.title.fullTerm.text=<html><nobr><b>Victory Points</b> <b>(full term)</b></nobr></html>
+contractScoreBar.title.targetReached.objectivesOutstanding.text=<html><center><b>Victory Points</b><br><b>(target reached, objectives outstanding)</b></center></html>
+contractScoreBar.title.earlyVictorySecured.text=<html><nobr><b>Victory Points</b> <b>(early victory secured)</b></nobr></html>
+contractScoreBar.title.targetReached.fullTerm.text=<html><nobr><b>Victory Points</b> <b>(target reached, full term)</b></nobr></html>
 contractSupportPointsBar.title.text=<html><nobr><b>Support Points</b></nobr></html>
 contractSupportPointsBar.tooltip=Support Points: {0} of {1}. Spend them on reinforcements and other StratCon support; you negotiate for more as the contract runs.
-contractScoreBar.tooltip.canEndEarly=Contract Victory Points: {0} of {1}. Reach the target to end the contract early in victory.
-contractScoreBar.tooltip.cannotEndEarly=Contract Victory Points: {0} of {1}. This contract cannot be ended early, but Victory Points still count toward its final outcome.
+contractScoreBar.tooltip.objectivesOutstanding=Contract Victory Points: {0} of {1}. Early victory requires the \
+  Victory Point target to be reached, at least one strategic objective to exist, and every objective to be resolved \
+  (completed or failed).
+contractScoreBar.tooltip.objectiveRequirementsSatisfied=Contract Victory Points: {0} of {1}. At least one strategic \
+  objective exists and every objective is resolved (completed or failed). Reach the Victory Point target to secure \
+  early victory; daily processing will schedule the contract end automatically.
+contractScoreBar.tooltip.fullTerm=Contract Victory Points: {0} of {1}. This contract cannot be ended early, but \
+  Victory Points still count toward its final outcome.
+contractScoreBar.tooltip.targetReached.objectivesOutstanding=Contract Victory Points: {0} of {1}. Victory Point \
+  target reached, but early victory is not yet secured. At least one strategic objective must exist, and every \
+  objective must be resolved (completed or failed).
+contractScoreBar.tooltip.earlyVictorySecured=Contract Victory Points: {0} of {1}. Victory Point target reached. At \
+  least one strategic objective exists and every objective is resolved (completed or failed). Early victory is \
+  secured; daily processing will schedule the contract end automatically.
+contractScoreBar.tooltip.targetReached.fullTerm=Contract Victory Points: {0} of {1}. Victory Point target \
+  reached. This contract must run its full term; Victory Points still count toward its final outcome.
 contractSalvageBar.title.text=<html><nobr><b>Salvage</b></nobr></html>
 contractSalvageBar.tooltip=Salvage claimed: {0}% of the negotiated {1}% maximum.
 contractThreatBar.title.text=<html><nobr><b>Threat Level</b></nobr></html>

--- a/MekHQ/src/mekhq/gui/StratConTab.java
+++ b/MekHQ/src/mekhq/gui/StratConTab.java
@@ -594,8 +594,7 @@ public class StratConTab extends CampaignGuiTab {
         int requiredScore = currentContract.getRequiredVictoryPoints();
 
         if (requiredScore > 0) {
-            boolean canEndEarly = (campaignState == null) || campaignState.allowEarlyVictory();
-            victoryPointsPanel.add(ContractMeterBar.victoryPoints(currentScore, requiredScore, canEndEarly),
+            victoryPointsPanel.add(ContractMeterBar.victoryPoints(currentScore, requiredScore, campaignState),
                   BorderLayout.CENTER);
         } else {
             // No positive target to chart (e.g., a contract with a zero requirement); show the figures as text instead,

--- a/MekHQ/src/mekhq/gui/view/ContractMeterBar.java
+++ b/MekHQ/src/mekhq/gui/view/ContractMeterBar.java
@@ -49,6 +49,7 @@ import javax.swing.UIManager;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import megamek.client.ui.util.UIUtil;
+import mekhq.campaign.digitalGM.stratCon.StratConCampaignState;
 import mekhq.gui.baseComponents.GradientMarkerBar;
 import mekhq.gui.baseComponents.GradientMarkerBar.Marker;
 import mekhq.gui.baseComponents.GradientMarkerBar.MarkerStyle;
@@ -73,15 +74,46 @@ import mekhq.gui.baseComponents.GradientMarkerBar.MarkerStyle;
  * </p>
  *
  * <p>
- * Instances are created through the {@link #victoryPoints(int, int, boolean)}, {@link #supportPoints(int, int)},
- * {@link #salvage(int, int)}, and {@link #timeline(LocalDate, LocalDate, LocalDate, String, String, String)} factory
- * methods, which supply the appropriate title, tooltip, and styling for each metric.
+ * Instances are created through the {@link #victoryPoints(int, int, StratConCampaignState)},
+ * {@link #supportPoints(int, int)}, {@link #salvage(int, int)}, and
+ * {@link #timeline(LocalDate, LocalDate, LocalDate, String, String, String)} factory methods, which supply the
+ * appropriate title, tooltip, and styling for each metric.
  * </p>
  *
  * @author The MegaMek Team
  */
 public class ContractMeterBar extends JPanel {
     private static final String RESOURCE_BUNDLE = "mekhq.resources.ContractViewPanel";
+
+    /**
+     * Presentation state for full-term contracts, contracts with outstanding objective requirements, and contracts
+     * whose objective requirements are satisfied. A missing campaign state maps conservatively to outstanding
+     * requirements; {@link StratConCampaignState#canEndContractEarly()} treats completed and failed objectives as
+     * resolved.
+     */
+    private enum EarlyVictoryStatus {
+        FULL_TERM,
+        OBJECTIVE_REQUIREMENTS_OUTSTANDING,
+        OBJECTIVE_REQUIREMENTS_SATISFIED;
+
+        /**
+         * Determines the presentation state from a contract's StratCon campaign state.
+         *
+         * @param campaignState the contract's StratCon campaign state, or {@code null} when unavailable
+         *
+         * @return the corresponding presentation state
+         */
+        private static @Nonnull EarlyVictoryStatus from(final @Nullable StratConCampaignState campaignState) {
+            if (campaignState == null) {
+                return OBJECTIVE_REQUIREMENTS_OUTSTANDING;
+            }
+            if (!campaignState.allowEarlyVictory()) {
+                return FULL_TERM;
+            }
+            return campaignState.canEndContractEarly() ? OBJECTIVE_REQUIREMENTS_SATISFIED
+                  : OBJECTIVE_REQUIREMENTS_OUTSTANDING;
+        }
+    }
 
     /** Deep red for a low or negative score; shared with {@link MoraleBar}'s palette for visual consistency. */
     private static final Color DEEP_RED = new Color(0xA8, 0x12, 0x12);
@@ -159,24 +191,42 @@ public class ContractMeterBar extends JPanel {
     }
 
     /**
-     * Creates a gauge of a contract's accumulated victory points against the score required to declare victory.
+     * Creates a gauge of a contract's accumulated victory points against its Victory Point target. Its title and
+     * tooltip distinguish full-term contracts, outstanding objective requirements, and secured early victory.
      *
      * @param currentScore  the contract's current accumulated victory points (may be negative)
-     * @param requiredScore the victory points required to declare victory; should be positive (callers should fall back
-     *                      to a plain-text display when the requirement is not a positive number)
-     * @param canEndEarly   {@code true} if reaching {@code requiredScore} lets the player declare victory early;
-     *                      {@code false} if the contract must run its full term, in which case the title carries a
-     *                      concise "full term" cue
+     * @param requiredScore the victory points required to declare victory; should be positive (callers should fall
+     *                      back to a plain-text display when the requirement is not a positive number)
+     * @param campaignState the contract's StratCon state; a missing state is treated conservatively as having
+     *                      outstanding objective requirements, rather than claiming either full term or secured early
+     *                      victory
      *
      * @return the configured gauge
      */
     public static @Nonnull ContractMeterBar victoryPoints(final int currentScore, final int requiredScore,
-          final boolean canEndEarly) {
-        final String tooltip = getFormattedTextAt(RESOURCE_BUNDLE,
-              canEndEarly ? "contractScoreBar.tooltip.canEndEarly" : "contractScoreBar.tooltip.cannotEndEarly",
-              currentScore, requiredScore);
-        final String titleKey = canEndEarly ? "contractScoreBar.title.text"
-                                      : "contractScoreBar.title.cannotEndEarly.text";
+          final @Nullable StratConCampaignState campaignState) {
+        final EarlyVictoryStatus earlyVictoryStatus = EarlyVictoryStatus.from(campaignState);
+        final boolean targetReached = currentScore >= requiredScore;
+        final String titleKey = switch (earlyVictoryStatus) {
+            case FULL_TERM -> targetReached ? "contractScoreBar.title.targetReached.fullTerm.text"
+                  : "contractScoreBar.title.fullTerm.text";
+            case OBJECTIVE_REQUIREMENTS_OUTSTANDING -> targetReached ?
+                  "contractScoreBar.title.targetReached.objectivesOutstanding.text" :
+                  "contractScoreBar.title.text";
+            case OBJECTIVE_REQUIREMENTS_SATISFIED -> targetReached ?
+                  "contractScoreBar.title.earlyVictorySecured.text" : "contractScoreBar.title.text";
+        };
+        final String tooltipKey = switch (earlyVictoryStatus) {
+            case FULL_TERM -> targetReached ? "contractScoreBar.tooltip.targetReached.fullTerm"
+                  : "contractScoreBar.tooltip.fullTerm";
+            case OBJECTIVE_REQUIREMENTS_OUTSTANDING -> targetReached ?
+                  "contractScoreBar.tooltip.targetReached.objectivesOutstanding" :
+                  "contractScoreBar.tooltip.objectivesOutstanding";
+            case OBJECTIVE_REQUIREMENTS_SATISFIED -> targetReached ?
+                  "contractScoreBar.tooltip.earlyVictorySecured" :
+                  "contractScoreBar.tooltip.objectiveRequirementsSatisfied";
+        };
+        final String tooltip = getFormattedTextAt(RESOURCE_BUNDLE, tooltipKey, currentScore, requiredScore);
         return valueMeter(getTextAt(RESOURCE_BUNDLE, titleKey), currentScore, requiredScore, tooltip);
     }
 

--- a/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
@@ -607,9 +607,8 @@ public class MissionViewPanel extends JScrollablePanel {
             int currentScore = contract.getContractScore(campaign.getCampaignOptions().isUseStratConMaplessMode());
             int neededScore = contract.getRequiredVictoryPoints();
             if (neededScore > 0) {
-                final boolean canEndEarly = (contract.getStratConCampaignState() == null) ||
-                                                  contract.getStratConCampaignState().allowEarlyVictory();
-                addGaugeRow(ContractMeterBar.victoryPoints(currentScore, neededScore, canEndEarly), y++);
+                addGaugeRow(ContractMeterBar.victoryPoints(currentScore, neededScore,
+                      contract.getStratConCampaignState()), y++);
             } else {
                 lblScore.setName("lblScore");
                 lblScore.setText(getTextAt(RESOURCE_BUNDLE, "lblScore.text"));

--- a/MekHQ/unittests/mekhq/gui/view/ContractMeterBarTest.java
+++ b/MekHQ/unittests/mekhq/gui/view/ContractMeterBarTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.view;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.awt.BorderLayout;
+import javax.swing.JLabel;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import mekhq.campaign.digitalGM.stratCon.StratConCampaignState;
+
+class ContractMeterBarTest {
+    private static final int REQUIRED_SCORE = 5;
+
+    @ParameterizedTest
+    @CsvSource({ "4, false", "5, true", "8, true" })
+    void contractWithOutstandingObjectivesDistinguishesTargetFromEarlyVictory(final int currentScore,
+          final boolean targetReached) {
+        final ContractMeterBar meter = ContractMeterBar.victoryPoints(currentScore, REQUIRED_SCORE,
+              campaignState(true, false));
+        final String expectedTitle;
+        final String expectedState;
+
+        if (targetReached) {
+            expectedTitle = "<html><center><b>Victory Points</b><br>"
+                  + "<b>(target reached, objectives outstanding)</b></center></html>";
+            expectedState = "Victory Point target reached, but early victory is not yet secured. At "
+                  + "least one strategic objective must exist, and every objective must "
+                  + "be resolved (completed or failed).";
+        } else {
+            expectedTitle = "<html><nobr><b>Victory Points</b></nobr></html>";
+            expectedState = "Early victory requires the Victory Point target to be reached, at least "
+                  + "one strategic objective to exist, and every objective to be "
+                  + "resolved (completed or failed).";
+        }
+
+        assertEquals(expectedTitle, titleText(meter));
+        assertEquals(scorePrefix(currentScore) + expectedState, tooltipText(meter));
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "4, false", "5, true", "8, true" })
+    void contractWithSatisfiedObjectivesDistinguishesTargetFromSecuredEarlyVictory(final int currentScore,
+          final boolean targetReached) {
+        final ContractMeterBar meter = ContractMeterBar.victoryPoints(currentScore, REQUIRED_SCORE,
+              campaignState(true, true));
+        final String expectedTitle;
+        final String expectedState;
+
+        if (targetReached) {
+            expectedTitle = "<html><nobr><b>Victory Points</b> "
+                  + "<b>(early victory secured)</b></nobr></html>";
+            expectedState = "Victory Point target reached. At least one strategic objective exists "
+                  + "and every objective is resolved (completed or failed). Early "
+                  + "victory is secured; daily processing will schedule the contract "
+                  + "end automatically.";
+        } else {
+            expectedTitle = "<html><nobr><b>Victory Points</b></nobr></html>";
+            expectedState = "At least one strategic objective exists and every objective is resolved "
+                  + "(completed or failed). Reach the Victory Point target to secure "
+                  + "early victory; daily processing will schedule the contract end "
+                  + "automatically.";
+        }
+
+        assertEquals(expectedTitle, titleText(meter));
+        assertEquals(scorePrefix(currentScore) + expectedState, tooltipText(meter));
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "4, false", "5, true", "8, true" })
+    void fullTermContractDistinguishesTargetFromFinalOutcome(final int currentScore,
+          final boolean targetReached) {
+        final ContractMeterBar meter = ContractMeterBar.victoryPoints(currentScore, REQUIRED_SCORE,
+              campaignState(false, false));
+        final String expectedTitle;
+        final String expectedState;
+
+        if (targetReached) {
+            expectedTitle = "<html><nobr><b>Victory Points</b> "
+                  + "<b>(target reached, full term)</b></nobr></html>";
+            expectedState = "Victory Point target reached. This contract must run its full term; "
+                  + "Victory Points still count toward its final outcome.";
+        } else {
+            expectedTitle = "<html><nobr><b>Victory Points</b> <b>(full term)</b></nobr></html>";
+            expectedState = "This contract cannot be ended early, but Victory Points still count "
+                  + "toward its final outcome.";
+        }
+
+        assertEquals(expectedTitle, titleText(meter));
+        assertEquals(scorePrefix(currentScore) + expectedState, tooltipText(meter));
+    }
+
+    @Test
+    void missingCampaignStateUsesConservativeNonSecuredStatus() {
+        final ContractMeterBar meter = ContractMeterBar.victoryPoints(REQUIRED_SCORE, REQUIRED_SCORE, null);
+        final String expectedTitle = "<html><center><b>Victory Points</b><br>"
+              + "<b>(target reached, objectives outstanding)</b></center></html>";
+        final String expectedState = "Victory Point target reached, but early victory is not yet secured. At least one "
+              + "strategic objective must exist, and every objective must be resolved (completed or failed).";
+
+        assertEquals(expectedTitle, titleText(meter));
+        assertEquals(scorePrefix(REQUIRED_SCORE) + expectedState, tooltipText(meter));
+    }
+
+    private static StratConCampaignState campaignState(final boolean allowEarlyVictory,
+          final boolean canEndContractEarly) {
+        final StratConCampaignState campaignState = mock(StratConCampaignState.class);
+        when(campaignState.allowEarlyVictory()).thenReturn(allowEarlyVictory);
+        when(campaignState.canEndContractEarly()).thenReturn(canEndContractEarly);
+        return campaignState;
+    }
+
+    private static String scorePrefix(final int currentScore) {
+        return "Contract Victory Points: " + currentScore + " of " + REQUIRED_SCORE + ". ";
+    }
+
+    private static String titleText(final ContractMeterBar meter) {
+        final BorderLayout layout = (BorderLayout) meter.getLayout();
+        return ((JLabel) layout.getLayoutComponent(BorderLayout.NORTH)).getText();
+    }
+
+    private static String tooltipText(final ContractMeterBar meter) {
+        return meter.getToolTipText().replaceAll("<[^>]*>", " ").replaceAll("\\s+", " ").trim();
+    }
+}


### PR DESCRIPTION
## Summary
- show persistent, bold CVP status text for objectives outstanding, early victory secured, and full-term contracts
- derive the display from the same StratCon objective predicate used by daily contract processing without changing campaign mechanics
- wrap the longest status for narrow Briefing Room and StratCon layouts
- add focused coverage for below-target, threshold, overshoot, full-term, objective, and missing-state cases

## Validation
- `./gradlew :MekHQ:compileJava :MekHQ:compileTestJava :MekHQ:checkstyleMain :MekHQ:checkstyleTest :MekHQ:test --tests "mekhq.gui.view.ContractMeterBarTest" -x :MekHQ:jacocoTestReport`
- 10 tests passed; 0 failures, errors, or skips
- offscreen layout checks at 1024x768 and 1440x900 for the Briefing Room and StratCon views
- `git diff --check`

## Screenshots
Some examples of how the CVP will look like in different stages:
<img width="1760" height="1475" alt="image" src="https://github.com/user-attachments/assets/fbe299aa-964b-4b44-a637-c321cfdea6bf" />

Related issue: https://github.com/MegaMek/mekhq/issues/9743