### PR TITLE
feat: adds search to glossary for glossary and documentation entries

### DIFF
--- a/MekHQ/resources/mekhq/resources/NewGlossaryDialog.properties
+++ b/MekHQ/resources/mekhq/resources/NewGlossaryDialog.properties
@@ -37,3 +37,6 @@ GlossaryDialog.aboutPane=<h1 style="text-align:center;">MekHQ Glossary</h1>This 
 GlossaryDialog.button.close=Close
 GlossaryDialog.button.closeTab.single=Close Tab
 GlossaryDialog.button.closeTab.all=Close All
+GlossaryDialog.search.tooltip=Search by title or document contents. Separate multiple words with spaces.
+GlossaryDialog.search.noResults=<i>No content matches your search.</i>
+GlossaryDialog.search.label=Search

--- a/MekHQ/src/mekhq/campaign/utilities/glossary/DocumentationEntry.java
+++ b/MekHQ/src/mekhq/campaign/utilities/glossary/DocumentationEntry.java
@@ -34,6 +34,18 @@ package mekhq.campaign.utilities.glossary;
 
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.apache.pdfbox.Loader;
+
+import megamek.logging.MMLogger;
+
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -80,6 +92,14 @@ public enum DocumentationEntry {
     UNIT_MARKETS("UNIT_MARKETS", "GlossaryDocs/Unit Markets", new Version("0.50.06"));
 
     private static final String RESOURCE_BUNDLE = "mekhq.resources.DocumentationEntry";
+
+    private static final MMLogger LOGGER = MMLogger.create(DocumentationEntry.class);
+
+    /**
+     * Cache of extracted PDF text per entry, lower-cased, used for full-text search. Populated lazily,
+     * or eagerly via {@link #preloadSearchableText()}.
+     */
+    private static final Map<DocumentationEntry, String> SEARCHABLE_TEXT_CACHE = new ConcurrentHashMap<>();
 
     private final String DIRECTORY = "docs/";
     private final String FILE_EXTENSION = ".pdf";
@@ -157,6 +177,41 @@ public enum DocumentationEntry {
      */
     public String getFileAddress() {
         return DIRECTORY + fileAddress + FILE_EXTENSION;
+    }
+
+    /**
+     * Returns the extracted, lower-cased plain-text content of this entry's PDF, for use in search
+     * filtering. Extraction happens once per entry and is cached for the lifetime of the application.
+     *
+     * @return the lower-cased extracted PDF text, or an empty string if it could not be read
+     */
+    public String getSearchableText() {
+        return SEARCHABLE_TEXT_CACHE.computeIfAbsent(this, DocumentationEntry::extractTextFromPdf);
+    }
+
+    private static String extractTextFromPdf(DocumentationEntry entry) {
+        File file = new File(entry.getFileAddress());
+        if (!file.exists()) {
+            return "";
+        }
+
+        try (PDDocument document = Loader.loadPDF(file)) {
+            PDFTextStripper stripper = new PDFTextStripper();
+            return stripper.getText(document).toLowerCase(Locale.ROOT);
+        } catch (IOException ex) {
+            LOGGER.warn("Failed to extract searchable text from {}: {}", entry.getFileAddress(), ex.getMessage());
+            return "";
+        }
+    }
+
+    /**
+     * Warms the searchable-text cache for every entry. Meant to be called off the EDT (e.g. from a
+     * {@link javax.swing.SwingWorker}) since PDF text extraction can take a moment.
+     */
+    public static void preloadSearchableText() {
+        for (DocumentationEntry entry : values()) {
+            entry.getSearchableText();
+        }
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/utilities/glossary/GlossaryEntry.java
+++ b/MekHQ/src/mekhq/campaign/utilities/glossary/GlossaryEntry.java
@@ -35,6 +35,9 @@ package mekhq.campaign.utilities.glossary;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import java.util.List;
+import java.util.EnumMap;
+import java.util.Locale;
+import java.util.Map;
 
 import megamek.Version;
 import megamek.common.annotations.Nullable;
@@ -183,6 +186,11 @@ public enum GlossaryEntry {
 
     private static final String RESOURCE_BUNDLE = "mekhq.resources.GlossaryEntry";
 
+    /**
+     * Cache of plain-text, lower-cased definitions (HTML stripped) per entry, used for search filtering.
+     */
+    private static final Map<GlossaryEntry, String> SEARCHABLE_TEXT_CACHE = new EnumMap<>(GlossaryEntry.class);
+
     private final String lookUpName;
     private final Version versionAddedOrLastUpdated;
 
@@ -265,6 +273,27 @@ public enum GlossaryEntry {
      */
     public String getDefinition() {
         return getTextAt(RESOURCE_BUNDLE, lookUpName + ".definition");
+    }
+
+    /**
+     * Returns this entry's definition as plain, lower-cased text with HTML markup stripped, for use in
+     * search filtering. Computed once and cached.
+     *
+     * @return the lower-cased, HTML-stripped definition text
+     *
+     */
+    public String getSearchableText() {
+        return SEARCHABLE_TEXT_CACHE.computeIfAbsent(this, entry -> stripHtml(entry.getDefinition()));
+    }
+
+    private static String stripHtml(String html) {
+        if (html == null || html.isBlank()) {
+            return "";
+        }
+        return html.replaceAll("<[^>]*>", " ")
+                    .replaceAll("\\s+", " ")
+                    .trim()
+                    .toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/dialog/glossary/GlossaryDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/glossary/GlossaryDialog.java
@@ -42,6 +42,10 @@ import java.awt.Frame;
 import java.util.List;
 import javax.swing.*;
 import javax.swing.event.HyperlinkEvent;
+import java.util.ArrayList;
+import java.util.Locale;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
@@ -110,6 +114,13 @@ public class GlossaryDialog extends JDialog {
     final static List<String> documentationEntries = DocumentationEntry.getLookUpNamesSortedByTitle();
     private int minimumWidth = 0;
 
+    private static final int SEARCH_DEBOUNCE_MS = 150;
+
+    private JTextPane txtGlossary;
+    private JTextPane txtDocumentation;
+    private JTextField txtSearch;
+    private Timer searchDebounceTimer;
+
     /**
      * Creates and displays a new glossary and documentation dialog. Automatically sizes and positions the dialog based
      * on UI scaling.
@@ -170,7 +181,21 @@ public class GlossaryDialog extends JDialog {
         contentDocsPanel.add(aboutWrapper);
         contentDocsPanel.add(contentsWrapper);
         contentDocsPanel.add(documentationWrapper);
-        return contentDocsPanel;
+
+        JPanel outerPanel = new JPanel(new BorderLayout());
+        outerPanel.add(buildSearchPanel(), BorderLayout.NORTH);
+        outerPanel.add(contentDocsPanel, BorderLayout.CENTER);
+
+        // Warm the PDF text cache off the EDT so full-text search feels instant once the user types.
+        new SwingWorker<Void, Void>() {
+            @Override
+            protected Void doInBackground() {
+                DocumentationEntry.preloadSearchableText();
+                return null;
+            }
+        }.execute();
+
+        return outerPanel;
     }
 
     /**
@@ -260,34 +285,23 @@ public class GlossaryDialog extends JDialog {
      * @since 0.50.07
      */
     private FastJScrollPane buildGlossaryPane() {
-        StringBuilder formatedGlossaryText = new StringBuilder();
-        formatedGlossaryText.append(getTextAt(RESOURCE_BUNDLE, "GlossaryDialog.contentsPane.title"));
-
-        String lastFirstLetter = "";
-        for (String entry : glossaryEntries) {
-            GlossaryEntry glossaryEntry = GlossaryEntry.getGlossaryEntryFromLookUpName(entry);
-            String title = glossaryEntry != null ? glossaryEntry.getTitleWithVersionUpdateIcon() : "-";
-
-            if (!lastFirstLetter.equals(title.substring(0, 1))) {
-                lastFirstLetter = title.substring(0, 1);
-                formatedGlossaryText.append("<h2>")
-                      .append(lastFirstLetter)
-                      .append("</h2>");
-            }
-
-            formatedGlossaryText.append("<a href='GLOSSARY:")
-                  .append(entry)
-                  .append("'>")
-                  .append(title)
-                  .append("</a><br>");
-        }
-
-        JTextPane txtGlossary = createGlossaryDialogTextPane(formatedGlossaryText);
+        txtGlossary = createGlossaryDialogTextPane(new StringBuilder());
+        refreshGlossaryList("");
 
         FastJScrollPane scrollGlossary = new FastJScrollPane(txtGlossary);
         scrollGlossary.setBorder(RoundedLineBorder.createRoundedLineBorder());
 
         return scrollGlossary;
+    }
+
+    private FastJScrollPane buildDocumentationPane() {
+        txtDocumentation = createGlossaryDialogTextPane(new StringBuilder());
+        refreshDocumentationList("");
+
+        FastJScrollPane scrollDocumentation = new FastJScrollPane(txtDocumentation);
+        scrollDocumentation.setBorder(RoundedLineBorder.createRoundedLineBorder());
+
+        return scrollDocumentation;
     }
 
     /**
@@ -301,60 +315,214 @@ public class GlossaryDialog extends JDialog {
      * @since 0.50.07
      */
     private JTextPane createGlossaryDialogTextPane(StringBuilder formatedGlossaryText) {
-        JTextPane txtGlossary = new JTextPane();
-        txtGlossary.setContentType("text/html");
-        txtGlossary.setText(formatedGlossaryText.toString());
-        txtGlossary.setEditable(false);
-        txtGlossary.setBorder(null);
-        txtGlossary.setBorder(BorderFactory.createEmptyBorder(PADDING, PADDING, PADDING, PADDING));
-        txtGlossary.setCaretPosition(0);
-        txtGlossary.addHyperlinkListener(e -> {
+        JTextPane pane = new JTextPane();
+        pane.setContentType("text/html");
+        pane.setText(formatedGlossaryText.toString());
+        pane.setEditable(false);
+        pane.setBorder(null);
+        pane.setBorder(BorderFactory.createEmptyBorder(PADDING, PADDING, PADDING, PADDING));
+        pane.setCaretPosition(0);
+        pane.addHyperlinkListener(e -> {
             if (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
                 dispose();
                 handleGlossaryHyperlinkClick(this, e);
             }
         });
 
-        return txtGlossary;
+        return pane;
     }
 
     /**
-     * Builds the scrollable documentation section, each entry as a clickable link.
-     *
-     * @return a {@link FastJScrollPane} containing the documentation links
-     *
-     * @author Illiani
-     * @since 0.50.07
+     * Builds the single search field shared by both the glossary and documentation columns. Typing
+     * filters both lists together.
      */
-    private FastJScrollPane buildDocumentationPane() {
+    private JPanel buildSearchPanel() {
+        JLabel lblSearch = new JLabel(getTextAt(RESOURCE_BUNDLE, "GlossaryDialog.search.label"));
+        lblSearch.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, PADDING));
+
+        txtSearch = new JTextField();
+        txtSearch.setToolTipText(getTextAt(RESOURCE_BUNDLE, "GlossaryDialog.search.tooltip"));
+        txtSearch.setBorder(BorderFactory.createCompoundBorder(RoundedLineBorder.createRoundedLineBorder(),
+            BorderFactory.createEmptyBorder(4, 8, 4, 8)));
+        txtSearch.setColumns(20);
+        txtSearch.setMaximumSize(txtSearch.getPreferredSize());
+
+        searchDebounceTimer = new Timer(SEARCH_DEBOUNCE_MS, e -> {
+            String query = txtSearch.getText();
+            refreshGlossaryList(query);
+            refreshDocumentationList(query);
+        });
+        searchDebounceTimer.setRepeats(false);
+
+        txtSearch.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                searchDebounceTimer.restart();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                searchDebounceTimer.restart();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                searchDebounceTimer.restart();
+            }
+        });
+
+        JPanel searchPanel = new JPanel(new FlowLayout(FlowLayout.CENTER, 0, 0));
+        searchPanel.setBorder(BorderFactory.createEmptyBorder(0, PADDING, PADDING, PADDING));
+        searchPanel.add(lblSearch);
+        searchPanel.add(txtSearch);
+        return searchPanel;
+    }
+
+    /**
+     * Refreshes the display of the glossary list based on the search string.
+     * 
+     * @param query the raw text from the search field
+     *
+     */
+    private void refreshGlossaryList(String query) {
+        List<String> searchTerms = parseSearchTerms(query);
+
+        StringBuilder formatedGlossaryText = new StringBuilder();
+        formatedGlossaryText.append(getTextAt(RESOURCE_BUNDLE, "GlossaryDialog.contentsPane.title"));
+
+        boolean hasMatch = false;
+        String lastFirstLetter = "";
+        for (String entryKey : glossaryEntries) {
+            GlossaryEntry glossaryEntry = GlossaryEntry.getGlossaryEntryFromLookUpName(entryKey);
+            if (glossaryEntry == null) {
+                continue;
+            }
+
+            if (!matchesGlossarySearch(glossaryEntry, searchTerms)) {
+                continue;
+            }
+
+            hasMatch = true;
+
+            String title = glossaryEntry.getTitleWithVersionUpdateIcon();
+            String firstLetter = title.substring(0, 1);
+            if (!lastFirstLetter.equals(firstLetter)) {
+                lastFirstLetter = firstLetter;
+                formatedGlossaryText.append("<h2>").append(lastFirstLetter).append("</h2>");
+            }
+
+            formatedGlossaryText.append("<a href='GLOSSARY:")
+                .append(entryKey)
+                .append("'>")
+                .append(title)
+                .append("</a><br>");
+        }
+
+        if (!hasMatch) {
+            formatedGlossaryText.append("<i>")
+                .append(getTextAt(RESOURCE_BUNDLE, "GlossaryDialog.search.noResults"))
+                .append("</i>");
+        }
+
+        txtGlossary.setText(formatedGlossaryText.toString());
+        txtGlossary.setCaretPosition(0);
+    }
+    
+
+    /**
+     * Refreshes the documentation list, filtering by the given search query.
+     *
+     * @param query the raw text from the search field
+     *
+     */
+    private void refreshDocumentationList(String query) {
+        List<String> searchTerms = parseSearchTerms(query);
+
         StringBuilder formatedDocumentationText = new StringBuilder();
         formatedDocumentationText.append(getTextAt(RESOURCE_BUNDLE, "GlossaryDialog.documentationPane.title"));
 
+        boolean hasMatch = false;
         String lastFirstLetter = "";
-        for (String entry : documentationEntries) {
-            DocumentationEntry documentationEntry = DocumentationEntry.getDocumentationEntryFromLookUpName(entry);
-            String title = documentationEntry != null ? documentationEntry.getTitleWithVersionUpdateIcon() : "-";
+        for (String entryKey : documentationEntries) {
+            DocumentationEntry documentationEntry = DocumentationEntry.getDocumentationEntryFromLookUpName(entryKey);
+            if (documentationEntry == null) {
+                continue;
+            }
 
-            if (!lastFirstLetter.equals(title.substring(0, 1))) {
-                lastFirstLetter = title.substring(0, 1);
-                formatedDocumentationText.append("<h2>")
-                      .append(lastFirstLetter)
-                      .append("</h2>");
+            if (!matchesSearch(documentationEntry, documentationEntry.getTitle(), searchTerms)) {
+                continue;
+            }
+
+            hasMatch = true;
+
+            String title = documentationEntry.getTitleWithVersionUpdateIcon();
+            String firstLetter = title.substring(0, 1);
+            if (!lastFirstLetter.equals(firstLetter)) {
+                lastFirstLetter = firstLetter;
+                formatedDocumentationText.append("<h2>").append(lastFirstLetter).append("</h2>");
             }
 
             formatedDocumentationText.append("<a href='DOCUMENTATION:")
-                  .append(entry)
-                  .append("'>")
-                  .append(title)
-                  .append("</a><br>");
+                .append(entryKey)
+                .append("'>")
+                .append(title)
+                .append("</a><br>");
         }
 
-        JTextPane txtDocumentation = createGlossaryDialogTextPane(formatedDocumentationText);
+        if (!hasMatch) {
+            formatedDocumentationText.append("<i>")
+                .append(getTextAt(RESOURCE_BUNDLE, "GlossaryDialog.search.noResults"))
+                .append("</i>");
+        }
 
-        FastJScrollPane scrollDocumentation = new FastJScrollPane(txtDocumentation);
-        scrollDocumentation.setBorder(RoundedLineBorder.createRoundedLineBorder());
+        txtDocumentation.setText(formatedDocumentationText.toString());
+        txtDocumentation.setCaretPosition(0);
+    }
 
-        return scrollDocumentation;
+    private static List<String> parseSearchTerms(String query) {
+        if (query == null || query.isBlank()) {
+            return List.of();
+        }
+
+        List<String> terms = new ArrayList<>();
+        for (String term : query.toLowerCase(Locale.ROOT).split("\\s+")) {
+            if (!term.isBlank()) {
+                terms.add(term);
+            }
+        }
+        return terms;
+    }
+
+    private static boolean matchesSearch(DocumentationEntry entry, String title, List<String> searchTerms) {
+        if (searchTerms.isEmpty()) {
+            return true;
+        }
+
+        String lowerTitle = title.toLowerCase(Locale.ROOT);
+        String content = entry.getSearchableText();
+
+        for (String term : searchTerms) {
+            if (!lowerTitle.contains(term) && !content.contains(term)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean matchesGlossarySearch(GlossaryEntry entry, List<String> searchTerms) {
+        if (searchTerms.isEmpty()) {
+            return true;
+        }
+
+        String lowerTitle = entry.getTitle().toLowerCase(Locale.ROOT);
+        String content = entry.getSearchableText();
+
+        for (String term : searchTerms) {
+            if (!lowerTitle.contains(term) && !content.contains(term)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/MekHQ/unittests/mekhq/campaign/utilities/glossary/DocumentationEntryTest.java
+++ b/MekHQ/unittests/mekhq/campaign/utilities/glossary/DocumentationEntryTest.java
@@ -35,6 +35,7 @@ package mekhq.campaign.utilities.glossary;
 import static mekhq.utilities.MHQInternationalization.isResourceKeyValid;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -109,6 +110,39 @@ class DocumentationEntryTest {
             assertTrue(pdf.getNumberOfPages() > 0, "PDF has no pages: " + fileAddress);
         } catch (IOException e) {
             fail("File '" + fileAddress + "' could not be opened as a PDF. Exception: " + e.getMessage());
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(DocumentationEntry.class)
+    void testGetSearchableTextReturnsNonEmptyLowercaseText(DocumentationEntry entry) {
+        String searchableText = entry.getSearchableText();
+
+        assertNotNull(searchableText, "Searchable text for " + entry.name() + " was null.");
+        assertTrue(!searchableText.isBlank(), "Searchable text for " + entry.name() + " was blank.");
+        assertEquals(searchableText, searchableText.toLowerCase(java.util.Locale.ROOT),
+            "Searchable text for " + entry.name() + " was not fully lower-cased.");
+    }
+
+    @ParameterizedTest
+    @EnumSource(DocumentationEntry.class)
+    void testGetSearchableTextIsCachedBetweenCalls(DocumentationEntry entry) {
+        String first = entry.getSearchableText();
+        String second = entry.getSearchableText();
+
+        // computeIfAbsent should only extract once; subsequent calls return the same cached instance
+        // rather than re-parsing the PDF.
+        assertSame(first, second, "getSearchableText() for " + entry.name() + " did not return a cached instance.");
+    }
+
+    @Test
+    void testPreloadSearchableTextPopulatesEveryEntry() {
+        DocumentationEntry.preloadSearchableText();
+
+        for (DocumentationEntry entry : DocumentationEntry.values()) {
+            String searchableText = entry.getSearchableText();
+            assertNotNull(searchableText, "Preload left null searchable text for " + entry.name());
+            assertTrue(!searchableText.isBlank(), "Preload left blank searchable text for " + entry.name());
         }
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/utilities/glossary/GlossaryEntryTest.java
+++ b/MekHQ/unittests/mekhq/campaign/utilities/glossary/GlossaryEntryTest.java
@@ -35,15 +35,22 @@ package mekhq.campaign.utilities.glossary;
 import static mekhq.utilities.MHQInternationalization.isResourceKeyValid;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 class GlossaryEntryTest {
+    private static final java.util.regex.Pattern HTML_TAG_PATTERN = java.util.regex.Pattern.compile("</?[a-zA-Z][^>]*>");
+    
+
     @ParameterizedTest
     @EnumSource(GlossaryEntry.class)
     void testAllEntriesHaveValidTitle(GlossaryEntry entry) {
@@ -84,5 +91,35 @@ class GlossaryEntryTest {
                                           .toList();
 
         assertEquals(lookUpNames.size(), uniqueTitles.size(), "Titles are not unique.");
+    }
+
+    @ParameterizedTest
+    @EnumSource(GlossaryEntry.class)
+    void testGetSearchableTextReturnsNonEmptyLowercaseText(GlossaryEntry entry) {
+        String searchableText = entry.getSearchableText();
+
+        assertNotNull(searchableText, "Searchable text for " + entry.name() + " was null.");
+        assertTrue(!searchableText.isBlank(), "Searchable text for " + entry.name() + " was blank.");
+        assertEquals(searchableText, searchableText.toLowerCase(Locale.ROOT),
+            "Searchable text for " + entry.name() + " was not fully lower-cased.");
+    }
+
+    @ParameterizedTest
+    @EnumSource(GlossaryEntry.class)
+    void testGetSearchableTextStripsHtmlTags(GlossaryEntry entry) {
+        String searchableText = entry.getSearchableText();
+
+        assertFalse(HTML_TAG_PATTERN.matcher(searchableText).find(),
+            "Searchable text for " + entry.name() + " still contains an HTML tag: " + searchableText);
+    }
+
+    @ParameterizedTest
+    @EnumSource(GlossaryEntry.class)
+    void testGetSearchableTextIsCachedBetweenCalls(GlossaryEntry entry) {
+        String first = entry.getSearchableText();
+        String second = entry.getSearchableText();
+
+        assertSame(first, second,
+            "getSearchableText() for " + entry.name() + " did not return a cached instance.");
     }
 }


### PR DESCRIPTION
feat: adds search to glossary for glossary and documentation entries, addresses #9340

This adds a search box to the glossary page.  You can search for one or more words.  If the items you search for don't appear in any results, it shows a message to the user detailing as such.  

This was AI generated by Claude Sonnet 5 and adjusted/tweaked.

The search only appears on the main glossary page, it does not appear when a user deep links and jumps straight to a page.  There may be some usability improvements to be made here such as adding search or consolidating the display and searching on a single dialog.  Something to consider.

Further improvements could include searching and highlighting the relevant text in the documents or PDFs themselves or even jumping to that section in the content.

Other improvements might also include semantic search to allow the user to search for similar words and return documents based on a score given the semantic similarity of the query.  This would require some work to chunk and turn the text content into vector embeddings for each document and then an embedding model to run on each search query.  This is probably overkill given the relatively small number of documentation materials so far.  However, this could be considered as it grows.

<img width="1180" height="518" alt="image" src="https://github.com/user-attachments/assets/eb2caee4-3425-43fa-8d20-6e2d87755fba" />

<img width="1180" height="518" alt="image" src="https://github.com/user-attachments/assets/80ba6f27-4f21-4bb7-b13e-162263dea1db" />

<img width="1180" height="518" alt="image" src="https://github.com/user-attachments/assets/284358df-b1d2-4d97-b4a6-b00e63ffac5d" />
