### PR TITLE
fix: adjusts the tooltip when setting attribute values

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -244,6 +244,10 @@ spendOnAttributes.tooltip=Improves the chosen Attribute by 1 (to a maximum of 10
   \ numbers (see A Time of War).\
   <br>\
   <br>Attributes also improve skill checks for skills the character does not possess.
+spendOnAttributesSetValue.tooltip=Set the value for the chosen Attribute (to a maximum of 10). Attributes can affect skill target\
+  \ numbers (see A Time of War).\
+  <br>\
+  <br>Attributes also improve skill checks for skills the character does not possess.
 spendOnAttributes.score=Attribute Score
 generateRandomCivilianProfession.text=Assign Random Civilian Profession
 generateRandomCivilianProfession.tooltip=Assigns the character a random civilian profession, including required skills.

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -4447,7 +4447,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     continue;
                 }
                 menuItem = new JMenuItem(attribute.getLabel());
-                menuItem.setToolTipText(wordWrap(String.format(resources.getString("spendOnAttributes.tooltip"))));
+                menuItem.setToolTipText(wordWrap(String.format(resources.getString("spendOnAttributesSetValue.tooltip"))));
                 menuItem.setActionCommand(makeCommand(CMD_SET_ATTRIBUTE, String.valueOf(attribute)));
                 menuItem.addActionListener(this);
                 menuItem.setEnabled(getCampaign().isGM());


### PR DESCRIPTION
fix: adjusts the tooltip when setting attribute values to better match the action, addresses #8623

This adds an additional tooltip property string to differentiate between increasing attribute values by one vs. setting the value to whatever the user desires.

<!-- TITLE: include the issue number, and start with "Fix" for a bug fix or "Close" for
     anything else:

         Fix #1234: Cheese has the wrong colour gradient
         Close #1234: Added 6 new cheese gradients

     More than one issue is fine: "Close #111, #5329: Added unit history tracking".
     Release notes are generated automatically from pull request titles, so the title is
     what players end up reading. -->

## What this changes

<!-- The effect someone actually sees, in plain language. One or two sentences is fine. -->

<!-- Keep this line as well as the number in the title. GitHub only closes an issue from a
     keyword in the description - a number in the title alone does not close anything.

     Any of these close an issue when this merges:
         Close / Closes / Closed
         Fix / Fixes / Fixed
         Resolve / Resolves / Resolved

     Closing more than one needs the keyword repeated in front of each number:
         Fixes #1234, fixes #5678          closes both
         Fixes #1234, #5678                closes only #1234

     For an issue in another repository, qualify it: Fixes MegaMek/mekhq#1234 -->
Fixes #8623

## Testing

Basic build and hover smoke-test.

## What is not proven yet

<!-- What you did not test, or could not. "Nothing" is a valid answer - say so explicitly. -->

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text

No AI was leveraged in this PR.

