### PR TITLE
Restyle campaign control buttons to match MegaMek's Report a Bug and prefill the issue form

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignGUI.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignGUI.properties
@@ -47,10 +47,8 @@ btnMassTraining.text=Mass Personnel Training
 btnMassTraining.toolTipText=This launches the Mass Personnel Training Dialog, which allows you to train large numbers of personnel at the same time.
 btnGlossary.text=Glossary
 btnGlossary.toolTipText=<html>Opens the reference guide for terminology and game mechanics.</html>
-btnBugReport.text=Report Bug
-btnBugReport.toolTipText=<html>Report an Issue. Please use this tool instead of creating manual GitHub \
-reports. It automatically bundles your current campaign save, active application logs, and other details ensuring \
-developers have the exact context needed to reproduce and fix the bug.</html>
+btnBugReport.text=Report a Bug
+btnBugReport.toolTipText=<html>Opens the bug report helper, which can save your campaign and gather the logs for you.</html>
 panCommand.TabConstraints.tabTitle=Command Center
 panHangar.TabConstraints.tabTitle=Hangar
 panRepairBay.TabConstraints.tabTitle=Repair Bay
@@ -98,7 +96,7 @@ lblTarget.text=<html><b>Target</b></html>
 lblTargetNum.text=-
 btnOvertime.text=Allow Overtime
 btnGoRogue.text=Change Faction
-btnCompanyGenerator.text=Company Generator
+btnCompanyGenerator.text=<html><center>Company<br>Generator</center></html>
 btnCompanyGenerator.toolTipText=<html>Primarily used for starting a new campaign. Instantly generates an \
 era-appropriate 'Mek force, assigns qualified combat / support personnel, and allocates starting C-Bills.</html>
 btnShowAllTechs.text=Show All Tech Types

--- a/MekHQ/resources/mekhq/resources/EasyBugReport.properties
+++ b/MekHQ/resources/mekhq/resources/EasyBugReport.properties
@@ -49,7 +49,7 @@ EasyBugReport.dialog.message.supplementary=<h1 style="text-align:center">Which B
   <br>- I think you got a unit, planet, or other data wrong: <b>Data</b>\
   <br>- I'm not sure: <b>MekHQ</b>
 EasyBugReport.dialog.button.cancel=Cancel
-EasyBugReport.dialog.button.discord=Discord
+EasyBugReport.dialog.button.discord=Join our Discord
 EasyBugReport.dialog.button.build=Save Campaign
 EasyBugReport.dialog.button.mm=MegaMek
 EasyBugReport.dialog.button.mml=MegaMekLab

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -68,7 +68,6 @@ import java.util.UUID;
 import java.util.stream.IntStream;
 import java.util.zip.GZIPOutputStream;
 import javax.swing.*;
-import javax.swing.SwingConstants;
 import javax.swing.border.Border;
 
 import megamek.client.ui.dialogs.UnitLoadingDialog;

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -41,6 +41,7 @@ import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import java.awt.*;
+import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
@@ -57,6 +58,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -67,6 +69,7 @@ import java.util.UUID;
 import java.util.stream.IntStream;
 import java.util.zip.GZIPOutputStream;
 import javax.swing.*;
+import javax.swing.SwingConstants;
 import javax.swing.border.Border;
 
 import megamek.client.ui.dialogs.UnitLoadingDialog;
@@ -120,10 +123,13 @@ import mekhq.campaign.universe.PlanetarySystem;
 import mekhq.campaign.utilities.AutomatedTechAssignments;
 import mekhq.gui.baseComponents.ScalingWidthConstrainedPanel;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
+import mekhq.gui.baseComponents.roundedComponents.AccentRoundedJButton;
+import mekhq.gui.baseComponents.roundedComponents.AccentRoundedJButton.Accent;
 import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
 import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
 import mekhq.gui.baseComponents.roundedComponents.RoundedMMToggleButton;
 import mekhq.gui.dialog.*;
+import mekhq.gui.dialog.CompanyGenerationDialog;
 import mekhq.gui.dialog.glossary.GlossaryDialog;
 import mekhq.gui.dialog.markets.contractMarket.ChaosContractMarketDialog;
 import mekhq.gui.enums.MHQTabType;
