### PR TITLE
docs: documentation improvements around Morale

### DIFF
--- a/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
+++ b/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
@@ -1471,7 +1471,7 @@ MORALE.title=Morale
 MORALE.definition=MekHQ Morale system is only in use while a <a href='GLOSSARY:DIGITAL_GM'>Digital GM</a> is enabled.\
   <p>This system reflects not only the mental state of opposing formations but also their ability to resist effectively. \
   Morale levels range from "routed" (very low) to "overwhelming" (very high), with several steps in between.\
-  <h1>Morale Levels</h1>\
+  <h2>Morale Levels</h2>\
   There are seven 'levels' of morale. Each represents a combination of both the enemy's willingness to fight, as well\
   \ as their capacity to do so. Morale, in many ways, can also be seen as reflecting the balance of power in a \
   contract.\
@@ -1525,7 +1525,7 @@ MORALE.definition=MekHQ Morale system is only in use while a <a href='GLOSSARY:D
   Decisive Defeat.</p>\
   <p>The exact modifiers applied to the morale roll for a Victory, Defeat, and so on are determined by Campaign \
   Options.</p>\
-  <h1>Routing the Enemy</h1>\
+  <h2>Routing the Enemy</h2>\
   When an enemy is routed, their formations are severely damaged and unable to offer effective resistance. Routed enemies\
  \ will not generate new scenarios. For any contract other than Garrison Duty, Cadre Duty, Security Duty, Riot Duty, \
   or Temporary Retainer, all remaining <a href='GLOSSARY:STRATEGIC_OBJECTIVES'>objectives</a> are considered \

--- a/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
+++ b/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
@@ -918,7 +918,7 @@ FORCE_TYPE_SUPPORT.definition=A Support Force is any formation not typically <a 
  \ in combat scenarios. This classification is ideal for units like support vehicles, civilians, or other formations that\
  \ belong in the <a href='GLOSSARY:TOE'>TO&E</a> but aren't meant to fight.\
  <p>If <a href='GLOSSARY:STRATCON'>StratCon</a> is enabled, Support Forces are rarely used as a \
-  <a href='GLOSSARY:SEED_FORCES'>Seed Force</a>, aking them a useful classification for logistical or non-combat \
+  <a href='GLOSSARY:SEED_FORCES'>Seed Force</a>, making them a useful classification for logistical or non-combat \
   units.</p>\
  <p>You should consider placing any DropShips and JumpShips into Support Forces unless you have enough Aerospace assets\
  \ to protect them. This represents you keeping these valuable vessels away from the fighting rather than risking them\
@@ -1597,7 +1597,7 @@ PRISONERS_OF_WAR.definition=War is an unforgiving battleground, and in the chaos
  \ captured by the enemy. Prisoners of war (POWs) are an inevitable reality of any prolonged military campaign, and how\
  \ they are treated can shape the perception and reputation of the formation that holds them.\
  <p>Prisoners may be spotted in the personnel roster by their special 'Prisoner' title. Some prisoners are willing to\
- \ defect, and these are marked with an astrisk next to 'Prisoner.'</p>\
+ \ defect, and these are marked with an asterisk next to 'Prisoner.'</p>\
  <p>Depending on your campaign options, you can have a vastly different prisoner experience. However, one thing is\
  \ <b>important</b> if you are using the MekHQ Capture Style, you are going to be invited to ransom prisoners during special\
  \ events. In prior versions, this could be done at any time. However, that is no longer the case.</p>\
@@ -1632,7 +1632,7 @@ PROSTHETICS.definition=Prosthetics & Advanced Surgeries are only available if Ad
   increases the total surgery cost tenfold.</p>\
   <h2>Surgery Cost</h2>\
   <p>The cost of each surgery is based on a number of factors. First, there is the base cost, listed in ATOW. This is\
-  \ then multiplied by the availability rating appropriate for the campaign era. Availabilitiy D has a x1.25 \
+  \ then multiplied by the availability rating appropriate for the campaign era. Availability D has a x1.25 \
   multiplier, E a x1.5 multiplier, and F a x10 multiplier. There is no multiplier for availabilities A, B, or C. Any \
   surgery with availability of F* or X is unavailable.</p>\
   <h2>Restrictions</h2>\
@@ -1774,7 +1774,7 @@ RESUPPLY.definition=Monthly Resupplies are the primary way to receive supplies w
  \ each month, your employer will offer to sell you surplus weapons, armor, and parts depending on the strategic situation.\
  \ When the situation is favorable, supplies are more plentiful and less expensive. During tough times, supplies are\
  \ scarcer and more expensive.\
