### PR TITLE
Fix: restore the bug report form to the MekHQ tracker

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,7 +15,8 @@ body:
         split into several ZIP parts - please attach all of them.
 
         If you would rather do it by hand, attach your campaign file and the contents of the `logs`
-        folder.
+        folder. GitHub will not accept a bare `.cpnx`, so zip it up first - a `.cpnx.gz` is fine as it
+        is.
 
   - type: textarea
     id: brief-description
@@ -55,11 +56,11 @@ body:
     attributes:
       label: "Attach your files"
       description: >
-        The ZIP from Help > Report Bug, or your campaign file and the files from the logs folder.
-        Archives up to 25 MB, video up to 100 MB.
+        The ZIP from Help > Report Bug, or your zipped campaign file and the files from the logs
+        folder. Archives up to 25 MB, video up to 100 MB.
     validations:
       required: false
-      accept: ".zip,.gz,.cpnx,.xml,.log,.txt,.csv,.png,.jpg,.jpeg,.gif,.mp4,.mov"
+      accept: ".zip,.gz,.xml,.log,.txt,.csv,.png,.jpg,.jpeg,.gif,.mp4,.mov"
 
   - type: textarea
     id: log-excerpt


### PR DESCRIPTION
## What this changes

The bug report form is missing from the MekHQ tracker. A reporter who goes to open an issue is
offered the enhancement request and nothing else, so there is currently no way to file a bug.

GitHub throws away an issue form entirely when any part of it fails validation, and it does so
silently - the form simply disappears from the chooser. Here the upload field listed `.cpnx`
among the accepted attachments, and `.cpnx` is not a file type GitHub accepts. That one extension
cost the whole form. The only place the fault is visible is the .yml file's own page on
github.com, which shows a red banner naming the offending extension.

Since GitHub will not take a bare `.cpnx` anywhere on the site, the instructions now say to zip
the campaign first, and point out that a `.cpnx.gz` uploads as it is because `.gz` is accepted.
The ZIP that Help > Report Bug produces was always fine.

No issue number: the form this restores is the one a reporter would have used.

## Testing

- Reproduced live. MekHQ's chooser offers only "Request an Enhancement".
- Checked all seven forms across the four repositories against GitHub's published supported-file
  list and its form schema. The check agrees with GitHub on every file: the three it calls broken
  are exactly the three missing from their choosers, and the four it passes are the four that
  render.
- This file passes after the change.
- GitHub itself now passes the file. On the PR branch, the red "There is a problem with this
  template" banner is gone from the .yml page and GitHub renders the full form preview instead,
  upload field included.

## What is not proven yet

- The chooser will not list the form until this merges, because GitHub builds that page from the
  default branch. GitHub validating the file on the branch is as far as it can be taken before
  then.
- Nobody has pushed a file through the upload field yet. GitHub accepts the extension list, but
  the attachment itself was never exercised end to end.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state (not applicable - this changes a GitHub issue form only)
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text (not applicable - no Java in this PR)
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have verified the result
