### PR TITLE
Fix #9804: Missions vanish from the briefing room after reloading a save

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3671,7 +3671,7 @@ public class Campaign implements ITechManager {
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "colour", getPlayerForce().getColour().name());
         getPlayerForce().getUnitIcon().writeToXML(writer, indent);
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "lastFormationId", playerForce.getLastFormationId());
-        getPlayerForce().writeContractsToXML(writer, indent, this);
+        contractHistory.writeToXML(writer, indent, this);
         getPlayerForce().getContractMarket().writeToXML(writer, indent, this);
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "lastMissionId", lastMissionId);
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "lastScenarioId", lastScenarioId);

--- a/MekHQ/src/mekhq/campaign/digitalGM/stratCon/StratConContractInitializer.java
+++ b/MekHQ/src/mekhq/campaign/digitalGM/stratCon/StratConContractInitializer.java
@@ -1376,6 +1376,11 @@ public class StratConContractInitializer {
         // the campaign for this contract
         StratConCampaignState campaignState = mission.getStratConCampaignState();
         if (campaignState != null) {
+            // The campaign state's contract is an @XmlTransient back-pointer, so it comes back null from the save.
+            // Restore it before anything reads it: deploying a force to a scenario goes through
+            // StratConCampaignState.getContract(), which would otherwise hand a null contract to scenario generation.
+            campaignState.setContract(mission);
+
             for (StratConTrackState track : campaignState.getTracks()) {
                 for (StratConScenario scenario : track.getScenarios().values()) {
                     Scenario campaignScenario = campaign.getScenario(scenario.getBackingScenarioID());

--- a/MekHQ/src/mekhq/campaign/force/PlayerForce.java
+++ b/MekHQ/src/mekhq/campaign/force/PlayerForce.java
@@ -32,30 +32,17 @@
  */
 package mekhq.campaign.force;
 
-import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.UUID;
 
-import jakarta.annotation.Nullable;
-import megamek.Version;
-import mekhq.campaign.Campaign;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.finances.Finances;
-import mekhq.campaign.mission.contract.AbstractContract;
 import mekhq.campaign.mission.contract.ContractMarket;
-import mekhq.campaign.mission.contract.contractData.MissionStatus;
-import mekhq.campaign.mission.contract.io.ContractXmlCodec;
 import mekhq.campaign.personnel.ranks.RankSystem;
 import mekhq.campaign.reputation.camOpsReputation.ForceReputationController;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.factionStanding.FactionStandings;
-import mekhq.utilities.MHQXMLUtility;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 /**
  * The human player's active force: the single {@link AbstractForce} a {@link mekhq.campaign.Campaign} is played
@@ -68,12 +55,7 @@ import org.w3c.dom.NodeList;
  */
 public class PlayerForce extends AbstractForce implements SingleDetachmentForce {
 
-    public static final String CONTRACTS_TAG = "contracts";
-
     private final Detachment forceDetachment = new Detachment();
-
-    /** The force's contracts, keyed by {@link AbstractContract#getId()} and iterated in insertion order. */
-    private final Map<UUID, AbstractContract> contractHistory = new LinkedHashMap<>();
 
     /** The force's contract market: the currently available offers, split by {@code ContractSearchType}. */
     private final ContractMarket contractMarket = new ContractMarket();
@@ -119,76 +101,5 @@ public class PlayerForce extends AbstractForce implements SingleDetachmentForce 
         return contractMarket;
     }
 
-    /**
-     * @return the live, insertion-ordered map of this force's contracts, keyed by contract id
-     */
-    public Map<UUID, AbstractContract> getContractHistory() {
-        return contractHistory;
-    }
-
-    /**
-     * @param contractId the id to look up
-     *
-     * @return the contract with the given id, or {@code null} if this force holds no such contract
-     */
-    public @Nullable AbstractContract getContract(final UUID contractId) {
-        return contractHistory.get(contractId);
-    }
-
-    /**
-     * Adds (or replaces) a contract, keyed by its own {@link AbstractContract#getId()}.
-     *
-     * @param contract the contract to store
-     */
-    public void addContract(final AbstractContract contract) {
-        contractHistory.put(contract.getId(), contract);
-    }
-
-    /**
-     * Writes this force's contracts as a single {@code <contracts>} block. Emits nothing when there are none.
-     *
-     * @param printWriter the writer to emit to
-     * @param indent      the indentation level of the {@code <contracts>} element
-     * @param campaign    the owning campaign (threaded through to serialize nested personnel)
-     */
-    public void writeContractsToXML(final PrintWriter printWriter, int indent, final Campaign campaign) {
-        if (contractHistory.isEmpty()) {
-            return;
-        }
-        MHQXMLUtility.writeSimpleXMLOpenTag(printWriter, indent++, CONTRACTS_TAG);
-        for (final AbstractContract contract : contractHistory.values()) {
-            ContractXmlCodec.writeContract(printWriter, indent, contract, campaign);
-        }
-        MHQXMLUtility.writeSimpleXMLCloseTag(printWriter, --indent, CONTRACTS_TAG);
-    }
-
-    /**
-     * Repopulates this force's contracts from a {@code <contracts>} node previously written by
-     * {@link #writeContractsToXML(PrintWriter, int, Campaign)}.
-     *
-     * @param contractsNode the {@code <contracts>} element
-     * @param campaign      the owning campaign
-     * @param version       the save file's version
-     */
-    public void loadContractsFromXML(final Node contractsNode, final Campaign campaign, final Version version) {
-        contractHistory.clear();
-        final NodeList children = contractsNode.getChildNodes();
-        for (int i = 0; i < children.getLength(); i++) {
-            final Node child = children.item(i);
-            if (child.getNodeType() != Node.ELEMENT_NODE
-                      || !ContractXmlCodec.CONTRACT_TAG.equals(child.getNodeName())) {
-                continue;
-            }
-            final AbstractContract contract = ContractXmlCodec.readContract(child, campaign, version);
-            if ((contract != null) && (contract.getId() != null)) {
-                // A contract in the history was accepted, so it has a status. Saves written before acceptance set one
-                // carry none; treat those as active rather than letting them drop out of every status filter.
-                if (contract.getStatus() == null) {
-                    contract.setStatus(MissionStatus.ACTIVE);
-                }
-                contractHistory.put(contract.getId(), contract);
-            }
-        }
-    }
     // endregion Contracts
 }

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -113,6 +113,7 @@ import mekhq.campaign.market.PersonnelMarket;
 import mekhq.campaign.market.RequestedStockLevels;
 import mekhq.campaign.mission.contract.AbstractContract;
 import mekhq.campaign.mission.contract.ContractMarket;
+import mekhq.campaign.mission.contract.contractData.ContractHistoryData;
 import mekhq.campaign.mission.contract.contractGeneration.ContractSearchType;
 import mekhq.campaign.mission.contract.io.LegacyContractConverter;
 import mekhq.campaign.mission.scenarios.Scenario;
@@ -260,8 +261,8 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                 } else if (nodeName.equalsIgnoreCase("initiativeMaxBonus")) {
                     int bonus = parseInt(childNode.getTextContent(), 1);
                     playerForce.setInitiativeMaxBonus(bonus);
-                } else if (nodeName.equalsIgnoreCase(PlayerForce.CONTRACTS_TAG)) {
-                    playerForce.loadContractsFromXML(childNode, campaign, version);
+                } else if (nodeName.equalsIgnoreCase(ContractHistoryData.CONTRACTS_TAG)) {
+                    ContractHistoryData.loadFromXML(childNode, campaign, version);
                 } else if (nodeName.equalsIgnoreCase(ContractMarket.MARKET_TAG)) {
                     playerForce.getContractMarket().loadFromXML(childNode, campaign, version);
                 } else if (nodeName.equalsIgnoreCase("crimePirateModifier")) {
@@ -1662,7 +1663,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
         final PlayerForce playerForce = campaign.getPlayerForce();
         final ContractMarket contractMarket = playerForce.getContractMarket();
 
-        final List<AbstractContract> contracts = new ArrayList<>(playerForce.getContractHistory().values());
+        final List<AbstractContract> contracts = new ArrayList<>(campaign.getContractHistoryAsMap().values());
         for (final ContractSearchType searchType : ContractSearchType.values()) {
             contracts.addAll(contractMarket.getContracts(searchType).values());
         }

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractData/ContractHistoryData.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractData/ContractHistoryData.java
@@ -32,6 +32,7 @@
  */
 package mekhq.campaign.mission.contract.contractData;
 
+import java.io.PrintWriter;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -39,11 +40,29 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.UUID;
 
+import megamek.Version;
 import mekhq.MekHQ;
+import mekhq.campaign.Campaign;
 import mekhq.campaign.events.missions.MissionNewEvent;
 import mekhq.campaign.mission.contract.AbstractContract;
+import mekhq.campaign.mission.contract.io.ContractXmlCodec;
+import mekhq.utilities.MHQXMLUtility;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
+/**
+ * The campaign's single store of every contract it has ever held, keyed by {@link AbstractContract#getId()} and
+ * iterated in insertion order.
+ *
+ * <p>This is the only place contract history lives. A campaign's contracts are global, not a property of any one
+ * force, so they are stored, queried and serialized here.</p>
+ *
+ * @param contractHistory the live, insertion-ordered map of contracts, keyed by contract id
+ */
 public record ContractHistoryData(LinkedHashMap<UUID, AbstractContract> contractHistory) {
+
+    public static final String CONTRACTS_TAG = "contracts";
+
     public ContractHistoryData() {
         this(new LinkedHashMap<>());
     }
@@ -166,6 +185,67 @@ public record ContractHistoryData(LinkedHashMap<UUID, AbstractContract> contract
         long startDay = startDate.toEpochDay();
         return isCompleted(mission) ? -startDay : startDay;
     }
+
+    // region I/O
+
+    /**
+     * Writes the whole history as a single {@code <contracts>} block. Emits nothing when there are no contracts.
+     *
+     * @param printWriter the writer to emit to
+     * @param indent      the indentation level of the {@code <contracts>} element
+     * @param campaign    the owning campaign (threaded through to serialize nested personnel)
+     */
+    public void writeToXML(final PrintWriter printWriter, int indent, final Campaign campaign) {
+        if (contractHistory.isEmpty()) {
+            return;
+        }
+
+        MHQXMLUtility.writeSimpleXMLOpenTag(printWriter, indent++, CONTRACTS_TAG);
+        for (final AbstractContract contract : contractHistory.values()) {
+            ContractXmlCodec.writeContract(printWriter, indent, contract, campaign);
+        }
+        MHQXMLUtility.writeSimpleXMLCloseTag(printWriter, --indent, CONTRACTS_TAG);
+    }
+
+    /**
+     * Repopulates the campaign's contract history from a {@code <contracts>} node previously written by
+     * {@link #writeToXML(PrintWriter, int, Campaign)}.
+     *
+     * <p>Each contract is handed to {@link Campaign#importMission(AbstractContract)} rather than put straight into
+     * the map, because importing also registers the contract's scenarios with the campaign and re-hooks StratCon's
+     * backing scenario pointers. A bare map put would restore the contract with neither.</p>
+     *
+     * @param contractsNode the {@code <contracts>} element
+     * @param campaign      the owning campaign, whose history is cleared and refilled
+     * @param version       the save file's version
+     */
+    public static void loadFromXML(final Node contractsNode, final Campaign campaign, final Version version) {
+        campaign.getContractHistoryData().clear();
+
+        final NodeList children = contractsNode.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            final Node contractNode = children.item(i);
+            if ((contractNode.getNodeType() != Node.ELEMENT_NODE)
+                      || !ContractXmlCodec.CONTRACT_TAG.equals(contractNode.getNodeName())) {
+                continue;
+            }
+
+            final AbstractContract contract = ContractXmlCodec.readContract(contractNode, campaign, version);
+            if ((contract == null) || (contract.getId() == null)) {
+                continue;
+            }
+
+            // A contract in the history was accepted, so it has a status. Saves written before acceptance set one
+            // carry none; treat those as active rather than letting them drop out of every status filter.
+            if (contract.getStatus() == null) {
+                contract.setStatus(MissionStatus.ACTIVE);
+            }
+
+            campaign.importMission(contract);
+        }
+    }
+
+    // endregion I/O
 
     /**
      * A contract only has a status once it has been accepted; an un-accepted market offer has none. These treat a

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/contractData/ContractHistoryDataTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/contractData/ContractHistoryDataTest.java
@@ -33,18 +33,33 @@
 package mekhq.campaign.mission.contract.contractData;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
+import megamek.Version;
+import megamek.common.equipment.EquipmentType;
+import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.contract.AbstractContract;
 import mekhq.campaign.mission.contract.ChaosContract;
+import mekhq.campaign.mission.scenarios.Scenario;
+import mekhq.campaign.personnel.skills.SkillType;
+import mekhq.utilities.MHQXMLUtility;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import testUtilities.MHQTestUtilities;
 
 /**
  * Tests {@link ContractHistoryData}, the campaign's single store of every contract it has ever held.
@@ -57,11 +72,23 @@ import org.junit.jupiter.api.Test;
 class ContractHistoryDataTest {
     private static final LocalDate TODAY = LocalDate.of(3051, 6, 1);
 
+    /** Any version at or above the current release; keeps the version-gated compatibility branches dormant. */
+    private static final Version VERSION = new Version(999, 0, 0);
+
     private ContractHistoryData history;
+    private Campaign campaign;
+
+    @BeforeAll
+    static void initSingletons() {
+        EquipmentType.initializeTypes();
+        // A full campaign save writes the skill-type table, so it has to exist before writeToXML is exercised.
+        SkillType.initializeTypes();
+    }
 
     @BeforeEach
     void setUp() {
         history = new ContractHistoryData();
+        campaign = MHQTestUtilities.getTestCampaign();
     }
 
     private AbstractContract add(MissionStatus status, LocalDate startDate, LocalDate endDate) {
@@ -252,4 +279,141 @@ class ContractHistoryDataTest {
     }
 
     // endregion sorting
+
+    // region save and load
+
+    /**
+     * Accepts a contract into {@code target}'s history the way {@code ContractAcceptance} does - status first, then
+     * {@link Campaign#addMission(AbstractContract)}.
+     */
+    private static AbstractContract acceptInto(Campaign target, String name) {
+        AbstractContract contract = new ChaosContract();
+        contract.setContractId(UUID.randomUUID());
+        contract.setContractName(name);
+        contract.setStatus(MissionStatus.ACTIVE);
+        contract.setScheduleData(new ContractScheduleData(TODAY, TODAY.plusMonths(6), 6));
+        target.addMission(contract);
+        return contract;
+    }
+
+    private static String write(Campaign source) {
+        StringWriter stringWriter = new StringWriter();
+        try (PrintWriter printWriter = new PrintWriter(stringWriter)) {
+            source.getContractHistoryData().writeToXML(printWriter, 0, source);
+        }
+        return stringWriter.toString();
+    }
+
+    private static void load(Campaign target, String contractsXml) throws Exception {
+        try (InputStream inputStream = new ByteArrayInputStream(contractsXml.getBytes(StandardCharsets.UTF_8))) {
+            Document document = MHQXMLUtility.newSafeDocumentBuilder().parse(inputStream);
+            assertNotNull(document.getDocumentElement());
+            ContractHistoryData.loadFromXML(document.getDocumentElement(), target, VERSION);
+        }
+    }
+
+    /**
+     * The regression behind issue #9804. Contract history used to be written from a second, always-empty map on
+     * {@code PlayerForce}, so nothing reached the save and the Briefing Room came back empty after every reload.
+     */
+    @Test
+    void anAcceptedContractSurvivesASaveAndReload() throws Exception {
+        AbstractContract accepted = acceptInto(campaign, "Reach Garrison");
+
+        Campaign reloaded = MHQTestUtilities.getTestCampaign();
+        load(reloaded, write(campaign));
+
+        AbstractContract restored = reloaded.getContract(accepted.getId());
+        assertNotNull(restored, "a contract in the campaign's history must still be there after a save and reload");
+        assertEquals("Reach Garrison", restored.getName());
+        assertEquals(1, reloaded.getContractHistoryData().size());
+    }
+
+    /** The history is what the save is written from, so a campaign holding contracts must emit a block. */
+    @Test
+    void aCampaignHoldingContractsActuallyWritesThem() {
+        acceptInto(campaign, "Reach Garrison");
+
+        String xml = write(campaign);
+
+        assertTrue(xml.contains('<' + ContractHistoryData.CONTRACTS_TAG + '>'),
+              "a campaign with contracts must emit a <contracts> block");
+        assertTrue(xml.contains("Reach Garrison"));
+    }
+
+    /**
+     * Guards the wiring rather than the codec. Issue #9804 was not a broken serializer - the serializer worked, but
+     * {@code Campaign.writeToXML} handed it a second, always-empty map on {@code PlayerForce}, so the block never
+     * reached the save. Pointing the save back at anything other than the campaign's own history fails here.
+     */
+    @Test
+    void aFullCampaignSaveCarriesTheContractHistory() {
+        acceptInto(campaign, "Reach Garrison");
+
+        StringWriter stringWriter = new StringWriter();
+        try (PrintWriter printWriter = new PrintWriter(stringWriter)) {
+            campaign.writeToXML(printWriter, false);
+        }
+        String saved = stringWriter.toString();
+
+        assertTrue(saved.contains('<' + ContractHistoryData.CONTRACTS_TAG + '>'),
+              "a full campaign save must contain the <contracts> block");
+        assertTrue(saved.contains("Reach Garrison"), "the accepted contract must appear in the campaign save");
+    }
+
+    @Test
+    void anEmptyHistoryWritesNothingAtAll() {
+        assertTrue(write(campaign).isEmpty(), "a campaign with no contracts must not emit an empty block");
+    }
+
+    @Test
+    void aLoadFullyReplacesTheCurrentHistory() throws Exception {
+        acceptInto(campaign, "Saved");
+        String saved = write(campaign);
+
+        Campaign target = MHQTestUtilities.getTestCampaign();
+        AbstractContract stale = acceptInto(target, "Stale");
+        load(target, saved);
+
+        assertNull(target.getContract(stale.getId()), "a load must not leave the previous history behind");
+        assertEquals(1, target.getContractHistoryData().size());
+    }
+
+    /**
+     * Loading goes through {@link Campaign#importMission(AbstractContract)} rather than a bare map put, so a restored
+     * contract's scenarios are registered with the campaign. A plain map put would bring the contract back with its
+     * scenarios unreachable through {@link Campaign#getScenario(int)}.
+     */
+    @Test
+    void aRestoredContractsScenariosAreRegisteredWithTheCampaign() throws Exception {
+        AbstractContract accepted = acceptInto(campaign, "Reach Garrison");
+        Scenario scenario = new Scenario("Ambush at Rasalhague");
+        scenario.setId(4242);
+        accepted.addScenario(scenario);
+
+        Campaign reloaded = MHQTestUtilities.getTestCampaign();
+        load(reloaded, write(campaign));
+
+        assertNotNull(reloaded.getScenario(4242),
+              "a restored contract's scenarios must be reachable through the campaign");
+    }
+
+    /**
+     * A contract in the history was accepted, so it has a status. Saves written before acceptance set one carry none;
+     * those load as active rather than dropping out of every status filter.
+     */
+    @Test
+    void aContractSavedWithoutAStatusLoadsAsActive() throws Exception {
+        AbstractContract accepted = acceptInto(campaign, "Reach Garrison");
+        accepted.setStatus(null);
+
+        Campaign reloaded = MHQTestUtilities.getTestCampaign();
+        load(reloaded, write(campaign));
+
+        AbstractContract restored = reloaded.getContract(accepted.getId());
+        assertNotNull(restored);
+        assertEquals(MissionStatus.ACTIVE, restored.getStatus());
+    }
+
+    // endregion save and load
 }

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/contractData/ContractHistoryDataTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/contractData/ContractHistoryDataTest.java
@@ -50,6 +50,7 @@ import java.util.UUID;
 import megamek.Version;
 import megamek.common.equipment.EquipmentType;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.digitalGM.stratCon.StratConCampaignState;
 import mekhq.campaign.mission.contract.AbstractContract;
 import mekhq.campaign.mission.contract.ChaosContract;
 import mekhq.campaign.mission.scenarios.Scenario;
@@ -396,6 +397,27 @@ class ContractHistoryDataTest {
 
         assertNotNull(reloaded.getScenario(4242),
               "a restored contract's scenarios must be reachable through the campaign");
+    }
+
+    /**
+     * {@code StratConCampaignState.contract} is an {@code @XmlTransient} back-pointer, so it is null on the way back
+     * in and has to be restored. Deploying a force to a StratCon scenario reads it, so a null there crashes scenario
+     * generation with no contract to draw an enemy faction from.
+     */
+    @Test
+    void restoredStratConStatePointsBackAtItsOwnContract() throws Exception {
+        AbstractContract accepted = acceptInto(campaign, "Reach Garrison");
+        accepted.setStratConCampaignState(new StratConCampaignState(accepted));
+
+        Campaign reloaded = MHQTestUtilities.getTestCampaign();
+        load(reloaded, write(campaign));
+
+        AbstractContract restored = reloaded.getContract(accepted.getId());
+        assertNotNull(restored);
+        StratConCampaignState restoredState = restored.getStratConCampaignState();
+        assertNotNull(restoredState, "the StratCon campaign state must survive the save");
+        assertSame(restored, restoredState.getContract(),
+              "a restored StratCon state must point back at its own contract, not null");
     }
 
     /**


### PR DESCRIPTION
## What this changes

Contracts survive a save and reload again. Before this you could accept a contract, save, load, and find the Briefing Room empty.

Fixes #9804

There were two maps named `contractHistory`. The campaign stored contracts in one and saved from the other:

- `Campaign.contractHistory` held every contract and was never written to the save.
- `PlayerForce.contractHistory` was the map written to the save, but its `addContract()` had no callers, so it was always empty.

That broke both ends. The writer emitted no `<contracts>` block at all. The loader read `<contracts>` back into the PlayerForce map, which nothing gameplay-facing reads - so even a save that did contain contracts would still show an empty Briefing Room.

**The fix.** Contract history is global, so `Campaign.contractHistory` is now the only copy. `ContractHistoryData` owns its own save and load. The `PlayerForce` map, its accessors and both codec methods are gone, and every call site uses the campaign map. `PlayerForce` keeps the contract *market*, which really is force-level.

Loading goes through `Campaign.importMission()` rather than filling the map directly. That is deliberate. `importMission()` is the only thing that registers a contract's scenarios with the campaign and re-hooks StratCon's backing scenario pointers. A bare map put would restore contracts with no scenarios and dead StratCon tracks.

**A second fix, found in testing.** Once contracts actually loaded, deploying a force to a StratCon scenario threw a NullPointerException. `StratConCampaignState.contract` is an `@XmlTransient` back-pointer, so it is deliberately not serialized, and only `LegacyContractConverter` restored it - pre-migration saves only. `restoreTransientStratconInformation()` now re-points the campaign state at its own contract alongside the backing scenario pointers it already restored. It runs from `importMission()`, so both load paths are covered.

This was unreachable before rather than absent: with no contracts loading at all, you could never get to the StratCon deploy UI from a modern save.

**Existing saves.** Anyone who saved on an affected nightly has already lost that history. The contracts are not in the file, so this cannot bring them back. It stops further loss.

## Testing

`ContractHistoryDataTest`: 26/26 pass, seven of them new. They cover the save/load round trip, scenario registration, the StratCon back-pointer, full-replace-on-load, and the missing-status fallback.

Two were verified by reverting the fix:

- Point the save back at an always-empty second map and `aFullCampaignSaveCarriesTheContractHistory` fails. Nothing else does. That is the point of it: a codec-level round-trip test still passes with the bug present, because the bug was in the wiring, not the serializer. This test drives the real `Campaign.writeToXML`.
- Swap the loader's `importMission()` for a bare map put and `aRestoredContractsScenariosAreRegisteredWithTheCampaign` fails. Nothing else does.
- Drop the back-pointer restore and `restoredStratConStatePointsBackAtItsOwnContract` fails. Nothing else does.

Full suite: 14,536 tests, 0 failures. `checkstyleMain` and `javadoc` both run and clean, with no warnings in any file touched here.

Checked against the save attached to the issue: 0 `<contracts>` blocks and 0 `<contract>` elements, but 4 `contractMarket` references, so the file itself is intact.

## What is not proven yet

In-game testing has started and is not finished. It already caught the StratCon NPE fixed in the second commit; that specific path has not yet been re-tested in game since the fix. The remaining passes worth doing are accept, save, reload, check the Briefing Room, and deploy a force to a StratCon scenario.

No migration was attempted for saves that have already lost their history.

---
- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have verified the result
