### PR TITLE
Fix NPE when selecting a scenario after reloading a save (Fixes #9815)

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -916,10 +916,28 @@ public class Campaign implements ITechManager {
      */
     public void importMission(final AbstractContract mission) {
         mission.setCampaignOptions(getCampaignOptions());
-        mission.getScenarios().forEach(this::importScenario);
+        mission.getScenarios().forEach(scenario -> importScenario(scenario, mission));
         contractHistory.contractHistory().put(mission.getId(), mission);
         MekHQ.triggerEvent(new MissionNewEvent(mission));
         StratConContractInitializer.restoreTransientStratconInformation(mission, this);
+    }
+
+    /**
+     * Imports a scenario that was loaded as part of {@code mission}, restoring its link back to that contract before
+     * registering it with the campaign.
+     *
+     * <p>{@link Scenario#getMissionId()} is a back-pointer that never reaches the save file. A contract's scenarios
+     * are nested inside the contract itself, so the link is implied by position rather than stored, and it is
+     * {@link AbstractContract#addScenario(Scenario)} that stamps it. Both load paths build the scenario list directly
+     * instead, so the id has to be restored here or every restored scenario comes back with no contract and each
+     * lookup of its contract returns {@code null}.</p>
+     *
+     * @param scenario the scenario being restored
+     * @param mission  the contract the scenario belongs to
+     */
+    private void importScenario(final Scenario scenario, final AbstractContract mission) {
+        scenario.setMissionId(mission.getId());
+        importScenario(scenario);
     }
 
     public ContractHistoryData getContractHistoryData() {
@@ -930,7 +948,13 @@ public class Campaign implements ITechManager {
         return contractHistory.contractHistory();
     }
 
-    public @jakarta.annotation.Nullable AbstractContract getContract(UUID contractId) {
+    /**
+     * @param contractId the id of the contract to look up, or {@code null} when the caller holds no id - for example a
+     *                   scenario that has yet to be attached to a contract
+     *
+     * @return the contract with that id, or {@code null} if the campaign has never held one
+     */
+    public @Nullable AbstractContract getContract(@Nullable UUID contractId) {
         return contractHistory.get(contractId);
     }
 

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -769,8 +769,21 @@ public final class BriefingTab extends CampaignGuiTab {
         refreshScenarioActionButtonEmphasis();
     }
 
+    /**
+     * @param scenario the scenario to test
+     *
+     * @return {@code true} if the scenario belongs to a contract that is running a StratCon campaign, otherwise
+     *       {@code false} - including when the scenario has no contract to ask
+     */
     private boolean isStratConScenario(Scenario scenario) {
         AbstractContract mission = getCampaign().getContract(scenario.getMissionId());
+        if (mission == null) {
+            logger.warn("[Briefing] Scenario {} ({}) is not linked to any contract; treating it as non-StratCon.",
+                  scenario.getId(),
+                  scenario.getName());
+            return false;
+        }
+
         return mission.getStratConCampaignState() != null;
     }
 

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/contractData/ContractHistoryDataTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/contractData/ContractHistoryDataTest.java
@@ -421,6 +421,50 @@ class ContractHistoryDataTest {
     }
 
     /**
+     * The regression behind issue #9815. A scenario's contract id is a back-pointer that is never written to the save -
+     * scenarios are nested inside their contract instead - and both load paths add scenarios straight to the
+     * contract's list rather than through {@code AbstractContract.addScenario}, which is what stamps it. Without the
+     * restore in {@code Campaign.importMission} every reloaded scenario comes back with no contract, which crashed the
+     * Briefing Room the moment one was selected.
+     */
+    @Test
+    void aRestoredScenarioStillKnowsWhichContractItBelongsTo() throws Exception {
+        AbstractContract accepted = acceptInto(campaign, "Reach Garrison");
+        Scenario scenario = new Scenario("Ambush at Rasalhague");
+        scenario.setId(4242);
+        accepted.addScenario(scenario);
+
+        Campaign reloaded = MHQTestUtilities.getTestCampaign();
+        load(reloaded, write(campaign));
+
+        Scenario restoredScenario = reloaded.getScenario(4242);
+        assertNotNull(restoredScenario, "a restored contract's scenarios must be reachable through the campaign");
+        assertEquals(accepted.getId(), restoredScenario.getMissionId(),
+              "a restored scenario must point back at its own contract, not null");
+    }
+
+    /**
+     * The lookup the Briefing Room, scenario resolution and the game launcher all make. Asserting the id alone would
+     * pass on an id that resolves to nothing, so this follows it all the way back to the contract object.
+     */
+    @Test
+    void aRestoredScenariosContractResolvesThroughTheCampaign() throws Exception {
+        AbstractContract accepted = acceptInto(campaign, "Reach Garrison");
+        Scenario scenario = new Scenario("Ambush at Rasalhague");
+        scenario.setId(4242);
+        accepted.addScenario(scenario);
+
+        Campaign reloaded = MHQTestUtilities.getTestCampaign();
+        load(reloaded, write(campaign));
+
+        Scenario restoredScenario = reloaded.getScenario(4242);
+        assertNotNull(restoredScenario);
+        AbstractContract restoredContract = reloaded.getContract(restoredScenario.getMissionId());
+        assertNotNull(restoredContract, "looking a restored scenario's contract up by id must not come back null");
+        assertEquals("Reach Garrison", restoredContract.getName());
+    }
+
+    /**
      * A contract in the history was accepted, so it has a status. Saves written before acceptance set one carry none;
      * those load as active rather than dropping out of every status filter.
      */


### PR DESCRIPTION
## What was broken

Save a campaign with an active scenario, reload it, then click that scenario in the Briefing Room and MekHQ throws a NullPointerException. The scenario stays in the list but you cannot deploy forces to it, whether or not forces are already assigned.

A scenario remembers which contract it belongs to, and that link is never written to the save file. The save nests a contract's scenarios inside the contract itself, so the link is implied by position rather than stored, and it gets stamped back on when the contract adds the scenario. Both loaders build the contract's scenario list directly instead, so the stamp never happens and every scenario comes back belonging to nothing. `BriefingTab.isStratConScenario` then asks that missing contract whether it is running a StratCon campaign, and that is the crash.

Worth knowing when reproducing it: the scenario details panel is painted before the buttons are refreshed, and the crash happens during the button refresh. So the symptom is a scenario that looks fine - right date, right assigned count - above a Deploy button that stays greyed out, with the exception only in the log.

The crash is the visible part. `AtBGameThread` reads the same contract to work out enemy formation sizes when it builds the bot forces, and `Campaign.removeScenario` quietly fails to detach a deleted scenario from its mission.

This could not happen before #9804 was fixed, because no contracts were loading at all, so there were no restored scenarios whose link could be broken. Fixing that exposed this.

## Changes

- `Campaign.importMission` re-stamps each scenario's contract id as it imports it. Both the modern codec and the legacy converter funnel through this one method, so both kinds of save are covered by a single restore - next to the StratCon back-pointer restore that already runs there for the same reason.
- `BriefingTab.isStratConScenario` now treats a missing contract as "not a StratCon scenario" and logs which scenario it was, instead of throwing. `MaplessStratCon.buildScenarioData` already guarded the identical lookup; the Briefing Room did not.
- `Campaign.getContract` uses the `@Nullable` the file already imports rather than an inline fully-qualified one, and documents that both its parameter and its return can be null.

## Testing

Played in game against the save attached to the issue. The campaign was loaded, the Assassination scenario selected in the Briefing Room, and it selected cleanly with no exception. The Deploy button enabled, and clicking it opened the force assignment dialog offering Able and Baker. That was checked on 3026-03-13, the campaign's current day, and again on 3026-03-14, the scenario's own date. The Deploy button enabling is itself meaningful: it is switched on only when the scenario's contract is found and that contract has a StratCon campaign state, which is exactly the lookup that was returning null.

The same save was also loaded through `CampaignXmlParser` directly to see the link itself. Without the fix, both of that campaign's scenarios come back with no contract at all:

```
scenario 1 'Critical Convoy Escort' missionId=null contract=NULL
scenario 2 'Assassination'          missionId=null contract=NULL
```

With the fix, both resolve to the contract they belong to:

```
scenario 1 'Critical Convoy Escort' missionId=7bf878b5-...  contract=3026-02-28 - Pirate Hunting: Lyran Commonwealth vs. Backordered Parts
scenario 2 'Assassination'          missionId=7bf878b5-...  contract=3026-02-28 - Pirate Hunting: Lyran Commonwealth vs. Backordered Parts
```

Two new tests in `ContractHistoryDataTest` cover it as a regression: they drive a real save and load, then assert that a restored scenario still names its contract and that looking that contract up through the campaign returns the contract object rather than null. The second matters because an id that resolves to nothing would satisfy the first. Both were verified by reverting the fix - with `importMission` back to its old form those two fail, and nothing else does.

Full MekHQ suite: 14,542 tests, 0 failures. `checkstyleMain` clean.

## What is NOT proven yet

The fight itself was never launched. Forces were offered for assignment but not committed through to Start Game, so the bot force generation path in `AtBGameThread` - which reads the same contract link to size enemy formations - has not been exercised. It should be fixed by this, but nothing here proves it.

`Campaign.removeScenario` also reads that link and was silently failing to detach a deleted scenario from its mission. Same reasoning, same lack of a test.

The reporter's second problem - no contracts offered between 3025 and 3026 - is untouched and unexamined.

Fixes #9815
