### PR TITLE
docs: small formatting and HTML fixes for the Glossary

### DIFF
--- a/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
+++ b/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
@@ -106,7 +106,7 @@ AGING.definition=As your character grows older, their skills change. Tasks that 
  <p>There are ten aging milestones. When a character reaches a milestone, they suffer that milestone's effects along\
  \ with all the effects from previous milestones. For example, a 35-year-old character will suffer the penalties from\
  \ both the 25-year and 31-year milestones.</p>\
- <p><b>Skill Modifiers</b><p>\
+ <p><b>Skill Modifiers</b></p>\
  <p>Each skill is linked to one or two <a href='GLOSSARY:LINKED_ATTRIBUTES'>Linked Attributes</a>. Every aging milestone\
  \ adjusts skills depending on these attributes. For each eligible milestone, combine the modifiers from the skill's linked\
  \ attributes. If a skill has two linked attributes, add their modifiers together and halve the result.</p>\
@@ -120,7 +120,7 @@ AGING.definition=As your character grows older, their skills change. Tasks that 
  <p>At certain aging milestones, characters are going to be inflicted with the Slow Learner and/or Glass Jaw SPAs. This\
   \ may be mitigated by taking the Fast Learner or Toughness SPAs. However, this will only be a temporary fix.\
  <p>For more details on Aging, refer to the documentation in:\
- <br><i>MekHQ/docs/Personnel Modules/Aging Effects.pdf</i></p>'
+ <br><i>MekHQ/docs/Personnel Modules/Aging Effects.pdf</i></p>
 AGGREGATE_COMBAT_VIEW.title=Aggregate Combat View
 AGGREGATE_COMBAT_VIEW.definition=The Aggregate Combat View is a new feature that allows you to see at a glance the \
   most commonly requested combat-related skills. Of special note is the 'Combat' column, the values shown here are \
@@ -245,7 +245,7 @@ ATB.definition=Against the Bot (AtB) is one of the oldest systems in MekHQ, serv
  <p>In late 2024, Legacy AtB was officially succeeded by <a href='GLOSSARY:STRATCON'>StratCon</a> and marked as\
   \ <a href='GLOSSARY:DEPRECATED'>Deprecated</a>.</p>\
   <p>In 50.10 (late 2025) the decision was made to finally retire AtB, and it is no longer available. Players looking \
-  for a comparable experience should use <a href='GLOSSARY:STRATCON_MAPLESS'>StratCon (Mapless)</a>.
+  for a comparable experience should use <a href='GLOSSARY:STRATCON_MAPLESS'>StratCon (Mapless)</a>.</p>
 ATOW_TRAITS.title=A Time of War Traits
 ATOW_TRAITS.definition=In <i>A Time of War</i> many of what we call 'SPAs' are actually 'Traits.' However, because of \
   the way MeKHQ implemented SPAs it made sense to have these as SPAs, not Traits. However, There are some Traits \
@@ -289,7 +289,7 @@ BLOODMARK.definition=Bloodmarks are a type of <a href='GLOSSARY:ATOW_TRAITS'>Tra
   <br>- <b>Bloodmark 2:</b> d6/2 attempts (rounded down)\
   <br>- <b>Bloodmark 3:</b> d6/3 attempts (rounded down)\
   <br>- <b>Bloodmark 4:</b> d6/2 attempts (rounded down)\
-  <br>- <b>Bloodmark 5:</b> d6 attempts\
+  <br>- <b>Bloodmark 5:</b> d6 attempts</p>\
   <p>When a Bloodhunt occurs, there is a 1-in-n chance that the assassination attempt will be successful. This is \
   based on the level of their Bloodmark Trait.</p>\
   <p>- <b>Bloodmark 1-2:</b> 1-in-20\
@@ -819,7 +819,7 @@ FORCE_GENERATION.definition=<a href='GLOSSARY:STRATCON'>StratCon</a> uses two fo
   <p>Force generation is a complex topic. This glossary entry is meant as a summary, not a step-by-step description of \
   the exact process used by MekHQ.</p>\
   <h1>Force Generation 2.5 (FG2.5)</h1>\
-  Under FG2.5, each NPC formation is given a BV2 budget. This budget is based on the formations listed in your \
+  <p>Under FG2.5, each NPC formation is given a BV2 budget. This budget is based on the formations listed in your \
   <a href='GLOSSARY:TOE'>TO&E</a>. The stronger your units and crews, the higher the BV2 budget assigned to NPC \
   formations. Veteran MekHQ players may recognize this system from older StratCon versions and \
   <a href='GLOSSARY:ATB'>Against the Bot</a>, though FG2.5 includes some minor improvements.</p>\
@@ -988,9 +988,9 @@ HR_STRAIN.definition=HR Strain reflects the extra paperwork and management effor
  <p><b>HR STRAIN</b></p>\
  <p>Each person typically adds 1 point of HR Strain unless noted below.</p>\
  <p><b>Civilians:</b> For civilians (those with <i>Dependent</i> or <i>None</i> as their primary role), divide the total\
- \ by 10 (rounded normally).\
+ \ by 10 (rounded normally).</p>\
  <p><b>AsTechs and Medics:</b> Characters with only the AsTech or Medic role don''t add to HR Strain since\
