### PR TITLE
Rework the issue templates: fix the Bug label, drop severity, real file upload

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,110 +1,111 @@
-name: "Report an Issue"
+name: "Report a Bug"
 description: >
-  Please make sure you're opening the issue on the correct repo;
-  you've checked to make sure this isn't a duplicate, and checked
-  on the Discord that there is an issue and not working as intended.
-title: "[Issue]"
+  Something in MekHQ is broken or behaving incorrectly. Please check that you are on the
+  right repository and that nobody has reported this already.
+type: "Bug"
 labels:
-  - bug
+  - Bug
 
 body:
+  - type: markdown
+    attributes:
+      value: |
+        The quickest way to file this is **Help > Report Bug** in MekHQ. It saves your campaign,
+        gathers the logs into a ZIP for you, and fills in the version fields below. Large campaigns are
+        split into several ZIP parts - please attach all of them.
+
+        If you would rather do it by hand, attach your campaign file and the contents of the `logs`
+        folder.
+
   - type: textarea
     id: brief-description
     attributes:
-      label: "Brief Description *"
+      label: "What went wrong"
       description: |
-        Please describe the issue in detail.
+        Describe what you saw. Screenshots help. If it happened on a particular date in the campaign,
+        say which.
 
-        For more detailed instructions, check out
+        If it is a rules problem, name the rulebook and its edition, give the page number, and quote the
+        relevant text. For more detail, see
         [our wiki](https://github.com/MegaMek/megamek/wiki/Creating-an-Issue-(Bug-Report%2C-Request-for-Enhancement%2C-Errata)).
+      placeholder: "Describe the problem here..."
+    validations:
+      required: true
 
-        1. Provide in-game screenshots if possible.
-        2. If it's a rules-related issue:
-           - Specify the rulebook edition
-           - Include the page number
-           - Quote the relevant text
-      placeholder: "Describe the issue here..."
+  - type: textarea
+    id: expected-behaviour
+    attributes:
+      label: "What you expected instead"
+      description: "One line is enough. This is what separates a bug from a rule working as written."
+      placeholder: "I expected..."
     validations:
       required: true
 
   - type: textarea
     id: steps-to-reproduce
     attributes:
-      label: "3. Steps to Reproduce"
-      description: "Provide a detailed numbered list of steps."
-      placeholder: "1. Step one\n2. Step two\n3. Step three"
+      label: "Steps to reproduce"
+      description: >
+        A numbered list, if you can make it happen again. If it happened once and never came back,
+        say so - that is still worth reporting.
+      placeholder: "1. ...\n2. ...\n3. ..."
+
+  - type: upload
+    id: report-files
+    attributes:
+      label: "Attach your files"
+      description: >
+        The ZIP from Help > Report Bug, or your campaign file and the files from the logs folder.
+        Archives up to 25 MB, video up to 100 MB.
+    validations:
+      required: false
+      accept: ".zip,.gz,.cpnx,.xml,.log,.txt,.csv,.png,.jpg,.jpeg,.gif,.mp4,.mov"
 
   - type: textarea
-    id: attached-files
+    id: log-excerpt
     attributes:
-      label: "Attach Files"
-      description: "Please provide all the logs from the logs folder (zipped), Custom Units, and you CPNX file."
-      placeholder: "Drag and drop or click to upload relevant files."
-
-  - type: dropdown
-    id: severity
-    attributes:
-      label: "Severity *"
-      description: "Choose the severity of the bug."
-      options:
-        - "Critical (Game-breaking/Crash): The game crashes or a core feature (like saving, loading, or network connection) is completely unusable."
-        - "High (Major Disruption): A major feature is broken or incorrect, but a workaround exists."
-        - "Medium (Gameplay Limitation): Non-core functionality is impaired, providing a suboptimal but playable experience."
-        - "Low (Minor/Nuisance): Minor glitches or cosmetic issues that don't affect gameplay and occur rarely."
-    validations:
-      required: true
-
-  - type: markdown
-    attributes:
-      value: |
-        ## User Environment
-        For the next sections, go to the "logs" folder. Find the MekHQ.log file and open it with a text editor. The information in the header will be needed.
-
-  - type: markdown
-    attributes:
-      value: |
-        ![Alt text](https://i.imgur.com/KD8cnvf.png)
+      label: "Relevant log lines"
+      description: "Only needed if you cannot attach the files. Paste the stack trace, or the lines around the problem."
+      render: text
 
   - type: input
     id: custom-megamek-version
     attributes:
-      label: "MekHQ Suite Version *"
-      description: "Enter your MekHQ version here"
-      placeholder: "Example: 0.50.02"
+      label: "MegaMek Suite Version"
+      description: >
+        Filled in for you if you opened this form from Help > Report Bug. By hand: open
+        logs/mekhq.log in a text editor and read the header.
+      placeholder: "Example: 0.51.0"
     validations:
       required: true
 
   - type: input
     id: operating-system
     attributes:
-      label: "Operating System *"
-      description: "Select your operating system"
-      placeholder: "Please be specific with the OS, e.g. Windows 11, macOS 15 Sequoia, Linux (Ubuntu)"
+      label: "Operating System"
+      description: "Please be specific - Windows 11, macOS 15 Sequoia, Ubuntu 24.04."
+      placeholder: "Example: Windows 11 (10.0.26200) amd64"
     validations:
       required: true
 
   - type: input
     id: java-version
     attributes:
-      label: "Java Version *"
-      description: "Enter the Java version from the .log file"
-      placeholder: "Example: Java Vendor: Eclipse Adoptium     Java Version: 17.0.11"
+      label: "Java Version"
+      description: "From the same log header."
+      placeholder: "Example: Eclipse Adoptium 21.0.8+9"
     validations:
       required: true
 
   - type: checkboxes
     id: final-checks
     attributes:
-      label: "Final Verification"
-      description: "Please confirm the following before submitting"
+      label: "Before you submit"
       options:
-        - label: "I confirm this is a single, unique issue that hasn't been reported before"
+        - label: "This report only contains one issue or request, and I haven't already reported it"
           required: true
-        - label: "I have filled and provided all necessary information above"
+        - label: >
+            I am on the right repository - MegaMek for battles, MegaMekLab for unit design, MekHQ for
+            campaigns, mm-data for unit and planet data
           required: true
-        - label: "I have included any and all logs, custom units, and CPNX (save) files"
-          required: true
-        - label: "I have asked on MegaMek Discord about this issue"
-          required: true
-        - label: "I have confirmed this issue is being opened on the correct repository: MegaMek, MegaMekLab, or MekHQ"
-          required: true
+        - label: "I have asked about this on the MegaMek Discord (optional)"

--- a/.github/ISSUE_TEMPLATE/request_for_enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/request_for_enhancement.yml
@@ -1,74 +1,71 @@
-name: "Request for Enhancement"
+name: "Request an Enhancement"
 description: >
-  Request an enhancement for MekHQ. Be sure you've confirmed it's not a duplicate 
-  and that you've checked on the Discord if your request is already known.
-title: "[RFE]"
+  Suggest a new feature, an improvement to an existing one, or a rule we have not implemented yet.
+  Please check that you are on the right repository and that nobody has asked for this already.
+type: "Feature"
 labels:
   - (RFE) Enhancement
-  
+
 body:
   - type: dropdown
     id: enhancement-type
     attributes:
-      label: "Enhancement Type *"
-      description: "Select the category of enhancement you are requesting."
+      label: "What kind of request is this?"
       options:
-        - "New Feature"
-        - "Improvement to Existing Feature"
-        - "Implementation of Missing Official Rule"
-        - "Implementation of Errata"
+        - "New feature"
+        - "Improvement to an existing feature"
+        - "Implementation of a missing official rule"
+        - "Implementation of errata"
     validations:
       required: true
 
   - type: textarea
     id: brief-description
     attributes:
-      label: "Brief Description of Enhancement *"
-      description: |
-        Please describe the feature or improvement you’d like to see. 
-        If it's based on any official rules or errata, mention that here.
-      placeholder: "Describe your enhancement here..."
+      label: "What would you like to see?"
+      description: >
+        If it comes from official rules or errata, name the book, its edition and the page, and quote
+        the relevant text.
+      placeholder: "Describe the enhancement here..."
     validations:
       required: true
 
   - type: textarea
     id: proposed-use-cases
     attributes:
-      label: "Use Cases or Rationale"
-      description: |
-        Elaborate on why this enhancement is needed or valuable:
-        - What problem does it solve?
-        - How does it improve gameplay or user experience?
-        - Are there any related rulebook references or official errata?
-      placeholder: "1. ...\n2. ...\n3. ..."
+      label: "Why is it worth doing?"
+      description: >
+        What problem does it solve, and who does it help? A rules citation counts as an answer on its
+        own.
+      placeholder: "1. ...\n2. ..."
 
-  - type: textarea
-    id: attached-files
+  - type: upload
+    id: reference-files
     attributes:
-      label: "Attach Files"
-      description: |
-        Provide any relevant files, images, or logs that illustrate your idea or 
-        help explain how it should work.
-      placeholder: "Drag and drop or click to upload relevant files."
+      label: "Reference material"
+      description: "Sketches, tables, screenshots, or a page from a rulebook."
+    validations:
+      required: false
+      accept: ".png,.jpg,.jpeg,.gif,.pdf,.txt,.csv,.zip"
 
   - type: input
     id: custom-megamek-version
     attributes:
-      label: "MekHQ Suite Version *"
-      description: "Which version of MekHQ (or related tool) are you currently using?"
-      placeholder: "Example 0.50.02"
+      label: "MegaMek Suite Version"
+      description: "Which version you are using now."
+      placeholder: "Example: 0.51.0"
     validations:
       required: true
 
   - type: checkboxes
     id: final-checks
     attributes:
-      label: "Final Verification"
-      description: "Before submitting, please confirm the following:"
+      label: "Before you submit"
       options:
-        - label: "I confirm this request hasn't already been submitted (checked the tracker)"
+        - label: "This report only contains one issue or request, and I haven't already reported it"
           required: true
-        - label: "I've discussed or asked about this enhancement on MegaMek Discord"
+        - label: >
+            I am on the right repository - MegaMek for battles, MegaMekLab for unit design, MekHQ for
+            campaigns, mm-data for unit and planet data
           required: true
-        - label: "I’m opening this on the correct repo (MegaMek, MegaMekLab, or MekHQ)"
-          required: true
+        - label: "I have discussed this on the MegaMek Discord (optional)"


### PR DESCRIPTION
## What this adds

Bug reports filed through the MekHQ form have been arriving with no label at all. The template asks for a label called `bug`; this repository's label is `Bug`, and the match is case sensitive, so nothing was applied. MegaMek had the same defect, fixed in MegaMek #8724. This fixes it here, and adds the organisation's issue types, which classify a report in a field that does not depend on label spelling.

The form also stops asking reporters to rate their own bug's severity, which was a required judgement they are not equipped to make and which triage does not act on. In its place it asks what you expected to happen, and it points reporters at Help > Report Bug, which already packages the campaign and the logs for them. It now also tells them to attach every part when a large campaign is split across several ZIPs, which is easy to miss and leaves a report unusable.

## Changes

- Removed the severity dropdown and made the Discord checkbox optional. That checkbox cannot be verified, it shuts out anyone who does not use Discord, and a required tick nobody can answer honestly devalues the ones that matter. Required fields drop from nine to seven.
- Fixed the label to `Bug`, and added `type: Bug` and `type: Feature`.
- Replaced the "Attach Files" textarea with an `upload` element and an accept list covering campaign files and archives.
- Added a "What you expected instead" field, and an optional log excerpt field using `render: text` for reporters who cannot attach files.
- Dropped the `[Issue]` title prefix, the stray "3." in a field label, the manual asterisks that made every required field render two of them, and the instructions screenshot hosted on imgur.
- The environment field ids are unchanged and identical to MegaMek's and MegaMekLab's, because all three open the same bug report dialog from the MegaMek jar, which fills those fields in through the prefilled issue URL.

## Testing

The YAML parses, and the field ids were compared against MegaMek's and MegaMekLab's to confirm all three repositories present the same ids to the shared dialog. The prefilled URL mechanism was exercised against MegaMek's live form, confirming the environment fields populate and that a parameter naming a field which does not exist is ignored rather than producing a 404.

## What is NOT proven yet

The rendered form cannot be seen until this merges, because GitHub only renders issue templates from the default branch. The `upload` element's appearance and behaviour, and whether the issue type is applied on submission, are therefore unverified. Reverting that one field to a textarea is a small follow-up if it disappoints.

The claim that Help > Report Bug splits large campaigns into multiple ZIP parts is taken from reading `EasyBugReport`, not from generating an oversized campaign and watching it split.
