### PR TITLE
fix: adjust location in documentation for prisoners PDF material

### DIFF
--- a/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
+++ b/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
@@ -1110,7 +1110,7 @@ MISSING_IN_ACTION.title=Missing in Action
 MISSING_IN_ACTION.definition=Sometimes your personnel may go MIA. When this happens each day an automatic attempt will\
  \ be made to track them down. Any MIA characters are abandoned if you leave the planet they went missing on.\
  <p>For more details on Missing in Action characters, refer to the documentation in:\
- <br><i>MekHQ/docs/Random Events/Prisoners of War & Abstracted Search and Rescue.pdf</i></p>
+ <br><i>MekHQ/docs/GlossaryDocs/Prisoners of War & Abstracted Search and Rescue.pdf</i></p>
 MISSING_LIMBS.title=Replacing Missing Limbs
 MISSING_LIMBS.definition=If you have 'Advanced Medical' enabled in Campaign Options, your personnel will occasionally find\
  \ themselves separated from their arms and legs. Luckily for them, in 50.04 medical science developed prosthetic\
@@ -1591,7 +1591,7 @@ PRISONER_CAPACITY.definition=Prisoner Capacity measures how many prisoners your 
   \ manage without risking a crisis. Typically, each prisoner occupies one unit of capacity, though certain events may\
   \ alter this value.\
  <p>For more details on Prisoner Capacity and its management, refer to the documentation in:\
- <br><i>MekHQ/docs/MekHQ Systems/Prisoners of War & Abstracted Search and Rescue.pdf</i></p>
+ <br><i>MekHQ/docs/GlossaryDocs/Prisoners of War & Abstracted Search and Rescue.pdf</i></p>
 PRISONERS_OF_WAR.title=Prisoners of War
 PRISONERS_OF_WAR.definition=War is an unforgiving battleground, and in the chaos of combat, soldiers may find themselves\
  \ captured by the enemy. Prisoners of war (POWs) are an inevitable reality of any prolonged military campaign, and how\
@@ -1602,7 +1602,7 @@ PRISONERS_OF_WAR.definition=War is an unforgiving battleground, and in the chaos
  \ <b>important</b> if you are using the MekHQ Capture Style, you are going to be invited to ransom prisoners during special\
  \ events. In prior versions, this could be done at any time. However, that is no longer the case.</p>\
  <p>For more details on Prisoners of War and their management, refer to the documentation in:\
- <br><i>MekHQ/docs/Random Events/Prisoners, Defection & Dependents.pdf</i></p>
+ <br><i>MekHQ/docs/GlossaryDocs/Prisoners of War & Abstracted Search and Rescue.pdf</i></p>
 PROFESSIONS.title=Professions
 PROFESSIONS.definition=Professions are the various jobs personnel can be assigned to. Each profession has a tooltip\
  \ which describes the profession, the skills required to take it, and the <a href='GLOSSARY:LINKED_ATTRIBUTES'>Linked\


### PR DESCRIPTION
fix: adjust location in documentation for prisoners PDF material, fixes #8624

see past reference and cleanup in: 60abf80

<!-- TITLE: include the issue number, and start with "Fix" for a bug fix or "Close" for
     anything else:

         Fix #1234: Cheese has the wrong colour gradient
         Close #1234: Added 6 new cheese gradients

     More than one issue is fine: "Close #111, #5329: Added unit history tracking".
     Release notes are generated automatically from pull request titles, so the title is
     what players end up reading. -->

## What this changes

<!-- The effect someone actually sees, in plain language. One or two sentences is fine. -->

<!-- Keep this line as well as the number in the title. GitHub only closes an issue from a
     keyword in the description - a number in the title alone does not close anything.

     Any of these close an issue when this merges:
         Close / Closes / Closed
         Fix / Fixes / Fixed
         Resolve / Resolves / Resolved

     Closing more than one needs the keyword repeated in front of each number:
         Fixes #1234, fixes #5678          closes both
         Fixes #1234, #5678                closes only #1234

     For an issue in another repository, qualify it: Fixes MegaMek/mekhq#1234 -->
Fixes #8624

## Testing

Basic build and smoke-test via running and opening documentation.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text

No AI usage.