- <p>In Guerilla Warfare contracts, Resupplies come from local smugglers instead of your employer. These supplies are\
+ <p>In Guerrilla Warfare contracts, Resupplies come from local smugglers instead of your employer. These supplies are\
  \ more expensive and less reliable. Smuggler deals carry the risk of scams, and offers may not appear every month.</p>\
  <p><b>CONTENTS</b></p>\
  <p>The contents of a Resupply depend on the combat units in your <a href='GLOSSARY:TOE'>TO&E</a> with an emphasis\

--- a/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
+++ b/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
@@ -732,7 +732,7 @@ ESSENTIAL_SCENARIOS.definition=Essential Scenarios are <a href='GLOSSARY:STRATCO
 EXPERIENCE_COSTS.title=Experience Costs
 EXPERIENCE_COSTS.definition=Both the New and Veteran Player presets model their xp costs on <i>A Time of War</i>. These\
   \ costs can be higher than expected if you've played MeKHQ for a long time.\
-  <p>In older versions, xp costs were based on <i>Total Warfare</i>, and where Total Warefare was missing information\
+  <p>In older versions, xp costs were based on <i>Total Warfare</i>, and where Total Warfare was missing information\
   \ (such as for most <a href='GLOSSARY:SKILL_TYPES'>Support Skills</a>), developers came up with their own costs.</p>\
   <p>The costs in <i>Total Warfare</i> are not well suited to MekHQ, as they are designed for very short-lived, in-person\
   \ campaigns. Campaigns where you might fight only a handful of scenarios across the entire campaign. Meanwhile, in\

--- a/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
+++ b/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
@@ -1527,8 +1527,8 @@ MORALE.definition=MekHQ Morale system is only in use while a <a href='GLOSSARY:D
   Options.</p>\
   <h2>Routing the Enemy</h2>\
   When an enemy is routed, their formations are severely damaged and unable to offer effective resistance. Routed enemies\
- \ will not generate new scenarios. For any contract other than Garrison Duty, Cadre Duty, Security Duty, Riot Duty, \
-  or Temporary Retainer, all remaining <a href='GLOSSARY:STRATEGIC_OBJECTIVES'>objectives</a> are considered \
+ \ will not generate new scenarios. For Pirate Hunts and Pirate Raids, all \
+  remaining <a href='GLOSSARY:STRATEGIC_OBJECTIVES'>objectives</a> are considered \
   completed, and the contract's conclusion date is automatically moved to the next day.\
   <p>For those contracts listed above (so-called 'garrison type contracts') the contract doesn't end early, but the \
   enemy formations are in full retreat. After the first month of peace, There's a 25% chance a new opposition will arrive;\

--- a/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
+++ b/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
@@ -1491,7 +1491,7 @@ MORALE.definition=MekHQ Morale system is only in use while a <a href='GLOSSARY:D
   \ victory. Allied formations are on the verge of collapse, with no hope of recovery.</blockquote>\
   <p>One thing to recognize is that not every battle is represented in MekHQ. You might be winning every scenario, \
   but your allies could be facing defeats across the board.</p>\
-  <h1>Morale Checks</h2>\
+  <h2>Morale Checks</h2>\
   At the start of each month, 2d6 is rolled to see if the enemy's morale changes. On a 6 or less, their morale \
   moves towards "Overwhelming." On an 8+ their morale moves one step towards "Routed."\
   <p>There are several factors that modify this roll. It's important to note that these modifiers are applied to the \


### PR DESCRIPTION
This addresses some of the formatting issues and spelling associated with the documentation, particularly the Morale page.  Based on looking at the contract system and looking at `ChaosObjectiveType.java`, the only two contracts that can be completed early are Pirate Raids and Pirate Hunts.  If this is incorrect or there are more changes desired please let me know.  Thanks

If you want it squashed/rebased I can also adjust.

## What this changes

<!-- The effect someone actually sees, in plain language. One or two sentences is fine. -->

<!-- Keep this line as well as the number in the title. GitHub only closes an issue from a
     keyword in the description - a number in the title alone does not close anything.

     Any of these close an issue when this merges:
         Close / Closes / Closed
         Fix / Fixes / Fixed
         Resolve / Resolves / Resolved

     Closing more than one needs the keyword repeated in front of each number:
         Fixes #1234, fixes #5678          closes both
         Fixes #1234, #5678                closes only #1234

     For an issue in another repository, qualify it: Fixes MegaMek/mekhq#1234 -->
Fixes #9105

## Testing

Built and ran smoke-test via game

## What is not proven yet

<!-- What you did not test, or could not. "Nothing" is a valid answer - say so explicitly. -->

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text

No AI was leveraged in this PR.
