### PR TITLE
Fix #9729: Fixed NPE When Planet is Missing Industry Data

### DIFF
--- a/MekHQ/src/mekhq/campaign/digitalGM/stratCon/sectorGeneration/PlanetProfile.java
+++ b/MekHQ/src/mekhq/campaign/digitalGM/stratCon/sectorGeneration/PlanetProfile.java
@@ -225,9 +225,7 @@ public record PlanetProfile(int temperatureCelsius, double diameterKm, int water
      * @return a resolved {@link PlanetProfile}
      */
     public static PlanetProfile from(Planet planet, LocalDate date) {
-        Integer temperature = planet.getTemperature(date);
-        int resolvedTemperature = (temperature != null) ? temperature : NEUTRAL_TEMPERATURE_CELSIUS;
-
+        int temperature = planet.getTemperature(date);
         double diameter = planet.getDiameter();
 
         int resolvedWater = NEUTRAL_WATER_PERCENT;
@@ -265,7 +263,7 @@ public record PlanetProfile(int temperatureCelsius, double diameterKm, int water
         Long population = planet.getPopulation(date);
         HPGRating hpg = planet.getHPG(date);
 
-        return new PlanetProfile(resolvedTemperature,
+        return new PlanetProfile(temperature,
               diameter,
               resolvedWater,
               airless,
@@ -274,7 +272,7 @@ public record PlanetProfile(int temperatureCelsius, double diameterKm, int water
               resolvedLandmassCount,
               resolvedGravity,
               population,
-              (hpg != null) ? hpg : HPGRating.X);
+              hpg);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/unit/Maintenance.java
+++ b/MekHQ/src/mekhq/campaign/unit/Maintenance.java
@@ -465,15 +465,19 @@ public class Maintenance {
                     zeroGSkillLevel = zeroGSkill.getTotalSkillLevel(skillModifierData);
                 }
 
-                if (planet.getGravity() < 0.8) {
+                // getGravity() is nullable (a planet may record no gravity); default to standard Terran gravity so
+                // an unrecorded value contributes no modifier rather than throwing on the unboxing below.
+                Double recordedGravity = planet.getGravity();
+                double gravity = (recordedGravity != null) ? recordedGravity : 1.0;
+                if (gravity < 0.8) {
                     int modifier = 2;
                     target.addModifier(modifier, "Low Gravity");
                     addZeroGOperationsModifier(zeroGSkillLevel, modifier, target);
-                } else if (planet.getGravity() >= 2.0) {
+                } else if (gravity >= 2.0) {
                     int modifier = 4;
                     target.addModifier(modifier, "Very High Gravity");
                     addZeroGOperationsModifier(zeroGSkillLevel, modifier, target);
-                } else if (planet.getGravity() > 1.2) {
+                } else if (gravity > 1.2) {
                     int modifier = 1;
                     target.addModifier(modifier, "High Gravity");
                     addZeroGOperationsModifier(zeroGSkillLevel, modifier, target);

--- a/MekHQ/src/mekhq/campaign/universe/Planet.java
+++ b/MekHQ/src/mekhq/campaign/universe/Planet.java
@@ -539,11 +539,11 @@ public class Planet {
         }
     }
 
-    public @Nullable String getName(LocalDate when) {
-        return getSourcedName(when).getValue();
+    public @Nonnull String getName(LocalDate when) {
+        return getSourcedName(when) == null ? "?" : getSourcedName(when).getValue();
     }
 
-    public @Nonnull SourceableValue<String> getSourcedName(LocalDate when) {
+    public @Nullable SourceableValue<String> getSourcedName(LocalDate when) {
         return getEventData(when, name, e -> e.name);
     }
 

--- a/MekHQ/src/mekhq/campaign/universe/Planet.java
+++ b/MekHQ/src/mekhq/campaign/universe/Planet.java
@@ -44,6 +44,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.util.StdConverter;
+import jakarta.annotation.Nonnull;
 import megamek.codeUtilities.ObjectUtility;
 import megamek.common.TargetRollModifier;
 import megamek.common.annotations.Nullable;
@@ -51,8 +52,8 @@ import megamek.common.enums.TechRating;
 import megamek.common.rolls.TargetRoll;
 import megamek.common.universe.FactionTag;
 import megamek.logging.MMLogger;
-import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.campaignOptions.CampaignOption;
+import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.universe.PlanetarySystem.PlanetaryRating;
 import mekhq.campaign.universe.PlanetarySystem.PlanetarySophistication;
 import mekhq.campaign.universe.enums.HPGRating;
@@ -69,6 +70,13 @@ import mekhq.campaign.universe.enums.PlanetaryType;
 @JsonDeserialize(converter = Planet.PlanetPostLoader.class)
 public class Planet {
     private static final MMLogger logger = MMLogger.create(Planet.class);
+
+    /**
+     * Temperature (in degrees Celsius) reported for a planet that records no temperature for the requested date. A
+     * world the surveys never bothered to log is treated as a barren, uninhabitable rock rather than a temperate one,
+     * so {@link #getTemperature(LocalDate)} never returns {@code null}.
+     */
+    public static final int UNINHABITABLE_TEMPERATURE_CELSIUS = -100;
 
     // Base data
     private String id;
@@ -166,15 +174,15 @@ public class Planet {
 
     // Constant base data
 
-    public String getId() {
+    public @Nullable String getId() {
         return id;
     }
 
-    public Double getGravity() {
+    public @Nullable Double getGravity() {
         return (null == getSourcedGravity()) ? null : getSourcedGravity().getValue();
     }
 
-    public SourceableValue<Double> getSourcedGravity() {
+    public @Nullable SourceableValue<Double> getSourcedGravity() {
         return gravity;
     }
 
@@ -182,7 +190,7 @@ public class Planet {
      * @deprecated no indicated uses
      */
     @Deprecated(since = "0.50.06", forRemoval = true)
-    public SourceableValue<Double> getSourcedDensity() {
+    public @Nullable SourceableValue<Double> getSourcedDensity() {
         return density;
     }
 
@@ -190,11 +198,11 @@ public class Planet {
         return (null == getSourcedDiameter() ? 0.0 : getSourcedDiameter().getValue());
     }
 
-    public SourceableValue<Double> getSourcedDiameter() {
+    public @Nullable SourceableValue<Double> getSourcedDiameter() {
         return diameter;
     }
 
-    public Double getOrbitRadius() {
+    public @Nullable Double getOrbitRadius() {
         return orbitRadius;
     }
 
@@ -202,7 +210,7 @@ public class Planet {
         parentSystem = system;
     }
 
-    public List<Satellite> getSatellites() {
+    public @Nullable List<Satellite> getSatellites() {
         return null != satellites ? new ArrayList<>(satellites) : null;
     }
 
@@ -214,23 +222,23 @@ public class Planet {
         this.satellites = (satellites == null || satellites.isEmpty()) ? null : new ArrayList<>(satellites);
     }
 
-    public Integer getSmallMoons() {
+    public @Nonnull Integer getSmallMoons() {
         return (null == getSourcedSmallMoons()) ? 0 : getSourcedSmallMoons().getValue();
     }
 
-    public SourceableValue<Integer> getSourcedSmallMoons() {
+    public @Nullable SourceableValue<Integer> getSourcedSmallMoons() {
         return smallMoons;
     }
 
-    public Boolean hasRing() {
+    public @Nonnull Boolean hasRing() {
         return null != getSourcedRing() && getSourcedRing().getValue();
     }
 
-    public SourceableValue<Boolean> getSourcedRing() {
+    public @Nullable SourceableValue<Boolean> getSourcedRing() {
         return ring;
     }
 
-    public List<LandMass> getLandMasses() {
+    public @Nullable List<LandMass> getLandMasses() {
         return null != landMasses ? new ArrayList<>(landMasses) : null;
     }
 
@@ -242,16 +250,16 @@ public class Planet {
         this.landMasses = (landMasses == null || landMasses.isEmpty()) ? null : new ArrayList<>(landMasses);
     }
 
-    public SourceableValue<Double> getSourcedDayLength(LocalDate when) {
+    public @Nullable SourceableValue<Double> getSourcedDayLength(LocalDate when) {
         // yes day length can change because Venus
         return getEventData(when, dayLength, e -> e.dayLength);
     }
 
-    public SourceableValue<Double> getSourcedYearLength() {
+    public @Nullable SourceableValue<Double> getSourcedYearLength() {
         return yearLength;
     }
 
-    public PlanetaryType getPlanetType() {
+    public @Nonnull PlanetaryType getPlanetType() {
         if (null == getSourcedPlanetType()) {
             logger.error("No planetary type for {}. Using Terrestrial", id);
             return PlanetaryType.TERRESTRIAL;
@@ -259,15 +267,15 @@ public class Planet {
         return getSourcedPlanetType().getValue();
     }
 
-    public SourceableValue<PlanetaryType> getSourcedPlanetType() {
+    public @Nullable SourceableValue<PlanetaryType> getSourcedPlanetType() {
         return planetType;
     }
 
-    public Integer getSystemPosition() {
+    public @Nullable Integer getSystemPosition() {
         return (null == sysPos) ? null : getSourcedSystemPosition().getValue();
     }
 
-    public SourceableValue<Integer> getSourcedSystemPosition() {
+    public @Nullable SourceableValue<Integer> getSourcedSystemPosition() {
         return sysPos;
     }
 
@@ -277,7 +285,7 @@ public class Planet {
      *
      * @return String of system position after removing asteroid belts
      */
-    public String getDisplayableSystemPosition() {
+    public @Nonnull String getDisplayableSystemPosition() {
         // We won't give the actual system position here, because we don't want asteroid
         // belts to count for system position
         if ((null == getParentSystem()) || (null == getSystemPosition())) {
@@ -293,11 +301,11 @@ public class Planet {
         return Integer.toString(pos);
     }
 
-    public String getDescription() {
+    public @Nullable String getDescription() {
         return desc;
     }
 
-    public String getIcon() {
+    public @Nullable String getIcon() {
         return icon;
     }
 
@@ -369,28 +377,28 @@ public class Planet {
 
     // Constant stellar data (to be moved out later)
 
-    public Double getX() {
+    public @Nonnull Double getX() {
         return null == getParentSystem() ? 0.0 : getParentSystem().getX();
     }
 
-    public Double getY() {
+    public @Nonnull Double getY() {
         return null == getParentSystem() ? 0.0 : getParentSystem().getY();
     }
 
-    public PlanetarySystem getParentSystem() {
+    public @Nullable PlanetarySystem getParentSystem() {
         return parentSystem;
     }
 
     // Date-dependant data
 
-    public PlanetaryEvent getEvent(LocalDate when) {
+    public @Nullable PlanetaryEvent getEvent(LocalDate when) {
         if ((null == when) || (null == events)) {
             return null;
         }
         return events.get(when);
     }
 
-    public List<PlanetaryEvent> getEvents() {
+    public @Nullable List<PlanetaryEvent> getEvents() {
         if (null == events) {
             return null;
         }
@@ -502,7 +510,7 @@ public class Planet {
          *
          * @return The up-to-date {@link PlanetaryEvent} as of {@code now}.
          */
-        public PlanetaryEvent getCurrentEvent(LocalDate now) {
+        public @Nonnull PlanetaryEvent getCurrentEvent(LocalDate now) {
             if ((lastUpdated == null) || lastUpdated.isAfter(now)) {
                 // initialize ourselves if we're fresh or if we went back in time (which breaks how the event stream
                 // works)
@@ -531,20 +539,20 @@ public class Planet {
         }
     }
 
-    public String getName(LocalDate when) {
+    public @Nullable String getName(LocalDate when) {
         return getSourcedName(when).getValue();
     }
 
-    public SourceableValue<String> getSourcedName(LocalDate when) {
+    public @Nonnull SourceableValue<String> getSourcedName(LocalDate when) {
         return getEventData(when, name, e -> e.name);
     }
 
-    public String getShortName(LocalDate when) {
+    public @Nullable String getShortName(LocalDate when) {
         return getEventData(when, shortName, e -> e.shortName);
     }
 
     /** @return short name if set, else full name, else "unnamed" */
-    public String getPrintableName(LocalDate when) {
+    public @Nonnull String getPrintableName(LocalDate when) {
         String result = getShortName(when);
         if (null == result) {
             result = getName(when);
@@ -552,27 +560,42 @@ public class Planet {
         return null != result ? result : "unnamed";
     }
 
-    public SocioIndustrialData getSocioIndustrial(LocalDate when) {
-        return (null == getSourcedSocioIndustrial(when)) ? null : getSourcedSocioIndustrial(when).getValue();
+    /**
+     * @return the planet's socio-industrial (USILR) ratings for the given date, or {@link SocioIndustrialData#NONE} (a
+     *       Regressed, all-F profile) when no data is recorded for that date. Never {@code null}, mirroring the
+     *       fallbacks returned by sibling getters such as {@link #getHPG(LocalDate)} and
+     *       {@link #getAtmosphere(LocalDate)}. Use {@link #getSourcedSocioIndustrial(LocalDate)} when the caller needs
+     *       to distinguish "no recorded data" from an actual reading.
+     */
+    public @Nonnull SocioIndustrialData getSocioIndustrial(LocalDate when) {
+        SourceableValue<SocioIndustrialData> sourced = getSourcedSocioIndustrial(when);
+        return (sourced == null || sourced.getValue() == null) ? SocioIndustrialData.NONE : sourced.getValue();
     }
 
-    public SourceableValue<SocioIndustrialData> getSourcedSocioIndustrial(LocalDate when) {
+    public @Nullable SourceableValue<SocioIndustrialData> getSourcedSocioIndustrial(LocalDate when) {
         return getEventData(when, null, e -> e.socioIndustrial);
     }
 
-    public HPGRating getHPG(LocalDate when) {
+    public @Nonnull HPGRating getHPG(LocalDate when) {
         return (null == getSourcedHPG(when)) ? HPGRating.X : getSourcedHPG(when).getValue();
     }
 
-    public SourceableValue<HPGRating> getSourcedHPG(LocalDate when) {
+    public @Nullable SourceableValue<HPGRating> getSourcedHPG(LocalDate when) {
         return getEventData(when, null, e -> e.hpg);
     }
 
-    public Long getPopulation(LocalDate when) {
-        return (null == getSourcedPopulation(when)) ? null : getSourcedPopulation(when).getValue();
+    /**
+     * @return the planet's population for the given date, or {@code 0} when no data is recorded for that date. Never
+     *       {@code null}; every caller already treats an absent or zero population identically (nobody to recruit or
+     *       fight over). Use {@link #getSourcedPopulation(LocalDate)} to distinguish "no recorded data" from a genuine
+     *       zero.
+     */
+    public @Nonnull Long getPopulation(LocalDate when) {
+        SourceableValue<Long> sourced = getSourcedPopulation(when);
+        return (sourced == null || sourced.getValue() == null) ? 0L : sourced.getValue();
     }
 
-    public SourceableValue<Long> getSourcedPopulation(LocalDate when) {
+    public @Nullable SourceableValue<Long> getSourcedPopulation(LocalDate when) {
         return getEventData(when, null, e -> e.population);
     }
 
@@ -580,51 +603,67 @@ public class Planet {
      * @deprecated no indicated uses.
      */
     @Deprecated(since = "0.50.06", forRemoval = true)
-    public LifeForm getLifeForm(LocalDate when) {
+    public @Nonnull LifeForm getLifeForm(LocalDate when) {
         return (null == getSourcedLifeForm(when)) ? LifeForm.NONE : getSourcedLifeForm(when).getValue();
     }
 
-    public SourceableValue<LifeForm> getSourcedLifeForm(LocalDate when) {
+    public @Nullable SourceableValue<LifeForm> getSourcedLifeForm(LocalDate when) {
         return getEventData(when, lifeForm, e -> e.lifeForm);
     }
 
-    public SourceableValue<Integer> getSourcedPercentWater(LocalDate when) {
+    public @Nullable SourceableValue<Integer> getSourcedPercentWater(LocalDate when) {
         return getEventData(when, percentWater, e -> e.percentWater);
     }
 
-    public Integer getTemperature(LocalDate when) {
-        return (null == getSourcedTemperature(when)) ? null : getSourcedTemperature(when).getValue();
+    /**
+     * @return the planet's surface temperature (°C) for the given date, or {@link #UNINHABITABLE_TEMPERATURE_CELSIUS}
+     *       when no data is recorded for that date. Never {@code null}. Use {@link #getSourcedTemperature(LocalDate)}
+     *       when the caller needs to distinguish "no recorded data" from an actual reading (for example to substitute a
+     *       temperate default for playability rather than the barren-rock fallback).
+     */
+    public @Nonnull Integer getTemperature(LocalDate when) {
+        SourceableValue<Integer> sourced = getSourcedTemperature(when);
+        return (sourced == null || sourced.getValue() == null) ? UNINHABITABLE_TEMPERATURE_CELSIUS : sourced.getValue();
     }
 
-    public SourceableValue<Integer> getSourcedTemperature(LocalDate when) {
+    public @Nullable SourceableValue<Integer> getSourcedTemperature(LocalDate when) {
         return getEventData(when, temperature, e -> e.temperature);
     }
 
-    public megamek.common.planetaryConditions.Atmosphere getPressure(LocalDate when) {
-        return (null == getSourcedPressure(when)) ? null : getSourcedPressure(when).getValue();
+    /**
+     * @return the planet's atmospheric pressure for the given date, or
+     *       {@link megamek.common.planetaryConditions.Atmosphere#STANDARD} when no data is recorded for that date.
+     *       Never {@code null}, mirroring the fallback returned by {@link #getAtmosphere(LocalDate)}. Use
+     *       {@link #getSourcedPressure(LocalDate)} to distinguish "no recorded data" from an actual reading.
+     */
+    public @Nonnull megamek.common.planetaryConditions.Atmosphere getPressure(LocalDate when) {
+        SourceableValue<megamek.common.planetaryConditions.Atmosphere> sourced = getSourcedPressure(when);
+        return (sourced == null || sourced.getValue() == null) ?
+                     megamek.common.planetaryConditions.Atmosphere.STANDARD :
+                     sourced.getValue();
     }
 
-    public SourceableValue<megamek.common.planetaryConditions.Atmosphere> getSourcedPressure(LocalDate when) {
+    public @Nullable SourceableValue<megamek.common.planetaryConditions.Atmosphere> getSourcedPressure(LocalDate when) {
         return getEventData(when, pressure, e -> e.pressure);
     }
 
-    public Atmosphere getAtmosphere(LocalDate when) {
+    public @Nonnull Atmosphere getAtmosphere(LocalDate when) {
         return (null == getSourcedAtmosphere(when)) ? Atmosphere.NONE : getSourcedAtmosphere(when).getValue();
     }
 
-    public SourceableValue<Atmosphere> getSourcedAtmosphere(LocalDate when) {
+    public @Nullable SourceableValue<Atmosphere> getSourcedAtmosphere(LocalDate when) {
         return getEventData(when, atmosphere, e -> e.atmosphere);
     }
 
-    public SourceableValue<String> getSourcedComposition(LocalDate when) {
+    public @Nullable SourceableValue<String> getSourcedComposition(LocalDate when) {
         return getEventData(when, composition, e -> e.composition);
     }
 
-    public List<String> getFactions(LocalDate when) {
+    public @Nonnull List<String> getFactions(LocalDate when) {
         return (null == getSourcedFactions(when)) ? Collections.emptyList() : getSourcedFactions(when).getValue();
     }
 
-    public SourceableValue<List<String>> getSourcedFactions(LocalDate when) {
+    public @Nullable SourceableValue<List<String>> getSourcedFactions(LocalDate when) {
         return getEventData(when, null, e -> e.faction);
     }
 
@@ -640,12 +679,12 @@ public class Planet {
     }
 
     /** @return set of factions at a given date */
-    public Set<Faction> getFactionSet(LocalDate when) {
+    public @Nonnull Set<Faction> getFactionSet(LocalDate when) {
         List<String> currentFactions = getFactions(when);
         return getFactionsFrom(currentFactions);
     }
 
-    public String getFactionDesc(LocalDate when) {
+    public @Nonnull String getFactionDesc(LocalDate when) {
         String toReturn = Faction.getFactionNames(getFactionSet(when), when.getYear());
         if (toReturn.isEmpty()) {
             toReturn = "Uncolonized";
@@ -662,7 +701,7 @@ public class Planet {
      *
      * @return The hiring hall level on the given date
      */
-    public HiringHallLevel getHiringHallLevel(LocalDate when) {
+    public @Nonnull HiringHallLevel getHiringHallLevel(LocalDate when) {
         HiringHallLevel staticHall = (null == getSourcedHiringHallLevel(when)) ?
                                            HiringHallLevel.NONE :
                                            getSourcedHiringHallLevel(when).getValue();
@@ -687,7 +726,7 @@ public class Planet {
         return resolveHiringHallLevel(score);
     }
 
-    public SourceableValue<HiringHallLevel> getSourcedHiringHallLevel(LocalDate when) {
+    public @Nullable SourceableValue<HiringHallLevel> getSourcedHiringHallLevel(LocalDate when) {
         return getEventData(when, null, e -> e.hiringHall);
     }
 
@@ -800,7 +839,7 @@ public class Planet {
      *
      * @return an updated TargetRoll with planet specific mods
      */
-    public List<TargetRollModifier> getAcquisitionMods(LocalDate when, CampaignOptions options,
+    public @Nonnull List<TargetRollModifier> getAcquisitionMods(LocalDate when, CampaignOptions options,
           Faction faction, boolean clanPart) {
         List<TargetRollModifier> result = new ArrayList<>();
         // check faction limitations

--- a/MekHQ/src/mekhq/utilities/SystemValidator.java
+++ b/MekHQ/src/mekhq/utilities/SystemValidator.java
@@ -483,7 +483,7 @@ public class SystemValidator {
           String planetInfo, ValidationResult result) {
         LocalDate baseDate = LocalDate.of(1, 1, 1);
 
-        if (planet.getPressure(baseDate) == null) {
+        if (planet.getSourcedPressure(baseDate) == null) {
             result.addMessage(new ValidationMessage(Severity.WARNING,
                   Category.MISSING_ATMOSPHERE_DATA, fileName, systemId, planetInfo,
                   "Terrestrial planet missing pressure"));

--- a/MekHQ/unittests/mekhq/campaign/digitalGM/stratCon/sectorGeneration/PlanetProfileTest.java
+++ b/MekHQ/unittests/mekhq/campaign/digitalGM/stratCon/sectorGeneration/PlanetProfileTest.java
@@ -402,7 +402,7 @@ class PlanetProfileTest {
         Planet planet = mock(Planet.class);
         when(planet.getTemperature(DATE)).thenReturn(Planet.UNINHABITABLE_TEMPERATURE_CELSIUS);
         when(planet.getGravity()).thenReturn(null);
-        when(planet.getPopulation(DATE)).thenReturn(null);
+        when(planet.getPopulation(DATE)).thenReturn(0L);
         when(planet.getHPG(DATE)).thenReturn(HPGRating.X);
         return planet;
     }

--- a/MekHQ/unittests/mekhq/campaign/digitalGM/stratCon/sectorGeneration/PlanetProfileTest.java
+++ b/MekHQ/unittests/mekhq/campaign/digitalGM/stratCon/sectorGeneration/PlanetProfileTest.java
@@ -400,22 +400,22 @@ class PlanetProfileTest {
      */
     private static Planet emptyPlanet() {
         Planet planet = mock(Planet.class);
-        when(planet.getTemperature(DATE)).thenReturn(null);
+        when(planet.getTemperature(DATE)).thenReturn(Planet.UNINHABITABLE_TEMPERATURE_CELSIUS);
         when(planet.getGravity()).thenReturn(null);
         when(planet.getPopulation(DATE)).thenReturn(null);
-        when(planet.getHPG(DATE)).thenReturn(null);
+        when(planet.getHPG(DATE)).thenReturn(HPGRating.X);
         return planet;
     }
 
     @Test
-    void from_planetRecordingNothing_usesEveryNeutralFallback() {
+    void from_planetRecordingNothing_usesEveryFallback() {
         // Most planets in play record only a handful of these fields, so the fallbacks below are the values improved
         // sector generation actually runs on.
         PlanetProfile resolved = PlanetProfile.from(emptyPlanet(), DATE);
 
-        assertEquals(NEUTRAL_TEMPERATURE_CELSIUS,
+        assertEquals(Planet.UNINHABITABLE_TEMPERATURE_CELSIUS,
               resolved.temperatureCelsius(),
-              "an unrecorded temperature should fall back to the neutral room temperature");
+              "an unrecorded temperature should fall back to the uninhabitable barren-rock default");
         assertEquals(NEUTRAL_WATER_PERCENT,
               resolved.waterPercent(),
               "unrecorded surface water should fall back to the neutral 50%");


### PR DESCRIPTION
Fix #9729

## What this changes

Planetary data had numerous getters returning undeclared `null` values. This was a time bomb that happened to get tripped by recent contract changes. This PR addresses that and ensures methods are labeled appropriately.