- \ their team leader is expected to manage them.\
+ \ their team leader is expected to manage them.</p>\
  <p><b>TURNOVER PENALTY</b></p>\
  <p>The penalty to the <a href='GLOSSARY:TURNOVER'>Turnover</a> target number from HR Strain is equal to\
  \ total <i>HR Strain</i> divided by total <i>HR Capacity</i>. There''s no cap to this penalty, so it can quickly \
@@ -1720,7 +1720,7 @@ RANDOM_PERSONALITIES.definition=Random personalities is a feature that assigns p
   \ Ambition, Greed, Social, Talent, and Quirks. Except for Talent and Quirks, each trait is considered either\
   \ positive or negative. Some traits are also noted to be 'major' traits. If enabled in Campaign Options, personality\
   \ traits can influence the 'Commander Rating' portion of <a href='GLOSSARY:FORCE_REPUTATION'>Force Reputation</a>.</p>\
- <p>Talent</b> is a special case, if enabled in Campaign Options, a character's Talent score can influence the XP \
+ <p><b>Talent</b> is a special case, if enabled in Campaign Options, a character's Talent score can influence the XP \
   cost of skills, SPAs, and Edge purchases.\
  <p>Don't like the personality generated? In GM Mode you can right-click on any given character and regenerate their\
  \ personality via the right-click menu. Alternatively, you can enter Edit Person in the same menu and pick a personality\
@@ -1803,7 +1803,7 @@ SCENARIO_VICTORY_POINTS.definition=Scenario Victory Points (SVP) determine the o
  <p>SVP should not be confused with <a href='GLOSSARY:CONTRACT_VICTORY_POINTS'>Contract Victory Points (CVP)</a>.</p>
 SEED_FORCES.title=Seed Forces
 SEED_FORCES.definition=<b>Note:</b> Seed Forces are no longer the default option for new campaigns. They have been \
-  largely replaced by the <a href='GLOSSARY:NO_SEED_FORCES'>No Seed Forces/a> feature.\
+  largely replaced by the <a href='GLOSSARY:NO_SEED_FORCES'>No Seed Forces</a> feature.\
   <p>When <a href='GLOSSARY:STRATCON'>StratCon</a> generates a scenario, it will pick a Seed Force. This can be any \
   <a href='GLOSSARY:FORCE_TYPE_COMBAT'>Combat Force</a> in your <a href='GLOSSARY:TOE'>TO&E</a>. The BV of that \
   Combat Force serves to balance the scenario. Forces assigned to the Auxiliary or Reserve \
@@ -2114,7 +2114,7 @@ TURNOVER.title=Turnover
 TURNOVER.definition=Turnover is the system that determines when and why personnel might leave your campaign. It simulates\
   \ the natural flow of people in and out of your unit, adding depth and realism.\
  <p>Key causes of turnover include...</p>\
- <p>Fatigue:</b> Physical and mental exhaustion from sustained operations may cause characters to take a break or leave\
+ <p><b>Fatigue:</b> Physical and mental exhaustion from sustained operations may cause characters to take a break or leave\
  \ permanently.</p>\
  <p><b>Employment Contracts:</b> Characters may leave when their contracts end.</p>\
  <p><b>Retirement:</b> Older characters may retire after reaching a certain age.</p>\
@@ -2200,7 +2200,7 @@ WINTER_HOLIDAY.definition=Winter Holiday is a canonical Inner Sphere holiday cel
  <p>It was created to be as inclusive as possible, merging aspects from multiple cultures and beliefs. That makes it\
  \ an ideal holiday for multicultural mercenary commands.</p>\
  <p>In later years, the holiday even evolved to include aspects of Clan culture.</p>\
- <p>For more information, please see <b>Shrapnel #7</b>.
+ <p>For more information, please see <b>Shrapnel #7</b>.</p>
 ### X
 ### Y
 ### Z


### PR DESCRIPTION
docs: small formatting and HTML fixes for the Glossary, mostly missing starting or ending tags

<!-- TITLE: include the issue number, and start with "Fix" for a bug fix or "Close" for
     anything else:

         Fix #1234: Cheese has the wrong colour gradient
         Close #1234: Added 6 new cheese gradients

     More than one issue is fine: "Close #111, #5329: Added unit history tracking".
     Release notes are generated automatically from pull request titles, so the title is
     what players end up reading. -->

## What this changes

<!-- The effect someone actually sees, in plain language. One or two sentences is fine. -->

<!-- Keep this line as well as the number in the title. GitHub only closes an issue from a
     keyword in the description - a number in the title alone does not close anything.

     Any of these close an issue when this merges:
         Close / Closes / Closed
         Fix / Fixes / Fixed
         Resolve / Resolves / Resolved

     Closing more than one needs the keyword repeated in front of each number:
         Fixes #1234, fixes #5678          closes both
         Fixes #1234, #5678                closes only #1234

     For an issue in another repository, qualify it: Fixes MegaMek/mekhq#1234 -->

## Testing

Build and look at Glossary pages for issues

## What is not proven yet

<!-- What you did not test, or could not. "Nothing" is a valid answer - say so explicitly. -->

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text

