### PR TITLE
feat: adds a warning message to users moving deployed units in TO&E

### DIFF
--- a/MekHQ/resources/mekhq/resources/TOETransferHandler.properties
+++ b/MekHQ/resources/mekhq/resources/TOETransferHandler.properties
@@ -1,0 +1,33 @@
+# Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+#
+# This file is part of MekHQ.
+#
+# MekHQ is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (GPL),
+# version 3 or (at your option) any later version,
+# as published by the Free Software Foundation.
+#
+# MekHQ is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# A copy of the GPL should have been included with this project;
+# if not, see <https://www.gnu.org/licenses/>.
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+popup.TOETransferHandler.cannotMove={0} cannot be moved because it is currently deployed to a mission.
+popup.TOETransferHandler.cannotMoveTitle=Cannot Move: {0}

--- a/MekHQ/src/mekhq/gui/handler/TOETransferHandler.java
+++ b/MekHQ/src/mekhq/gui/handler/TOETransferHandler.java
@@ -32,6 +32,8 @@
  */
 package mekhq.gui.handler;
 
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.Transferable;
@@ -55,6 +57,8 @@ import mekhq.gui.CampaignGUI;
 
 public class TOETransferHandler extends TransferHandler {
     private static final MMLogger LOGGER = MMLogger.create(TOETransferHandler.class);
+
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.TOETransferHandler";
 
     private final CampaignGUI gui;
 
@@ -109,8 +113,8 @@ public class TOETransferHandler extends TransferHandler {
     private void showCannotMoveDialog(JComponent parent, String unit_formation_string) {
         JOptionPane.showMessageDialog(
             parent,
-            unit_formation_string + " cannot be moved because it is currently deployed to a mission.",
-            "Cannot Move: " + unit_formation_string,
+            getFormattedTextAt(RESOURCE_BUNDLE, "popup.TOETransferHandler.cannotMove", unit_formation_string),
+            getFormattedTextAt(RESOURCE_BUNDLE, "popup.TOETransferHandler.cannotMoveTitle", unit_formation_string),
             JOptionPane.WARNING_MESSAGE);
     }
 

--- a/MekHQ/src/mekhq/gui/handler/TOETransferHandler.java
+++ b/MekHQ/src/mekhq/gui/handler/TOETransferHandler.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.util.StringTokenizer;
 import java.util.UUID;
 import javax.swing.JComponent;
+import javax.swing.JOptionPane;
 import javax.swing.JTree;
 import javax.swing.TransferHandler;
 import javax.swing.tree.TreePath;
@@ -83,13 +84,34 @@ public class TOETransferHandler extends TransferHandler {
     protected Transferable createTransferable(JComponent c) {
         JTree tree = (JTree) c;
         Object node = tree.getLastSelectedPathComponent();
-        if (node instanceof Unit) {
-            return new StringSelection("UNIT|" + ((Unit) node).getId().toString());
-        } else if (node instanceof Formation) {
-            return new StringSelection("FORCE|" + ((Formation) node).getId());
+        if (node instanceof Unit unit) {
+            if (unit.isDeployed()) {
+                showCannotMoveDialog(c, unit.getEntity().getShortName());
+                return null;
+            }
+            return new StringSelection("UNIT|" + unit.getId().toString());
+        } else if (node instanceof Formation formation) {
+            if (formation.isDeployed()) {
+                showCannotMoveDialog(c, formation.toString());
+                return null;
+            }
+            return new StringSelection("FORCE|" + formation.getId());
         } else {
             return null;
         }
+    }
+
+    /**
+     * A method that displays a dialog for units or formations that cannot be moved in the
+     * TO&E because they are already deployed.
+     *
+     */
+    private void showCannotMoveDialog(JComponent parent, String unit_formation_string) {
+        JOptionPane.showMessageDialog(
+            parent,
+            unit_formation_string + " cannot be moved because it is currently deployed to a mission.",
+            "Cannot Move: " + unit_formation_string,
+            JOptionPane.WARNING_MESSAGE);
     }
 
     @Override


### PR DESCRIPTION
feat: adds a warning message to users that they cannot move units or formations that are already deployed, addresses #5837

This helps with usability and assists users who may be unaware of what the highlighting means.

<!-- TITLE: include the issue number, and start with "Fix" for a bug fix or "Close" for
     anything else:

         Fix #1234: Cheese has the wrong colour gradient
         Close #1234: Added 6 new cheese gradients

     More than one issue is fine: "Close #111, #5329: Added unit history tracking".
     Release notes are generated automatically from pull request titles, so the title is
     what players end up reading. -->

<img width="1048" height="797" alt="image" src="https://github.com/user-attachments/assets/5a0df671-0bb3-4a64-a515-44235c880cdb" />

<img width="1048" height="797" alt="image" src="https://github.com/user-attachments/assets/57d7be09-dfab-496f-bbd9-9e68665c8598" />


## What this changes

<!-- The effect someone actually sees, in plain language. One or two sentences is fine. -->

<!-- Keep this line as well as the number in the title. GitHub only closes an issue from a
     keyword in the description - a number in the title alone does not close anything.

     Any of these close an issue when this merges:
         Close / Closes / Closed
         Fix / Fixes / Fixed
         Resolve / Resolves / Resolved

     Closing more than one needs the keyword repeated in front of each number:
         Fixes #1234, fixes #5678          closes both
         Fixes #1234, #5678                closes only #1234

     For an issue in another repository, qualify it: Fixes MegaMek/mekhq#1234 -->
Addresses feature request #5837

## Testing

Ran unit tests and basic manual smoke-test.

## Questions/Considerations

* Should text strings be placed in a `.properties` file?  I leaned towards no since I didn't think it would be reused.
* Should a different dialog be used?  Elsewhere, I saw `showMessageDialog` used for warnings and such.

## What is not proven yet

<!-- What you did not test, or could not. "Nothing" is a valid answer - say so explicitly. -->

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text

No AI usage.