@@ -484,9 +490,37 @@ public class CampaignGUI extends JPanel {
         pnlTop.add(createMarketsPanel(95, 130));
         pnlTop.add(new CommandSummaryPanel(250, 280, getCampaign()));
         pnlTop.add(Box.createHorizontalGlue());
-        pnlTop.add(new AdvanceTimePanel(170, 240, getCampaign().getLocalDate(),
-              getCampaignController()::advanceDay, () -> new AdvanceDaysDialog(getFrame(), this).setVisible(true)));
+        AdvanceTimePanel advanceTimePanel = new AdvanceTimePanel(170, 240, getCampaign().getLocalDate(),
+              getCampaignController()::advanceDay, () -> new AdvanceDaysDialog(getFrame(), this).setVisible(true));
+        pnlTop.add(createCompanyGeneratorButton());
+        pnlTop.add(Box.createHorizontalStrut(SMALL_GAP));
+        pnlTop.add(advanceTimePanel);
         pnlTop.add(createCampaignControlPanel(140, 170));
+
+        // The box layout stretches every child to the panel's height, so the button is squared to that height,
+        // measured once all the other children are in place.
+        int side = pnlTop.getPreferredSize().height;
+        btnCompanyGenerator.setMinimumSize(new Dimension(side, side));
+        btnCompanyGenerator.setPreferredSize(new Dimension(side, side));
+        btnCompanyGenerator.setMaximumSize(new Dimension(side, side));
+    }
+
+    /**
+     * Creates the Company Generator button that sits to the left of the Advance Day panel. It is squared to the
+     * top panel's height by {@link #initTopPanel()}, and is only shown while the campaign has no units and no
+     * personnel - the one time a player needs it. See {@link #refreshCampaignControlButtons()}.
+     *
+     * @return the button
+     */
+    private RoundedJButton createCompanyGeneratorButton() {
+        btnCompanyGenerator = new RoundedJButton(resourceMap.getString("btnCompanyGenerator.text"));
+        btnCompanyGenerator.setToolTipText(resourceMap.getString("btnCompanyGenerator.toolTipText"));
+        btnCompanyGenerator.setHorizontalAlignment(SwingConstants.CENTER);
+        btnCompanyGenerator.addActionListener(event -> {
+            new CompanyGenerationDialog(getFrame(), getCampaign()).setVisible(true);
+            refreshCampaignControlButtons();
+        });
+        return btnCompanyGenerator;
     }
 
     private JPanel createMarketsPanel(int minWidth, int maxWidth) {
@@ -538,46 +572,34 @@ public class CampaignGUI extends JPanel {
 
         gridBagConstraints.weightx = 1;
         gridBagConstraints.weighty = 1;
-        gridBagConstraints.gridwidth = 2;
         gridBagConstraints.fill = GridBagConstraints.BOTH;
 
-        btnCompanyGenerator = new RoundedJButton(resourceMap.getString("btnCompanyGenerator.text"));
-        btnCompanyGenerator.setToolTipText(resourceMap.getString("btnCompanyGenerator.toolTipText"));
-        btnCompanyGenerator.addActionListener(
-              e -> new CompanyGenerationDialog(getFrame(), getCampaign()).setVisible(true));
+        AccentRoundedJButton btnGlossary = new AccentRoundedJButton(resourceMap.getString("btnGlossary.text"),
+              Accent.REFERENCE);
+        btnGlossary.setToolTipText(resourceMap.getString("btnGlossary.toolTipText"));
+        btnGlossary.addActionListener(event -> new GlossaryDialog(getFrame()));
         gridBagConstraints.gridy = 0;
         gridBagConstraints.insets = new Insets(MEDIUM_GAP - 2, SMALL_GAP, -2, SMALL_GAP);
-        pnlButton.add(btnCompanyGenerator, gridBagConstraints);
+        pnlButton.add(btnGlossary, gridBagConstraints);
+
+        AccentRoundedJButton btnBugReport = new AccentRoundedJButton(resourceMap.getString("btnBugReport.text"),
+              Accent.HAZARD);
+        btnBugReport.setToolTipText(resourceMap.getString("btnBugReport.toolTipText"));
+        btnBugReport.addActionListener(event -> new EasyBugReportDialog(getFrame(), getCampaign()));
+        gridBagConstraints.gridy = 1;
+        gridBagConstraints.insets = new Insets(MEDIUM_GAP - 2, SMALL_GAP, -2, SMALL_GAP);
+        pnlButton.add(btnBugReport, gridBagConstraints);
 
         RoundedMMToggleButton btnGMMode = new RoundedMMToggleButton(resourceMap.getString("btnGMMode.text"));
         btnGMMode.setToolTipText(resourceMap.getString("btnGMMode.toolTipText"));
         btnGMMode.setSelected(getCampaign().isGM());
-        btnGMMode.addActionListener(e -> {
+        btnGMMode.addActionListener(event -> {
             getCampaign().setGMMode(btnGMMode.isSelected());
             windowMenu.refreshGMMenuItems();
         });
-        gridBagConstraints.gridy = 1;
-        gridBagConstraints.insets = new Insets(MEDIUM_GAP - 2, SMALL_GAP, 0, SMALL_GAP);
-        pnlButton.add(btnGMMode, gridBagConstraints);
-
         gridBagConstraints.gridy = 2;
-        gridBagConstraints.weighty = 0;
-        gridBagConstraints.gridwidth = 1;
-        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
-
-        RoundedJButton btnGlossary = new RoundedJButton(resourceMap.getString("btnGlossary.text"));
-        btnGlossary.setToolTipText(resourceMap.getString("btnGlossary.toolTipText"));
-        btnGlossary.addActionListener(evt -> new GlossaryDialog(getFrame()));
-        gridBagConstraints.weightx = 0.4;
-        gridBagConstraints.insets = new Insets(SMALL_GAP, SMALL_GAP, THIN_GAP, 0);
-        pnlButton.add(btnGlossary, gridBagConstraints);
-
-        RoundedJButton btnBugReport = new RoundedJButton(resourceMap.getString("btnBugReport.text"));
-        btnBugReport.setToolTipText(resourceMap.getString("btnBugReport.toolTipText"));
-        btnBugReport.addActionListener(evt -> new EasyBugReportDialog(getFrame(), getCampaign()));
-        gridBagConstraints.weightx = 0.6;
-        gridBagConstraints.insets = new Insets(SMALL_GAP, SMALL_GAP, THIN_GAP, SMALL_GAP);
-        pnlButton.add(btnBugReport, gridBagConstraints);
+        gridBagConstraints.insets = new Insets(MEDIUM_GAP - 2, SMALL_GAP, SMALL_GAP, SMALL_GAP);
+        pnlButton.add(btnGMMode, gridBagConstraints);
 
         return pnlButton;
     }
@@ -1672,13 +1694,28 @@ public class CampaignGUI extends JPanel {
         }
     }
 
+    /**
+     * Shows the Company Generator button only while the campaign is empty: no units anywhere, including base
+     * hangars, and no personnel.
+     */
     private void refreshCampaignControlButtons() {
-        boolean emptyHangar = getCampaign().getUnits().isEmpty() &&
-                                    getCampaign().getCampaignLocationManager().getPlayerBases()
-                                          .stream()
-                                          .allMatch(base -> base.getBaseHangar().getUnits().isEmpty());
-        boolean noPersonnel = getCampaign().getPlayerForce().getHumanResources().getPersonnel().isEmpty();
-        btnCompanyGenerator.setVisible(emptyHangar && noPersonnel);
+        btnCompanyGenerator.setVisible(isHangarEmpty() && getPlayerPersonnel().isEmpty());
+    }
+
+    private boolean isHangarEmpty() {
+        if (!getCampaign().getUnits().isEmpty()) {
+            return false;
+        }
+        for (PlayerBase base : getCampaign().getCampaignLocationManager().getPlayerBases()) {
+            if (!base.getBaseHangar().getUnits().isEmpty()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private Collection<Person> getPlayerPersonnel() {
+        return getCampaign().getPlayerForce().getHumanResources().getPersonnel();
     }
 
     public int getTabIndexByName(String tabTitle) {
@@ -1983,6 +2020,17 @@ public class CampaignGUI extends JPanel {
      *
      * @param newDayEvent the event signalling that a new day has started
      */
+    /**
+     * Hides the Company Generator button as soon as the campaign gains units or personnel, which the generator
+     * reports by firing this event when it completes.
+     *
+     * @param organizationChangedEvent the event
+     */
+    @Subscribe
+    public void handleOrganizationChanged(OrganizationChangedEvent organizationChangedEvent) {
+        refreshCampaignControlButtons();
+    }
+
     @Subscribe
     public void handleNewDay(NewDayEvent newDayEvent) {
         refreshWindowTitle();

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -41,7 +41,6 @@ import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import java.awt.*;
-import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
@@ -2010,17 +2009,6 @@ public class CampaignGUI extends JPanel {
     }
 
     /**
-     * Handles the transition to a new day in the campaign.
-     *
-     * <p>Refreshes the calendar, location, funds, parts availability, and all relevant UI tabs to ensure the user
-     * interface and data are up to date at the beginning of a new day.</p>
-     *
-     * <p><b>Important:</b> This method is not directly evoked, so IDEA will tell you it has no uses. IDEA is
-     * wrong.</p>
-     *
-     * @param newDayEvent the event signalling that a new day has started
-     */
-    /**
      * Hides the Company Generator button as soon as the campaign gains units or personnel, which the generator
      * reports by firing this event when it completes.
      *
@@ -2031,6 +2019,17 @@ public class CampaignGUI extends JPanel {
         refreshCampaignControlButtons();
     }
 
+    /**
+     * Handles the transition to a new day in the campaign.
+     *
+     * <p>Refreshes the calendar, location, funds, parts availability, and all relevant UI tabs to ensure the user
+     * interface and data are up to date at the beginning of a new day.</p>
+     *
+     * <p><b>Important:</b> This method is not directly evoked, so IDEA will tell you it has no uses. IDEA is
+     * wrong.</p>
+     *
+     * @param newDayEvent the event signalling that a new day has started
+     */
     @Subscribe
     public void handleNewDay(NewDayEvent newDayEvent) {
         refreshWindowTitle();

--- a/MekHQ/src/mekhq/gui/baseComponents/roundedComponents/AccentRoundedJButton.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/roundedComponents/AccentRoundedJButton.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.baseComponents.roundedComponents;
+
+import java.awt.Color;
+import java.awt.Font;
+import javax.swing.BorderFactory;
+import javax.swing.border.Border;
+
+/**
+ * A {@link RoundedJButton} painted in a fixed accent colour scheme instead of the theme's button colour, so that
+ * one button stands out from the ordinary ones around it: a coloured face inside a contrasting rounded frame with a
+ * bold label.
+ *
+ * <p>The {@link Accent#HAZARD} scheme is the MekHQ counterpart of MegaMek's {@code HazardButton}. MegaMek tints its
+ * skinned button images; MekHQ buttons are drawn from plain colours, so this class sets the accent colours directly
+ * and keeps the same rounded shape as every other {@link RoundedJButton}. Hover and pressed shades come from the
+ * parent's painting, which brightens or darkens the face colour.</p>
+ *
+ * @author Illiani
+ * @since 0.50.12
+ */
+public class AccentRoundedJButton extends RoundedJButton {
+
+    /**
+     * The colour schemes an {@link AccentRoundedJButton} can wear.
+     */
+    public enum Accent {
+        /** Emergency-stop red and yellow, the same values as MegaMek's hazard widgets. Used for Report a Bug. */
+        HAZARD(new Color(204, 34, 34), new Color(255, 204, 0),
+              new Color(255, 221, 0), new Color(255, 245, 150), new Color(160, 110, 40)),
+        /** Calm green, for reference material such as the Glossary. */
+        REFERENCE(new Color(34, 120, 60), new Color(150, 220, 120),
+              new Color(225, 255, 215), new Color(255, 255, 255), new Color(120, 160, 120));
+
+        private final Color face;
+        private final Color frame;
+        private final Color label;
+        private final Color labelHover;
+        private final Color labelDisabled;
+
+        Accent(Color face, Color frame, Color label, Color labelHover, Color labelDisabled) {
+            this.face = face;
+            this.frame = frame;
+            this.label = label;
+            this.labelHover = labelHover;
+            this.labelDisabled = labelDisabled;
+        }
+
+        /** @return the colour the face is filled with when the button is idle */
+        public Color getFace() {
+            return face;
+        }
+
+        /** @return the colour of the rounded frame */
+        public Color getFrame() {
+            return frame;
+        }
+
+        /** @return the label colour when the button is idle */
+        public Color getLabel() {
+            return label;
+        }
+
+        /** @return the label colour when the button is hovered or focused */
+        public Color getLabelHover() {
+            return labelHover;
+        }
+
+        /** @return the label colour when the button is disabled */
+        public Color getLabelDisabled() {
+            return labelDisabled;
+        }
+    }
+
+    private final Accent accent;
+
+    /**
+     * Creates an accent-coloured button with the given label.
+     *
+     * @param text   the button label
+     * @param accent the colour scheme to paint it in
+     */
+    public AccentRoundedJButton(final String text, final Accent accent) {
+        super(text);
+        this.accent = accent;
+        setFont(getFont().deriveFont(Font.BOLD));
+        setBackground(accent.getFace());
+
+        Border frame = new RoundedLineBorder(accent.getFrame(), THICKNESS, ARC);
+        Border padding = BorderFactory.createEmptyBorder(VERTICAL_PADDING, HORIZONTAL_PADDING, VERTICAL_PADDING,
+              HORIZONTAL_PADDING);
+        setBorder(BorderFactory.createCompoundBorder(frame, padding));
+    }
+
+    /** @return the colour scheme this button wears */
+    public Accent getAccent() {
+        return accent;
+    }
+
+    /**
+     * The label colour for the button's current state. The look and feel reads this when it draws the text, so the
+     * label follows hover, focus and enabled state without any extra painting here.
+     *
+     * @return the accent's idle label colour, its hover colour on hover or focus, and its disabled colour when
+     *       disabled
+     */
+    @Override
+    public Color getForeground() {
+        if (accent == null) {
+            // Called from the superclass constructor, before this button's fields are set.
+            return super.getForeground();
+        }
+        if (!isEnabled()) {
+            return accent.getLabelDisabled();
+        }
+        if ((getModel() != null) && (getModel().isRollover() || hasFocus())) {
+            return accent.getLabelHover();
+        }
+        return accent.getLabel();
+    }
+}

--- a/MekHQ/src/mekhq/gui/baseComponents/roundedComponents/RoundedJButton.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/roundedComponents/RoundedJButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -53,18 +53,18 @@ public class RoundedJButton extends JButton {
     /**
      * The padding between the button border and its contents, in pixels.
      */
-    private static final int VERTICAL_PADDING = 5;
-    private static final int HORIZONTAL_PADDING = 5;
+    protected static final int VERTICAL_PADDING = 5;
+    protected static final int HORIZONTAL_PADDING = 5;
 
     /**
      * The thickness of the border, in pixels.
      */
-    private static final int THICKNESS = 2;
+    protected static final int THICKNESS = 2;
 
     /**
      * The arc diameter for the button's rounded corners, in pixels.
      */
-    private static final int ARC = 16;
+    protected static final int ARC = 16;
 
     /**
      * Constructs a default {@link RoundedJButton} with no text.

--- a/MekHQ/src/mekhq/gui/dialog/EasyBugReportDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EasyBugReportDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -39,6 +39,8 @@ import static mekhq.utilities.MHQInternationalization.getTextAt;
 import java.awt.Component;
 import java.awt.Cursor;
 import java.awt.Desktop;
+import java.awt.Dimension;
+import java.awt.Font;
 import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -49,11 +51,14 @@ import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 
+import megamek.common.util.IssueReportUrl;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.utilities.EasyBugReport;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogWidth;
+import mekhq.gui.baseComponents.roundedComponents.AccentRoundedJButton;
+import mekhq.gui.baseComponents.roundedComponents.AccentRoundedJButton.Accent;
 import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
 
 /**
@@ -83,6 +88,11 @@ public class EasyBugReportDialog extends ImmersiveDialogCore {
     private static final String REPORT_LINK_MML = "https://github.com/MegaMek/megameklab/issues/new/choose";
     private static final String REPORT_LINK_MHQ = "https://github.com/MegaMek/mekhq/issues/new/choose";
     private static final String REPORT_LINK_MM_DATA = "https://github.com/MegaMek/mm-data/issues/new";
+
+    /** Size and font of the Save Campaign button, matching the main button of MegaMek's bug report dialog. */
+    private static final int UNSCALED_SAVE_BUTTON_WIDTH = 260;
+    private static final int UNSCALED_SAVE_BUTTON_HEIGHT = 48;
+    private static final float SAVE_BUTTON_FONT_FACTOR = 1.4f;
 
     private static final Map<String, String> URI_LABELS = new LinkedHashMap<>();
 
@@ -167,8 +177,12 @@ public class EasyBugReportDialog extends ImmersiveDialogCore {
         row1.add(btnDiscord);
 
         String lblPackageBundle = getTextAt(RESOURCE_BUNDLE, "EasyBugReport.dialog.button.build");
-        RoundedJButton btnPackage = new RoundedJButton(lblPackageBundle);
+        // Sized and coloured as the main thing to press: every other button here only opens a link.
+        AccentRoundedJButton btnPackage = new AccentRoundedJButton(lblPackageBundle, Accent.HAZARD);
         btnPackage.setName(lblPackageBundle);
+        btnPackage.setFont(btnPackage.getFont().deriveFont(btnPackage.getFont().getSize2D() * SAVE_BUTTON_FONT_FACTOR));
+        btnPackage.setPreferredSize(new Dimension(scaleForGUI(UNSCALED_SAVE_BUTTON_WIDTH),
+              scaleForGUI(UNSCALED_SAVE_BUTTON_HEIGHT)));
         btnPackage.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
         btnPackage.setAlignmentX(Component.CENTER_ALIGNMENT);
         btnPackage.addActionListener(evt -> EasyBugReport.saveCampaignForBugReport(frame, campaign));
@@ -180,7 +194,11 @@ public class EasyBugReportDialog extends ImmersiveDialogCore {
         for (Map.Entry<String, String> entry : URI_LABELS.entrySet()) {
             RoundedJButton btnURL = new RoundedJButton(entry.getKey());
             btnURL.setName(entry.getKey());
-            buildUrlButton(btnURL, entry.getValue());
+            String issuesUrl = entry.getValue();
+            // The issue chooser links are opened as the bug form with the version, OS and Java fields filled in,
+            // as MegaMek does; the tooltip keeps the plain link. mm-data has no form, so its link is unchanged.
+            String target = issuesUrl.equals(REPORT_LINK_MM_DATA) ? issuesUrl : IssueReportUrl.forIssueForm(issuesUrl);
+            buildUrlButton(btnURL, target, issuesUrl);
             row2.add(btnURL);
         }
 
@@ -210,16 +228,28 @@ public class EasyBugReportDialog extends ImmersiveDialogCore {
      * @since 0.50.11
      */
     private static void buildUrlButton(JButton btnURL, String address) {
-        btnURL.setToolTipText(address);
+        buildUrlButton(btnURL, address, address);
+    }
+
+    /**
+     * As {@link #buildUrlButton(JButton, String)}, but with a separate address for the tooltip, for links whose
+     * real target carries a long query string.
+     *
+     * @param btnURL         the button to configure
+     * @param address        the URL opened when the button is pressed
+     * @param displayAddress the URL shown in the tooltip
+     */
+    private static void buildUrlButton(JButton btnURL, String address, String displayAddress) {
+        btnURL.setToolTipText(displayAddress);
         btnURL.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
         btnURL.setAlignmentX(Component.CENTER_ALIGNMENT);
-        btnURL.addActionListener(e -> {
+        btnURL.addActionListener(event -> {
             if (Desktop.isDesktopSupported()) {
                 try {
                     URI uri = new URI(address);
                     Desktop.getDesktop().browse(uri);
-                } catch (Exception ex) {
-                    LOGGER.error(ex, "Failed to open URL: {}", address);
+                } catch (Exception exception) {
+                    LOGGER.error(exception, "Failed to open URL: {}", address);
                 }
             }
         });

--- a/MekHQ/src/mekhq/gui/dialog/EasyBugReportDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EasyBugReportDialog.java
@@ -40,7 +40,6 @@ import java.awt.Component;
 import java.awt.Cursor;
 import java.awt.Desktop;
 import java.awt.Dimension;
-import java.awt.Font;
 import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/MekHQ/unittests/mekhq/gui/baseComponents/roundedComponents/AccentRoundedJButtonTest.java
+++ b/MekHQ/unittests/mekhq/gui/baseComponents/roundedComponents/AccentRoundedJButtonTest.java
@@ -36,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.Font;
+import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 
 import org.junit.jupiter.api.Test;
@@ -82,7 +83,12 @@ class AccentRoundedJButtonTest {
         button.setSize(120, 40);
 
         BufferedImage image = new BufferedImage(120, 40, BufferedImage.TYPE_INT_ARGB);
-        button.paint(image.getGraphics());
+        Graphics2D graphics = image.createGraphics();
+        try {
+            button.paint(graphics);
+        } finally {
+            graphics.dispose();
+        }
 
         // A point well inside the face, away from the text, is the hazard red.
         assertEquals(Accent.HAZARD.getFace().getRGB(), image.getRGB(12, 20));

--- a/MekHQ/unittests/mekhq/gui/baseComponents/roundedComponents/AccentRoundedJButtonTest.java
+++ b/MekHQ/unittests/mekhq/gui/baseComponents/roundedComponents/AccentRoundedJButtonTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.baseComponents.roundedComponents;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Font;
+import java.awt.image.BufferedImage;
+
+import org.junit.jupiter.api.Test;
+
+import mekhq.gui.baseComponents.roundedComponents.AccentRoundedJButton.Accent;
+
+class AccentRoundedJButtonTest {
+
+    @Test
+    void faceIsHazardRedAndLabelIsBold() {
+        AccentRoundedJButton button = new AccentRoundedJButton("Report a Bug", Accent.HAZARD);
+
+        assertEquals(Accent.HAZARD.getFace(), button.getBackground());
+        assertTrue(button.getFont().isBold());
+    }
+
+    @Test
+    void labelColourFollowsState() {
+        AccentRoundedJButton button = new AccentRoundedJButton("Report a Bug", Accent.HAZARD);
+
+        assertEquals(Accent.HAZARD.getLabel(), button.getForeground());
+
+        button.getModel().setRollover(true);
+        assertEquals(Accent.HAZARD.getLabelHover(), button.getForeground());
+
+        button.getModel().setRollover(false);
+        button.setEnabled(false);
+        assertEquals(Accent.HAZARD.getLabelDisabled(), button.getForeground());
+    }
+
+    @Test
+    void referenceAccentUsesItsOwnColours() {
+        AccentRoundedJButton button = new AccentRoundedJButton("Glossary", Accent.REFERENCE);
+
+        assertEquals(Accent.REFERENCE, button.getAccent());
+        assertEquals(Accent.REFERENCE.getFace(), button.getBackground());
+        assertEquals(Accent.REFERENCE.getLabel(), button.getForeground());
+    }
+
+    @Test
+    void paintsRedFaceInsideYellowFrame() {
+        AccentRoundedJButton button = new AccentRoundedJButton("Report a Bug", Accent.HAZARD);
+        button.setFont(button.getFont().deriveFont(Font.BOLD, 12f));
+        button.setSize(120, 40);
+
+        BufferedImage image = new BufferedImage(120, 40, BufferedImage.TYPE_INT_ARGB);
+        button.paint(image.getGraphics());
+
+        // A point well inside the face, away from the text, is the hazard red.
+        assertEquals(Accent.HAZARD.getFace().getRGB(), image.getRGB(12, 20));
+        // The middle of the top edge is the yellow frame.
+        assertEquals(Accent.HAZARD.getFrame().getRGB(), image.getRGB(60, 1));
+    }
+}


### PR DESCRIPTION
## Summary
[MegaMek PR 8790](https://github.com/MegaMek/megamek/pull/8790) turned Report a Bug into a red emergency-stop button. This does the same in MekHQ using MekHQ's rounded button style, and aligns the bug helper with MegaMek: "Report a Bug" label and tooltip, and the MegaMek / MegaMekLab / MekHQ buttons now open the issue form with version, OS and Java already filled in (through MegaMek's `IssueReportUrl`, already on main).

<img width="433" height="167" alt="image" src="https://github.com/user-attachments/assets/6a8910a2-3fcc-495e-bd9d-c43a5b61b2d1" />


## Changes
- Campaign control panel is three stacked, equal-size buttons: Glossary (green), Report a Bug (red), GM Mode.
- Company Generator moves to a square button left of Advance Day, the same height as the top panel. It is shown only while the campaign has no units and no personnel, and hides as soon as the generator completes or the player gains a unit or person.
- Bug helper: Save Campaign is the big red main button, "Discord" reads "Join our Discord", and the three project buttons open a prefilled bug form. The Data link is unchanged because mm-data has no issue form.
- New `AccentRoundedJButton` with an `Accent` enum (`HAZARD`, `REFERENCE`); `RoundedJButton`'s shape constants become protected so the subclass shares them.
- The old stream-inside-a-conditional visibility check is a loop now.

## Testing
- `AccentRoundedJButtonTest` (4 new): colours per accent, bold label, label colour per state, painted pixels red inside and yellow on the frame.
- compile, checkstyle, javadoc clean. Headless renders in FlatLaf dark and light.
- Tested live in a campaign by Dave: stacked buttons, dialog, Company Generator button size, and its disappearance after the generator runs.

## Not proven yet
- GUI scale above 100% checked by reading the code only.
- The prefilled issue URL was checked by eye, not opened in a browser from inside MekHQ.

