### PR TITLE
Close: Add a pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,62 @@
+<!-- TITLE: include the issue number, and start with "Fix" for a bug fix or "Close" for
+     anything else:
+
+         Fix #1234: Cheese has the wrong colour gradient
+         Close #1234: Added 6 new cheese gradients
+
+     More than one issue is fine: "Close #111, #5329: Added unit history tracking".
+     Release notes are generated automatically from pull request titles, so the title is
+     what players end up reading. -->
+
+## What this changes
+
+<!-- The effect someone actually sees, in plain language. One or two sentences is fine. -->
+
+<!-- Keep this line as well as the number in the title. GitHub only closes an issue from a
+     keyword in the description - a number in the title alone does not close anything.
+
+     Any of these close an issue when this merges:
+         Close / Closes / Closed
+         Fix / Fixes / Fixed
+         Resolve / Resolves / Resolved
+
+     Closing more than one needs the keyword repeated in front of each number:
+         Fixes #1234, fixes #5678          closes both
+         Fixes #1234, #5678                closes only #1234
+
+     For an issue in another repository, qualify it: Fixes MegaMek/mekhq#1234 -->
+Fixes #
+
+## Testing
+
+<!-- What you ran. Unit tests? Did you load a campaign and exercise this path?
+     Once it has been tested in game, add the "AI ready for Review" label. -->
+
+## What is not proven yet
+
+<!-- What you did not test, or could not. "Nothing" is a valid answer - say so explicitly. -->
+
+---
+
+- [ ] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
+- [ ] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
+- [ ] Tests added or updated, if this implements a rule or changes campaign state
+- [ ] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
+- [ ] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
+      explain and have verified the result
+
+<!-- ABOUT THAT LAST BOX, IF YOU ARE NOT ON THE DEV TEAM:
+
+     Only active members of the dev team may use AI tools on contributions. That is not a judgement
+     on your work. A developer carries the history of why the codebase is the way it is, and an AI
+     tool starts without any of it every single session - the developer is what makes the difference.
+
+     Contributions you have written yourself are very welcome, and you do not need to be on the dev
+     team to send one:
+     https://github.com/MegaMek/megamek/wiki/Creating-a-Pull-Request-%28PR%29-as-an-Outside-Contributor
+
+     Generative AI art is never accepted, from anyone. A pull request containing it will be rejected.
+
+     Full policy:
+     https://github.com/MegaMek/megamek/wiki/Guidelines-for-Developer%E2%80%90Led-AI-Tool-Usage-in-MegaMek -->
+


### PR DESCRIPTION
## What this changes

Adds the pull request template that MegaMek merged in MegaMek#8749, so the pull request box is no longer empty here either. It is a prompt, not a gate - GitHub has no required fields for pull requests, so anything in it can be deleted by the author.

Same four sections and the same short checklist, with two things reworded for this repository rather than copied verbatim, since the question "did you play a game and exercise this path" does not mean anything here.

The content came from what the suite already asks for. The title convention is the one on the Commit Procedures wiki page, which was updated at the same time to document `Fix #1234:` for a bug fix and `Close #1234:` for anything else. The template also asks for a closing keyword in the description, because a number in the title does not close an issue - GitHub only acts on keywords in the description, which is why issues here have been closing by hand.

The AI note reflects the project's own guidelines: only active dev team members may use AI tools, and generative AI art is never accepted from anyone. My first draft of it implied AI use was fine for anybody as long as it was labelled, which would have led an outside contributor into doing exactly the thing the policy forbids while believing they had complied.

## Testing

Rendered the Markdown to confirm the comment blocks disappear and the checklist renders as checkboxes. The template cannot be seen in the pull request composer until it is on the default branch, which is the same constraint the issue templates had.

## What is not proven yet

Whether it helps. MegaMek merged its copy first for exactly that reason; if it turns out to be noise, it is one file to revise or remove.

The checklist is deliberately short. A long checklist gets ticked without being read, which is why the mandatory Discord confirmation came out of the bug report form.

Fixes nothing - this is new tooling rather than a fix, so there is no issue to close.
