### PR TITLE
Fixed Salvage Terms for Step Two in Chaos Contract Steps Table

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/contract/contractData/ChaosContractStepsTable.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractData/ChaosContractStepsTable.java
@@ -39,7 +39,7 @@ import jakarta.annotation.Nullable;
 public enum ChaosContractStepsTable {
     // Hot Spots Draconis Reach pg 145 first printing
     STEP_ONE(1, 0.5, ContractCommandRights.INTEGRATED, 0.0, false, 0.0, 0.0, 0.0),
-    STEP_TWO(2, 0.55, ContractCommandRights.INTEGRATED, 0.25, true, 0.2, 0.0, 0.0),
+    STEP_TWO(2, 0.55, ContractCommandRights.INTEGRATED, 0.0, false, 0.2, 0.0, 0.0),
     STEP_THREE(3, 0.6, ContractCommandRights.INTEGRATED, 0.25, true, 0.4, 0.0, 0.0),
     STEP_FOUR(4, 0.7, ContractCommandRights.HOUSE, 0.1, false, 0.6, 0.0, 0.0),
     STEP_FIVE(5, 0.8, ContractCommandRights.HOUSE, 0.2, false, 0.7, 0.0, 0.0),

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/AbstractContractDeterminationPay.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/AbstractContractDeterminationPay.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.mission.contract.contractGeneration;
+
+import static java.lang.Math.round;
+
+import java.time.LocalDate;
+
+import mekhq.campaign.AbstractLocation;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.JumpPath;
+import mekhq.campaign.campaignOptions.CampaignOption;
+import mekhq.campaign.chaosCampaign.ChaosCampaignUtilities;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.mission.contract.AbstractContract;
+import mekhq.campaign.mission.contract.contractData.ContractFinanceData;
+import mekhq.campaign.mission.utilities.ContractUtilities;
+import mekhq.campaign.universe.PlanetarySystem;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Base class for the contract pay schemes: given a generated contract, each scheme decides how much the employer pays
+ * as a monthly retainer, a per-battle combat bonus, and up-front transport compensation.
+ *
+ * <p>Two schemes exist. The default {@link ChaosContractDeterminationPay} derives pay from the contract's abstract
+ * scale and support-point multipliers; {@link CamOpsContractDeterminationPay} grounds the monthly retainer in the
+ * Campaign Operations force-value calculation instead. A campaign opts into the CamOps scheme with
+ * {@link CampaignOption#USE_LEGACY_CONTRACT_PAY}; use {@link #forCampaign(Campaign)} to obtain the scheme it has
+ * chosen.</p>
+ *
+ * <p>Both schemes share the transport-pay calculation, so it lives here rather than in either subclass.</p>
+ *
+ * @see ChaosContractDeterminationPay
+ * @see CamOpsContractDeterminationPay
+ */
+public abstract class AbstractContractDeterminationPay {
+    public final static int DEFAULT_TRANSPORT_COST_MULTIPLIER = 50; // Draconis Reach first printing pg 26
+    public final static int HIRING_HALL_RETURN_MULTIPLIER = 2; // Draconis Reach first printing pg 26
+
+    /**
+     * Returns the pay scheme the campaign has opted into: the CamOps force-value scheme when
+     * {@link CampaignOption#USE_LEGACY_CONTRACT_PAY} is set, otherwise the default Chaos scheme.
+     */
+    public static @NonNull AbstractContractDeterminationPay forCampaign(Campaign campaign) {
+        if (campaign.getCampaignOptions().get(CampaignOption.USE_LEGACY_CONTRACT_PAY)) {
+            return new CamOpsContractDeterminationPay();
+        }
+        return new ChaosContractDeterminationPay();
+    }
+
+    /**
+     * Populates the contract's {@link ContractFinanceData} from this scheme's three pay components: the monthly
+     * retainer, the per-battle combat bonus, and up-front transport compensation.
+     */
+    public void determineContractPay(Campaign campaign, LocalDate currentDate, AbstractContract contract,
+          AbstractLocation currentLocation) {
+        Money monthlyPay = getMonthlyPay(campaign, contract);
+        Money combatPay = getCombatPay(campaign, contract);
+        Money transportPay = getTransportPay(campaign, currentDate, contract, currentLocation);
+
+        ContractFinanceData contractFinanceData = new ContractFinanceData(transportPay, monthlyPay, combatPay);
+        contract.setContractFinanceData(contractFinanceData);
+    }
+
+    /** The monthly retainer the employer pays. */
+    public abstract @NonNull Money getMonthlyPay(Campaign campaign, AbstractContract contract);
+
+    /** The per-battle combat bonus the employer pays; some schemes fold this into the monthly retainer and return zero. */
+    public abstract @NonNull Money getCombatPay(Campaign campaign, AbstractContract contract);
+
+    /**
+     * Up-front transport compensation for the journey from the player's current location to the contract's target,
+     * derived from the contract's scale, transport terms, and jump count. Shared by every pay scheme.
+     */
+    public @NonNull Money getTransportPay(Campaign campaign, LocalDate currentDate, AbstractContract contract,
+          AbstractLocation currentLocation) {
+        PlanetarySystem currentSystem = currentLocation.getCurrentSystem();
+
+        JumpPath cachedJumpPath = ContractUtilities.getJumpPath(campaign, contract, currentLocation);
+        int jumpCount = cachedJumpPath == null ? 0 : cachedJumpPath.getJumps();
+
+        if (jumpCount == 0) {
+            return Money.zero();
+        }
+
+        int transportCostInSupportPoints = DEFAULT_TRANSPORT_COST_MULTIPLIER * contract.getScale();
+        transportCostInSupportPoints *= jumpCount;
+
+        // Two-way pay for hiring halls: when the player sets out from a hiring hall, the employer covers the return
+        // journey too, doubling transport pay. Only applied when the campaign opts into it.
+        boolean isAtHiringHall = currentSystem.isHiringHall(currentDate);
+        boolean useTwoWayPayForHiringHalls = campaign.getCampaignOptions().get(CampaignOption.IS_USE_TWO_WAY_PAY);
+        if (isAtHiringHall && useTwoWayPayForHiringHalls) {
+            transportCostInSupportPoints *= HIRING_HALL_RETURN_MULTIPLIER;
+        }
+
+        transportCostInSupportPoints = (int) round(transportCostInSupportPoints * contract.getTransportMultiplier());
+        return ChaosCampaignUtilities.getMoneyFromChaosSupportPoints(transportCostInSupportPoints,
+              shouldConvertSupportPoints(campaign));
+    }
+
+    /**
+     * Whether Chaos support-point pay should be converted to C-bills (the "BSP to BV" conversion). Enabled by default;
+     * when disabled, pay is expressed in raw support points.
+     */
+    protected static boolean shouldConvertSupportPoints(Campaign campaign) {
+        return campaign.getCampaignOptions().get(CampaignOption.USE_CHAOS_SUPPORT_POINT_CONVERSION);
+    }
+}

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/AbstractContractGeneration.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/AbstractContractGeneration.java
@@ -203,13 +203,8 @@ public class AbstractContractGeneration {
         contract.setStratConCampaignState(stratConCampaignState);
 
         // Pay - the default Chaos Campaign scheme, or the CamOps force-value scheme when the campaign opts into it.
-        if (campaign.getCampaignOptions().get(CampaignOption.USE_LEGACY_CONTRACT_PAY)) {
-            CamOpsContractDeterminationPay.determineContractPayForCamOpsContract(campaign, currentDate, contract,
-                  currentLocation);
-        } else {
-            ChaosContractDeterminationPay.determineContractPayForChaosContract(campaign, currentDate, contract,
-                  currentLocation);
-        }
+        AbstractContractDeterminationPay.forCampaign(campaign)
+              .determineContractPay(campaign, currentDate, contract, currentLocation);
 
         // Intel Obfuscation - optionally hide some market-offer intel from the player.
         applyIntelObfuscation(campaign, contract);
@@ -324,10 +319,7 @@ public class AbstractContractGeneration {
      * when {@link CampaignOption#USE_LEGACY_CONTRACT_PAY} is set, otherwise the Chaos scale-and-base-pay scheme.
      */
     public static Money determineMonthlyPay(Campaign campaign, AbstractContract contract) {
-        if (campaign.getCampaignOptions().get(CampaignOption.USE_LEGACY_CONTRACT_PAY)) {
-            return CamOpsContractDeterminationPay.getMonthlyPay(campaign, contract);
-        }
-        return ChaosContractDeterminationPay.getMonthlyPay(campaign, contract);
+        return AbstractContractDeterminationPay.forCampaign(campaign).getMonthlyPay(campaign, contract);
     }
 
     /**
@@ -336,10 +328,7 @@ public class AbstractContractGeneration {
      * bonus derived from scale.
      */
     public static Money determineCombatPay(Campaign campaign, AbstractContract contract) {
-        if (campaign.getCampaignOptions().get(CampaignOption.USE_LEGACY_CONTRACT_PAY)) {
-            return CamOpsContractDeterminationPay.getCombatPay();
-        }
-        return ChaosContractDeterminationPay.getCombatPay(campaign, contract);
+        return AbstractContractDeterminationPay.forCampaign(campaign).getCombatPay(campaign, contract);
     }
 
     /**
@@ -347,7 +336,8 @@ public class AbstractContractGeneration {
      * to the target from the player's current location).
      */
     public static Money determineTransportPay(Campaign campaign, AbstractContract contract) {
-        return ChaosContractDeterminationPay.getTransportPay(campaign, campaign.getLocalDate(), contract,
+        return AbstractContractDeterminationPay.forCampaign(campaign).getTransportPay(campaign,
+              campaign.getLocalDate(), contract,
               campaign.getPlayerForce().getForceDetachment().getCurrentLocation());
     }
 

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/AbstractContractGeneration.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/AbstractContractGeneration.java
@@ -204,10 +204,10 @@ public class AbstractContractGeneration {
 
         // Pay - the default Chaos Campaign scheme, or the CamOps force-value scheme when the campaign opts into it.
         if (campaign.getCampaignOptions().get(CampaignOption.USE_LEGACY_CONTRACT_PAY)) {
-            CamOpsContractPayDetermination.determineContractPayForCamOpsContract(campaign, currentDate, contract,
+            CamOpsContractDeterminationPay.determineContractPayForCamOpsContract(campaign, currentDate, contract,
                   currentLocation);
         } else {
-            ChaosContractPayDetermination.determineContractPayForChaosContract(campaign, currentDate, contract,
+            ChaosContractDeterminationPay.determineContractPayForChaosContract(campaign, currentDate, contract,
                   currentLocation);
         }
 
@@ -276,7 +276,8 @@ public class AbstractContractGeneration {
      * @return the automatically determined track count
      */
     public static int determineTrackCount(AbstractContract contract) {
-        return ChaosContractDetermineIntensity.determineTrackCount(contract.getObjectiveType().getChaosObjectiveType());
+        return ChaosContractDeterminationIntensity.determineTrackCount(contract.getObjectiveType()
+                                                                               .getChaosObjectiveType());
     }
 
     /**
@@ -324,9 +325,9 @@ public class AbstractContractGeneration {
      */
     public static Money determineMonthlyPay(Campaign campaign, AbstractContract contract) {
         if (campaign.getCampaignOptions().get(CampaignOption.USE_LEGACY_CONTRACT_PAY)) {
-            return CamOpsContractPayDetermination.getMonthlyPay(campaign, contract);
+            return CamOpsContractDeterminationPay.getMonthlyPay(campaign, contract);
         }
-        return ChaosContractPayDetermination.getMonthlyPay(campaign, contract);
+        return ChaosContractDeterminationPay.getMonthlyPay(campaign, contract);
     }
 
     /**
@@ -336,9 +337,9 @@ public class AbstractContractGeneration {
      */
     public static Money determineCombatPay(Campaign campaign, AbstractContract contract) {
         if (campaign.getCampaignOptions().get(CampaignOption.USE_LEGACY_CONTRACT_PAY)) {
-            return CamOpsContractPayDetermination.getCombatPay();
+            return CamOpsContractDeterminationPay.getCombatPay();
         }
-        return ChaosContractPayDetermination.getCombatPay(campaign, contract);
+        return ChaosContractDeterminationPay.getCombatPay(campaign, contract);
     }
 
     /**
@@ -346,7 +347,7 @@ public class AbstractContractGeneration {
      * to the target from the player's current location).
      */
     public static Money determineTransportPay(Campaign campaign, AbstractContract contract) {
-        return ChaosContractPayDetermination.getTransportPay(campaign, campaign.getLocalDate(), contract,
+        return ChaosContractDeterminationPay.getTransportPay(campaign, campaign.getLocalDate(), contract,
               campaign.getPlayerForce().getForceDetachment().getCurrentLocation());
     }
 
@@ -478,7 +479,7 @@ public class AbstractContractGeneration {
 
     private static void setContractTerms(ChaosObjectiveType objectiveType, ChaosEmployerType employerType,
           Faction employerFaction, boolean useFactionModifiers, ChaosContract contract) {
-        ContractTermsData initialContractTerms = ChaosContractDetermineTerms.determineInitialTerms(objectiveType,
+        ContractTermsData initialContractTerms = ChaosContractDeterminationTerms.determineInitialTerms(objectiveType,
               employerType, employerFaction, useFactionModifiers);
         contract.setContractTerms(initialContractTerms);
     }
@@ -565,7 +566,7 @@ public class AbstractContractGeneration {
 
     private static @Nonnull ContractObjectiveData pickObjective(int contractGenerationModifier,
           ChaosContract contract) {
-        ContractObjectiveData objectiveData = ChaosContractObjectiveDetermination.determineContractObjectiveType(
+        ContractObjectiveData objectiveData = ChaosContractDeterminationObjective.determineContractObjectiveType(
               contractGenerationModifier);
         contract.setObjectiveData(objectiveData);
         return objectiveData;
@@ -573,7 +574,7 @@ public class AbstractContractGeneration {
 
     private static @Nullable EmployerData pickEmployer(Campaign campaign, LocalDate currentDate,
           ILocation currentLocation, ContractSearchType searchType, ChaosContract contract) {
-        EmployerData employerData = ChaosContractEmployerDetermination.getEmployerGenerationData(currentDate,
+        EmployerData employerData = ChaosContractDeterminationEmployer.getEmployerGenerationData(currentDate,
               currentLocation,
               campaign,
               searchType);

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/CamOpsContractDeterminationPay.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/CamOpsContractDeterminationPay.java
@@ -32,9 +32,6 @@
  */
 package mekhq.campaign.mission.contract.contractGeneration;
 
-import java.time.LocalDate;
-
-import mekhq.campaign.AbstractLocation;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.mission.contract.AbstractContract;
@@ -57,35 +54,27 @@ import org.jspecify.annotations.NonNull;
  *     negotiation terms still matter under CamOps.</li>
  *     <li><b>Combat pay</b> &mdash; zero; CamOps folds combat compensation into the monthly retainer rather than a
  *     separate battle bonus.</li>
- *     <li><b>Transport pay</b> &mdash; reuses the Chaos transport calculation (scale, transport terms, and the journey
- *     to the target), which already applies the negotiated transport multiplier.</li>
+ *     <li><b>Transport pay</b> &mdash; inherited from {@link AbstractContractDeterminationPay} (scale, transport terms,
+ *     and the journey to the target), which already applies the negotiated transport multiplier.</li>
  * </ul>
  *
+ * @see AbstractContractDeterminationPay
  * @see ChaosContractDeterminationPay
  */
-public class CamOpsContractDeterminationPay {
-    public static void determineContractPayForCamOpsContract(Campaign campaign, LocalDate currentDate,
-          AbstractContract contract, AbstractLocation currentLocation) {
-        Money monthlyPay = getMonthlyPay(campaign, contract);
-        Money combatPay = getCombatPay();
-        Money transportPay = ChaosContractDeterminationPay.getTransportPay(campaign, currentDate, contract,
-              currentLocation);
-
-        ContractFinanceData contractFinanceData = new ContractFinanceData(transportPay, monthlyPay, combatPay);
-        contract.setContractFinanceData(contractFinanceData);
-    }
-
+public class CamOpsContractDeterminationPay extends AbstractContractDeterminationPay {
     /**
      * The CamOps monthly retainer: the campaign's CamOps contract-base force value, scaled by the contract's negotiated
      * base-pay multiplier.
      */
-    public static @NonNull Money getMonthlyPay(Campaign campaign, AbstractContract contract) {
+    @Override
+    public @NonNull Money getMonthlyPay(Campaign campaign, AbstractContract contract) {
         Money base = campaign.getAccountant().getContractBase();
         return base.multipliedBy(contract.getBasePayMultiplier());
     }
 
     /** CamOps folds combat compensation into the monthly retainer, so there is no separate combat bonus. */
-    public static @NonNull Money getCombatPay() {
+    @Override
+    public @NonNull Money getCombatPay(Campaign campaign, AbstractContract contract) {
         return Money.zero();
     }
 }

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/CamOpsContractDeterminationPay.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/CamOpsContractDeterminationPay.java
@@ -43,7 +43,7 @@ import org.jspecify.annotations.NonNull;
 
 /**
  * Determines contract pay the Campaign Operations (CamOps) way, as an alternative to the default Chaos Campaign scheme
- * in {@link ChaosContractPayDetermination}.
+ * in {@link ChaosContractDeterminationPay}.
  *
  * <p>Where the Chaos scheme derives pay from the contract's abstract scale and support-point multipliers, the CamOps
  * scheme grounds the monthly retainer in the force-value calculation configured on the Contract Market campaign options
@@ -61,14 +61,14 @@ import org.jspecify.annotations.NonNull;
  *     to the target), which already applies the negotiated transport multiplier.</li>
  * </ul>
  *
- * @see ChaosContractPayDetermination
+ * @see ChaosContractDeterminationPay
  */
-public class CamOpsContractPayDetermination {
+public class CamOpsContractDeterminationPay {
     public static void determineContractPayForCamOpsContract(Campaign campaign, LocalDate currentDate,
           AbstractContract contract, AbstractLocation currentLocation) {
         Money monthlyPay = getMonthlyPay(campaign, contract);
         Money combatPay = getCombatPay();
-        Money transportPay = ChaosContractPayDetermination.getTransportPay(campaign, currentDate, contract,
+        Money transportPay = ChaosContractDeterminationPay.getTransportPay(campaign, currentDate, contract,
               currentLocation);
 
         ContractFinanceData contractFinanceData = new ContractFinanceData(transportPay, monthlyPay, combatPay);

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationEmployer.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationEmployer.java
@@ -63,8 +63,8 @@ import mekhq.campaign.universe.RandomFactionGenerator;
 import mekhq.campaign.universe.enums.HiringHallLevel;
 import org.jspecify.annotations.NonNull;
 
-public class ChaosContractEmployerDetermination {
-    private static final MMLogger LOGGER = MMLogger.create(ChaosContractEmployerDetermination.class);
+public class ChaosContractDeterminationEmployer {
+    private static final MMLogger LOGGER = MMLogger.create(ChaosContractDeterminationEmployer.class);
 
     private static final int COMSTAR_EMPLOYER_CHANCE = 100;
     private static final int WORD_OF_BLAKE_EMPLOYER_CHANCE = 40;

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationIntensity.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationIntensity.java
@@ -34,7 +34,7 @@ package mekhq.campaign.mission.contract.contractGeneration;
 
 import static megamek.common.compute.Compute.d6;
 
-public class ChaosContractDetermineIntensity {
+public class ChaosContractDeterminationIntensity {
     public static int determineTrackCount(ChaosObjectiveType objectiveType) {
         int roll = d6(2);
 

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationObjective.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationObjective.java
@@ -39,7 +39,7 @@ import mekhq.campaign.mission.contract.contractData.ContractObjectiveData;
 import mekhq.campaign.mission.contract.contractData.ContractObjectiveType;
 import org.jspecify.annotations.NonNull;
 
-public class ChaosContractObjectiveDetermination {
+public class ChaosContractDeterminationObjective {
     public static ContractObjectiveData determineContractObjectiveType(int contractGenerationModifier) {
         int roll = d6(2);
         int result = clamp(roll + contractGenerationModifier, 1, 13);

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationPay.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationPay.java
@@ -48,7 +48,7 @@ import mekhq.campaign.mission.utilities.ContractUtilities;
 import mekhq.campaign.universe.PlanetarySystem;
 import org.jspecify.annotations.NonNull;
 
-public class ChaosContractPayDetermination {
+public class ChaosContractDeterminationPay {
     public final static int DEFAULT_MONTHLY_PAY_MULTIPLIER = 500; // Draconis Reach first printing pg 26
     public final static int DEFAULT_COMBAT_PAY_MULTIPLIER = 500; // Draconis Reach first printing pg 26
     public final static int DEFAULT_TRANSPORT_COST_MULTIPLIER = 50; // Draconis Reach first printing pg 26

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationPay.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationPay.java
@@ -34,82 +34,36 @@ package mekhq.campaign.mission.contract.contractGeneration;
 
 import static java.lang.Math.round;
 
-import java.time.LocalDate;
-
-import mekhq.campaign.AbstractLocation;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.JumpPath;
-import mekhq.campaign.campaignOptions.CampaignOption;
 import mekhq.campaign.chaosCampaign.ChaosCampaignUtilities;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.mission.contract.AbstractContract;
-import mekhq.campaign.mission.contract.contractData.ContractFinanceData;
-import mekhq.campaign.mission.utilities.ContractUtilities;
-import mekhq.campaign.universe.PlanetarySystem;
 import org.jspecify.annotations.NonNull;
 
-public class ChaosContractDeterminationPay {
+/**
+ * The default Chaos Campaign pay scheme: monthly and combat pay are derived from the contract's abstract scale and
+ * fixed support-point multipliers, then optionally converted to C-bills. Transport pay is inherited unchanged from
+ * {@link AbstractContractDeterminationPay}.
+ *
+ * @see AbstractContractDeterminationPay
+ * @see CamOpsContractDeterminationPay
+ */
+public class ChaosContractDeterminationPay extends AbstractContractDeterminationPay {
     public final static int DEFAULT_MONTHLY_PAY_MULTIPLIER = 500; // Draconis Reach first printing pg 26
     public final static int DEFAULT_COMBAT_PAY_MULTIPLIER = 500; // Draconis Reach first printing pg 26
-    public final static int DEFAULT_TRANSPORT_COST_MULTIPLIER = 50; // Draconis Reach first printing pg 26
-    public final static int HIRING_HALL_RETURN_MULTIPLIER = 2; // Draconis Reach first printing pg 26
 
-    public static void determineContractPayForChaosContract(Campaign campaign, LocalDate currentDate,
-          AbstractContract contract,
-          AbstractLocation currentLocation) {
-        Money monthlyPay = getMonthlyPay(campaign, contract);
-        Money combatPay = getCombatPay(campaign, contract);
-        Money transportPay = getTransportPay(campaign, currentDate, contract, currentLocation);
-
-        ContractFinanceData contractFinanceData = new ContractFinanceData(transportPay, monthlyPay, combatPay);
-        contract.setContractFinanceData(contractFinanceData);
-    }
-
-    public static @NonNull Money getTransportPay(Campaign campaign, LocalDate currentDate, AbstractContract contract,
-          AbstractLocation currentLocation) {
-        PlanetarySystem currentSystem = currentLocation.getCurrentSystem();
-
-        JumpPath cachedJumpPath = ContractUtilities.getJumpPath(campaign, contract, currentLocation);
-        int jumpCount = cachedJumpPath == null ? 0 : cachedJumpPath.getJumps();
-
-        if (jumpCount == 0) {
-            return Money.zero();
-        }
-
-        int transportCostInSupportPoints = DEFAULT_TRANSPORT_COST_MULTIPLIER * contract.getScale();
-        transportCostInSupportPoints *= jumpCount;
-
-        // Two-way pay for hiring halls: when the player sets out from a hiring hall, the employer covers the return
-        // journey too, doubling transport pay. Only applied when the campaign opts into it.
-        boolean isAtHiringHall = currentSystem.isHiringHall(currentDate);
-        boolean useTwoWayPayForHiringHalls = campaign.getCampaignOptions().get(CampaignOption.IS_USE_TWO_WAY_PAY);
-        if (isAtHiringHall && useTwoWayPayForHiringHalls) {
-            transportCostInSupportPoints *= HIRING_HALL_RETURN_MULTIPLIER;
-        }
-
-        transportCostInSupportPoints = (int) round(transportCostInSupportPoints * contract.getTransportMultiplier());
-        return ChaosCampaignUtilities.getMoneyFromChaosSupportPoints(transportCostInSupportPoints,
-              shouldConvertSupportPoints(campaign));
-    }
-
-    public static @NonNull Money getCombatPay(Campaign campaign, AbstractContract contract) {
+    @Override
+    public @NonNull Money getCombatPay(Campaign campaign, AbstractContract contract) {
         int combatPayInSupportPoints = DEFAULT_COMBAT_PAY_MULTIPLIER * contract.getScale();
         return ChaosCampaignUtilities.getMoneyFromChaosSupportPoints(combatPayInSupportPoints,
               shouldConvertSupportPoints(campaign));
     }
 
-    public static @NonNull Money getMonthlyPay(Campaign campaign, AbstractContract contract) {
+    @Override
+    public @NonNull Money getMonthlyPay(Campaign campaign, AbstractContract contract) {
         int monthlyPayInSupportPoints = DEFAULT_MONTHLY_PAY_MULTIPLIER * contract.getScale();
         monthlyPayInSupportPoints = (int) round(monthlyPayInSupportPoints * contract.getBasePayMultiplier());
         return ChaosCampaignUtilities.getMoneyFromChaosSupportPoints(monthlyPayInSupportPoints,
               shouldConvertSupportPoints(campaign));
-    }
-
-    /**
-     * Whether Chaos support-point pay should be converted to C-bills (the "BSP to BV" conversion). Enabled by default;
-     * when disabled, pay is expressed in raw support points.
-     */
-    private static boolean shouldConvertSupportPoints(Campaign campaign) {
-        return campaign.getCampaignOptions().get(CampaignOption.USE_CHAOS_SUPPORT_POINT_CONVERSION);
     }
 }

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationTerms.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationTerms.java
@@ -39,7 +39,7 @@ import mekhq.campaign.mission.contract.contractData.ChaosContractStepsTable;
 import mekhq.campaign.mission.contract.contractData.ContractTermsData;
 import mekhq.campaign.universe.Faction;
 
-public class ChaosContractDetermineTerms {
+public class ChaosContractDeterminationTerms {
     public static ContractTermsData determineInitialTerms(ChaosObjectiveType objectiveType,
           ChaosEmployerType employerType, @Nullable Faction employerFaction, boolean useFactionModifiers) {
         int factionPayDelta = useFactionModifiers ? getFactionPayRateModifier(employerFaction) : 0;

--- a/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractNegotiationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractNegotiationDialog.java
@@ -691,8 +691,9 @@ public class ContractNegotiationDialog extends JDialog {
         ChaosContractStepsTable command = step(Clause.COMMAND);
 
         contract.setContractTerms(new ContractTermsData(payRate, support, transport, salvage, command));
-        contract.updateMonthlyPay(ChaosContractDeterminationPay.getMonthlyPay(campaign, contract));
-        contract.updateTransportPay(ChaosContractDeterminationPay.getTransportPay(campaign,
+        ChaosContractDeterminationPay payScheme = new ChaosContractDeterminationPay();
+        contract.updateMonthlyPay(payScheme.getMonthlyPay(campaign, contract));
+        contract.updateTransportPay(payScheme.getTransportPay(campaign,
               campaign.getLocalDate(), contract, currentLocation));
 
         contract.setRentedFacilitiesData(new RentedFacilitiesData(facilityQuantity[0],

--- a/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractNegotiationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractNegotiationDialog.java
@@ -74,7 +74,7 @@ import mekhq.campaign.mission.contract.contractData.ChaosContractStepsTable;
 import mekhq.campaign.mission.contract.contractData.ContractTermsData;
 import mekhq.campaign.mission.contract.contractData.NegotiationData;
 import mekhq.campaign.mission.contract.contractData.RentedFacilitiesData;
-import mekhq.campaign.mission.contract.contractGeneration.ChaosContractPayDetermination;
+import mekhq.campaign.mission.contract.contractGeneration.ChaosContractDeterminationPay;
 import mekhq.campaign.mission.contract.contractGeneration.negotiationsAndNPCs.TermFunding;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.universe.Faction;
@@ -691,8 +691,8 @@ public class ContractNegotiationDialog extends JDialog {
         ChaosContractStepsTable command = step(Clause.COMMAND);
 
         contract.setContractTerms(new ContractTermsData(payRate, support, transport, salvage, command));
-        contract.updateMonthlyPay(ChaosContractPayDetermination.getMonthlyPay(campaign, contract));
-        contract.updateTransportPay(ChaosContractPayDetermination.getTransportPay(campaign,
+        contract.updateMonthlyPay(ChaosContractDeterminationPay.getMonthlyPay(campaign, contract));
+        contract.updateTransportPay(ChaosContractDeterminationPay.getTransportPay(campaign,
               campaign.getLocalDate(), contract, currentLocation));
 
         contract.setRentedFacilitiesData(new RentedFacilitiesData(facilityQuantity[0],

--- a/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractNegotiationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractNegotiationDialog.java
@@ -74,7 +74,7 @@ import mekhq.campaign.mission.contract.contractData.ChaosContractStepsTable;
 import mekhq.campaign.mission.contract.contractData.ContractTermsData;
 import mekhq.campaign.mission.contract.contractData.NegotiationData;
 import mekhq.campaign.mission.contract.contractData.RentedFacilitiesData;
-import mekhq.campaign.mission.contract.contractGeneration.ChaosContractDeterminationPay;
+import mekhq.campaign.mission.contract.contractGeneration.AbstractContractDeterminationPay;
 import mekhq.campaign.mission.contract.contractGeneration.negotiationsAndNPCs.TermFunding;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.universe.Faction;
@@ -691,7 +691,7 @@ public class ContractNegotiationDialog extends JDialog {
         ChaosContractStepsTable command = step(Clause.COMMAND);
 
         contract.setContractTerms(new ContractTermsData(payRate, support, transport, salvage, command));
-        ChaosContractDeterminationPay payScheme = new ChaosContractDeterminationPay();
+        AbstractContractDeterminationPay payScheme = AbstractContractDeterminationPay.forCampaign(campaign);
         contract.updateMonthlyPay(payScheme.getMonthlyPay(campaign, contract));
         contract.updateTransportPay(payScheme.getTransportPay(campaign,
               campaign.getLocalDate(), contract, currentLocation));

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/AbstractContractTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/AbstractContractTest.java
@@ -235,10 +235,10 @@ class AbstractContractTest {
     @Test
     void salvageIsAvailableWhenTheNegotiatedStepGrantsAShare() {
         AbstractContract contract = contract();
-        contract.setContractTerms(termsWithSalvage(ChaosContractStepsTable.STEP_TWO));
+        contract.setContractTerms(termsWithSalvage(ChaosContractStepsTable.STEP_THREE));
 
-        assertTrue(contract.canSalvage(), "STEP_TWO grants a positive salvage share");
-        assertTrue(contract.isSalvageExchange(), "STEP_TWO grants that share as an exchange");
+        assertTrue(contract.canSalvage(), "STEP_THREE grants a positive salvage share");
+        assertTrue(contract.isSalvageExchange(), "STEP_THREE grants that share as an exchange");
     }
 
     @Test

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/AbstractContractDeterminationPayTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/AbstractContractDeterminationPayTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.mission.contract.contractGeneration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+
+import mekhq.campaign.AbstractLocation;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.JumpPath;
+import mekhq.campaign.campaignOptions.CampaignOption;
+import mekhq.campaign.campaignOptions.CampaignOptions;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.mission.contract.AbstractContract;
+import mekhq.campaign.mission.contract.contractData.ContractFinanceData;
+import mekhq.campaign.mission.utilities.ContractUtilities;
+import mekhq.campaign.universe.PlanetarySystem;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+/**
+ * Tests the shared behavior on {@link AbstractContractDeterminationPay}: the
+ * {@link AbstractContractDeterminationPay#forCampaign(Campaign)} scheme selector, the
+ * {@link AbstractContractDeterminationPay#determineContractPay} template method that composes the three pay components
+ * into the contract's {@link ContractFinanceData}, and the shared transport-pay calculation.
+ */
+class AbstractContractDeterminationPayTest {
+    private static final LocalDate DATE = LocalDate.of(3025, 1, 1);
+
+    /** A campaign whose {@code campaignOptions.get(option)} returns the supplied value, and nothing else stubbed. */
+    private static Campaign campaignWithOption(CampaignOption<Boolean> option, boolean value) {
+        CampaignOptions options = mock(CampaignOptions.class);
+        when(options.get(option)).thenReturn(value);
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getCampaignOptions()).thenReturn(options);
+        return campaign;
+    }
+
+    // region forCampaign
+
+    @Test
+    void forCampaignPicksChaosByDefault() {
+        Campaign campaign = campaignWithOption(CampaignOption.USE_LEGACY_CONTRACT_PAY, false);
+        assertInstanceOf(ChaosContractDeterminationPay.class,
+              AbstractContractDeterminationPay.forCampaign(campaign));
+    }
+
+    @Test
+    void forCampaignPicksCamOpsWhenLegacyContractPayIsSet() {
+        Campaign campaign = campaignWithOption(CampaignOption.USE_LEGACY_CONTRACT_PAY, true);
+        assertInstanceOf(CamOpsContractDeterminationPay.class,
+              AbstractContractDeterminationPay.forCampaign(campaign));
+    }
+
+    // endregion forCampaign
+
+    // region determineContractPay template
+
+    /** A scheme with fixed, distinct pay components, so the template's wiring into the record can be checked. */
+    private static class FixedPay extends AbstractContractDeterminationPay {
+        static final Money MONTHLY = Money.of(500);
+        static final Money COMBAT = Money.of(250);
+        static final Money TRANSPORT = Money.of(1_000);
+
+        @Override
+        public Money getMonthlyPay(Campaign campaign, AbstractContract contract) {
+            return MONTHLY;
+        }
+
+        @Override
+        public Money getCombatPay(Campaign campaign, AbstractContract contract) {
+            return COMBAT;
+        }
+
+        @Override
+        public Money getTransportPay(Campaign campaign, LocalDate currentDate, AbstractContract contract,
+              AbstractLocation currentLocation) {
+            return TRANSPORT;
+        }
+    }
+
+    @Test
+    void determineContractPayComposesTheThreeComponentsIntoTheContract() {
+        AbstractContract contract = mock(AbstractContract.class);
+
+        new FixedPay().determineContractPay(mock(Campaign.class), DATE, contract, mock(AbstractLocation.class));
+
+        ArgumentCaptor<ContractFinanceData> captor = ArgumentCaptor.forClass(ContractFinanceData.class);
+        verify(contract).setContractFinanceData(captor.capture());
+        ContractFinanceData financeData = captor.getValue();
+        assertEquals(FixedPay.MONTHLY, financeData.monthlyPay());
+        assertEquals(FixedPay.COMBAT, financeData.combatPay());
+        assertEquals(FixedPay.TRANSPORT, financeData.transport());
+    }
+
+    // endregion determineContractPay template
+
+    // region transport pay
+
+    /**
+     * Sets up a campaign/contract/location for the transport calculation and runs it. The jump path is stubbed via a
+     * static mock; a {@code jumps} of {@code 0} stands in for "no route" (a {@code null} jump path).
+     */
+    private static Money transportPay(int scale, int jumps, double transportMultiplier, boolean atHiringHall,
+          boolean twoWayPay, boolean convertSupportPoints) {
+        CampaignOptions options = mock(CampaignOptions.class);
+        when(options.get(CampaignOption.IS_USE_TWO_WAY_PAY)).thenReturn(twoWayPay);
+        when(options.get(CampaignOption.USE_CHAOS_SUPPORT_POINT_CONVERSION)).thenReturn(convertSupportPoints);
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getCampaignOptions()).thenReturn(options);
+
+        PlanetarySystem currentSystem = mock(PlanetarySystem.class);
+        when(currentSystem.isHiringHall(DATE)).thenReturn(atHiringHall);
+        AbstractLocation currentLocation = mock(AbstractLocation.class);
+        when(currentLocation.getCurrentSystem()).thenReturn(currentSystem);
+
+        AbstractContract contract = mock(AbstractContract.class);
+        when(contract.getScale()).thenReturn(scale);
+        when(contract.getTransportMultiplier()).thenReturn(transportMultiplier);
+
+        JumpPath jumpPath = jumps == 0 ? null : mock(JumpPath.class);
+        if (jumpPath != null) {
+            when(jumpPath.getJumps()).thenReturn(jumps);
+        }
+
+        // Any concrete subclass inherits the shared transport calculation unchanged.
+        AbstractContractDeterminationPay payScheme = new ChaosContractDeterminationPay();
+        try (MockedStatic<ContractUtilities> contractUtilities = mockStatic(ContractUtilities.class)) {
+            contractUtilities.when(() -> ContractUtilities.getJumpPath(eq(campaign), eq(contract), eq(currentLocation)))
+                  .thenReturn(jumpPath);
+            return payScheme.getTransportPay(campaign, DATE, contract, currentLocation);
+        }
+    }
+
+    @Test
+    void transportPayIsZeroWhenThereIsNoJourney() {
+        assertEquals(Money.zero(), transportPay(4, 0, 1.0, false, false, false));
+    }
+
+    @Test
+    void transportPayScalesWithScaleAndJumpCount() {
+        // 50 * scale(3) * jumps(2) = 300 support points, unconverted.
+        assertEquals(Money.of(300), transportPay(3, 2, 1.0, false, false, false));
+    }
+
+    @Test
+    void transportPayAppliesTheNegotiatedTransportMultiplier() {
+        // 50 * 2 * 1 = 100, rounded after the 1.5x multiplier -> 150 support points.
+        assertEquals(Money.of(150), transportPay(2, 1, 1.5, false, false, false));
+    }
+
+    @Test
+    void transportPayDoublesForTwoWayHiringHallPay() {
+        // 50 * 2 * 1 = 100, doubled by the hiring-hall return leg -> 200 support points.
+        assertEquals(Money.of(200), transportPay(2, 1, 1.0, true, true, false));
+    }
+
+    @Test
+    void transportPayIgnoresHiringHallReturnWhenTwoWayPayIsOff() {
+        assertEquals(Money.of(100), transportPay(2, 1, 1.0, true, false, false));
+    }
+
+    @Test
+    void transportPayConvertsSupportPointsToCBillsWhenEnabled() {
+        // 50 * 2 * 1 = 100 support points, converted at 10,000 C-bills each.
+        assertEquals(Money.of(1_000_000), transportPay(2, 1, 1.0, false, false, true));
+    }
+
+    // endregion transport pay
+}

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/CamOpsContractDeterminationPayTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/CamOpsContractDeterminationPayTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.mission.contract.contractGeneration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Accountant;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.mission.contract.AbstractContract;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the CamOps pay scheme: {@link CamOpsContractDeterminationPay#getMonthlyPay} grounds the retainer in the
+ * campaign's CamOps contract-base force value scaled by the negotiated base-pay multiplier, while
+ * {@link CamOpsContractDeterminationPay#getCombatPay} is always zero because CamOps folds combat compensation into the
+ * monthly retainer.
+ */
+class CamOpsContractDeterminationPayTest {
+    private final CamOpsContractDeterminationPay payScheme = new CamOpsContractDeterminationPay();
+
+    private static Campaign campaignWithContractBase(Money contractBase) {
+        Accountant accountant = mock(Accountant.class);
+        when(accountant.getContractBase()).thenReturn(contractBase);
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getAccountant()).thenReturn(accountant);
+        return campaign;
+    }
+
+    private static AbstractContract contractWithBasePayMultiplier(double basePayMultiplier) {
+        AbstractContract contract = mock(AbstractContract.class);
+        when(contract.getBasePayMultiplier()).thenReturn(basePayMultiplier);
+        return contract;
+    }
+
+    @Test
+    void monthlyPayIsTheContractBaseUnchangedAtAUnitMultiplier() {
+        assertEquals(Money.of(5_000_000),
+              payScheme.getMonthlyPay(campaignWithContractBase(Money.of(5_000_000)),
+                    contractWithBasePayMultiplier(1.0)));
+    }
+
+    @Test
+    void monthlyPayScalesTheContractBaseByTheNegotiatedMultiplier() {
+        // 5,000,000 force value * 1.5 negotiated base-pay multiplier.
+        assertEquals(Money.of(7_500_000),
+              payScheme.getMonthlyPay(campaignWithContractBase(Money.of(5_000_000)),
+                    contractWithBasePayMultiplier(1.5)));
+    }
+
+    @Test
+    void combatPayIsAlwaysZero() {
+        assertEquals(Money.zero(),
+              payScheme.getCombatPay(mock(Campaign.class), mock(AbstractContract.class)));
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationEmployerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationEmployerTest.java
@@ -48,7 +48,7 @@ import java.util.List;
 
 import megamek.common.compute.Compute;
 import mekhq.campaign.location.ILocation;
-import mekhq.campaign.mission.contract.contractGeneration.ChaosContractEmployerDetermination.EmployerFactions;
+import mekhq.campaign.mission.contract.contractGeneration.ChaosContractDeterminationEmployer.EmployerFactions;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.PlanetarySystem;
@@ -57,14 +57,14 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 /**
- * Covers the flavor/anchor/sponsor resolution in {@link ChaosContractEmployerDetermination#determineEmployerFactions}
+ * Covers the flavor/anchor/sponsor resolution in {@link ChaosContractDeterminationEmployer#determineEmployerFactions}
  * &mdash; in particular the rebel-sponsor rule: rebels always remain the visible employer, and a ComStar/Word of Blake
  * patron that would otherwise take over the contract instead becomes their covert backer on a mercenary search.
  *
  * <p>The faction singletons, the random faction generator, and the dice are all stubbed so these tests are fully
  * deterministic and need no loaded universe.</p>
  */
-class ChaosContractEmployerDeterminationTest {
+class ChaosContractDeterminationEmployerTest {
 
     private static final int YEAR = 3050;
     private static final LocalDate DATE = LocalDate.of(YEAR, 1, 1);
@@ -121,7 +121,7 @@ class ChaosContractEmployerDeterminationTest {
             // A roll of 0 opens the ComStar override, which is checked before Word of Blake.
             compute.when(() -> Compute.randomInt(anyInt())).thenReturn(0);
 
-            EmployerFactions result = ChaosContractEmployerDetermination.determineEmployerFactions(
+            EmployerFactions result = ChaosContractDeterminationEmployer.determineEmployerFactions(
                   ChaosEmployerType.CIVILIAN_ORGANIZATION_REBELS, DATE, locationOwnedByHouse(), true);
 
             assertSame(rebels, result.flavor(), "rebels remain the visible employer");
@@ -143,7 +143,7 @@ class ChaosContractEmployerDeterminationTest {
             // A non-zero roll misses both the ComStar and Word of Blake override windows.
             compute.when(() -> Compute.randomInt(anyInt())).thenReturn(1);
 
-            EmployerFactions result = ChaosContractEmployerDetermination.determineEmployerFactions(
+            EmployerFactions result = ChaosContractDeterminationEmployer.determineEmployerFactions(
                   ChaosEmployerType.CIVILIAN_ORGANIZATION_REBELS, DATE, locationOwnedByHouse(), true);
 
             assertSame(rebels, result.flavor());
@@ -162,7 +162,7 @@ class ChaosContractEmployerDeterminationTest {
         try (MockedStatic<Factions> factionsStatic = mockStatic(Factions.class)) {
             stubFactions(factionsStatic, rebels, house, comStar, wordOfBlake);
 
-            EmployerFactions result = ChaosContractEmployerDetermination.determineEmployerFactions(
+            EmployerFactions result = ChaosContractDeterminationEmployer.determineEmployerFactions(
                   ChaosEmployerType.CIVILIAN_ORGANIZATION_REBELS, DATE, locationOwnedByHouse(), false);
 
             assertSame(rebels, result.flavor());
@@ -181,7 +181,7 @@ class ChaosContractEmployerDeterminationTest {
         try (MockedStatic<Factions> factionsStatic = mockStatic(Factions.class)) {
             stubFactions(factionsStatic, rebels, house, comStar, wordOfBlake);
 
-            EmployerFactions result = ChaosContractEmployerDetermination.determineEmployerFactions(
+            EmployerFactions result = ChaosContractDeterminationEmployer.determineEmployerFactions(
                   ChaosEmployerType.LOCAL_SYSTEM_OWNER, DATE, locationOwnedByHouse(), false);
 
             assertSame(house, result.flavor(), "a local system owner is the current system's controller");
@@ -209,7 +209,7 @@ class ChaosContractEmployerDeterminationTest {
             // Resolves the fronting corporation's flavor faction.
             when(generator.getRandomEmployerFaction(eq(location), eq(DATE), eq(true), any())).thenReturn(house);
 
-            EmployerFactions result = ChaosContractEmployerDetermination.determineEmployerFactions(
+            EmployerFactions result = ChaosContractDeterminationEmployer.determineEmployerFactions(
                   ChaosEmployerType.CORPORATION, DATE, location, true);
 
             assertEquals(ChaosEmployerType.CORPORATION, result.type(),
@@ -240,7 +240,7 @@ class ChaosContractEmployerDeterminationTest {
             generatorStatic.when(RandomFactionGenerator::getInstance).thenReturn(generator);
             when(generator.getRandomEmployerFaction(eq(location), eq(DATE), eq(true), any())).thenReturn(house);
 
-            EmployerFactions result = ChaosContractEmployerDetermination.determineEmployerFactions(
+            EmployerFactions result = ChaosContractDeterminationEmployer.determineEmployerFactions(
                   ChaosEmployerType.CORPORATION, DATE, location, true);
 
             assertEquals(ChaosEmployerType.CORPORATION, result.type(), "Word of Blake keeps the rolled employer type");

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationIntensityTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationIntensityTest.java
@@ -40,16 +40,16 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 /**
- * Tests the roll-to-track-count tables in {@link ChaosContractDetermineIntensity}. The 2d6 roll is stubbed so each
+ * Tests the roll-to-track-count tables in {@link ChaosContractDeterminationIntensity}. The 2d6 roll is stubbed so each
  * branch of every objective family is pinned, including the boundary rolls (2 and 12) where an off-by-one in the switch
  * would show up.
  */
-class ChaosContractDetermineIntensityTest {
+class ChaosContractDeterminationIntensityTest {
 
     private static int trackCountForRoll(final ChaosObjectiveType objectiveType, final int roll) {
         try (MockedStatic<Compute> compute = mockStatic(Compute.class)) {
             compute.when(() -> Compute.d6(2)).thenReturn(roll);
-            return ChaosContractDetermineIntensity.determineTrackCount(objectiveType);
+            return ChaosContractDeterminationIntensity.determineTrackCount(objectiveType);
         }
     }
 

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationObjectiveTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationObjectiveTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 /**
- * Tests {@link ChaosContractObjectiveDetermination#determineContractObjectiveType(int)} - which bracket the 2d6 roll
+ * Tests {@link ChaosContractDeterminationObjective#determineContractObjectiveType(int)} - which bracket the 2d6 roll
  * (plus a generation modifier, clamped to 1..13) lands in, and the follow-up roll that picks the opposing objective.
  *
  * <p>Each call rolls d6 more than once, so the stub feeds a sequence: the first value is the bracket roll and the rest
@@ -53,14 +53,14 @@ import org.mockito.MockedStatic;
  * map back to a category (e.g. RAID -> Recon Raid or Diversionary Raid), so the concrete variant is not deterministic
  * across two independent invocations.</p>
  */
-class ChaosContractObjectiveDeterminationTest {
+class ChaosContractDeterminationObjectiveTest {
 
     /** The first roll is the bracket; any further rolls feed the sub-objective picks in call order. */
     private static ContractObjectiveData determine(final int modifier, final Integer firstRoll,
           final Integer... furtherRolls) {
         try (MockedStatic<Compute> compute = mockStatic(Compute.class)) {
             compute.when(() -> Compute.d6(2)).thenReturn(firstRoll, furtherRolls);
-            return ChaosContractObjectiveDetermination.determineContractObjectiveType(modifier);
+            return ChaosContractDeterminationObjective.determineContractObjectiveType(modifier);
         }
     }
 

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationPayTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationPayTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.mission.contract.contractGeneration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import mekhq.campaign.Campaign;
+import mekhq.campaign.campaignOptions.CampaignOption;
+import mekhq.campaign.campaignOptions.CampaignOptions;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.mission.contract.AbstractContract;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the Chaos pay scheme's two scale-derived components: {@link ChaosContractDeterminationPay#getMonthlyPay} (500
+ * support points per scale, scaled by the negotiated base-pay multiplier) and
+ * {@link ChaosContractDeterminationPay#getCombatPay} (500 support points per scale). Both optionally convert support
+ * points to C-bills at 10,000 each; the tests leave conversion off so the raw support-point arithmetic is visible.
+ */
+class ChaosContractDeterminationPayTest {
+    private final ChaosContractDeterminationPay payScheme = new ChaosContractDeterminationPay();
+
+    private static Campaign campaignWithConversion(boolean convertSupportPoints) {
+        CampaignOptions options = mock(CampaignOptions.class);
+        when(options.get(CampaignOption.USE_CHAOS_SUPPORT_POINT_CONVERSION)).thenReturn(convertSupportPoints);
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getCampaignOptions()).thenReturn(options);
+        return campaign;
+    }
+
+    private static AbstractContract contract(int scale, double basePayMultiplier) {
+        AbstractContract contract = mock(AbstractContract.class);
+        when(contract.getScale()).thenReturn(scale);
+        when(contract.getBasePayMultiplier()).thenReturn(basePayMultiplier);
+        return contract;
+    }
+
+    @Test
+    void monthlyPayIsScaleTimesTheMultiplierInSupportPoints() {
+        // 500 * scale(2) * basePay(1.0) = 1000 support points, unconverted.
+        assertEquals(Money.of(1_000),
+              payScheme.getMonthlyPay(campaignWithConversion(false), contract(2, 1.0)));
+    }
+
+    @Test
+    void monthlyPayAppliesTheNegotiatedBasePayMultiplier() {
+        // 500 * 2 = 1000, scaled by 1.5 -> 1500 support points.
+        assertEquals(Money.of(1_500),
+              payScheme.getMonthlyPay(campaignWithConversion(false), contract(2, 1.5)));
+    }
+
+    @Test
+    void monthlyPayConvertsSupportPointsToCBillsWhenEnabled() {
+        // 1000 support points converted at 10,000 C-bills each.
+        assertEquals(Money.of(10_000_000),
+              payScheme.getMonthlyPay(campaignWithConversion(true), contract(2, 1.0)));
+    }
+
+    @Test
+    void combatPayIsScaleInSupportPointsAndIgnoresTheBasePayMultiplier() {
+        // 500 * scale(3) = 1500 support points; the base-pay multiplier does not affect combat pay.
+        assertEquals(Money.of(1_500),
+              payScheme.getCombatPay(campaignWithConversion(false), contract(3, 2.0)));
+    }
+
+    @Test
+    void combatPayConvertsSupportPointsToCBillsWhenEnabled() {
+        assertEquals(Money.of(15_000_000),
+              payScheme.getCombatPay(campaignWithConversion(true), contract(3, 1.0)));
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationTermsTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationTermsTest.java
@@ -50,7 +50,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 /**
- * Tests the roll-to-step tables in {@link ChaosContractDetermineTerms}.
+ * Tests the roll-to-step tables in {@link ChaosContractDeterminationTerms}.
  *
  * <p>Every clause rolls the same stubbed 2d6, then shifts the base step by (objective modifier + employer modifier).
  * The cases below pair {@link ChaosObjectiveType#RAID} with {@link ChaosEmployerType#NOBLE}: NOBLE is neutral on every
@@ -58,12 +58,13 @@ import org.mockito.MockedStatic;
  * tables directly and only salvage carries a one-step drop. That keeps the roll tables - the typo-prone part - pinned
  * without re-deriving the modifier arithmetic.</p>
  */
-class ChaosContractDetermineTermsTest {
+class ChaosContractDeterminationTermsTest {
 
     private static ContractTermsData termsForRoll(final int roll) {
         try (MockedStatic<Compute> compute = mockStatic(Compute.class)) {
             compute.when(() -> Compute.d6(2)).thenReturn(roll);
-            return ChaosContractDetermineTerms.determineInitialTerms(ChaosObjectiveType.RAID, ChaosEmployerType.NOBLE,
+            return ChaosContractDeterminationTerms.determineInitialTerms(ChaosObjectiveType.RAID,
+                    ChaosEmployerType.NOBLE,
                   null, false);
         }
     }
@@ -92,7 +93,7 @@ class ChaosContractDetermineTermsTest {
             compute.when(() -> Compute.d6(2)).thenReturn(2);
             // CORPORATION carries a +2 pay-rate modifier; RAID adds nothing to pay, so base STEP_THREE climbs to
             // STEP_FIVE. This proves the employer modifier reaches influenceStep rather than being dropped.
-            ContractTermsData terms = ChaosContractDetermineTerms.determineInitialTerms(ChaosObjectiveType.RAID,
+            ContractTermsData terms = ChaosContractDeterminationTerms.determineInitialTerms(ChaosObjectiveType.RAID,
                   ChaosEmployerType.CORPORATION, null, false);
 
             assertEquals(STEP_FIVE, terms.payRate());


### PR DESCRIPTION
# Requires #9821

## What this changes
Step Two for salvage should be 'none', not exchange.

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result