### PR TITLE
Fixed Text in Low Intel Contracts

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractCardPanel.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractCardPanel.java
@@ -158,7 +158,7 @@ public class ContractCardPanel extends JPanel {
     private void applyTitleText() {
         // The name reveals the enemy, so a hidden opposition blanks the card title too, matching the dossier.
         String rawName = contract.isIntelObfuscated(ObfuscatableIntel.OPPOSITION)
-                               ? getTextAt(RESOURCE_BUNDLE, "dossier.contractMarket.title.obfuscated")
+                               ? getTextAt(RESOURCE_BUNDLE, "dossier.contractMarket.intel.obfuscated")
                                : contract.getName().replace('_', ' ');
         String name = wrapInner(escape(rawName), NAME_MAX_CHARS);
         String subtitle = wrapInner(escape(contract.getEmployerMarketDisplayName()) + " &middot; "

--- a/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractDossierPanel.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractDossierPanel.java
@@ -119,7 +119,7 @@ public class ContractDossierPanel extends JPanel {
         // The title names the enemy, so when the opposition is hidden the title reads as unknown too.
         boolean oppositionHidden = contract.isIntelObfuscated(ObfuscatableIntel.OPPOSITION);
         String titleText = oppositionHidden
-                                 ? getTextAt(RESOURCE_BUNDLE, "dossier.contractMarket.title.obfuscated")
+                                 ? getTextAt(RESOURCE_BUNDLE, "dossier.contractMarket.intel.obfuscated")
                                  : contract.getName();
         JLabel title = new JLabel("<html><span style='font-size:smaller'>"
                                         +


### PR DESCRIPTION
## What this changes
Fixes a couple of text calls

## Testing
Launched and beheld the correct text

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result