### PR TITLE
Contract Overhaul Project: Updated Negotiations Edge Use to Function Within New Negotiations System

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -2034,6 +2034,11 @@ lblUseIntelObfuscation.tooltip=When enabled, newly generated contract offers may
   Command, Opposition, Threat, or Morale) from the player, so they must sometimes pick contracts with incomplete \
   information. Hiding the opposition also blanks the offer's title. Assessment is never hidden, and a GM can always \
   adjust what is hidden in the contract editor. Obfuscation has no effect once a contract is accepted.
+lblUseNonNegotiableTerms.text=Non-Negotiable Terms
+lblUseNonNegotiableTerms.tooltip=When enabled (the default), each term of a newly generated contract has a 1-in-4 \
+  chance of being locked by the employer as non-negotiable. A locked term is fixed at its generated value, it can \
+  neither be improved nor sacrificed in the negotiation screen. You can still change a locked term in the contract \
+  editor.
 lblUseContractFactionModifiers.text=Use Faction Modifiers
 lblUseContractFactionModifiers.tooltip=When enabled (the default), an employing faction's disposition (CamOps p. 42) \
   shifts a contract's terms: a generous faction pays more and a stingy one pays less (Base Pay), while a lenient \

--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -2039,6 +2039,9 @@ lblUseNonNegotiableTerms.tooltip=When enabled (the default), each term of a newl
   chance of being locked by the employer as non-negotiable. A locked term is fixed at its generated value, it can \
   neither be improved nor sacrificed in the negotiation screen. You can still change a locked term in the contract \
   editor.
+lblUseActiveNegotiators.text=Active Negotiators
+lblUseActiveNegotiators.tooltip=When enabled, the negotiation screen offers a Re-Negotiate action, where your \
+  chosen negotiator and the employer's can make an opposed Negotiation check to influence the contract's terms.
 lblUseContractFactionModifiers.text=Use Faction Modifiers
 lblUseContractFactionModifiers.tooltip=When enabled (the default), an employing faction's disposition (CamOps p. 42) \
   shifts a contract's terms: a generous faction pays more and a stingy one pays less (Base Pay), while a lenient \

--- a/MekHQ/resources/mekhq/resources/ChaosContractMarketDialog.properties
+++ b/MekHQ/resources/mekhq/resources/ChaosContractMarketDialog.properties
@@ -259,7 +259,7 @@ button.contractMarket.negotiate.reset=Reset
 button.contractMarket.negotiate.cancel=Cancel
 button.contractMarket.negotiate.explain=Explain negotiations
 negotiate.contractMarket.explain.title=How negotiation works
-negotiate.contractMarket.explain.body=<html><body style="width:{0}px"><b>Improve the contract before you accept it.</b><br><br>&bull; <b>Reputation:</b> each point raises one term by one step. You can apply up to twice the contract''s Scale in reputation.<br>&bull; <b>Per-term limit:</b> no single term may be raised more than Scale steps, however it is funded.<br>&bull; <b>Sacrifice:</b> lower terms to bank steps; two banked steps raise another term one step, up to twice. You may sacrifice at most two terms, four steps in total.<br>&bull; <b>Lowering:</b> a term drops straight to the next step that changes its value, counting every step crossed toward your four - a move that would exceed the limit is refused. Raising a lowered term back reverses each lower and returns those banked steps.<br>&bull; <b>Plateaus:</b> some steps leave a term''s value unchanged - raising into one still costs a step, so spend enough to cross into the next band.<br>&bull; <b>Facilities:</b> you may also rent hospital beds, kitchens, and holding cells for the duration of the contract.</body></html>
+negotiate.contractMarket.explain.body=<html><body style="width:{0}px"><b>Improve the contract before you accept it.</b><br><br>&bull; <b>Reputation:</b> each point raises one term by one step. You can apply up to twice the contract''s Scale in reputation.<br>&bull; <b>Per-term limit:</b> no single term may be raised more than Scale steps, however it is funded.<br>&bull; <b>Sacrifice:</b> lower terms to bank steps; two banked steps raise another term one step, up to twice. You may sacrifice at most two terms, four steps in total.<br>&bull; <b>Lowering:</b> a term drops straight to the next step that changes its value, counting every step crossed toward your four - a move that would exceed the limit is refused. Raising a lowered term back reverses each lower and returns those banked steps.<br>&bull; <b>Plateaus:</b> some steps leave a term''s value unchanged - raising into one still costs a step, so spend enough to cross into the next band.<br>&bull; <b>Non-negotiable terms:</b> the employer may lock a term (marked <i>non-negotiable</i>); a locked term cannot be improved or sacrificed.<br>&bull; <b>Facilities:</b> you may also rent hospital beds, kitchens, and holding cells for the duration of the contract.</body></html>
 button.contractMarket.close=Close
 button.contractMarket.accept=Accept Contract
 button.contractMarket.negotiate=Negotiate
@@ -349,6 +349,12 @@ edit.contractMarket.field.support=Support
 edit.contractMarket.field.transport=Transport
 edit.contractMarket.field.salvage=Salvage Rights
 edit.contractMarket.field.command=Command Rights
+edit.contractMarket.field.nonNegotiable=Non-negotiable
+edit.contractMarket.field.nonNegotiable.tooltip=When ticked, the employer has locked this term: the player cannot \
+  improve or sacrifice it in the negotiation screen. Which terms are locked can only be changed while the contract is \
+  still an offer.
+edit.contractMarket.field.nonNegotiable.disabled.tooltip=Which terms are non-negotiable is fixed once the contract \
+  has been accepted, so this can no longer be changed.
 # Per-option tooltips for the Terms pickers - each describes only the effect relevant to that term.
 edit.contractMarket.term.tooltip.payRate=Base Pay: {0}% of the standard rate.
 edit.contractMarket.term.tooltip.support=Straight Support: {0}%; battlefield loss compensation: {1}%.

--- a/MekHQ/resources/mekhq/resources/ChaosContractMarketDialog.properties
+++ b/MekHQ/resources/mekhq/resources/ChaosContractMarketDialog.properties
@@ -230,6 +230,33 @@ negotiate.contractMarket.factionModifier.controlling=Controlling
 negotiate.contractMarket.factionModifier.lenient=Lenient
 negotiate.contractMarket.plateau=no change
 negotiate.contractMarket.locked=non-negotiable
+negotiate.contractMarket.section.results=Negotiation Results
+negotiate.contractMarket.results.none=No re-negotiation has been attempted for this contract.
+negotiate.contractMarket.results.won=Your negotiator prevailed by a Margin of Success of {0}.
+negotiate.contractMarket.results.lost=The employer''s negotiator prevailed by a Margin of Success of {0}.
+negotiate.contractMarket.results.stalemate=Stalemate. Neither negotiator gained the upper hand.
+negotiate.contractMarket.results.termImproved={0} improved by {1}.
+negotiate.contractMarket.results.termWorsened={0} worsened by {1}.
+negotiate.contractMarket.results.noTerms=No terms could be affected.
+negotiate.contractMarket.results.termUnlocked={0} is now open to negotiation.
+negotiate.contractMarket.results.termLocked={0} is now non-negotiable.
+negotiate.contractMarket.renegotiate.prompt=I'm listening...
+negotiate.contractMarket.renegotiate.ooc=Re-negotiating is a one-time move per contract. Both choices pit your \
+  negotiator against the employer's in the same opposed Negotiation check. Either choice spends your one attempt per \
+  contract and cannot be undone.\
+  <br><br>"Give me a better offer" shifts a random terms' values up per margin of success, or down per margin of \
+  failure.\
+  <br><br>"You'll make an exception" instead affects a terms' 'non-negotiable' flag, unlocking a random locked term \
+  per margin of success, but locking a random unlocked term per margin of failure.
+negotiate.contractMarket.renegotiate.option.better=Come on, give me a better offer
+negotiate.contractMarket.renegotiate.option.exception=You'll make an exception, right?
+negotiate.contractMarket.renegotiate.option.cancel=(Cancel) On second thoughts...
+negotiate.contractMarket.renegotiate.roll.player=Contract re-negotiation (your negotiator)
+negotiate.contractMarket.renegotiate.roll.employer=Contract re-negotiation (employer's negotiator)
+negotiate.contractMarket.renegotiate.tooltip=Make an opposed Negotiation check against the employer to shift the \
+  contract terms. This can only be done once per contract.
+negotiate.contractMarket.renegotiate.tooltip.spent=This contract has already been re-negotiated.
+negotiate.contractMarket.renegotiate.tooltip.noNegotiator=Choose a negotiator before re-negotiating.
 negotiate.contractMarket.cap=cap {0}/{1}
 negotiate.contractMarket.pay=Monthly Pay
 negotiate.contractMarket.percent={0}%
@@ -258,6 +285,7 @@ button.contractMarket.negotiate.confirm=Confirm terms
 button.contractMarket.negotiate.reset=Reset
 button.contractMarket.negotiate.cancel=Cancel
 button.contractMarket.negotiate.explain=Explain negotiations
+button.contractMarket.negotiate.renegotiate=Re-Negotiate
 negotiate.contractMarket.explain.title=How negotiation works
 negotiate.contractMarket.explain.body=<html><body style="width:{0}px"><b>Improve the contract before you accept it.</b><br><br>&bull; <b>Reputation:</b> each point raises one term by one step. You can apply up to twice the contract''s Scale in reputation.<br>&bull; <b>Per-term limit:</b> no single term may be raised more than Scale steps, however it is funded.<br>&bull; <b>Sacrifice:</b> lower terms to bank steps; two banked steps raise another term one step, up to twice. You may sacrifice at most two terms, four steps in total.<br>&bull; <b>Lowering:</b> a term drops straight to the next step that changes its value, counting every step crossed toward your four - a move that would exceed the limit is refused. Raising a lowered term back reverses each lower and returns those banked steps.<br>&bull; <b>Plateaus:</b> some steps leave a term''s value unchanged - raising into one still costs a step, so spend enough to cross into the next band.<br>&bull; <b>Non-negotiable terms:</b> the employer may lock a term (marked <i>non-negotiable</i>); a locked term cannot be improved or sacrificed.<br>&bull; <b>Facilities:</b> you may also rent hospital beds, kitchens, and holding cells for the duration of the contract.</body></html>
 button.contractMarket.close=Close

--- a/MekHQ/resources/mekhq/resources/ChaosContractMarketDialog.properties
+++ b/MekHQ/resources/mekhq/resources/ChaosContractMarketDialog.properties
@@ -216,8 +216,8 @@ negotiate.contractMarket.budget.swaps=Swaps
 negotiate.contractMarket.budget.bank=Sacrifice Bank
 negotiate.contractMarket.bank.value={0} steps
 negotiate.contractMarket.section.terms=Contract Terms
-negotiate.contractMarket.section.terms.hint=Raise a term with Reputation, or lower one to bank sacrifice steps and \
-  lift another.
+negotiate.contractMarket.section.terms.hint=Raise a term with Reputation, or sacrifice steps from up to two terms \
+  (four steps total) to lift others.
 negotiate.contractMarket.section.facilities=Support facilities rented for the contract
 negotiate.contractMarket.term.command=Command Rights
 negotiate.contractMarket.term.pay=Base Pay
@@ -252,13 +252,13 @@ negotiate.contractMarket.facility.kitchens.benefit=+150 field-kitchen capacity
 negotiate.contractMarket.facility.holdingCells=Holding cells
 negotiate.contractMarket.facility.holdingCells.benefit=+35 prisoner capacity
 negotiate.contractMarket.facility.each={0} each
-negotiate.contractMarket.summary=Facility rentals {0} | {1} reputation and {2} sacrifice steps unspent
+negotiate.contractMarket.summary=Facility rentals {0} | {1} reputation left | Sacrificed {2}/{3} steps across {4}/{5} terms
 button.contractMarket.negotiate.confirm=Confirm terms
 button.contractMarket.negotiate.reset=Reset
 button.contractMarket.negotiate.cancel=Cancel
 button.contractMarket.negotiate.explain=Explain negotiations
 negotiate.contractMarket.explain.title=How negotiation works
-negotiate.contractMarket.explain.body=<html><body style="width:{0}px"><b>Improve the contract before you accept it.</b><br><br>&bull; <b>Reputation:</b> each point raises one term by one step. You can apply up to twice the contract''s Scale in reputation.<br>&bull; <b>Per-term limit:</b> no single term may be raised more than Scale steps, however it is funded.<br>&bull; <b>Sacrifice:</b> lower one term by two steps to raise another by one, up to twice.<br>&bull; <b>Plateaus:</b> some steps leave a term''s value unchanged - you must spend enough steps to cross into the next band.<br>&bull; <b>Facilities:</b> you may also rent hospital beds, kitchens, and holding cells for the duration of the contract.</body></html>
+negotiate.contractMarket.explain.body=<html><body style="width:{0}px"><b>Improve the contract before you accept it.</b><br><br>&bull; <b>Reputation:</b> each point raises one term by one step. You can apply up to twice the contract''s Scale in reputation.<br>&bull; <b>Per-term limit:</b> no single term may be raised more than Scale steps, however it is funded.<br>&bull; <b>Sacrifice:</b> lower terms to bank steps; two banked steps raise another term one step, up to twice. You may sacrifice at most two terms, four steps in total.<br>&bull; <b>Lowering:</b> a term drops straight to the next step that changes its value, counting every step crossed toward your four - a move that would exceed the limit is refused. Raising a lowered term back reverses each lower and returns those banked steps.<br>&bull; <b>Plateaus:</b> some steps leave a term''s value unchanged - raising into one still costs a step, so spend enough to cross into the next band.<br>&bull; <b>Facilities:</b> you may also rent hospital beds, kitchens, and holding cells for the duration of the contract.</body></html>
 button.contractMarket.close=Close
 button.contractMarket.accept=Accept Contract
 button.contractMarket.negotiate=Negotiate

--- a/MekHQ/resources/mekhq/resources/ChaosContractMarketDialog.properties
+++ b/MekHQ/resources/mekhq/resources/ChaosContractMarketDialog.properties
@@ -229,6 +229,7 @@ negotiate.contractMarket.factionModifier.generous=Generous
 negotiate.contractMarket.factionModifier.controlling=Controlling
 negotiate.contractMarket.factionModifier.lenient=Lenient
 negotiate.contractMarket.plateau=no change
+negotiate.contractMarket.locked=non-negotiable
 negotiate.contractMarket.cap=cap {0}/{1}
 negotiate.contractMarket.pay=Monthly Pay
 negotiate.contractMarket.percent={0}%

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOption.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOption.java
@@ -771,6 +771,8 @@ public final class CampaignOption<T> {
           of(Boolean.class, true, "useContractFactionModifiers");
     public static final CampaignOption<Boolean> USE_INTEL_OBFUSCATION =
           of(Boolean.class, true, "useIntelObfuscation");
+    public static final CampaignOption<Boolean> USE_NON_NEGOTIABLE_TERMS =
+          of(Boolean.class, true, "useNonNegotiableTerms");
     public static final CampaignOption<Double> CONTRACT_BASE_PAY_MULTIPLIER =
           of(Double.class, 1.0, "contractBasePayMultiplier");
     public static final CampaignOption<Double> CONTRACT_STRAIGHT_SUPPORT_MULTIPLIER =

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOption.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOption.java
@@ -773,6 +773,8 @@ public final class CampaignOption<T> {
           of(Boolean.class, true, "useIntelObfuscation");
     public static final CampaignOption<Boolean> USE_NON_NEGOTIABLE_TERMS =
           of(Boolean.class, true, "useNonNegotiableTerms");
+    public static final CampaignOption<Boolean> USE_ACTIVE_NEGOTIATORS =
+          of(Boolean.class, true, "useActiveNegotiators");
     public static final CampaignOption<Double> CONTRACT_BASE_PAY_MULTIPLIER =
           of(Double.class, 1.0, "contractBasePayMultiplier");
     public static final CampaignOption<Double> CONTRACT_STRAIGHT_SUPPORT_MULTIPLIER =

--- a/MekHQ/src/mekhq/campaign/mission/contract/AbstractContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/AbstractContract.java
@@ -104,6 +104,7 @@ public abstract class AbstractContract {
     private SystemsTargetData systemsTargetData;
 
     private RentedFacilitiesData rentedFacilitiesData;
+    private NonNegotiableTermsData nonNegotiableTermsData;
     /**
      * Seeded with neutral morale so a freshly-constructed contract is always well-formed: generation performs its first
      * morale check (which reads the current level as its baseline) before any morale data is assigned.
@@ -380,6 +381,14 @@ public abstract class AbstractContract {
 
     public void setRentedFacilitiesData(RentedFacilitiesData rentedFacilitiesData) {
         this.rentedFacilitiesData = rentedFacilitiesData;
+    }
+
+    public @Nullable NonNegotiableTermsData getNonNegotiableTermsData() {
+        return nonNegotiableTermsData;
+    }
+
+    public void setNonNegotiableTermsData(NonNegotiableTermsData nonNegotiableTermsData) {
+        this.nonNegotiableTermsData = nonNegotiableTermsData;
     }
 
     public @Nonnull MoraleData getMoraleData() {

--- a/MekHQ/src/mekhq/campaign/mission/contract/AbstractContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/AbstractContract.java
@@ -105,6 +105,7 @@ public abstract class AbstractContract {
 
     private RentedFacilitiesData rentedFacilitiesData;
     private NonNegotiableTermsData nonNegotiableTermsData;
+    private ActiveNegotiationData activeNegotiationData;
     /**
      * Seeded with neutral morale so a freshly-constructed contract is always well-formed: generation performs its first
      * morale check (which reads the current level as its baseline) before any morale data is assigned.
@@ -389,6 +390,14 @@ public abstract class AbstractContract {
 
     public void setNonNegotiableTermsData(NonNegotiableTermsData nonNegotiableTermsData) {
         this.nonNegotiableTermsData = nonNegotiableTermsData;
+    }
+
+    public @Nullable ActiveNegotiationData getActiveNegotiationData() {
+        return activeNegotiationData;
+    }
+
+    public void setActiveNegotiationData(ActiveNegotiationData activeNegotiationData) {
+        this.activeNegotiationData = activeNegotiationData;
     }
 
     public @Nonnull MoraleData getMoraleData() {

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractData/ActiveNegotiationData.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractData/ActiveNegotiationData.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.mission.contract.contractData;
+
+import mekhq.campaign.mission.contract.contractData.NegotiationStepMath.Term;
+
+/**
+ * The outcome of the one active-negotiation attempt a contract is allowed. Its presence on a contract records that the
+ * attempt has been spent (so it cannot be repeated), and describes what happened.
+ *
+ * <p>Both outcomes come from the same opposed check and carry a {@code netMargin} (positive = the player prevailed,
+ * negative = the employer did) plus a signed per-term change. What the change means depends on the {@link Kind}: for a
+ * {@link Kind#HAGGLE} it is the number of meaningful steps the term moved (positive improved it, negative lowered it);
+ * for a {@link Kind#EXCEPTION} it is {@code +1} if the term's non-negotiable status was waived, {@code -1} if it was
+ * newly locked, {@code 0} if unchanged.</p>
+ *
+ * @author Illiani
+ * @since 0.51.01
+ */
+public record ActiveNegotiationData(Kind kind, int netMargin, int payDelta, int supportDelta, int transportDelta,
+      int salvageDelta, int commandDelta) {
+
+    /** Which stakes the re-negotiation played for: the terms' values, or their non-negotiable flags. */
+    public enum Kind {
+        HAGGLE, EXCEPTION
+    }
+
+    /** A haggle outcome: per-term change is the signed count of meaningful steps the term moved. */
+    public static ActiveNegotiationData haggle(int netMargin, int payDelta, int supportDelta, int transportDelta,
+          int salvageDelta, int commandDelta) {
+        return new ActiveNegotiationData(Kind.HAGGLE, netMargin, payDelta, supportDelta, transportDelta, salvageDelta,
+              commandDelta);
+    }
+
+    /** An exception outcome: per-term change is +1 (waived), -1 (newly locked), or 0 (unchanged). */
+    public static ActiveNegotiationData exception(int netMargin, int payDelta, int supportDelta, int transportDelta,
+          int salvageDelta, int commandDelta) {
+        return new ActiveNegotiationData(Kind.EXCEPTION,
+              netMargin,
+              payDelta,
+              supportDelta,
+              transportDelta,
+              salvageDelta,
+              commandDelta);
+    }
+
+    /** The signed change applied to the given term (steps for a haggle, lock toggle for an exception). */
+    public int deltaFor(Term term) {
+        return switch (term) {
+            case BASE_PAY -> payDelta;
+            case SUPPORT -> supportDelta;
+            case TRANSPORT -> transportDelta;
+            case SALVAGE -> salvageDelta;
+            case COMMAND_RIGHTS -> commandDelta;
+        };
+    }
+}

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractData/ActiveNegotiationMath.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractData/ActiveNegotiationMath.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.mission.contract.contractData;
+
+import mekhq.campaign.personnel.skills.enums.MarginOfSuccess;
+
+/**
+ * Pure scoring behind active negotiation: turning the two negotiators' opposed {@link MarginOfSuccess} results into a
+ * single net margin. Kept free of dice and GUI so it can be tested in isolation.
+ *
+ * <p>Each margin is scored on a scale centered on {@link MarginOfSuccess#BARELY_MADE_IT} (zero), with better results
+ * positive and worse results negative. The net margin is the player's score minus the employer's: a positive net means
+ * the player's negotiator came out ahead by that many margin-of-success levels (improving that many terms), a negative
+ * net means the employer did (lowering that many).</p>
+ *
+ * @author Illiani
+ * @since 0.51.01
+ */
+public final class ActiveNegotiationMath {
+    private ActiveNegotiationMath() {
+    }
+
+    /**
+     * The signed level score for a margin: {@code 0} at {@link MarginOfSuccess#BARELY_MADE_IT}, positive for better
+     * results, negative for worse. Derived from enum position so it stays correct if labels change.
+     *
+     * @author Illiani
+     * @since 0.51.01
+     */
+    public static int marginScore(MarginOfSuccess margin) {
+        // The enum is ordered best-first (SPECTACULAR at ordinal 0), so a lower ordinal is a better result.
+        return MarginOfSuccess.BARELY_MADE_IT.ordinal() - margin.ordinal();
+    }
+
+    /**
+     * The net margin of an opposed negotiation: the player's level score minus the employer's. Positive favors the
+     * player (that many terms improve), negative favors the employer (that many lower), zero is a stalemate.
+     *
+     * @author Illiani
+     * @since 0.51.01
+     */
+    public static int netMargin(MarginOfSuccess playerMargin, MarginOfSuccess employerMargin) {
+        return marginScore(playerMargin) - marginScore(employerMargin);
+    }
+}

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractData/NegotiationStepMath.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractData/NegotiationStepMath.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.mission.contract.contractData;
+
+import static mekhq.campaign.mission.contract.contractData.ChaosContractStepsTable.CHAOS_CONTRACT_MINIMUM_STEP_VALUE;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Pure arithmetic behind the contract negotiation table: crossing the plateaus on the {@link ChaosContractStepsTable}
+ * when a term is lowered, and the caps on how much may be sacrificed. Kept free of any GUI so it can be reasoned about
+ * and tested in isolation; {@code ContractNegotiationDialog} delegates to it.
+ *
+ * <p>Lowering a term does not move one raw step - it drops straight to the next step whose value actually changes,
+ * counting every raw step crossed. Two global caps bound sacrifice across the whole negotiation: at most a set number
+ * of distinct terms, and at most a set number of raw steps in total over them.</p>
+ *
+ * @author Illiani
+ * @since 0.51.01
+ */
+public final class NegotiationStepMath {
+    private NegotiationStepMath() {
+    }
+
+    /** The five negotiable contract terms, each a column on the {@link ChaosContractStepsTable}. */
+    public enum Term {
+        BASE_PAY, SUPPORT, TRANSPORT, SALVAGE, COMMAND_RIGHTS
+    }
+
+    /**
+     * The book's raw value column for a term at a given step, used to detect plateaus (adjacent steps that share a
+     * value). Two composite terms carry two columns each: Support pairs its straight-support and battlefield-loss
+     * multipliers; Salvage pairs its exchange flag with its multiplier.
+     *
+     * @author Illiani
+     * @since 0.51.01
+     */
+    public static Object rawValue(Term term, ChaosContractStepsTable step) {
+        return switch (term) {
+            case COMMAND_RIGHTS -> step.getContractCommandRights();
+            case BASE_PAY -> step.getBasePayMultiplier();
+            case SUPPORT -> List.of(step.getStraightSupportMultiplier(), step.getBattlefieldLossMultiplier());
+            case TRANSPORT -> step.getTransportMultiplier();
+            case SALVAGE -> List.of(step.isExchangeSalvage(), step.getSalvageMultiplier());
+        };
+    }
+
+    /**
+     * The nearest step below {@code fromStep} whose value for this term differs from the value at {@code fromStep}, or
+     * {@code -1} when every lower step shares the same value (the term already sits at its lowest distinct value).
+     * Comparing the per-term column means plateaus - runs of steps that leave a term's value unchanged, such as Command
+     * Rights holding HOUSE across steps 4-7 - are crossed in a single move.
+     *
+     * @author Illiani
+     * @since 0.51.01
+     */
+    public static int nextLowerDifferentStep(Term term, int fromStep) {
+        Object currentValue = rawValue(term, ChaosContractStepsTable.fromStepValue(fromStep));
+        for (int step = fromStep - 1; step >= CHAOS_CONTRACT_MINIMUM_STEP_VALUE; step--) {
+            if (!Objects.equals(currentValue, rawValue(term, ChaosContractStepsTable.fromStepValue(step)))) {
+                return step;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * The step a sacrificed term rises to when a single raise undoes one lower: the sacrifice boundary directly above
+     * {@code currentStep} on the deterministic path lowered down from {@code originalStep}.
+     *
+     * <p>Lowering always lands on value boundaries (it skips whole plateaus), so the boundaries a term passes through
+     * as it is lowered from its baseline are fixed - {@code originalStep}, then {@code nextLowerDifferentStep} of that,
+     * and so on. Restoring walks that same path and returns the boundary just above where the term now sits, i.e. the
+     * exact step the most recent lower started from. One raise therefore mirrors one lower, refunding precisely that
+     * lower's banked steps. Crucially it never returns a mid-plateau step that shares the baseline's value: every step
+     * on the path below the baseline has a value distinct from the baseline's, so a restored term can never sit below
+     * its baseline while showing no concession yet still holding spendable bank.</p>
+     *
+     * <p>Returns {@code originalStep} when the term is not below its baseline.</p>
+     *
+     * @author Illiani
+     * @since 0.51.01
+     */
+    public static int restoreStep(Term term, int originalStep, int currentStep) {
+        int previous = originalStep;
+        int step = originalStep;
+        while (step > currentStep) {
+            previous = step;
+            step = nextLowerDifferentStep(term, step);
+            if (step < CHAOS_CONTRACT_MINIMUM_STEP_VALUE) {
+                break;
+            }
+        }
+        return previous;
+    }
+
+    /**
+     * Total raw steps currently sacrificed (lowered below baseline) summed over every term. The two arrays are parallel
+     * - same length, same term at each index - holding each term's baseline step and its current step.
+     *
+     * @author Illiani
+     * @since 0.51.01
+     */
+    public static int totalStepsSacrificed(int[] originalSteps, int[] currentSteps) {
+        int total = 0;
+        for (int i = 0; i < originalSteps.length; i++) {
+            total += Math.max(0, originalSteps[i] - currentSteps[i]);
+        }
+        return total;
+    }
+
+    /**
+     * How many distinct terms are currently sacrificed (sitting below their baseline).
+     *
+     * @author Illiani
+     * @since 0.51.01
+     */
+    public static int distinctTermsSacrificed(int[] originalSteps, int[] currentSteps) {
+        int count = 0;
+        for (int i = 0; i < originalSteps.length; i++) {
+            if (currentSteps[i] < originalSteps[i]) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /**
+     * Whether {@code gap} further raw steps may be sacrificed from a term, honoring both global caps.
+     *
+     * @param gap                     raw steps this move would sacrifice; a non-positive gap is never allowed
+     * @param termAlreadySacrificed   whether this term is already below its baseline (so it counts against the
+     *                                distinct-term cap already, and adding to it opens no new term)
+     * @param distinctTermsSacrificed how many distinct terms are already sacrificed
+     * @param totalStepsSacrificed    how many raw steps are already sacrificed in total
+     * @param maxTerms                the distinct-term cap
+     * @param maxSteps                the total-steps cap
+     *
+     * @author Illiani
+     * @since 0.51.01
+     */
+    public static boolean sacrificeAllowed(int gap, boolean termAlreadySacrificed, int distinctTermsSacrificed,
+          int totalStepsSacrificed, int maxTerms, int maxSteps) {
+        if (gap <= 0) {
+            return false;
+        }
+        if (!termAlreadySacrificed && distinctTermsSacrificed >= maxTerms) {
+            return false;
+        }
+        return totalStepsSacrificed + gap <= maxSteps;
+    }
+}

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractData/NegotiationStepMath.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractData/NegotiationStepMath.java
@@ -32,6 +32,7 @@
  */
 package mekhq.campaign.mission.contract.contractData;
 
+import static mekhq.campaign.mission.contract.contractData.ChaosContractStepsTable.CHAOS_CONTRACT_MAXIMUM_STEP_VALUE;
 import static mekhq.campaign.mission.contract.contractData.ChaosContractStepsTable.CHAOS_CONTRACT_MINIMUM_STEP_VALUE;
 
 import java.util.List;
@@ -88,6 +89,25 @@ public final class NegotiationStepMath {
     public static int nextLowerDifferentStep(Term term, int fromStep) {
         Object currentValue = rawValue(term, ChaosContractStepsTable.fromStepValue(fromStep));
         for (int step = fromStep - 1; step >= CHAOS_CONTRACT_MINIMUM_STEP_VALUE; step--) {
+            if (!Objects.equals(currentValue, rawValue(term, ChaosContractStepsTable.fromStepValue(step)))) {
+                return step;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * The nearest step above {@code fromStep} whose value for this term differs from the value at {@code fromStep}, or
+     * {@code -1} when every higher step shares the same value (the term already sits at its highest distinct value).
+     * The upward mirror of {@link #nextLowerDifferentStep}: it moves a term to the next better value in a single
+     * meaningful step, crossing any plateau in one move. Used by active negotiation to improve a term.
+     *
+     * @author Illiani
+     * @since 0.51.01
+     */
+    public static int nextHigherDifferentStep(Term term, int fromStep) {
+        Object currentValue = rawValue(term, ChaosContractStepsTable.fromStepValue(fromStep));
+        for (int step = fromStep + 1; step <= CHAOS_CONTRACT_MAXIMUM_STEP_VALUE; step++) {
             if (!Objects.equals(currentValue, rawValue(term, ChaosContractStepsTable.fromStepValue(step)))) {
                 return step;
             }

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractData/NonNegotiableTermsData.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractData/NonNegotiableTermsData.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.mission.contract.contractData;
+
+import mekhq.campaign.mission.contract.contractData.NegotiationStepMath.Term;
+
+/**
+ * Which of a contract's five terms the employer has locked as non-negotiable. A locked term is fixed at the value it
+ * was generated with: the player can neither improve it nor sacrifice it in the negotiation dialog. Locks are rolled
+ * once, at contract generation, and only bind the player's negotiation - generation sets them and a GM may still edit a
+ * locked term in the contract editor.
+ *
+ * @author Illiani
+ * @since 0.51.01
+ */
+public record NonNegotiableTermsData(boolean payLocked, boolean supportLocked, boolean transportLocked,
+      boolean salvageLocked, boolean commandLocked) {
+
+    /** A set of terms with nothing locked - the default when a contract carries no lock data (e.g. older saves). */
+    public static NonNegotiableTermsData none() {
+        return new NonNegotiableTermsData(false, false, false, false, false);
+    }
+
+    /** Whether the given term is locked. */
+    public boolean isLocked(Term term) {
+        return switch (term) {
+            case BASE_PAY -> payLocked;
+            case SUPPORT -> supportLocked;
+            case TRANSPORT -> transportLocked;
+            case SALVAGE -> salvageLocked;
+            case COMMAND_RIGHTS -> commandLocked;
+        };
+    }
+
+    /** Whether any term is locked. */
+    public boolean anyLocked() {
+        return payLocked || supportLocked || transportLocked || salvageLocked || commandLocked;
+    }
+}

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractData/NonNegotiableTermsData.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractData/NonNegotiableTermsData.java
@@ -66,4 +66,22 @@ public record NonNegotiableTermsData(boolean payLocked, boolean supportLocked, b
     public boolean anyLocked() {
         return payLocked || supportLocked || transportLocked || salvageLocked || commandLocked;
     }
+
+    /** A copy with the given term's lock cleared. */
+    public NonNegotiableTermsData withUnlocked(Term term) {
+        return new NonNegotiableTermsData(payLocked && term != Term.BASE_PAY,
+              supportLocked && term != Term.SUPPORT,
+              transportLocked && term != Term.TRANSPORT,
+              salvageLocked && term != Term.SALVAGE,
+              commandLocked && term != Term.COMMAND_RIGHTS);
+    }
+
+    /** A copy with the given term locked. */
+    public NonNegotiableTermsData withLocked(Term term) {
+        return new NonNegotiableTermsData(payLocked || term == Term.BASE_PAY,
+              supportLocked || term == Term.SUPPORT,
+              transportLocked || term == Term.TRANSPORT,
+              salvageLocked || term == Term.SALVAGE,
+              commandLocked || term == Term.COMMAND_RIGHTS);
+    }
 }

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/AbstractContractDeterminationPay.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/AbstractContractDeterminationPay.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.mission.contract.contractGeneration;
+
+import static java.lang.Math.round;
+
+import java.time.LocalDate;
+
+import mekhq.campaign.AbstractLocation;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.JumpPath;
+import mekhq.campaign.campaignOptions.CampaignOption;
+import mekhq.campaign.chaosCampaign.ChaosCampaignUtilities;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.mission.contract.AbstractContract;
+import mekhq.campaign.mission.contract.contractData.ContractFinanceData;
+import mekhq.campaign.mission.utilities.ContractUtilities;
+import mekhq.campaign.universe.PlanetarySystem;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Base class for the contract pay schemes: given a generated contract, each scheme decides how much the employer pays
+ * as a monthly retainer, a per-battle combat bonus, and up-front transport compensation.
+ *
+ * <p>Two schemes exist. The default {@link ChaosContractDeterminationPay} derives pay from the contract's abstract
+ * scale and support-point multipliers; {@link CamOpsContractDeterminationPay} grounds the monthly retainer in the
+ * Campaign Operations force-value calculation instead. A campaign opts into the CamOps scheme with
+ * {@link CampaignOption#USE_LEGACY_CONTRACT_PAY}; use {@link #forCampaign(Campaign)} to obtain the scheme it has
+ * chosen.</p>
+ *
+ * <p>Both schemes share the transport-pay calculation, so it lives here rather than in either subclass.</p>
+ *
+ * @see ChaosContractDeterminationPay
+ * @see CamOpsContractDeterminationPay
+ */
+public abstract class AbstractContractDeterminationPay {
+    public final static int DEFAULT_TRANSPORT_COST_MULTIPLIER = 50; // Draconis Reach first printing pg 26
+    public final static int HIRING_HALL_RETURN_MULTIPLIER = 2; // Draconis Reach first printing pg 26
+
+    /**
+     * Returns the pay scheme the campaign has opted into: the CamOps force-value scheme when
+     * {@link CampaignOption#USE_LEGACY_CONTRACT_PAY} is set, otherwise the default Chaos scheme.
+     */
+    public static @NonNull AbstractContractDeterminationPay forCampaign(Campaign campaign) {
+        if (campaign.getCampaignOptions().get(CampaignOption.USE_LEGACY_CONTRACT_PAY)) {
+            return new CamOpsContractDeterminationPay();
+        }
+        return new ChaosContractDeterminationPay();
+    }
+
+    /**
+     * Populates the contract's {@link ContractFinanceData} from this scheme's three pay components: the monthly
+     * retainer, the per-battle combat bonus, and up-front transport compensation.
+     */
+    public void determineContractPay(Campaign campaign, LocalDate currentDate, AbstractContract contract,
+          AbstractLocation currentLocation) {
+        Money monthlyPay = getMonthlyPay(campaign, contract);
+        Money combatPay = getCombatPay(campaign, contract);
+        Money transportPay = getTransportPay(campaign, currentDate, contract, currentLocation);
+
+        ContractFinanceData contractFinanceData = new ContractFinanceData(transportPay, monthlyPay, combatPay);
+        contract.setContractFinanceData(contractFinanceData);
+    }
+
+    /** The monthly retainer the employer pays. */
+    public abstract @NonNull Money getMonthlyPay(Campaign campaign, AbstractContract contract);
+
+    /** The per-battle combat bonus the employer pays; some schemes fold this into the monthly retainer and return zero. */
+    public abstract @NonNull Money getCombatPay(Campaign campaign, AbstractContract contract);
+
+    /**
+     * Up-front transport compensation for the journey from the player's current location to the contract's target,
+     * derived from the contract's scale, transport terms, and jump count. Shared by every pay scheme.
+     */
+    public @NonNull Money getTransportPay(Campaign campaign, LocalDate currentDate, AbstractContract contract,
+          AbstractLocation currentLocation) {
+        PlanetarySystem currentSystem = currentLocation.getCurrentSystem();
+
+        JumpPath cachedJumpPath = ContractUtilities.getJumpPath(campaign, contract, currentLocation);
+        int jumpCount = cachedJumpPath == null ? 0 : cachedJumpPath.getJumps();
+
+        if (jumpCount == 0) {
+            return Money.zero();
+        }
+
+        int transportCostInSupportPoints = DEFAULT_TRANSPORT_COST_MULTIPLIER * contract.getScale();
+        transportCostInSupportPoints *= jumpCount;
+
+        // Two-way pay for hiring halls: when the player sets out from a hiring hall, the employer covers the return
+        // journey too, doubling transport pay. Only applied when the campaign opts into it.
+        boolean isAtHiringHall = currentSystem.isHiringHall(currentDate);
+        boolean useTwoWayPayForHiringHalls = campaign.getCampaignOptions().get(CampaignOption.IS_USE_TWO_WAY_PAY);
+        if (isAtHiringHall && useTwoWayPayForHiringHalls) {
+            transportCostInSupportPoints *= HIRING_HALL_RETURN_MULTIPLIER;
+        }
+
+        transportCostInSupportPoints = (int) round(transportCostInSupportPoints * contract.getTransportMultiplier());
+        return ChaosCampaignUtilities.getMoneyFromChaosSupportPoints(transportCostInSupportPoints,
+              shouldConvertSupportPoints(campaign));
+    }
+
+    /**
+     * Whether Chaos support-point pay should be converted to C-bills (the "BSP to BV" conversion). Enabled by default;
+     * when disabled, pay is expressed in raw support points.
+     */
+    protected static boolean shouldConvertSupportPoints(Campaign campaign) {
+        return campaign.getCampaignOptions().get(CampaignOption.USE_CHAOS_SUPPORT_POINT_CONVERSION);
+    }
+}

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/AbstractContractGeneration.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/AbstractContractGeneration.java
@@ -203,13 +203,8 @@ public class AbstractContractGeneration {
         contract.setStratConCampaignState(stratConCampaignState);
 
         // Pay - the default Chaos Campaign scheme, or the CamOps force-value scheme when the campaign opts into it.
-        if (campaign.getCampaignOptions().get(CampaignOption.USE_LEGACY_CONTRACT_PAY)) {
-            CamOpsContractDeterminationPay.determineContractPayForCamOpsContract(campaign, currentDate, contract,
-                  currentLocation);
-        } else {
-            ChaosContractDeterminationPay.determineContractPayForChaosContract(campaign, currentDate, contract,
-                  currentLocation);
-        }
+        AbstractContractDeterminationPay.forCampaign(campaign)
+              .determineContractPay(campaign, currentDate, contract, currentLocation);
 
         // Intel Obfuscation - optionally hide some market-offer intel from the player.
         applyIntelObfuscation(campaign, contract);
@@ -324,10 +319,7 @@ public class AbstractContractGeneration {
      * when {@link CampaignOption#USE_LEGACY_CONTRACT_PAY} is set, otherwise the Chaos scale-and-base-pay scheme.
      */
     public static Money determineMonthlyPay(Campaign campaign, AbstractContract contract) {
-        if (campaign.getCampaignOptions().get(CampaignOption.USE_LEGACY_CONTRACT_PAY)) {
-            return CamOpsContractDeterminationPay.getMonthlyPay(campaign, contract);
-        }
-        return ChaosContractDeterminationPay.getMonthlyPay(campaign, contract);
+        return AbstractContractDeterminationPay.forCampaign(campaign).getMonthlyPay(campaign, contract);
     }
 
     /**
@@ -336,10 +328,7 @@ public class AbstractContractGeneration {
      * bonus derived from scale.
      */
     public static Money determineCombatPay(Campaign campaign, AbstractContract contract) {
-        if (campaign.getCampaignOptions().get(CampaignOption.USE_LEGACY_CONTRACT_PAY)) {
-            return CamOpsContractDeterminationPay.getCombatPay();
-        }
-        return ChaosContractDeterminationPay.getCombatPay(campaign, contract);
+        return AbstractContractDeterminationPay.forCampaign(campaign).getCombatPay(campaign, contract);
     }
 
     /**
@@ -347,7 +336,8 @@ public class AbstractContractGeneration {
      * to the target from the player's current location).
      */
     public static Money determineTransportPay(Campaign campaign, AbstractContract contract) {
-        return ChaosContractDeterminationPay.getTransportPay(campaign, campaign.getLocalDate(), contract,
+        return AbstractContractDeterminationPay.forCampaign(campaign).getTransportPay(campaign,
+              campaign.getLocalDate(), contract,
               campaign.getPlayerForce().getForceDetachment().getCurrentLocation());
     }
 

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/AbstractContractGeneration.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/AbstractContractGeneration.java
@@ -204,10 +204,10 @@ public class AbstractContractGeneration {
 
         // Pay - the default Chaos Campaign scheme, or the CamOps force-value scheme when the campaign opts into it.
         if (campaign.getCampaignOptions().get(CampaignOption.USE_LEGACY_CONTRACT_PAY)) {
-            CamOpsContractPayDetermination.determineContractPayForCamOpsContract(campaign, currentDate, contract,
+            CamOpsContractDeterminationPay.determineContractPayForCamOpsContract(campaign, currentDate, contract,
                   currentLocation);
         } else {
-            ChaosContractPayDetermination.determineContractPayForChaosContract(campaign, currentDate, contract,
+            ChaosContractDeterminationPay.determineContractPayForChaosContract(campaign, currentDate, contract,
                   currentLocation);
         }
 
@@ -276,7 +276,8 @@ public class AbstractContractGeneration {
      * @return the automatically determined track count
      */
     public static int determineTrackCount(AbstractContract contract) {
-        return ChaosContractDetermineIntensity.determineTrackCount(contract.getObjectiveType().getChaosObjectiveType());
+        return ChaosContractDeterminationIntensity.determineTrackCount(contract.getObjectiveType()
+                                                                               .getChaosObjectiveType());
     }
 
     /**
@@ -324,9 +325,9 @@ public class AbstractContractGeneration {
      */
     public static Money determineMonthlyPay(Campaign campaign, AbstractContract contract) {
         if (campaign.getCampaignOptions().get(CampaignOption.USE_LEGACY_CONTRACT_PAY)) {
-            return CamOpsContractPayDetermination.getMonthlyPay(campaign, contract);
+            return CamOpsContractDeterminationPay.getMonthlyPay(campaign, contract);
         }
-        return ChaosContractPayDetermination.getMonthlyPay(campaign, contract);
+        return ChaosContractDeterminationPay.getMonthlyPay(campaign, contract);
     }
 
     /**
@@ -336,9 +337,9 @@ public class AbstractContractGeneration {
      */
     public static Money determineCombatPay(Campaign campaign, AbstractContract contract) {
         if (campaign.getCampaignOptions().get(CampaignOption.USE_LEGACY_CONTRACT_PAY)) {
-            return CamOpsContractPayDetermination.getCombatPay();
+            return CamOpsContractDeterminationPay.getCombatPay();
         }
-        return ChaosContractPayDetermination.getCombatPay(campaign, contract);
+        return ChaosContractDeterminationPay.getCombatPay(campaign, contract);
     }
 
     /**
@@ -346,7 +347,7 @@ public class AbstractContractGeneration {
      * to the target from the player's current location).
      */
     public static Money determineTransportPay(Campaign campaign, AbstractContract contract) {
-        return ChaosContractPayDetermination.getTransportPay(campaign, campaign.getLocalDate(), contract,
+        return ChaosContractDeterminationPay.getTransportPay(campaign, campaign.getLocalDate(), contract,
               campaign.getPlayerForce().getForceDetachment().getCurrentLocation());
     }
 
@@ -478,7 +479,7 @@ public class AbstractContractGeneration {
 
     private static void setContractTerms(ChaosObjectiveType objectiveType, ChaosEmployerType employerType,
           Faction employerFaction, boolean useFactionModifiers, ChaosContract contract) {
-        ContractTermsData initialContractTerms = ChaosContractDetermineTerms.determineInitialTerms(objectiveType,
+        ContractTermsData initialContractTerms = ChaosContractDeterminationTerms.determineInitialTerms(objectiveType,
               employerType, employerFaction, useFactionModifiers);
         contract.setContractTerms(initialContractTerms);
     }
@@ -565,7 +566,7 @@ public class AbstractContractGeneration {
 
     private static @Nonnull ContractObjectiveData pickObjective(int contractGenerationModifier,
           ChaosContract contract) {
-        ContractObjectiveData objectiveData = ChaosContractObjectiveDetermination.determineContractObjectiveType(
+        ContractObjectiveData objectiveData = ChaosContractDeterminationObjective.determineContractObjectiveType(
               contractGenerationModifier);
         contract.setObjectiveData(objectiveData);
         return objectiveData;
@@ -573,7 +574,7 @@ public class AbstractContractGeneration {
 
     private static @Nullable EmployerData pickEmployer(Campaign campaign, LocalDate currentDate,
           ILocation currentLocation, ContractSearchType searchType, ChaosContract contract) {
-        EmployerData employerData = ChaosContractEmployerDetermination.getEmployerGenerationData(currentDate,
+        EmployerData employerData = ChaosContractDeterminationEmployer.getEmployerGenerationData(currentDate,
               currentLocation,
               campaign,
               searchType);

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/AbstractContractGeneration.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/AbstractContractGeneration.java
@@ -62,6 +62,7 @@ import mekhq.campaign.mission.contract.contractData.ContractScheduleData;
 import mekhq.campaign.mission.contract.contractData.ContractTermsData;
 import mekhq.campaign.mission.contract.contractData.EmployerData;
 import mekhq.campaign.mission.contract.contractData.EnemyData;
+import mekhq.campaign.mission.contract.contractData.NonNegotiableTermsData;
 import mekhq.campaign.mission.contract.contractData.ObfuscatableIntel;
 import mekhq.campaign.mission.contract.contractData.RentedFacilitiesData;
 import mekhq.campaign.mission.contract.contractData.SystemsTargetData;
@@ -85,6 +86,8 @@ public class AbstractContractGeneration {
 
     /** Auto intel obfuscation hides each obfuscatable field with a 1-in-this chance (so ~1 field hidden on average). */
     private static final int INTEL_OBFUSCATION_ODDS = 4;
+    /** Each contract term independently has a 1-in-this chance of being locked as non-negotiable at generation. */
+    private static final int NON_NEGOTIABLE_TERM_ODDS = 4;
 
     public static @Nullable AbstractContract createContract(Campaign campaign, CampaignOptions campaignOptions,
           LocalDate currentDate, Detachment detachment, int contractGenerationModifier, ContractSearchType searchType,
@@ -163,6 +166,9 @@ public class AbstractContractGeneration {
         boolean useFactionModifiers = campaignOptions.get(CampaignOption.USE_CONTRACT_FACTION_MODIFIERS);
         setContractTerms(chaosObjectiveType, employerData.type(), employerData.getFaction(), useFactionModifiers,
               contract);
+        if (campaignOptions.get(CampaignOption.USE_NON_NEGOTIABLE_TERMS)) {
+            lockNonNegotiableTerms(contract);
+        }
 
         // Step 9: Final Tasks
         performFinalTasks(campaign, currentDate, contract, currentLocation);
@@ -472,6 +478,20 @@ public class AbstractContractGeneration {
         ContractTermsData initialContractTerms = ChaosContractDeterminationTerms.determineInitialTerms(objectiveType,
               employerType, employerFaction, useFactionModifiers);
         contract.setContractTerms(initialContractTerms);
+    }
+
+    /**
+     * Rolls, independently for each of the five terms, a 1-in-4 chance that the employer locks it as non-negotiable.
+     * Locked terms are fixed at their generated value: the player can neither improve nor sacrifice them in the
+     * negotiation dialog.
+     */
+    private static void lockNonNegotiableTerms(ChaosContract contract) {
+        contract.setNonNegotiableTermsData(new NonNegotiableTermsData(rollNonNegotiable(), rollNonNegotiable(),
+              rollNonNegotiable(), rollNonNegotiable(), rollNonNegotiable()));
+    }
+
+    private static boolean rollNonNegotiable() {
+        return Compute.randomInt(NON_NEGOTIABLE_TERM_ODDS) == 0;
     }
 
     private static void determineSchedule(Campaign campaign, boolean useVariableContractLength, LocalDate currentDate,

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/CamOpsContractDeterminationPay.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/CamOpsContractDeterminationPay.java
@@ -32,9 +32,6 @@
  */
 package mekhq.campaign.mission.contract.contractGeneration;
 
-import java.time.LocalDate;
-
-import mekhq.campaign.AbstractLocation;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.mission.contract.AbstractContract;
@@ -57,35 +54,27 @@ import org.jspecify.annotations.NonNull;
  *     negotiation terms still matter under CamOps.</li>
  *     <li><b>Combat pay</b> &mdash; zero; CamOps folds combat compensation into the monthly retainer rather than a
  *     separate battle bonus.</li>
- *     <li><b>Transport pay</b> &mdash; reuses the Chaos transport calculation (scale, transport terms, and the journey
- *     to the target), which already applies the negotiated transport multiplier.</li>
+ *     <li><b>Transport pay</b> &mdash; inherited from {@link AbstractContractDeterminationPay} (scale, transport terms,
+ *     and the journey to the target), which already applies the negotiated transport multiplier.</li>
  * </ul>
  *
+ * @see AbstractContractDeterminationPay
  * @see ChaosContractDeterminationPay
  */
-public class CamOpsContractDeterminationPay {
-    public static void determineContractPayForCamOpsContract(Campaign campaign, LocalDate currentDate,
-          AbstractContract contract, AbstractLocation currentLocation) {
-        Money monthlyPay = getMonthlyPay(campaign, contract);
-        Money combatPay = getCombatPay();
-        Money transportPay = ChaosContractDeterminationPay.getTransportPay(campaign, currentDate, contract,
-              currentLocation);
-
-        ContractFinanceData contractFinanceData = new ContractFinanceData(transportPay, monthlyPay, combatPay);
-        contract.setContractFinanceData(contractFinanceData);
-    }
-
+public class CamOpsContractDeterminationPay extends AbstractContractDeterminationPay {
     /**
      * The CamOps monthly retainer: the campaign's CamOps contract-base force value, scaled by the contract's negotiated
      * base-pay multiplier.
      */
-    public static @NonNull Money getMonthlyPay(Campaign campaign, AbstractContract contract) {
+    @Override
+    public @NonNull Money getMonthlyPay(Campaign campaign, AbstractContract contract) {
         Money base = campaign.getAccountant().getContractBase();
         return base.multipliedBy(contract.getBasePayMultiplier());
     }
 
     /** CamOps folds combat compensation into the monthly retainer, so there is no separate combat bonus. */
-    public static @NonNull Money getCombatPay() {
+    @Override
+    public @NonNull Money getCombatPay(Campaign campaign, AbstractContract contract) {
         return Money.zero();
     }
 }

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/CamOpsContractDeterminationPay.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/CamOpsContractDeterminationPay.java
@@ -43,7 +43,7 @@ import org.jspecify.annotations.NonNull;
 
 /**
  * Determines contract pay the Campaign Operations (CamOps) way, as an alternative to the default Chaos Campaign scheme
- * in {@link ChaosContractPayDetermination}.
+ * in {@link ChaosContractDeterminationPay}.
  *
  * <p>Where the Chaos scheme derives pay from the contract's abstract scale and support-point multipliers, the CamOps
  * scheme grounds the monthly retainer in the force-value calculation configured on the Contract Market campaign options
@@ -61,14 +61,14 @@ import org.jspecify.annotations.NonNull;
  *     to the target), which already applies the negotiated transport multiplier.</li>
  * </ul>
  *
- * @see ChaosContractPayDetermination
+ * @see ChaosContractDeterminationPay
  */
-public class CamOpsContractPayDetermination {
+public class CamOpsContractDeterminationPay {
     public static void determineContractPayForCamOpsContract(Campaign campaign, LocalDate currentDate,
           AbstractContract contract, AbstractLocation currentLocation) {
         Money monthlyPay = getMonthlyPay(campaign, contract);
         Money combatPay = getCombatPay();
-        Money transportPay = ChaosContractPayDetermination.getTransportPay(campaign, currentDate, contract,
+        Money transportPay = ChaosContractDeterminationPay.getTransportPay(campaign, currentDate, contract,
               currentLocation);
 
         ContractFinanceData contractFinanceData = new ContractFinanceData(transportPay, monthlyPay, combatPay);

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationEmployer.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationEmployer.java
@@ -63,8 +63,8 @@ import mekhq.campaign.universe.RandomFactionGenerator;
 import mekhq.campaign.universe.enums.HiringHallLevel;
 import org.jspecify.annotations.NonNull;
 
-public class ChaosContractEmployerDetermination {
-    private static final MMLogger LOGGER = MMLogger.create(ChaosContractEmployerDetermination.class);
+public class ChaosContractDeterminationEmployer {
+    private static final MMLogger LOGGER = MMLogger.create(ChaosContractDeterminationEmployer.class);
 
     private static final int COMSTAR_EMPLOYER_CHANCE = 100;
     private static final int WORD_OF_BLAKE_EMPLOYER_CHANCE = 40;

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationIntensity.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationIntensity.java
@@ -34,7 +34,7 @@ package mekhq.campaign.mission.contract.contractGeneration;
 
 import static megamek.common.compute.Compute.d6;
 
-public class ChaosContractDetermineIntensity {
+public class ChaosContractDeterminationIntensity {
     public static int determineTrackCount(ChaosObjectiveType objectiveType) {
         int roll = d6(2);
 

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationObjective.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationObjective.java
@@ -39,7 +39,7 @@ import mekhq.campaign.mission.contract.contractData.ContractObjectiveData;
 import mekhq.campaign.mission.contract.contractData.ContractObjectiveType;
 import org.jspecify.annotations.NonNull;
 
-public class ChaosContractObjectiveDetermination {
+public class ChaosContractDeterminationObjective {
     public static ContractObjectiveData determineContractObjectiveType(int contractGenerationModifier) {
         int roll = d6(2);
         int result = clamp(roll + contractGenerationModifier, 1, 13);

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationPay.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationPay.java
@@ -48,7 +48,7 @@ import mekhq.campaign.mission.utilities.ContractUtilities;
 import mekhq.campaign.universe.PlanetarySystem;
 import org.jspecify.annotations.NonNull;
 
-public class ChaosContractPayDetermination {
+public class ChaosContractDeterminationPay {
     public final static int DEFAULT_MONTHLY_PAY_MULTIPLIER = 500; // Draconis Reach first printing pg 26
     public final static int DEFAULT_COMBAT_PAY_MULTIPLIER = 500; // Draconis Reach first printing pg 26
     public final static int DEFAULT_TRANSPORT_COST_MULTIPLIER = 50; // Draconis Reach first printing pg 26

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationPay.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationPay.java
@@ -34,82 +34,36 @@ package mekhq.campaign.mission.contract.contractGeneration;
 
 import static java.lang.Math.round;
 
-import java.time.LocalDate;
-
-import mekhq.campaign.AbstractLocation;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.JumpPath;
-import mekhq.campaign.campaignOptions.CampaignOption;
 import mekhq.campaign.chaosCampaign.ChaosCampaignUtilities;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.mission.contract.AbstractContract;
-import mekhq.campaign.mission.contract.contractData.ContractFinanceData;
-import mekhq.campaign.mission.utilities.ContractUtilities;
-import mekhq.campaign.universe.PlanetarySystem;
 import org.jspecify.annotations.NonNull;
 
-public class ChaosContractDeterminationPay {
+/**
+ * The default Chaos Campaign pay scheme: monthly and combat pay are derived from the contract's abstract scale and
+ * fixed support-point multipliers, then optionally converted to C-bills. Transport pay is inherited unchanged from
+ * {@link AbstractContractDeterminationPay}.
+ *
+ * @see AbstractContractDeterminationPay
+ * @see CamOpsContractDeterminationPay
+ */
+public class ChaosContractDeterminationPay extends AbstractContractDeterminationPay {
     public final static int DEFAULT_MONTHLY_PAY_MULTIPLIER = 500; // Draconis Reach first printing pg 26
     public final static int DEFAULT_COMBAT_PAY_MULTIPLIER = 500; // Draconis Reach first printing pg 26
-    public final static int DEFAULT_TRANSPORT_COST_MULTIPLIER = 50; // Draconis Reach first printing pg 26
-    public final static int HIRING_HALL_RETURN_MULTIPLIER = 2; // Draconis Reach first printing pg 26
 
-    public static void determineContractPayForChaosContract(Campaign campaign, LocalDate currentDate,
-          AbstractContract contract,
-          AbstractLocation currentLocation) {
-        Money monthlyPay = getMonthlyPay(campaign, contract);
-        Money combatPay = getCombatPay(campaign, contract);
-        Money transportPay = getTransportPay(campaign, currentDate, contract, currentLocation);
-
-        ContractFinanceData contractFinanceData = new ContractFinanceData(transportPay, monthlyPay, combatPay);
-        contract.setContractFinanceData(contractFinanceData);
-    }
-
-    public static @NonNull Money getTransportPay(Campaign campaign, LocalDate currentDate, AbstractContract contract,
-          AbstractLocation currentLocation) {
-        PlanetarySystem currentSystem = currentLocation.getCurrentSystem();
-
-        JumpPath cachedJumpPath = ContractUtilities.getJumpPath(campaign, contract, currentLocation);
-        int jumpCount = cachedJumpPath == null ? 0 : cachedJumpPath.getJumps();
-
-        if (jumpCount == 0) {
-            return Money.zero();
-        }
-
-        int transportCostInSupportPoints = DEFAULT_TRANSPORT_COST_MULTIPLIER * contract.getScale();
-        transportCostInSupportPoints *= jumpCount;
-
-        // Two-way pay for hiring halls: when the player sets out from a hiring hall, the employer covers the return
-        // journey too, doubling transport pay. Only applied when the campaign opts into it.
-        boolean isAtHiringHall = currentSystem.isHiringHall(currentDate);
-        boolean useTwoWayPayForHiringHalls = campaign.getCampaignOptions().get(CampaignOption.IS_USE_TWO_WAY_PAY);
-        if (isAtHiringHall && useTwoWayPayForHiringHalls) {
-            transportCostInSupportPoints *= HIRING_HALL_RETURN_MULTIPLIER;
-        }
-
-        transportCostInSupportPoints = (int) round(transportCostInSupportPoints * contract.getTransportMultiplier());
-        return ChaosCampaignUtilities.getMoneyFromChaosSupportPoints(transportCostInSupportPoints,
-              shouldConvertSupportPoints(campaign));
-    }
-
-    public static @NonNull Money getCombatPay(Campaign campaign, AbstractContract contract) {
+    @Override
+    public @NonNull Money getCombatPay(Campaign campaign, AbstractContract contract) {
         int combatPayInSupportPoints = DEFAULT_COMBAT_PAY_MULTIPLIER * contract.getScale();
         return ChaosCampaignUtilities.getMoneyFromChaosSupportPoints(combatPayInSupportPoints,
               shouldConvertSupportPoints(campaign));
     }
 
-    public static @NonNull Money getMonthlyPay(Campaign campaign, AbstractContract contract) {
+    @Override
+    public @NonNull Money getMonthlyPay(Campaign campaign, AbstractContract contract) {
         int monthlyPayInSupportPoints = DEFAULT_MONTHLY_PAY_MULTIPLIER * contract.getScale();
         monthlyPayInSupportPoints = (int) round(monthlyPayInSupportPoints * contract.getBasePayMultiplier());
         return ChaosCampaignUtilities.getMoneyFromChaosSupportPoints(monthlyPayInSupportPoints,
               shouldConvertSupportPoints(campaign));
-    }
-
-    /**
-     * Whether Chaos support-point pay should be converted to C-bills (the "BSP to BV" conversion). Enabled by default;
-     * when disabled, pay is expressed in raw support points.
-     */
-    private static boolean shouldConvertSupportPoints(Campaign campaign) {
-        return campaign.getCampaignOptions().get(CampaignOption.USE_CHAOS_SUPPORT_POINT_CONVERSION);
     }
 }

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationTerms.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationTerms.java
@@ -39,7 +39,7 @@ import mekhq.campaign.mission.contract.contractData.ChaosContractStepsTable;
 import mekhq.campaign.mission.contract.contractData.ContractTermsData;
 import mekhq.campaign.universe.Faction;
 
-public class ChaosContractDetermineTerms {
+public class ChaosContractDeterminationTerms {
     public static ContractTermsData determineInitialTerms(ChaosObjectiveType objectiveType,
           ChaosEmployerType employerType, @Nullable Faction employerFaction, boolean useFactionModifiers) {
         int factionPayDelta = useFactionModifiers ? getFactionPayRateModifier(employerFaction) : 0;

--- a/MekHQ/src/mekhq/campaign/mission/contract/io/ContractXmlCodec.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/io/ContractXmlCodec.java
@@ -143,6 +143,8 @@ public final class ContractXmlCodec {
         writeRentedFacilitiesData(printWriter, indent, contract.getRentedFacilitiesData());
 
         writeNonNegotiableTermsData(printWriter, indent, contract.getNonNegotiableTermsData());
+
+        writeActiveNegotiationData(printWriter, indent, contract.getActiveNegotiationData());
         writeMoraleData(printWriter, indent, contract.getMoraleData());
         writeNegotiationData(printWriter, indent, contract.getNegotiationData());
 
@@ -291,6 +293,22 @@ public final class ContractXmlCodec {
         MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "nonNegotiableTermsData");
     }
 
+    private static void writeActiveNegotiationData(final PrintWriter pw, int indent,
+          final @Nullable ActiveNegotiationData data) {
+        if (data == null) {
+            return;
+        }
+        MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "activeNegotiationData");
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "kind", data.kind().name());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "netMargin", data.netMargin());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "payDelta", data.payDelta());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "supportDelta", data.supportDelta());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "transportDelta", data.transportDelta());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "salvageDelta", data.salvageDelta());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "commandDelta", data.commandDelta());
+        MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "activeNegotiationData");
+    }
+
     private static void writeMoraleData(final PrintWriter pw, int indent, final @Nullable MoraleData data) {
         if (data == null) {
             return;
@@ -427,6 +445,10 @@ public final class ContractXmlCodec {
         readers.put("nonNegotiableTermsData",
               (contract, node, campaign, version) -> contract.setNonNegotiableTermsData(
                     parseNonNegotiableTermsData(node)));
+
+        readers.put("activeNegotiationData",
+              (contract, node, campaign, version) -> contract.setActiveNegotiationData(
+                    parseActiveNegotiationData(node)));
         readers.put("moraleData", (contract, node, campaign, version) -> contract.setMoraleData(parseMoraleData(node)));
         readers.put("negotiationData",
               (contract, node, campaign, version) -> contract.setNegotiationData(parseNegotiationData(node)));
@@ -829,6 +851,39 @@ public final class ContractXmlCodec {
               NON_NEGOTIABLE_TERMS_BINDERS, null, null, "nonNegotiableTermsData");
         return new NonNegotiableTermsData(builder.payLocked, builder.supportLocked, builder.transportLocked,
               builder.salvageLocked, builder.commandLocked);
+    }
+
+    private static final class ActiveNegotiationBuilder {
+        ActiveNegotiationData.Kind kind = ActiveNegotiationData.Kind.HAGGLE;
+        int netMargin;
+        int payDelta;
+        int supportDelta;
+        int transportDelta;
+        int salvageDelta;
+        int commandDelta;
+    }
+
+    private static final Map<String, FieldBinder<ActiveNegotiationBuilder>> ACTIVE_NEGOTIATION_BINDERS =
+          createActiveNegotiationBinders();
+
+    private static Map<String, FieldBinder<ActiveNegotiationBuilder>> createActiveNegotiationBinders() {
+        final Map<String, FieldBinder<ActiveNegotiationBuilder>> binders = new HashMap<>();
+        binders.put("kind",
+              (builder, node, campaign, version) -> builder.kind = ActiveNegotiationData.Kind.valueOf(text(node)));
+        binders.put("netMargin", (builder, node, campaign, version) -> builder.netMargin = parseInt(node));
+        binders.put("payDelta", (builder, node, campaign, version) -> builder.payDelta = parseInt(node));
+        binders.put("supportDelta", (builder, node, campaign, version) -> builder.supportDelta = parseInt(node));
+        binders.put("transportDelta", (builder, node, campaign, version) -> builder.transportDelta = parseInt(node));
+        binders.put("salvageDelta", (builder, node, campaign, version) -> builder.salvageDelta = parseInt(node));
+        binders.put("commandDelta", (builder, node, campaign, version) -> builder.commandDelta = parseInt(node));
+        return binders;
+    }
+
+    private static ActiveNegotiationData parseActiveNegotiationData(final Node wn) {
+        final ActiveNegotiationBuilder builder = readFields(wn, new ActiveNegotiationBuilder(),
+              ACTIVE_NEGOTIATION_BINDERS, null, null, "activeNegotiationData");
+        return new ActiveNegotiationData(builder.kind, builder.netMargin, builder.payDelta, builder.supportDelta,
+              builder.transportDelta, builder.salvageDelta, builder.commandDelta);
     }
 
     private static final class MoraleDataBuilder {

--- a/MekHQ/src/mekhq/campaign/mission/contract/io/ContractXmlCodec.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/io/ContractXmlCodec.java
@@ -141,6 +141,8 @@ public final class ContractXmlCodec {
         writeScheduleData(printWriter, indent, contract.getScheduleData());
         writeSystemsTargetData(printWriter, indent, contract.getSystemsTargetData());
         writeRentedFacilitiesData(printWriter, indent, contract.getRentedFacilitiesData());
+
+        writeNonNegotiableTermsData(printWriter, indent, contract.getNonNegotiableTermsData());
         writeMoraleData(printWriter, indent, contract.getMoraleData());
         writeNegotiationData(printWriter, indent, contract.getNegotiationData());
 
@@ -275,6 +277,20 @@ public final class ContractXmlCodec {
         MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "rentedFacilitiesData");
     }
 
+    private static void writeNonNegotiableTermsData(final PrintWriter pw, int indent,
+          final @Nullable NonNegotiableTermsData data) {
+        if (data == null || !data.anyLocked()) {
+            return;
+        }
+        MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "nonNegotiableTermsData");
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "payLocked", data.payLocked());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "supportLocked", data.supportLocked());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "transportLocked", data.transportLocked());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "salvageLocked", data.salvageLocked());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "commandLocked", data.commandLocked());
+        MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "nonNegotiableTermsData");
+    }
+
     private static void writeMoraleData(final PrintWriter pw, int indent, final @Nullable MoraleData data) {
         if (data == null) {
             return;
@@ -407,6 +423,10 @@ public final class ContractXmlCodec {
               (contract, node, campaign, version) -> contract.setSystemsTargetData(parseSystemsTargetData(node)));
         readers.put("rentedFacilitiesData",
               (contract, node, campaign, version) -> contract.setRentedFacilitiesData(parseRentedFacilitiesData(node)));
+
+        readers.put("nonNegotiableTermsData",
+              (contract, node, campaign, version) -> contract.setNonNegotiableTermsData(
+                    parseNonNegotiableTermsData(node)));
         readers.put("moraleData", (contract, node, campaign, version) -> contract.setMoraleData(parseMoraleData(node)));
         readers.put("negotiationData",
               (contract, node, campaign, version) -> contract.setNegotiationData(parseNegotiationData(node)));
@@ -776,6 +796,39 @@ public final class ContractXmlCodec {
         final RentedFacilitiesBuilder builder = readFields(wn, new RentedFacilitiesBuilder(),
               RENTED_FACILITIES_BINDERS, null, null, "rentedFacilitiesData");
         return new RentedFacilitiesData(builder.hospitalBeds, builder.kitchens, builder.holdingCells);
+    }
+
+    private static final class NonNegotiableTermsBuilder {
+        boolean payLocked;
+        boolean supportLocked;
+        boolean transportLocked;
+        boolean salvageLocked;
+        boolean commandLocked;
+    }
+
+    private static final Map<String, FieldBinder<NonNegotiableTermsBuilder>> NON_NEGOTIABLE_TERMS_BINDERS =
+          createNonNegotiableTermsBinders();
+
+    private static Map<String, FieldBinder<NonNegotiableTermsBuilder>> createNonNegotiableTermsBinders() {
+        final Map<String, FieldBinder<NonNegotiableTermsBuilder>> binders = new HashMap<>();
+        binders.put("payLocked",
+              (builder, node, campaign, version) -> builder.payLocked = Boolean.parseBoolean(text(node)));
+        binders.put("supportLocked",
+              (builder, node, campaign, version) -> builder.supportLocked = Boolean.parseBoolean(text(node)));
+        binders.put("transportLocked",
+              (builder, node, campaign, version) -> builder.transportLocked = Boolean.parseBoolean(text(node)));
+        binders.put("salvageLocked",
+              (builder, node, campaign, version) -> builder.salvageLocked = Boolean.parseBoolean(text(node)));
+        binders.put("commandLocked",
+              (builder, node, campaign, version) -> builder.commandLocked = Boolean.parseBoolean(text(node)));
+        return binders;
+    }
+
+    private static NonNegotiableTermsData parseNonNegotiableTermsData(final Node wn) {
+        final NonNegotiableTermsBuilder builder = readFields(wn, new NonNegotiableTermsBuilder(),
+              NON_NEGOTIABLE_TERMS_BINDERS, null, null, "nonNegotiableTermsData");
+        return new NonNegotiableTermsData(builder.payLocked, builder.supportLocked, builder.transportLocked,
+              builder.salvageLocked, builder.commandLocked);
     }
 
     private static final class MoraleDataBuilder {

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/ContractMarketPage.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/ContractMarketPage.java
@@ -111,6 +111,7 @@ class ContractMarketPage {
     private JCheckBox chkUseContractFactionModifiers;
     private JCheckBox chkUseIntelObfuscation;
     private JCheckBox chkUseNonNegotiableTerms;
+    private JCheckBox chkUseActiveNegotiators;
     private JLabel lblDropShipBonusPercentage;
     private JSpinner spnDropShipBonusPercentage;
     private JLabel lblPityContracts;
@@ -269,6 +270,10 @@ class ContractMarketPage {
               getMetadata(new Version(0, 51, 1), CUSTOM_SYSTEM));
         chkUseNonNegotiableTerms.addMouseListener(createTipPanelUpdater("UseNonNegotiableTerms"));
 
+        chkUseActiveNegotiators = new CampaignOptionsCheckBox("UseActiveNegotiators",
+              getMetadata(new Version(0, 51, 1), CUSTOM_SYSTEM));
+        chkUseActiveNegotiators.addMouseListener(createTipPanelUpdater("UseActiveNegotiators"));
+
         lblDropShipBonusPercentage = new CampaignOptionsLabel("DropShipBonusPercentage");
         lblDropShipBonusPercentage.addMouseListener(createTipPanelUpdater("DropShipBonusPercentage"));
         spnDropShipBonusPercentage = new CampaignOptionsSpinner("DropShipBonusPercentage", 0, 0, 20, 5);
@@ -301,6 +306,7 @@ class ContractMarketPage {
               chkUseContractFactionModifiers,
               chkUseIntelObfuscation,
               chkUseNonNegotiableTerms,
+              chkUseActiveNegotiators,
               chkBLCSaleValue,
               chkOverageRepaymentInFinalPayment);
         panel.addRow(lblDropShipBonusPercentage, spnDropShipBonusPercentage);
@@ -624,6 +630,7 @@ class ContractMarketPage {
         chkUseContractFactionModifiers.setSelected(model.useContractFactionModifiers);
         chkUseIntelObfuscation.setSelected(model.useIntelObfuscation);
         chkUseNonNegotiableTerms.setSelected(model.useNonNegotiableTerms);
+        chkUseActiveNegotiators.setSelected(model.useActiveNegotiators);
         spnDropShipBonusPercentage.setValue(model.dropShipBonusPercentage);
         spnPityContracts.setValue(model.pityContracts);
         spnContractBasePayMultiplier.setValue(model.contractBasePayMultiplier);
@@ -675,6 +682,7 @@ class ContractMarketPage {
         model.useContractFactionModifiers = chkUseContractFactionModifiers.isSelected();
         model.useIntelObfuscation = chkUseIntelObfuscation.isSelected();
         model.useNonNegotiableTerms = chkUseNonNegotiableTerms.isSelected();
+        model.useActiveNegotiators = chkUseActiveNegotiators.isSelected();
         model.dropShipBonusPercentage = (int) spnDropShipBonusPercentage.getValue();
         model.pityContracts = (int) spnPityContracts.getValue();
         model.contractBasePayMultiplier = (double) spnContractBasePayMultiplier.getValue();

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/ContractMarketPage.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/ContractMarketPage.java
@@ -110,6 +110,7 @@ class ContractMarketPage {
     private JCheckBox chkUseChaosScaleSupportPointConversion;
     private JCheckBox chkUseContractFactionModifiers;
     private JCheckBox chkUseIntelObfuscation;
+    private JCheckBox chkUseNonNegotiableTerms;
     private JLabel lblDropShipBonusPercentage;
     private JSpinner spnDropShipBonusPercentage;
     private JLabel lblPityContracts;
@@ -264,6 +265,10 @@ class ContractMarketPage {
               getMetadata(new Version(0, 51, 1), CUSTOM_SYSTEM));
         chkUseIntelObfuscation.addMouseListener(createTipPanelUpdater("UseIntelObfuscation"));
 
+        chkUseNonNegotiableTerms = new CampaignOptionsCheckBox("UseNonNegotiableTerms",
+              getMetadata(new Version(0, 51, 1), CUSTOM_SYSTEM));
+        chkUseNonNegotiableTerms.addMouseListener(createTipPanelUpdater("UseNonNegotiableTerms"));
+
         lblDropShipBonusPercentage = new CampaignOptionsLabel("DropShipBonusPercentage");
         lblDropShipBonusPercentage.addMouseListener(createTipPanelUpdater("DropShipBonusPercentage"));
         spnDropShipBonusPercentage = new CampaignOptionsSpinner("DropShipBonusPercentage", 0, 0, 20, 5);
@@ -295,6 +300,7 @@ class ContractMarketPage {
               chkUseChaosScaleSupportPointConversion,
               chkUseContractFactionModifiers,
               chkUseIntelObfuscation,
+              chkUseNonNegotiableTerms,
               chkBLCSaleValue,
               chkOverageRepaymentInFinalPayment);
         panel.addRow(lblDropShipBonusPercentage, spnDropShipBonusPercentage);
@@ -617,6 +623,7 @@ class ContractMarketPage {
         chkUseChaosScaleSupportPointConversion.setSelected(model.useChaosScaleSupportPointConversion);
         chkUseContractFactionModifiers.setSelected(model.useContractFactionModifiers);
         chkUseIntelObfuscation.setSelected(model.useIntelObfuscation);
+        chkUseNonNegotiableTerms.setSelected(model.useNonNegotiableTerms);
         spnDropShipBonusPercentage.setValue(model.dropShipBonusPercentage);
         spnPityContracts.setValue(model.pityContracts);
         spnContractBasePayMultiplier.setValue(model.contractBasePayMultiplier);
@@ -667,6 +674,7 @@ class ContractMarketPage {
         model.useChaosScaleSupportPointConversion = chkUseChaosScaleSupportPointConversion.isSelected();
         model.useContractFactionModifiers = chkUseContractFactionModifiers.isSelected();
         model.useIntelObfuscation = chkUseIntelObfuscation.isSelected();
+        model.useNonNegotiableTerms = chkUseNonNegotiableTerms.isSelected();
         model.dropShipBonusPercentage = (int) spnDropShipBonusPercentage.getValue();
         model.pityContracts = (int) spnPityContracts.getValue();
         model.contractBasePayMultiplier = (double) spnContractBasePayMultiplier.getValue();

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/MarketsOptionsModel.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/MarketsOptionsModel.java
@@ -68,6 +68,7 @@ class MarketsOptionsModel {
     boolean useChaosScaleSupportPointConversion;
     boolean useContractFactionModifiers;
     boolean useIntelObfuscation;
+    boolean useNonNegotiableTerms;
     boolean contractMarketReportRefresh;
     int contractMaxSalvagePercentage;
     int dropShipBonusPercentage;
@@ -114,6 +115,7 @@ class MarketsOptionsModel {
         useChaosScaleSupportPointConversion = options.get(CampaignOption.USE_CHAOS_SCALE_SUPPORT_POINT_CONVERSION);
         useContractFactionModifiers = options.get(CampaignOption.USE_CONTRACT_FACTION_MODIFIERS);
         useIntelObfuscation = options.get(CampaignOption.USE_INTEL_OBFUSCATION);
+        useNonNegotiableTerms = options.get(CampaignOption.USE_NON_NEGOTIABLE_TERMS);
         contractMarketReportRefresh = options.get(CampaignOption.CONTRACT_MARKET_REPORT_REFRESH);
         contractMaxSalvagePercentage = options.get(CampaignOption.CONTRACT_MAX_SALVAGE_PERCENTAGE);
         dropShipBonusPercentage = options.get(CampaignOption.DROP_SHIP_BONUS_PERCENTAGE);
@@ -175,6 +177,7 @@ class MarketsOptionsModel {
         options.set(CampaignOption.USE_CHAOS_SCALE_SUPPORT_POINT_CONVERSION, useChaosScaleSupportPointConversion);
         options.set(CampaignOption.USE_CONTRACT_FACTION_MODIFIERS, useContractFactionModifiers);
         options.set(CampaignOption.USE_INTEL_OBFUSCATION, useIntelObfuscation);
+        options.set(CampaignOption.USE_NON_NEGOTIABLE_TERMS, useNonNegotiableTerms);
         options.set(CampaignOption.CONTRACT_MARKET_REPORT_REFRESH, contractMarketReportRefresh);
         options.set(CampaignOption.CONTRACT_MAX_SALVAGE_PERCENTAGE, contractMaxSalvagePercentage);
         options.set(CampaignOption.DROP_SHIP_BONUS_PERCENTAGE, dropShipBonusPercentage);

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/MarketsOptionsModel.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/MarketsOptionsModel.java
@@ -69,6 +69,7 @@ class MarketsOptionsModel {
     boolean useContractFactionModifiers;
     boolean useIntelObfuscation;
     boolean useNonNegotiableTerms;
+    boolean useActiveNegotiators;
     boolean contractMarketReportRefresh;
     int contractMaxSalvagePercentage;
     int dropShipBonusPercentage;
@@ -116,6 +117,7 @@ class MarketsOptionsModel {
         useContractFactionModifiers = options.get(CampaignOption.USE_CONTRACT_FACTION_MODIFIERS);
         useIntelObfuscation = options.get(CampaignOption.USE_INTEL_OBFUSCATION);
         useNonNegotiableTerms = options.get(CampaignOption.USE_NON_NEGOTIABLE_TERMS);
+        useActiveNegotiators = options.get(CampaignOption.USE_ACTIVE_NEGOTIATORS);
         contractMarketReportRefresh = options.get(CampaignOption.CONTRACT_MARKET_REPORT_REFRESH);
         contractMaxSalvagePercentage = options.get(CampaignOption.CONTRACT_MAX_SALVAGE_PERCENTAGE);
         dropShipBonusPercentage = options.get(CampaignOption.DROP_SHIP_BONUS_PERCENTAGE);
@@ -178,6 +180,7 @@ class MarketsOptionsModel {
         options.set(CampaignOption.USE_CONTRACT_FACTION_MODIFIERS, useContractFactionModifiers);
         options.set(CampaignOption.USE_INTEL_OBFUSCATION, useIntelObfuscation);
         options.set(CampaignOption.USE_NON_NEGOTIABLE_TERMS, useNonNegotiableTerms);
+        options.set(CampaignOption.USE_ACTIVE_NEGOTIATORS, useActiveNegotiators);
         options.set(CampaignOption.CONTRACT_MARKET_REPORT_REFRESH, contractMarketReportRefresh);
         options.set(CampaignOption.CONTRACT_MAX_SALVAGE_PERCENTAGE, contractMaxSalvagePercentage);
         options.set(CampaignOption.DROP_SHIP_BONUS_PERCENTAGE, dropShipBonusPercentage);

--- a/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractEditorDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractEditorDialog.java
@@ -196,6 +196,11 @@ public class ContractEditorDialog extends JDialog {
     private JComboBox<ChaosContractStepsTable> transportTermCombo;
     private JComboBox<ChaosContractStepsTable> salvageCombo;
     private JComboBox<ChaosContractStepsTable> commandCombo;
+    private JCheckBox payNonNegotiableCheck;
+    private JCheckBox supportNonNegotiableCheck;
+    private JCheckBox transportNonNegotiableCheck;
+    private JCheckBox salvageNonNegotiableCheck;
+    private JCheckBox commandNonNegotiableCheck;
 
     // Objectives
     private JComboBox<ContractObjectiveType> playerObjectiveCombo;
@@ -799,22 +804,52 @@ public class ContractEditorDialog extends JDialog {
     private JPanel buildTermsCard() {
         JPanel rows = rowsPanel();
 
+        NonNegotiableTermsData locks = contract.getNonNegotiableTermsData();
+        if (locks == null) {
+            locks = NonNegotiableTermsData.none();
+        }
+        // Which terms the employer has locked can only be set while the contract is still an offer; once it has been
+        // accepted the player has agreed to those terms, so the checkboxes show their state but are disabled.
+        boolean lockEditable = contract.getStatus() == null;
+
         payRateCombo = stepsCombo(contract.getBasePayRateStep(), TermEffect.PAY_RATE);
-        rows.add(formRow("edit.contractMarket.field.payRate", payRateCombo));
+        payNonNegotiableCheck = nonNegotiableCheckbox(locks.payLocked(), lockEditable);
+        rows.add(formRow("edit.contractMarket.field.payRate", withAutomatic(payRateCombo, payNonNegotiableCheck)));
 
         supportCombo = stepsCombo(contract.getSupportStep(), TermEffect.SUPPORT);
-        rows.add(formRow("edit.contractMarket.field.support", supportCombo));
+        supportNonNegotiableCheck = nonNegotiableCheckbox(locks.supportLocked(), lockEditable);
+        rows.add(formRow("edit.contractMarket.field.support", withAutomatic(supportCombo, supportNonNegotiableCheck)));
 
         transportTermCombo = stepsCombo(contract.getTransportStep(), TermEffect.TRANSPORT);
-        rows.add(formRow("edit.contractMarket.field.transport", transportTermCombo));
+        transportNonNegotiableCheck = nonNegotiableCheckbox(locks.transportLocked(), lockEditable);
+        rows.add(formRow("edit.contractMarket.field.transport",
+              withAutomatic(transportTermCombo, transportNonNegotiableCheck)));
 
         salvageCombo = stepsCombo(contract.getSalvageRightsStep(), TermEffect.SALVAGE);
-        rows.add(formRow("edit.contractMarket.field.salvage", salvageCombo));
+        salvageNonNegotiableCheck = nonNegotiableCheckbox(locks.salvageLocked(), lockEditable);
+        rows.add(formRow("edit.contractMarket.field.salvage", withAutomatic(salvageCombo, salvageNonNegotiableCheck)));
 
         commandCombo = stepsCombo(contract.getCommandRightsStep(), TermEffect.COMMAND);
-        rows.add(formRow("edit.contractMarket.field.command", commandCombo));
+        commandNonNegotiableCheck = nonNegotiableCheckbox(locks.commandLocked(), lockEditable);
+        rows.add(formRow("edit.contractMarket.field.command", withAutomatic(commandCombo, commandNonNegotiableCheck)));
 
         return card(rows);
+    }
+
+    /**
+     * A "non-negotiable" checkbox for a term: ticked when the employer has locked that term, disabled (but still
+     * showing its state) once the contract has been accepted, since the locks can no longer change at that point.
+     */
+    private JCheckBox nonNegotiableCheckbox(boolean locked, boolean editable) {
+        JCheckBox checkbox = new JCheckBox(getTextAt(RESOURCE_BUNDLE, "edit.contractMarket.field.nonNegotiable"),
+              locked);
+        checkbox.setToolTipText(wordWrap(getTextAt(RESOURCE_BUNDLE, editable
+                                                                          ?
+                                                                          "edit.contractMarket.field.nonNegotiable.tooltip"
+                                                                          :
+                                                                          "edit.contractMarket.field.nonNegotiable.disabled.tooltip")));
+        checkbox.setEnabled(editable);
+        return checkbox;
     }
 
     private JPanel buildObjectivesCard() {
@@ -1099,6 +1134,11 @@ public class ContractEditorDialog extends JDialog {
         // Terms
         contract.setContractTerms(new ContractTermsData(stepValue(payRateCombo), stepValue(supportCombo),
               stepValue(transportTermCombo), stepValue(salvageCombo), stepValue(commandCombo)));
+        // A disabled checkbox still reports its loaded state, so on an accepted contract this preserves the existing
+        // locks unchanged.
+        contract.setNonNegotiableTermsData(new NonNegotiableTermsData(payNonNegotiableCheck.isSelected(),
+              supportNonNegotiableCheck.isSelected(), transportNonNegotiableCheck.isSelected(),
+              salvageNonNegotiableCheck.isSelected(), commandNonNegotiableCheck.isSelected()));
 
         // Objectives
         contract.setObjectiveData(new ContractObjectiveData(objectiveValue(playerObjectiveCombo),

--- a/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractNegotiationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractNegotiationDialog.java
@@ -61,6 +61,7 @@ import javax.swing.SwingConstants;
 
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
+import megamek.common.compute.Compute;
 import megamek.common.icons.Portrait;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
@@ -68,8 +69,11 @@ import mekhq.campaign.AbstractLocation;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.campaignOptions.CampaignOption;
 import mekhq.campaign.campaignOptions.CampaignOptions;
+import mekhq.campaign.enums.DailyReportType;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.mission.contract.AbstractContract;
+import mekhq.campaign.mission.contract.contractData.ActiveNegotiationData;
+import mekhq.campaign.mission.contract.contractData.ActiveNegotiationMath;
 import mekhq.campaign.mission.contract.contractData.ChaosContractStepsTable;
 import mekhq.campaign.mission.contract.contractData.ContractTermsData;
 import mekhq.campaign.mission.contract.contractData.NegotiationData;
@@ -80,7 +84,11 @@ import mekhq.campaign.mission.contract.contractData.RentedFacilitiesData;
 import mekhq.campaign.mission.contract.contractGeneration.ChaosContractDeterminationPay;
 import mekhq.campaign.mission.contract.contractGeneration.negotiationsAndNPCs.TermFunding;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.skills.ActionCheckResult;
+import mekhq.campaign.personnel.skills.SkillType;
+import mekhq.campaign.personnel.skills.enums.MarginOfSuccess;
 import mekhq.campaign.universe.Faction;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
 import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
 import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
 
@@ -121,11 +129,12 @@ public class ContractNegotiationDialog extends JDialog {
     private final transient Campaign campaign;
     private final transient AbstractContract contract;
     private final transient AbstractLocation currentLocation;
-    private final transient NonNegotiableTermsData nonNegotiableTerms;
+    private transient NonNegotiableTermsData nonNegotiableTerms;
 
     private final int scale;
     private final int capPerTerm;
     private final int reputationPool;
+    private final boolean activeNegotiators;
 
     private int reputationUsed;
     private int swapsUsed;
@@ -156,6 +165,8 @@ public class ContractNegotiationDialog extends JDialog {
     private JLabel bankBudgetLabel;
     private JLabel payImpactLabel;
     private JLabel summaryLabel;
+    private JLabel resultsLabel;
+    private RoundedJButton renegotiateButton;
 
     private boolean confirmed;
 
@@ -199,6 +210,7 @@ public class ContractNegotiationDialog extends JDialog {
 
         NonNegotiableTermsData lockedTerms = contract.getNonNegotiableTermsData();
         this.nonNegotiableTerms = lockedTerms != null ? lockedTerms : NonNegotiableTermsData.none();
+        this.activeNegotiators = campaignOptions.get(CampaignOption.USE_ACTIVE_NEGOTIATORS);
 
         for (Clause clause : Clause.values()) {
             currentStep[clause.ordinal()] = initialStep(clause);
@@ -359,6 +371,7 @@ public class ContractNegotiationDialog extends JDialog {
         if (picker.wasConfirmed()) {
             contract.setPlayerNegotiator(picker.getSelectedNegotiator());
             updateNegotiatorControl();
+            updateRenegotiateButton();
         }
     }
 
@@ -559,7 +572,7 @@ public class ContractNegotiationDialog extends JDialog {
     }
 
     private JPanel buildFooter() {
-        // Summary on its own line (left), buttons on the line below (right).
+        // Summary on its own line (top), the results area below it, buttons on the line below that (right).
         JPanel footer = new JPanel(new BorderLayout(0, PADDING));
         footer.setBorder(BorderFactory.createEmptyBorder(PADDING, PADDING, 0, PADDING));
 
@@ -567,7 +580,18 @@ public class ContractNegotiationDialog extends JDialog {
         summaryLabel.setForeground(muted());
         footer.add(summaryLabel, BorderLayout.NORTH);
 
+        // The active-negotiation results area only appears when the feature is enabled.
+        if (activeNegotiators) {
+            footer.add(buildResultsCard(), BorderLayout.CENTER);
+        }
+
         JPanel buttons = new JPanel(new FlowLayout(FlowLayout.RIGHT, PADDING, 0));
+        if (activeNegotiators) {
+            renegotiateButton = new RoundedJButton(getTextAt(RESOURCE_BUNDLE,
+                  "button.contractMarket.negotiate.renegotiate"));
+            renegotiateButton.addActionListener(e -> renegotiateAction());
+            buttons.add(renegotiateButton);
+        }
         RoundedJButton explain = new RoundedJButton(getTextAt(RESOURCE_BUNDLE,
               "button.contractMarket.negotiate.explain"));
         explain.addActionListener(e -> explainAction());
@@ -586,6 +610,25 @@ public class ContractNegotiationDialog extends JDialog {
         footer.add(buttons, BorderLayout.SOUTH);
 
         return footer;
+    }
+
+    /** The bordered "Negotiation Results" area shown at the bottom when active negotiators are enabled. */
+    private JPanel buildResultsCard() {
+        JPanel card = new JPanel(new BorderLayout());
+        card.setBorder(BorderFactory.createCompoundBorder(RoundedLineBorder.createSubtleRoundedLineBorder(),
+              BorderFactory.createEmptyBorder(PADDING, PADDING, PADDING, PADDING)));
+
+        JLabel section = new JLabel(getTextAt(RESOURCE_BUNDLE,
+              "negotiate.contractMarket.section.results").toUpperCase());
+        section.setFont(section.getFont().deriveFont(section.getFont().getSize2D() - 2f));
+        section.setForeground(muted());
+        card.add(section, BorderLayout.NORTH);
+
+        resultsLabel = new JLabel();
+        resultsLabel.setBorder(BorderFactory.createEmptyBorder(PADDING, 0, 0, 0));
+        card.add(resultsLabel, BorderLayout.CENTER);
+
+        return card;
     }
 
     private JButton stepperButton(String text, Runnable action) {
@@ -756,17 +799,7 @@ public class ContractNegotiationDialog extends JDialog {
     }
 
     private void confirmAction() {
-        ChaosContractStepsTable payRate = step(Clause.PAY);
-        ChaosContractStepsTable support = step(Clause.SUPPORT);
-        ChaosContractStepsTable transport = step(Clause.TRANSPORT);
-        ChaosContractStepsTable salvage = step(Clause.SALVAGE);
-        ChaosContractStepsTable command = step(Clause.COMMAND);
-
-        contract.setContractTerms(new ContractTermsData(payRate, support, transport, salvage, command));
-        ChaosContractDeterminationPay payScheme = new ChaosContractDeterminationPay();
-        contract.updateMonthlyPay(payScheme.getMonthlyPay(campaign, contract));
-        contract.updateTransportPay(payScheme.getTransportPay(campaign,
-              campaign.getLocalDate(), contract, currentLocation));
+        commitTermsAndPay();
 
         contract.setRentedFacilitiesData(new RentedFacilitiesData(facilityQuantity[0],
               facilityQuantity[1], facilityQuantity[2]));
@@ -785,7 +818,259 @@ public class ContractNegotiationDialog extends JDialog {
         dispose();
     }
 
+    /** Writes the current proposed term steps onto the contract and recomputes its pay from them. */
+    private void commitTermsAndPay() {
+        contract.setContractTerms(new ContractTermsData(step(Clause.PAY), step(Clause.SUPPORT), step(Clause.TRANSPORT),
+              step(Clause.SALVAGE), step(Clause.COMMAND)));
+        ChaosContractDeterminationPay payScheme = new ChaosContractDeterminationPay();
+        contract.updateMonthlyPay(payScheme.getMonthlyPay(campaign, contract));
+        contract.updateTransportPay(payScheme.getTransportPay(campaign,
+              campaign.getLocalDate(), contract, currentLocation));
+    }
+
     // endregion Negotiation logic
+
+    // region Active negotiation
+
+    /**
+     * Runs the one active-negotiation attempt a contract allows: an opposed Negotiation check between the player's and
+     * the employer's negotiators. Each margin-of-success level the player wins improves a random term one meaningful
+     * step; each level lost lowers one (non-negotiable terms are skipped). The outcome rewrites the contract's terms as
+     * a fresh baseline - clearing any in-progress manual haggling - and is committed immediately: it cannot be undone,
+     * and the attempt can only be made once per contract.
+     */
+    private void renegotiateAction() {
+        if (contract.getPlayerNegotiator() == null || contract.getActiveNegotiationData() != null) {
+            return;
+        }
+
+        // The employer's negotiator opens the floor; the player picks how to press their case. The player's own
+        // negotiator is deliberately not shown as a speaker. Cancel is first (index 0) so closing the window - which
+        // defaults the dialog choice to 0 - safely cancels rather than spending the one-shot attempt.
+        List<String> options = List.of(getTextAt(RESOURCE_BUNDLE, "negotiate.contractMarket.renegotiate.option.cancel"),
+              getTextAt(RESOURCE_BUNDLE, "negotiate.contractMarket.renegotiate.option.better"),
+              getTextAt(RESOURCE_BUNDLE, "negotiate.contractMarket.renegotiate.option.exception"));
+        ImmersiveDialogSimple dialog = new ImmersiveDialogSimple(campaign,
+              contract.getEmployerNegotiator(), null,
+              getTextAt(RESOURCE_BUNDLE, "negotiate.contractMarket.renegotiate.prompt"),
+              options,
+              getTextAt(RESOURCE_BUNDLE, "negotiate.contractMarket.renegotiate.ooc"),
+              null, true);
+
+        switch (dialog.getDialogChoice()) {
+            case 1 -> performHaggle();
+            case 2 -> performException();
+            default -> { /* cancelled (or window closed) - the attempt is not spent */ }
+        }
+    }
+
+    /**
+     * The net margin of the opposed Negotiation check between the player's and the employer's negotiators (positive
+     * favors the player). A missing employer negotiator counts as a neutral result.
+     */
+    private int rollNetMargin() {
+        MarginOfSuccess playerMargin = reportedNegotiationCheck(contract.getPlayerNegotiator(),
+              "negotiate.contractMarket.renegotiate.roll.player");
+        Person employerNegotiator = contract.getEmployerNegotiator();
+        MarginOfSuccess employerMargin = employerNegotiator != null
+                                               ?
+                                               reportedNegotiationCheck(employerNegotiator,
+                                                     "negotiate.contractMarket.renegotiate.roll.employer")
+                                               :
+                                               MarginOfSuccess.BARELY_MADE_IT;
+        return ActiveNegotiationMath.netMargin(playerMargin, employerMargin);
+    }
+
+    /**
+     * Resolves a Negotiation check for the given person, posts the result to the daily report's skill-checks tab, and
+     * returns its margin of success.
+     */
+    private MarginOfSuccess reportedNegotiationCheck(Person negotiator, String reasonKey) {
+        ActionCheckResult result = negotiator.checkSkill(SkillType.S_NEGOTIATION, campaign)
+                                         .resolve(false, getTextAt(RESOURCE_BUNDLE, reasonKey));
+        campaign.addReport(DailyReportType.SKILL_CHECKS, result.getReport(true));
+        return result.getReportMargin();
+    }
+
+    /** Runs the opposed check and rewrites the terms as a fresh baseline. Spends the contract's one attempt. */
+    private void performHaggle() {
+        int net = rollNetMargin();
+        int[] moveCounts = applyActiveNegotiation(net);
+
+        // The re-negotiated terms become the new baseline; manual haggling starts fresh from here.
+        reputationUsed = 0;
+        swapsUsed = 0;
+        sacrificeBank = 0;
+        for (Clause clause : Clause.values()) {
+            funding.get(clause.ordinal()).clear();
+        }
+
+        commitTermsAndPay();
+        contract.setNegotiationData(null);
+        contract.setActiveNegotiationData(ActiveNegotiationData.haggle(net,
+              moveCounts[Clause.PAY.ordinal()], moveCounts[Clause.SUPPORT.ordinal()],
+              moveCounts[Clause.TRANSPORT.ordinal()], moveCounts[Clause.SALVAGE.ordinal()],
+              moveCounts[Clause.COMMAND.ordinal()]));
+
+        LOGGER.info("Active negotiation (haggle) for contract {}: net margin {}", contract.getName(), net);
+        refresh();
+    }
+
+    /**
+     * Runs the same opposed check, but the stakes are the non-negotiable flags: each margin of success waives a random
+     * locked term, each margin of failure locks a random unlocked one. Spends the contract's one attempt.
+     */
+    private void performException() {
+        int net = rollNetMargin();
+        int[] lockChanges = applyLockChanges(net);
+        contract.setNonNegotiableTermsData(nonNegotiableTerms);
+        contract.setActiveNegotiationData(ActiveNegotiationData.exception(net,
+              lockChanges[Clause.PAY.ordinal()], lockChanges[Clause.SUPPORT.ordinal()],
+              lockChanges[Clause.TRANSPORT.ordinal()], lockChanges[Clause.SALVAGE.ordinal()],
+              lockChanges[Clause.COMMAND.ordinal()]));
+
+        LOGGER.info("Active negotiation (exception) for contract {}: net margin {}", contract.getName(), net);
+        refresh();
+    }
+
+    /**
+     * Applies {@code net} lock toggles: each step (net &gt; 0) waives a randomly chosen still-locked term, or (net &lt;
+     * 0) locks a randomly chosen still-unlocked one, with the pool shrinking as it goes; when none remain the rest are
+     * dropped. Returns the signed change per term (+1 waived, -1 locked, indexed by clause ordinal).
+     */
+    private int[] applyLockChanges(int net) {
+        int[] changes = new int[Clause.values().length];
+        boolean waive = net > 0;
+        int count = Math.abs(net);
+        for (int move = 0; move < count; move++) {
+            List<Clause> eligible = new ArrayList<>();
+            for (Clause clause : Clause.values()) {
+                if (nonNegotiableTerms.isLocked(clause.term) != waive) {
+                    eligible.add(clause);
+                }
+            }
+            if (eligible.isEmpty()) {
+                break;
+            }
+            Clause chosen = eligible.get(Compute.randomInt(eligible.size()));
+            nonNegotiableTerms = waive
+                                       ? nonNegotiableTerms.withUnlocked(chosen.term)
+                                       : nonNegotiableTerms.withLocked(chosen.term);
+            changes[chosen.ordinal()] += waive ? 1 : -1;
+        }
+        return changes;
+    }
+
+    /**
+     * Applies {@code net} meaningful steps to the term baseline: each step improves (net &gt; 0) or lowers (net &lt; 0)
+     * a randomly chosen eligible term, with repeats. Non-negotiable terms, and terms already at the end of the table in
+     * that direction, are skipped; when none remain eligible the remaining steps are dropped. Sets both the baseline
+     * and the current step to the outcome, and returns the signed count of meaningful steps applied to each term
+     * (indexed by clause ordinal).
+     */
+    private int[] applyActiveNegotiation(int net) {
+        int[] moveCounts = new int[Clause.values().length];
+        boolean improve = net > 0;
+        int moves = Math.abs(net);
+        for (int move = 0; move < moves; move++) {
+            List<Clause> eligible = new ArrayList<>();
+            for (Clause clause : Clause.values()) {
+                if (!isLocked(clause) && meaningfulStep(clause, improve) >= CHAOS_CONTRACT_MINIMUM_STEP_VALUE) {
+                    eligible.add(clause);
+                }
+            }
+            if (eligible.isEmpty()) {
+                break;
+            }
+            Clause chosen = eligible.get(Compute.randomInt(eligible.size()));
+            originalStep[chosen.ordinal()] = meaningfulStep(chosen, improve);
+            moveCounts[chosen.ordinal()] += improve ? 1 : -1;
+        }
+        System.arraycopy(originalStep, 0, currentStep, 0, originalStep.length);
+        return moveCounts;
+    }
+
+    /** The step a term's baseline moves to on one meaningful improve/lower, or -1 if there is none in that direction. */
+    private int meaningfulStep(Clause clause, boolean improve) {
+        int from = originalStep[clause.ordinal()];
+        return improve
+                     ? NegotiationStepMath.nextHigherDifferentStep(clause.term, from)
+                     : NegotiationStepMath.nextLowerDifferentStep(clause.term, from);
+    }
+
+    /** Enables the Re-negotiate button only when a negotiator is set and the one attempt has not been spent. */
+    private void updateRenegotiateButton() {
+        if (renegotiateButton == null) {
+            return;
+        }
+        boolean attempted = contract.getActiveNegotiationData() != null;
+        boolean hasNegotiator = contract.getPlayerNegotiator() != null;
+        renegotiateButton.setEnabled(!attempted && hasNegotiator);
+        String tooltipKey = attempted
+                                  ? "negotiate.contractMarket.renegotiate.tooltip.spent"
+                                  : hasNegotiator
+                                          ? "negotiate.contractMarket.renegotiate.tooltip"
+                                          : "negotiate.contractMarket.renegotiate.tooltip.noNegotiator";
+        renegotiateButton.setToolTipText(wordWrap(getTextAt(RESOURCE_BUNDLE, tooltipKey)));
+    }
+
+    /** Renders the active-negotiation results area from the contract's stored outcome, or a placeholder when unspent. */
+    private void renderResults() {
+        if (resultsLabel == null) {
+            return;
+        }
+        ActiveNegotiationData data = contract.getActiveNegotiationData();
+        if (data == null) {
+            resultsLabel.setText("<html><span style='color:" +
+                                       MUTED_HEX +
+                                       "'>"
+                                       +
+                                       escape(getTextAt(RESOURCE_BUNDLE, "negotiate.contractMarket.results.none")) +
+                                       "</span></html>");
+            return;
+        }
+
+        int net = data.netMargin();
+        String headlineKey = net > 0 ? "negotiate.contractMarket.results.won"
+                                   : net < 0 ? "negotiate.contractMarket.results.lost"
+                                           : "negotiate.contractMarket.results.stalemate";
+        String headlineColor = net > 0 ? hex(positiveHex()) : net < 0 ? hex(negativeHex()) : MUTED_HEX;
+        StringBuilder html = new StringBuilder("<html><b style='color:").append(headlineColor)
+                                   .append("'>")
+                                   .append(escape(getFormattedTextAt(RESOURCE_BUNDLE, headlineKey, Math.abs(net))))
+                                   .append("</b>");
+
+        boolean anyTerm = false;
+        for (Clause clause : Clause.values()) {
+            int change = data.deltaFor(clause.term);
+            if (change == 0) {
+                continue;
+            }
+            anyTerm = true;
+            String termLabel = getTextAt(RESOURCE_BUNDLE, clause.labelKey);
+            String color = change > 0 ? hex(positiveHex()) : hex(negativeHex());
+            String line = switch (data.kind()) {
+                case HAGGLE -> getFormattedTextAt(RESOURCE_BUNDLE,
+                      change > 0 ? "negotiate.contractMarket.results.termImproved"
+                            : "negotiate.contractMarket.results.termWorsened",
+                      termLabel, Math.abs(change));
+                case EXCEPTION -> getFormattedTextAt(RESOURCE_BUNDLE,
+                      change > 0 ? "negotiate.contractMarket.results.termUnlocked"
+                            : "negotiate.contractMarket.results.termLocked",
+                      termLabel);
+            };
+            html.append("<br><span style='color:").append(color).append("'>").append(escape(line)).append("</span>");
+        }
+        if (!anyTerm && net != 0) {
+            // A win or loss that changed nothing (no eligible term left in that direction).
+            html.append("<br><span style='color:").append(MUTED_HEX).append("'>")
+                  .append(escape(getTextAt(RESOURCE_BUNDLE, "negotiate.contractMarket.results.noTerms")))
+                  .append("</span>");
+        }
+        resultsLabel.setText(html.append("</html>").toString());
+    }
+
+    // endregion Active negotiation
 
     // region Rendering
 
@@ -825,6 +1110,9 @@ public class ContractNegotiationDialog extends JDialog {
               rentalTotal.toAmountAndSymbolString(), reputationPool - reputationUsed,
               NegotiationStepMath.totalStepsSacrificed(originalStep, currentStep), MAXIMUM_SACRIFICED_STEPS,
               NegotiationStepMath.distinctTermsSacrificed(originalStep, currentStep), MAXIMUM_SACRIFICED_TERMS));
+
+        updateRenegotiateButton();
+        renderResults();
     }
 
     private boolean canRaise(Clause clause) {

--- a/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractNegotiationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractNegotiationDialog.java
@@ -85,6 +85,7 @@ import mekhq.campaign.mission.contract.contractData.RentedFacilitiesData;
 import mekhq.campaign.mission.contract.contractGeneration.ChaosContractDeterminationPay;
 import mekhq.campaign.mission.contract.contractGeneration.negotiationsAndNPCs.TermFunding;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.skills.ActionCheckResult;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.personnel.skills.enums.MarginOfSuccess;
@@ -876,12 +877,19 @@ public class ContractNegotiationDialog extends JDialog {
             LOGGER.warn("Contract {} has no player negotiator", contract.getName());
             return DISASTROUS.getLowerBound();
         }
+
+        boolean isUseEdge = campaign.getCampaignOptions().get(CampaignOption.USE_EDGE);
+        boolean playerUsesEdge = isUseEdge &&
+                                       playerNegotiator.getOptions()
+                                             .booleanOption(PersonnelOptions.EDGE_COMMANDER_NEGOTIATION);
         MarginOfSuccess playerMargin = reportedNegotiationCheck(playerNegotiator,
-              "negotiate.contractMarket.renegotiate.roll.player");
+              "negotiate.contractMarket.renegotiate.roll.player",
+              playerUsesEdge);
         Person employerNegotiator = contract.getEmployerNegotiator();
         MarginOfSuccess employerMargin = employerNegotiator != null ?
                                                reportedNegotiationCheck(employerNegotiator,
-                                                     "negotiate.contractMarket.renegotiate.roll.employer") :
+                                                     "negotiate.contractMarket.renegotiate.roll.employer",
+                                                     isUseEdge) :
                                                MarginOfSuccess.BARELY_MADE_IT;
         return ActiveNegotiationMath.netMargin(playerMargin, employerMargin);
     }
@@ -890,9 +898,9 @@ public class ContractNegotiationDialog extends JDialog {
      * Resolves a Negotiation check for the given person, posts the result to the daily report's skill-checks tab, and
      * returns its margin of success.
      */
-    private MarginOfSuccess reportedNegotiationCheck(Person negotiator, String reasonKey) {
+    private MarginOfSuccess reportedNegotiationCheck(Person negotiator, String reasonKey, boolean useEdge) {
         ActionCheckResult result = negotiator.checkSkill(SkillType.S_NEGOTIATION, campaign)
-                                         .resolve(false, getTextAt(RESOURCE_BUNDLE, reasonKey));
+                                         .resolve(useEdge, getTextAt(RESOURCE_BUNDLE, reasonKey));
         campaign.addReport(DailyReportType.SKILL_CHECKS, result.getReport(true));
         return result.getReportMargin();
     }

--- a/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractNegotiationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractNegotiationDialog.java
@@ -75,6 +75,7 @@ import mekhq.campaign.mission.contract.contractData.ContractTermsData;
 import mekhq.campaign.mission.contract.contractData.NegotiationData;
 import mekhq.campaign.mission.contract.contractData.NegotiationStepMath;
 import mekhq.campaign.mission.contract.contractData.NegotiationStepMath.Term;
+import mekhq.campaign.mission.contract.contractData.NonNegotiableTermsData;
 import mekhq.campaign.mission.contract.contractData.RentedFacilitiesData;
 import mekhq.campaign.mission.contract.contractGeneration.ChaosContractDeterminationPay;
 import mekhq.campaign.mission.contract.contractGeneration.negotiationsAndNPCs.TermFunding;
@@ -120,6 +121,7 @@ public class ContractNegotiationDialog extends JDialog {
     private final transient Campaign campaign;
     private final transient AbstractContract contract;
     private final transient AbstractLocation currentLocation;
+    private final transient NonNegotiableTermsData nonNegotiableTerms;
 
     private final int scale;
     private final int capPerTerm;
@@ -194,6 +196,9 @@ public class ContractNegotiationDialog extends JDialog {
         boolean useChaosReputation = campaignOptions.get(CampaignOption.USE_CHAOS_REPUTATION);
         int reputation = campaign.getPlayerForce().getReputationRating(useChaosReputation);
         this.reputationPool = Math.clamp(reputation, 0, 2 * scale);
+
+        NonNegotiableTermsData lockedTerms = contract.getNonNegotiableTermsData();
+        this.nonNegotiableTerms = lockedTerms != null ? lockedTerms : NonNegotiableTermsData.none();
 
         for (Clause clause : Clause.values()) {
             currentStep[clause.ordinal()] = initialStep(clause);
@@ -704,8 +709,16 @@ public class ContractNegotiationDialog extends JDialog {
               MAXIMUM_SACRIFICED_TERMS, MAXIMUM_SACRIFICED_STEPS);
     }
 
+    /** Whether the employer has locked this clause as non-negotiable - it can be neither raised nor lowered. */
+    private boolean isLocked(Clause clause) {
+        return nonNegotiableTerms.isLocked(clause.term);
+    }
+
     /** Whether this clause's lower button should be active: an earlier raise can be undone, or a sacrifice is allowed. */
     private boolean canLower(Clause clause) {
+        if (isLocked(clause)) {
+            return false;
+        }
         int index = clause.ordinal();
         if (currentStep[index] > originalStep[index]) {
             return true;
@@ -789,7 +802,10 @@ public class ContractNegotiationDialog extends JDialog {
         for (Clause clause : Clause.values()) {
             int index = clause.ordinal();
             termValueLabels[index].setText(termValueHtml(clause));
-            termCapLabels[index].setText(getFormattedTextAt(RESOURCE_BUNDLE, "negotiate.contractMarket.cap",
+            // A locked term shows a "non-negotiable" badge in place of its raise-cap counter; its steppers are disabled.
+            termCapLabels[index].setText(isLocked(clause)
+                                               ? getTextAt(RESOURCE_BUNDLE, "negotiate.contractMarket.locked")
+                                               : getFormattedTextAt(RESOURCE_BUNDLE, "negotiate.contractMarket.cap",
                   max(0, currentStep[index] - originalStep[index]), capPerTerm));
             termRaiseButtons[index].setEnabled(canRaise(clause));
             termLowerButtons[index].setEnabled(canLower(clause));
@@ -812,6 +828,9 @@ public class ContractNegotiationDialog extends JDialog {
     }
 
     private boolean canRaise(Clause clause) {
+        if (isLocked(clause)) {
+            return false;
+        }
         int index = clause.ordinal();
         if (currentStep[index] >= CHAOS_CONTRACT_MAXIMUM_STEP_VALUE) {
             return false;

--- a/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractNegotiationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractNegotiationDialog.java
@@ -73,6 +73,8 @@ import mekhq.campaign.mission.contract.AbstractContract;
 import mekhq.campaign.mission.contract.contractData.ChaosContractStepsTable;
 import mekhq.campaign.mission.contract.contractData.ContractTermsData;
 import mekhq.campaign.mission.contract.contractData.NegotiationData;
+import mekhq.campaign.mission.contract.contractData.NegotiationStepMath;
+import mekhq.campaign.mission.contract.contractData.NegotiationStepMath.Term;
 import mekhq.campaign.mission.contract.contractData.RentedFacilitiesData;
 import mekhq.campaign.mission.contract.contractGeneration.ChaosContractPayDetermination;
 import mekhq.campaign.mission.contract.contractGeneration.negotiationsAndNPCs.TermFunding;
@@ -85,10 +87,16 @@ import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
  * The contract negotiation table. Lets the player improve a contract's terms - spending reputation or sacrificing steps
  * between terms - and rent support facilities, before accepting the offer.
  *
- * <p>Rules (Hot Spots: Draconis Reach): each of the five terms may be raised at most {@code Scale} steps; reputation
- * raises one term one step per point, up to {@code 2 x Scale} points total; and a term may be lowered two steps to
- * raise another one step, at most twice. Steps that leave a term's value unchanged (the em-dash plateaus on the
- * Contract Steps Table) are surfaced as "no change" so the player can see they must spend more to cross a band.</p>
+ * <p>Rules (Hot Spots: Draconis Reach): each of the five terms may be raised at most {@code Scale} steps above its
+ * baseline; reputation raises one term one step per point, up to {@code 2 x Scale} points total. Lowering a term skips
+ * straight to the next step whose value differs (whole plateaus on the Contract Steps Table are crossed in one move),
+ * banking one sacrifice step per raw step crossed; at most two distinct terms may be sacrificed, four raw steps in
+ * total. Two banked steps fund a one-step raise of another term (a "swap"), at most twice.</p>
+ *
+ * <p>Raising a sacrificed term reverses its lowers one at a time, returning it to the step each lower started from and
+ * reclaiming those banked steps. Raising a term above its baseline is single-step, and such a step may land on a
+ * plateau that leaves the value unchanged - surfaced as "no change" so the player sees they must spend more to cross a
+ * band.</p>
  *
  * @author Illiani
  * @since 0.51.01
@@ -99,6 +107,8 @@ public class ContractNegotiationDialog extends JDialog {
 
     private static final int SACRIFICE_STEPS_PER_SWAP = 2;
     private static final int MAXIMUM_SWAPS = 2;
+    private static final int MAXIMUM_SACRIFICED_TERMS = 2;
+    private static final int MAXIMUM_SACRIFICED_STEPS = 4;
     private static final int MAXIMUM_FACILITY_UNITS = 100;
 
     private static final String REPUTATION_HEX = "#1d5fa5";
@@ -149,16 +159,18 @@ public class ContractNegotiationDialog extends JDialog {
 
     /** The five negotiable clauses, in display order. */
     private enum Clause {
-        COMMAND("negotiate.contractMarket.term.command"),
-        PAY("negotiate.contractMarket.term.pay"),
-        SUPPORT("negotiate.contractMarket.term.support"),
-        TRANSPORT("negotiate.contractMarket.term.transport"),
-        SALVAGE("negotiate.contractMarket.term.salvage");
+        COMMAND("negotiate.contractMarket.term.command", Term.COMMAND_RIGHTS),
+        PAY("negotiate.contractMarket.term.pay", Term.BASE_PAY),
+        SUPPORT("negotiate.contractMarket.term.support", Term.SUPPORT),
+        TRANSPORT("negotiate.contractMarket.term.transport", Term.TRANSPORT),
+        SALVAGE("negotiate.contractMarket.term.salvage", Term.SALVAGE);
 
         private final String labelKey;
+        private final Term term;
 
-        Clause(String labelKey) {
+        Clause(String labelKey, Term term) {
             this.labelKey = labelKey;
+            this.term = term;
         }
     }
 
@@ -614,8 +626,23 @@ public class ContractNegotiationDialog extends JDialog {
 
     private void raise(Clause clause) {
         int index = clause.ordinal();
-        if ((currentStep[index] - originalStep[index]) >= capPerTerm
-                  || currentStep[index] >= CHAOS_CONTRACT_MAXIMUM_STEP_VALUE) {
+        if (currentStep[index] >= CHAOS_CONTRACT_MAXIMUM_STEP_VALUE) {
+            return;
+        }
+
+        if (currentStep[index] < originalStep[index]) {
+            int target = restoreTarget(clause);
+            int gap = target - currentStep[index];
+            if (gap > sacrificeBank) {
+                return;
+            }
+            sacrificeBank -= gap;
+            currentStep[index] = target;
+            refresh();
+            return;
+        }
+
+        if ((currentStep[index] - originalStep[index]) >= capPerTerm) {
             return;
         }
 
@@ -636,12 +663,8 @@ public class ContractNegotiationDialog extends JDialog {
 
     private void lower(Clause clause) {
         int index = clause.ordinal();
-        if (currentStep[index] <= CHAOS_CONTRACT_MINIMUM_STEP_VALUE) {
-            return;
-        }
 
         if (currentStep[index] > originalStep[index]) {
-            // Undo a raise, refunding whatever paid for it.
             TermFunding paidWith = funding.get(index).removeLast();
             if (paidWith == TermFunding.REPUTATION) {
                 reputationUsed--;
@@ -649,13 +672,49 @@ public class ContractNegotiationDialog extends JDialog {
                 swapsUsed--;
                 sacrificeBank += SACRIFICE_STEPS_PER_SWAP;
             }
-        } else {
-            // Drop below the original, banking a sacrifice step.
-            sacrificeBank++;
+            currentStep[index]--;
+            refresh();
+            return;
         }
 
-        currentStep[index]--;
+        int target = NegotiationStepMath.nextLowerDifferentStep(clause.term, currentStep[index]);
+        if (target < CHAOS_CONTRACT_MINIMUM_STEP_VALUE) {
+            return;
+        }
+        int gap = currentStep[index] - target;
+        if (!canSacrifice(clause, gap)) {
+            return;
+        }
+
+        currentStep[index] = target;
+        sacrificeBank += gap;
         refresh();
+    }
+
+    /**
+     * Whether {@code gap} more raw steps may be sacrificed from this clause, honoring the two global caps: at most
+     * {@link #MAXIMUM_SACRIFICED_TERMS} distinct terms sacrificed, and at most {@link #MAXIMUM_SACRIFICED_STEPS} raw
+     * steps in total across them.
+     */
+    private boolean canSacrifice(Clause clause, int gap) {
+        boolean alreadySacrificed = currentStep[clause.ordinal()] < originalStep[clause.ordinal()];
+        return NegotiationStepMath.sacrificeAllowed(gap, alreadySacrificed,
+              NegotiationStepMath.distinctTermsSacrificed(originalStep, currentStep),
+              NegotiationStepMath.totalStepsSacrificed(originalStep, currentStep),
+              MAXIMUM_SACRIFICED_TERMS, MAXIMUM_SACRIFICED_STEPS);
+    }
+
+    /** Whether this clause's lower button should be active: an earlier raise can be undone, or a sacrifice is allowed. */
+    private boolean canLower(Clause clause) {
+        int index = clause.ordinal();
+        if (currentStep[index] > originalStep[index]) {
+            return true;
+        }
+        int target = NegotiationStepMath.nextLowerDifferentStep(clause.term, currentStep[index]);
+        if (target < CHAOS_CONTRACT_MINIMUM_STEP_VALUE) {
+            return false;
+        }
+        return canSacrifice(clause, currentStep[index] - target);
     }
 
     private void adjustFacility(int index, int delta) {
@@ -719,8 +778,8 @@ public class ContractNegotiationDialog extends JDialog {
     private void refresh() {
         reputationBudgetLabel.setText(budgetHtml(getTextAt(RESOURCE_BUNDLE,
                     "negotiate.contractMarket.budget.reputation"),
-              pips(reputationPool - reputationUsed, reputationPool, REPUTATION_HEX)
-                    + " " + (reputationPool - reputationUsed) + "/" + reputationPool));
+              pips(reputationUsed, reputationPool, REPUTATION_HEX)
+                    + " " + reputationUsed + "/" + reputationPool));
         swapsBudgetLabel.setText(budgetHtml(getTextAt(RESOURCE_BUNDLE, "negotiate.contractMarket.budget.swaps"),
               pips(swapsUsed, MAXIMUM_SWAPS, SACRIFICE_HEX) + " " + swapsUsed + "/" + MAXIMUM_SWAPS));
         bankBudgetLabel.setText(budgetHtml(getTextAt(RESOURCE_BUNDLE, "negotiate.contractMarket.budget.bank"),
@@ -732,7 +791,7 @@ public class ContractNegotiationDialog extends JDialog {
             termCapLabels[index].setText(getFormattedTextAt(RESOURCE_BUNDLE, "negotiate.contractMarket.cap",
                   max(0, currentStep[index] - originalStep[index]), capPerTerm));
             termRaiseButtons[index].setEnabled(canRaise(clause));
-            termLowerButtons[index].setEnabled(currentStep[index] > CHAOS_CONTRACT_MINIMUM_STEP_VALUE);
+            termLowerButtons[index].setEnabled(canLower(clause));
         }
 
         payImpactLabel.setText(payImpactHtml());
@@ -746,17 +805,34 @@ public class ContractNegotiationDialog extends JDialog {
         }
 
         summaryLabel.setText(getFormattedTextAt(RESOURCE_BUNDLE, "negotiate.contractMarket.summary",
-              rentalTotal.toAmountAndSymbolString(), reputationPool - reputationUsed, sacrificeBank));
+              rentalTotal.toAmountAndSymbolString(), reputationPool - reputationUsed,
+              NegotiationStepMath.totalStepsSacrificed(originalStep, currentStep), MAXIMUM_SACRIFICED_STEPS,
+              NegotiationStepMath.distinctTermsSacrificed(originalStep, currentStep), MAXIMUM_SACRIFICED_TERMS));
     }
 
     private boolean canRaise(Clause clause) {
         int index = clause.ordinal();
-        if ((currentStep[index] - originalStep[index]) >= capPerTerm
-                  || currentStep[index] >= CHAOS_CONTRACT_MAXIMUM_STEP_VALUE) {
+        if (currentStep[index] >= CHAOS_CONTRACT_MAXIMUM_STEP_VALUE) {
+            return false;
+        }
+        if (currentStep[index] < originalStep[index]) {
+            return (restoreTarget(clause) - currentStep[index]) <= sacrificeBank;
+        }
+        if ((currentStep[index] - originalStep[index]) >= capPerTerm) {
             return false;
         }
         return reputationUsed < reputationPool
                      || (sacrificeBank >= SACRIFICE_STEPS_PER_SWAP && swapsUsed < MAXIMUM_SWAPS);
+    }
+
+    /**
+     * The step a below-baseline (sacrificed) term rises to on a single raise: the sacrifice boundary directly above
+     * where it now sits, i.e. the exact step the most recent lower started from. One raise mirrors one lower, and the
+     * term never rests on a mid-plateau step that shares the baseline's value.
+     */
+    private int restoreTarget(Clause clause) {
+        int index = clause.ordinal();
+        return NegotiationStepMath.restoreStep(clause.term, originalStep[index], currentStep[index]);
     }
 
     private String termValueHtml(Clause clause) {

--- a/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractNegotiationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractNegotiationDialog.java
@@ -691,8 +691,9 @@ public class ContractNegotiationDialog extends JDialog {
         ChaosContractStepsTable command = step(Clause.COMMAND);
 
         contract.setContractTerms(new ContractTermsData(payRate, support, transport, salvage, command));
-        contract.updateMonthlyPay(ChaosContractDeterminationPay.getMonthlyPay(campaign, contract));
-        contract.updateTransportPay(ChaosContractDeterminationPay.getTransportPay(campaign,
+        ChaosContractDeterminationPay payScheme = new ChaosContractDeterminationPay();
+        contract.updateMonthlyPay(payScheme.getMonthlyPay(campaign, contract));
+        contract.updateTransportPay(payScheme.getTransportPay(campaign,
               campaign.getLocalDate(), contract, currentLocation));
 
         contract.setRentedFacilitiesData(new RentedFacilitiesData(facilityQuantity[0],

--- a/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractNegotiationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractNegotiationDialog.java
@@ -74,7 +74,7 @@ import mekhq.campaign.mission.contract.contractData.ChaosContractStepsTable;
 import mekhq.campaign.mission.contract.contractData.ContractTermsData;
 import mekhq.campaign.mission.contract.contractData.NegotiationData;
 import mekhq.campaign.mission.contract.contractData.RentedFacilitiesData;
-import mekhq.campaign.mission.contract.contractGeneration.ChaosContractPayDetermination;
+import mekhq.campaign.mission.contract.contractGeneration.ChaosContractDeterminationPay;
 import mekhq.campaign.mission.contract.contractGeneration.negotiationsAndNPCs.TermFunding;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.universe.Faction;
@@ -691,8 +691,8 @@ public class ContractNegotiationDialog extends JDialog {
         ChaosContractStepsTable command = step(Clause.COMMAND);
 
         contract.setContractTerms(new ContractTermsData(payRate, support, transport, salvage, command));
-        contract.updateMonthlyPay(ChaosContractPayDetermination.getMonthlyPay(campaign, contract));
-        contract.updateTransportPay(ChaosContractPayDetermination.getTransportPay(campaign,
+        contract.updateMonthlyPay(ChaosContractDeterminationPay.getMonthlyPay(campaign, contract));
+        contract.updateTransportPay(ChaosContractDeterminationPay.getTransportPay(campaign,
               campaign.getLocalDate(), contract, currentLocation));
 
         contract.setRentedFacilitiesData(new RentedFacilitiesData(facilityQuantity[0],

--- a/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractNegotiationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractNegotiationDialog.java
@@ -37,6 +37,7 @@ import static megamek.client.ui.WrapLayout.wordWrap;
 import static megamek.client.ui.util.UIUtil.scaleForGUI;
 import static mekhq.campaign.mission.contract.contractData.ChaosContractStepsTable.CHAOS_CONTRACT_MAXIMUM_STEP_VALUE;
 import static mekhq.campaign.mission.contract.contractData.ChaosContractStepsTable.CHAOS_CONTRACT_MINIMUM_STEP_VALUE;
+import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.DISASTROUS;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 
@@ -869,14 +870,18 @@ public class ContractNegotiationDialog extends JDialog {
      * favors the player). A missing employer negotiator counts as a neutral result.
      */
     private int rollNetMargin() {
-        MarginOfSuccess playerMargin = reportedNegotiationCheck(contract.getPlayerNegotiator(),
+        Person playerNegotiator = contract.getPlayerNegotiator();
+        if (playerNegotiator == null) {
+            // This shouldn't happen, so we go ahead and log it.
+            LOGGER.warn("Contract {} has no player negotiator", contract.getName());
+            return DISASTROUS.getLowerBound();
+        }
+        MarginOfSuccess playerMargin = reportedNegotiationCheck(playerNegotiator,
               "negotiate.contractMarket.renegotiate.roll.player");
         Person employerNegotiator = contract.getEmployerNegotiator();
-        MarginOfSuccess employerMargin = employerNegotiator != null
-                                               ?
+        MarginOfSuccess employerMargin = employerNegotiator != null ?
                                                reportedNegotiationCheck(employerNegotiator,
-                                                     "negotiate.contractMarket.renegotiate.roll.employer")
-                                               :
+                                                     "negotiate.contractMarket.renegotiate.roll.employer") :
                                                MarginOfSuccess.BARELY_MADE_IT;
         return ActiveNegotiationMath.netMargin(playerMargin, employerMargin);
     }

--- a/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractNegotiationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractNegotiationDialog.java
@@ -874,7 +874,7 @@ public class ContractNegotiationDialog extends JDialog {
         if (playerNegotiator == null) {
             // This shouldn't happen, so we go ahead and log it.
             LOGGER.warn("Contract {} has no player negotiator", contract.getName());
-            return DISASTROUS.getLowerBound();
+            return ActiveNegotiationMath.netMargin(DISASTROUS, MarginOfSuccess.BARELY_MADE_IT);
         }
         MarginOfSuccess playerMargin = reportedNegotiationCheck(playerNegotiator,
               "negotiate.contractMarket.renegotiate.roll.player");
@@ -950,7 +950,7 @@ public class ContractNegotiationDialog extends JDialog {
         for (int move = 0; move < count; move++) {
             List<Clause> eligible = new ArrayList<>();
             for (Clause clause : Clause.values()) {
-                if (nonNegotiableTerms.isLocked(clause.term) != waive) {
+                if (nonNegotiableTerms.isLocked(clause.term) == waive) {
                     eligible.add(clause);
                 }
             }

--- a/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractNegotiationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractNegotiationDialog.java
@@ -74,7 +74,7 @@ import mekhq.campaign.mission.contract.contractData.ChaosContractStepsTable;
 import mekhq.campaign.mission.contract.contractData.ContractTermsData;
 import mekhq.campaign.mission.contract.contractData.NegotiationData;
 import mekhq.campaign.mission.contract.contractData.RentedFacilitiesData;
-import mekhq.campaign.mission.contract.contractGeneration.ChaosContractDeterminationPay;
+import mekhq.campaign.mission.contract.contractGeneration.AbstractContractDeterminationPay;
 import mekhq.campaign.mission.contract.contractGeneration.negotiationsAndNPCs.TermFunding;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.universe.Faction;
@@ -691,7 +691,7 @@ public class ContractNegotiationDialog extends JDialog {
         ChaosContractStepsTable command = step(Clause.COMMAND);
 
         contract.setContractTerms(new ContractTermsData(payRate, support, transport, salvage, command));
-        ChaosContractDeterminationPay payScheme = new ChaosContractDeterminationPay();
+        AbstractContractDeterminationPay payScheme = AbstractContractDeterminationPay.forCampaign(campaign);
         contract.updateMonthlyPay(payScheme.getMonthlyPay(campaign, contract));
         contract.updateTransportPay(payScheme.getTransportPay(campaign,
               campaign.getLocalDate(), contract, currentLocation));

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/contractData/ActiveNegotiationDataTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/contractData/ActiveNegotiationDataTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.mission.contract.contractData;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import mekhq.campaign.mission.contract.contractData.ActiveNegotiationData.Kind;
+import mekhq.campaign.mission.contract.contractData.NegotiationStepMath.Term;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies {@link ActiveNegotiationData}: the kind discriminator and the {@link Term}-to-delta mapping shared by both
+ * outcomes.
+ */
+class ActiveNegotiationDataTest {
+
+    @Test
+    void haggleIsTaggedHaggleAndExposesPerTermDeltas() {
+        ActiveNegotiationData data = ActiveNegotiationData.haggle(2, 1, -1, 2, -2, 3);
+        assertEquals(Kind.HAGGLE, data.kind());
+        assertEquals(1, data.deltaFor(Term.BASE_PAY));
+        assertEquals(-1, data.deltaFor(Term.SUPPORT));
+        assertEquals(2, data.deltaFor(Term.TRANSPORT));
+        assertEquals(-2, data.deltaFor(Term.SALVAGE));
+        assertEquals(3, data.deltaFor(Term.COMMAND_RIGHTS));
+    }
+
+    @Test
+    void exceptionIsTaggedExceptionAndExposesPerTermLockChanges() {
+        // +1 waived, -1 newly locked, 0 unchanged.
+        ActiveNegotiationData data = ActiveNegotiationData.exception(1, 1, 0, -1, 0, 0);
+        assertEquals(Kind.EXCEPTION, data.kind());
+        assertEquals(1, data.deltaFor(Term.BASE_PAY));
+        assertEquals(0, data.deltaFor(Term.SUPPORT));
+        assertEquals(-1, data.deltaFor(Term.TRANSPORT));
+        assertEquals(0, data.deltaFor(Term.SALVAGE));
+        assertEquals(0, data.deltaFor(Term.COMMAND_RIGHTS));
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/contractData/ActiveNegotiationMathTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/contractData/ActiveNegotiationMathTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.mission.contract.contractData;
+
+import static mekhq.campaign.mission.contract.contractData.ActiveNegotiationMath.marginScore;
+import static mekhq.campaign.mission.contract.contractData.ActiveNegotiationMath.netMargin;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import mekhq.campaign.personnel.skills.enums.MarginOfSuccess;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/**
+ * Verifies {@link ActiveNegotiationMath}: the level scoring of a {@link MarginOfSuccess} and the net of an opposed
+ * pair.
+ */
+class ActiveNegotiationMathTest {
+
+    @Test
+    void barelyMadeItScoresZeroAndBetterOutscoresWorse() {
+        assertEquals(0, marginScore(MarginOfSuccess.BARELY_MADE_IT));
+        assertTrue(marginScore(MarginOfSuccess.SPECTACULAR) > 0, "the best result must score positive");
+        assertTrue(marginScore(MarginOfSuccess.DISASTROUS) < 0, "the worst result must score negative");
+        assertTrue(marginScore(MarginOfSuccess.GOOD) > marginScore(MarginOfSuccess.IT_WILL_DO),
+              "a better margin must score higher");
+    }
+
+    @ParameterizedTest
+    @EnumSource(MarginOfSuccess.class)
+    void marginScoreIsStrictlyBetterForBetterResults(final MarginOfSuccess margin) {
+        // Enum is ordered best-first, so a lower ordinal (better result) must never score lower than a worse one.
+        for (MarginOfSuccess worse : MarginOfSuccess.values()) {
+            if (margin.ordinal() < worse.ordinal()) {
+                assertTrue(marginScore(margin) > marginScore(worse),
+                      margin + " should outscore " + worse);
+            }
+        }
+    }
+
+    @Test
+    void netMarginFavorsTheStrongerNegotiator() {
+        // Player clearly better -> positive net (that many terms improve).
+        assertTrue(netMargin(MarginOfSuccess.SPECTACULAR, MarginOfSuccess.DISASTROUS) > 0);
+        // Employer clearly better -> negative net (that many lower).
+        assertTrue(netMargin(MarginOfSuccess.DISASTROUS, MarginOfSuccess.SPECTACULAR) < 0);
+        // Equal results -> stalemate.
+        assertEquals(0, netMargin(MarginOfSuccess.GOOD, MarginOfSuccess.GOOD));
+        // The contest is antisymmetric: swapping the sides negates the net.
+        assertEquals(-netMargin(MarginOfSuccess.GOOD, MarginOfSuccess.BAD),
+              netMargin(MarginOfSuccess.BAD, MarginOfSuccess.GOOD));
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/contractData/NegotiationStepMathTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/contractData/NegotiationStepMathTest.java
@@ -33,6 +33,7 @@
 package mekhq.campaign.mission.contract.contractData;
 
 import static mekhq.campaign.mission.contract.contractData.NegotiationStepMath.distinctTermsSacrificed;
+import static mekhq.campaign.mission.contract.contractData.NegotiationStepMath.nextHigherDifferentStep;
 import static mekhq.campaign.mission.contract.contractData.NegotiationStepMath.nextLowerDifferentStep;
 import static mekhq.campaign.mission.contract.contractData.NegotiationStepMath.rawValue;
 import static mekhq.campaign.mission.contract.contractData.NegotiationStepMath.restoreStep;
@@ -95,6 +96,30 @@ class NegotiationStepMathTest {
     void nextLowerDifferentStepFromTheBottomStepIsAlwaysMinusOne(final Term term) {
         assertEquals(-1, nextLowerDifferentStep(term, 1),
               "no term has a lower distinct value than its step-1 value");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+          // Base Pay: every step distinct, so the next higher value is the next step (until the top).
+          "BASE_PAY, 1, 2", "BASE_PAY, 16, 17", "BASE_PAY, 17, -1",
+          // Command Rights bands crossed upward; INDEPENDENT (11-17) has nothing higher that differs.
+          "COMMAND_RIGHTS, 1, 4", "COMMAND_RIGHTS, 3, 4", "COMMAND_RIGHTS, 7, 8", "COMMAND_RIGHTS, 10, 11",
+          "COMMAND_RIGHTS, 11, -1", "COMMAND_RIGHTS, 15, -1",
+          // Transport: 0.0(1-5) -> 0.25, and 1.0(9-17) is the top band.
+          "TRANSPORT, 1, 6", "TRANSPORT, 5, 6", "TRANSPORT, 8, 9", "TRANSPORT, 9, -1",
+          // Salvage: percent-0(1) -> exchange(2-3) -> percentages, 1.0(13-17) top band.
+          "SALVAGE, 1, 2", "SALVAGE, 2, 4", "SALVAGE, 12, 13", "SALVAGE, 13, -1",
+          // Support: (1.0,1.0) spans 15-17.
+          "SUPPORT, 1, 2", "SUPPORT, 8, 9", "SUPPORT, 14, 15", "SUPPORT, 15, -1" })
+    void nextHigherDifferentStepCrossesPlateaus(final Term term, final int fromStep, final int expected) {
+        assertEquals(expected, nextHigherDifferentStep(term, fromStep));
+    }
+
+    @ParameterizedTest
+    @EnumSource(Term.class)
+    void nextHigherDifferentStepFromTheTopStepIsAlwaysMinusOne(final Term term) {
+        assertEquals(-1, nextHigherDifferentStep(term, 17),
+              "no term has a higher distinct value than its step-17 value");
     }
 
     @ParameterizedTest

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/contractData/NegotiationStepMathTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/contractData/NegotiationStepMathTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.mission.contract.contractData;
+
+import static mekhq.campaign.mission.contract.contractData.NegotiationStepMath.distinctTermsSacrificed;
+import static mekhq.campaign.mission.contract.contractData.NegotiationStepMath.nextLowerDifferentStep;
+import static mekhq.campaign.mission.contract.contractData.NegotiationStepMath.rawValue;
+import static mekhq.campaign.mission.contract.contractData.NegotiationStepMath.restoreStep;
+import static mekhq.campaign.mission.contract.contractData.NegotiationStepMath.sacrificeAllowed;
+import static mekhq.campaign.mission.contract.contractData.NegotiationStepMath.totalStepsSacrificed;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import mekhq.campaign.mission.contract.contractData.NegotiationStepMath.Term;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/**
+ * Exercises {@link NegotiationStepMath}: the plateau-crossing lowering logic ({@code nextLowerDifferentStep}) and the
+ * sacrifice caps ({@code sacrificeAllowed} and the two counters).
+ */
+class NegotiationStepMathTest {
+
+    // The distinct-term and total-step caps the dialog uses, so the cap tests read against real limits.
+    private static final int MAX_TERMS = 2;
+    private static final int MAX_STEPS = 4;
+
+    @ParameterizedTest
+    @CsvSource({
+          // Base Pay has no plateaus - every step is distinct, so lowering always drops exactly one step.
+          "BASE_PAY, 17, 16", "BASE_PAY, 5, 4", "BASE_PAY, 2, 1", "BASE_PAY, 1, -1",
+          // Command Rights: INTEGRATED(1-3), HOUSE(4-7), LIAISON(8-10), INDEPENDENT(11-17).
+          "COMMAND_RIGHTS, 11, 10",  // INDEPENDENT -> LIAISON, one step
+          "COMMAND_RIGHTS, 17, 10",  // INDEPENDENT (top) -> LIAISON, crossing the whole 11-17 band (gap 7)
+          "COMMAND_RIGHTS, 8, 7",    // LIAISON -> HOUSE
+          "COMMAND_RIGHTS, 7, 3",    // HOUSE -> INTEGRATED, crossing 4-7 (gap 4)
+          "COMMAND_RIGHTS, 4, 3",    // HOUSE bottom -> INTEGRATED
+          "COMMAND_RIGHTS, 3, -1",   // INTEGRATED is the floor band
+          "COMMAND_RIGHTS, 1, -1",
+          // Transport: 0.0(1-5), 0.25, 0.5, 0.75, then 1.0(9-17).
+          "TRANSPORT, 9, 8",         // 1.0 -> 0.75
+          "TRANSPORT, 6, 5",         // 0.25 -> 0.0
+          "TRANSPORT, 5, -1",        // 0.0 spans 1-5 and is the floor
+          "TRANSPORT, 1, -1",
+          // Salvage pairs exchange flag with multiplier: percent-0(1), exchange-0.25(2-3), then percentages.
+          "SALVAGE, 3, 1",           // exchange 0.25 (2-3) -> percent 0.0 at step 1 (gap 2)
+          "SALVAGE, 2, 1",
+          "SALVAGE, 13, 12",         // 1.0 -> 0.9 (13-17 all read 1.0)
+          "SALVAGE, 1, -1",
+          // Support pairs straight-support with battlefield-loss; (1.0,1.0) spans 15-17.
+          "SUPPORT, 17, 14",         // (1.0,1.0) -> (1.0,0.75), crossing 15-17 (gap 3)
+          "SUPPORT, 9, 8",           // (1.0,0.1) -> (1.0,0.0)
+          "SUPPORT, 8, 7",           // (1.0,0.0) -> (0.9,0.0)
+          "SUPPORT, 1, -1" })
+    void nextLowerDifferentStepCrossesPlateaus(final Term term, final int fromStep, final int expected) {
+        assertEquals(expected, nextLowerDifferentStep(term, fromStep));
+    }
+
+    @ParameterizedTest
+    @EnumSource(Term.class)
+    void nextLowerDifferentStepFromTheBottomStepIsAlwaysMinusOne(final Term term) {
+        assertEquals(-1, nextLowerDifferentStep(term, 1),
+              "no term has a lower distinct value than its step-1 value");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+          // A single plateau-crossing lower is undone by a single raise straight back to the baseline: Command Rights
+          // baseline 7 (top of HOUSE) sacrificed to 3 (INTEGRATED) restores directly to 7, never resting on step 4-6
+          // (which share the baseline's HOUSE value and would leave spendable bank for no concession).
+          "COMMAND_RIGHTS, 7, 3, 7",
+          "COMMAND_RIGHTS, 11, 10, 11",  // one-step lower, one-step restore
+          // Not below baseline: nothing to restore, returns the baseline itself.
+          "COMMAND_RIGHTS, 7, 7, 7",
+          "BASE_PAY, 8, 8, 8",
+          // Base Pay has no plateaus, so each lower is one step and each restore is one step.
+          "BASE_PAY, 8, 5, 6",   // lowered 8->7->6->5; one raise undoes the last, 5->6
+          "BASE_PAY, 8, 7, 8",
+          // Transport: distinct values 6-9, so stepping; one raise undoes one lower.
+          "TRANSPORT, 9, 5, 6",  // 9->8->7->6->5 down; restore 5->6
+          "TRANSPORT, 9, 8, 9",
+          // Support was lowered twice: 17->14 (crossing the 15-17 plateau), then 14->13. One raise undoes only the
+          // last lower (13->14), leaving the term on a genuine boundary whose value differs from the baseline's.
+          "SUPPORT, 17, 13, 14",
+          "SUPPORT, 17, 14, 17" })
+    void restoreStepUndoesExactlyOneLower(final Term term, final int originalStep, final int currentStep,
+          final int expected) {
+        assertEquals(expected, restoreStep(term, originalStep, currentStep));
+    }
+
+    @Test
+    void restoreStepNeverRestsOnAStepSharingTheBaselineValue() {
+        // The anti-exploit property: from any sacrificed position, the step a raise restores to either is the baseline
+        // itself or carries a value different from the baseline's - so a term can never sit below baseline showing no
+        // concession while still holding spendable bank. Checked exhaustively over Command Rights, the widest bands.
+        for (int baseline = 1; baseline <= 17; baseline++) {
+            for (int current = 1; current < baseline; current++) {
+                int target = restoreStep(Term.COMMAND_RIGHTS, baseline, current);
+                if (target != baseline) {
+                    assertNotEquals(rawValue(Term.COMMAND_RIGHTS, ChaosContractStepsTable.fromStepValue(baseline)),
+                          rawValue(Term.COMMAND_RIGHTS, ChaosContractStepsTable.fromStepValue(target)),
+                          "restore target " + target + " must not share baseline " + baseline + "'s value");
+                }
+            }
+        }
+    }
+
+    @Test
+    void totalAndDistinctCountOnlyStepsBelowBaseline() {
+        // Two parallel terms: the first sacrificed by 3 steps, the second raised by 2 (must not count as sacrifice).
+        int[] original = { 11, 5 };
+        int[] current = { 8, 7 };
+        assertEquals(3, totalStepsSacrificed(original, current));
+        assertEquals(1, distinctTermsSacrificed(original, current));
+    }
+
+    @Test
+    void sacrificeAllowedRefusesNonPositiveGaps() {
+        assertFalse(sacrificeAllowed(0, true, 0, 0, MAX_TERMS, MAX_STEPS));
+        assertFalse(sacrificeAllowed(-1, true, 0, 0, MAX_TERMS, MAX_STEPS));
+    }
+
+    @Test
+    void sacrificeAllowedRefusesAThirdDistinctTerm() {
+        // Two terms already sacrificed; opening a new one is refused even though only 2 of 4 steps are spent.
+        assertFalse(sacrificeAllowed(1, false, MAX_TERMS, 2, MAX_TERMS, MAX_STEPS));
+        // ...but adding to a term already sacrificed is fine while steps remain.
+        assertTrue(sacrificeAllowed(1, true, MAX_TERMS, 2, MAX_TERMS, MAX_STEPS));
+    }
+
+    @Test
+    void sacrificeAllowedRefusesCrossingTheTotalStepCap() {
+        assertFalse(sacrificeAllowed(3, false, 1, 2, MAX_TERMS, MAX_STEPS), "2 spent + 3 more = 5 exceeds 4");
+        assertTrue(sacrificeAllowed(2, false, 1, 2, MAX_TERMS, MAX_STEPS), "2 spent + 2 more = 4 is exactly the cap");
+    }
+
+    @Test
+    void commandRightsHighInIndependentCannotBeSacrificed() {
+        // A contract generated deep in the INDEPENDENT band: the nearest lower value (LIAISON at step 10) is 5 steps
+        // away, over the 4-step cap, so the term cannot be lowered at all.
+        int fromStep = 15;
+        int target = nextLowerDifferentStep(Term.COMMAND_RIGHTS, fromStep);
+        assertEquals(10, target);
+        assertFalse(sacrificeAllowed(fromStep - target, false, 0, 0, MAX_TERMS, MAX_STEPS),
+              "crossing 5 steps must be refused against a 4-step cap");
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/contractData/NonNegotiableTermsDataTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/contractData/NonNegotiableTermsDataTest.java
@@ -67,4 +67,15 @@ class NonNegotiableTermsDataTest {
                   "only " + locked + " should read as locked, but " + term + " disagreed");
         }
     }
+
+    @ParameterizedTest
+    @EnumSource(Term.class)
+    void withUnlockedClearsOnlyThatTerm(final Term toUnlock) {
+        NonNegotiableTermsData allLocked = new NonNegotiableTermsData(true, true, true, true, true);
+        NonNegotiableTermsData result = allLocked.withUnlocked(toUnlock);
+        for (Term term : Term.values()) {
+            assertEquals(term != toUnlock, result.isLocked(term),
+                  toUnlock + " should be the only term cleared, but " + term + " disagreed");
+        }
+    }
 }

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/contractData/NonNegotiableTermsDataTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/contractData/NonNegotiableTermsDataTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.mission.contract.contractData;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import mekhq.campaign.mission.contract.contractData.NegotiationStepMath.Term;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/**
+ * Verifies {@link NonNegotiableTermsData}: the {@link Term}-to-field mapping in {@code isLocked}, plus the {@code none}
+ * and {@code anyLocked} helpers.
+ */
+class NonNegotiableTermsDataTest {
+
+    @Test
+    void noneLocksNothing() {
+        NonNegotiableTermsData none = NonNegotiableTermsData.none();
+        assertFalse(none.anyLocked());
+        for (Term term : Term.values()) {
+            assertFalse(none.isLocked(term), term + " must be unlocked in none()");
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(Term.class)
+    void isLockedReflectsOnlyTheMatchingTerm(final Term locked) {
+        NonNegotiableTermsData data = new NonNegotiableTermsData(locked == Term.BASE_PAY, locked == Term.SUPPORT,
+              locked == Term.TRANSPORT, locked == Term.SALVAGE, locked == Term.COMMAND_RIGHTS);
+        assertTrue(data.anyLocked());
+        for (Term term : Term.values()) {
+            assertEquals(term == locked, data.isLocked(term),
+                  "only " + locked + " should read as locked, but " + term + " disagreed");
+        }
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/AbstractContractDeterminationPayTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/AbstractContractDeterminationPayTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.mission.contract.contractGeneration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+
+import mekhq.campaign.AbstractLocation;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.JumpPath;
+import mekhq.campaign.campaignOptions.CampaignOption;
+import mekhq.campaign.campaignOptions.CampaignOptions;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.mission.contract.AbstractContract;
+import mekhq.campaign.mission.contract.contractData.ContractFinanceData;
+import mekhq.campaign.mission.utilities.ContractUtilities;
+import mekhq.campaign.universe.PlanetarySystem;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+/**
+ * Tests the shared behavior on {@link AbstractContractDeterminationPay}: the
+ * {@link AbstractContractDeterminationPay#forCampaign(Campaign)} scheme selector, the
+ * {@link AbstractContractDeterminationPay#determineContractPay} template method that composes the three pay components
+ * into the contract's {@link ContractFinanceData}, and the shared transport-pay calculation.
+ */
+class AbstractContractDeterminationPayTest {
+    private static final LocalDate DATE = LocalDate.of(3025, 1, 1);
+
+    /** A campaign whose {@code campaignOptions.get(option)} returns the supplied value, and nothing else stubbed. */
+    private static Campaign campaignWithOption(CampaignOption<Boolean> option, boolean value) {
+        CampaignOptions options = mock(CampaignOptions.class);
+        when(options.get(option)).thenReturn(value);
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getCampaignOptions()).thenReturn(options);
+        return campaign;
+    }
+
+    // region forCampaign
+
+    @Test
+    void forCampaignPicksChaosByDefault() {
+        Campaign campaign = campaignWithOption(CampaignOption.USE_LEGACY_CONTRACT_PAY, false);
+        assertInstanceOf(ChaosContractDeterminationPay.class,
+              AbstractContractDeterminationPay.forCampaign(campaign));
+    }
+
+    @Test
+    void forCampaignPicksCamOpsWhenLegacyContractPayIsSet() {
+        Campaign campaign = campaignWithOption(CampaignOption.USE_LEGACY_CONTRACT_PAY, true);
+        assertInstanceOf(CamOpsContractDeterminationPay.class,
+              AbstractContractDeterminationPay.forCampaign(campaign));
+    }
+
+    // endregion forCampaign
+
+    // region determineContractPay template
+
+    /** A scheme with fixed, distinct pay components, so the template's wiring into the record can be checked. */
+    private static class FixedPay extends AbstractContractDeterminationPay {
+        static final Money MONTHLY = Money.of(500);
+        static final Money COMBAT = Money.of(250);
+        static final Money TRANSPORT = Money.of(1_000);
+
+        @Override
+        public Money getMonthlyPay(Campaign campaign, AbstractContract contract) {
+            return MONTHLY;
+        }
+
+        @Override
+        public Money getCombatPay(Campaign campaign, AbstractContract contract) {
+            return COMBAT;
+        }
+
+        @Override
+        public Money getTransportPay(Campaign campaign, LocalDate currentDate, AbstractContract contract,
+              AbstractLocation currentLocation) {
+            return TRANSPORT;
+        }
+    }
+
+    @Test
+    void determineContractPayComposesTheThreeComponentsIntoTheContract() {
+        AbstractContract contract = mock(AbstractContract.class);
+
+        new FixedPay().determineContractPay(mock(Campaign.class), DATE, contract, mock(AbstractLocation.class));
+
+        ArgumentCaptor<ContractFinanceData> captor = ArgumentCaptor.forClass(ContractFinanceData.class);
+        verify(contract).setContractFinanceData(captor.capture());
+        ContractFinanceData financeData = captor.getValue();
+        assertEquals(FixedPay.MONTHLY, financeData.monthlyPay());
+        assertEquals(FixedPay.COMBAT, financeData.combatPay());
+        assertEquals(FixedPay.TRANSPORT, financeData.transport());
+    }
+
+    // endregion determineContractPay template
+
+    // region transport pay
+
+    /**
+     * Sets up a campaign/contract/location for the transport calculation and runs it. The jump path is stubbed via a
+     * static mock; a {@code jumps} of {@code 0} stands in for "no route" (a {@code null} jump path).
+     */
+    private static Money transportPay(int scale, int jumps, double transportMultiplier, boolean atHiringHall,
+          boolean twoWayPay, boolean convertSupportPoints) {
+        CampaignOptions options = mock(CampaignOptions.class);
+        when(options.get(CampaignOption.IS_USE_TWO_WAY_PAY)).thenReturn(twoWayPay);
+        when(options.get(CampaignOption.USE_CHAOS_SUPPORT_POINT_CONVERSION)).thenReturn(convertSupportPoints);
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getCampaignOptions()).thenReturn(options);
+
+        PlanetarySystem currentSystem = mock(PlanetarySystem.class);
+        when(currentSystem.isHiringHall(DATE)).thenReturn(atHiringHall);
+        AbstractLocation currentLocation = mock(AbstractLocation.class);
+        when(currentLocation.getCurrentSystem()).thenReturn(currentSystem);
+
+        AbstractContract contract = mock(AbstractContract.class);
+        when(contract.getScale()).thenReturn(scale);
+        when(contract.getTransportMultiplier()).thenReturn(transportMultiplier);
+
+        JumpPath jumpPath = jumps == 0 ? null : mock(JumpPath.class);
+        if (jumpPath != null) {
+            when(jumpPath.getJumps()).thenReturn(jumps);
+        }
+
+        // Any concrete subclass inherits the shared transport calculation unchanged.
+        AbstractContractDeterminationPay payScheme = new ChaosContractDeterminationPay();
+        try (MockedStatic<ContractUtilities> contractUtilities = mockStatic(ContractUtilities.class)) {
+            contractUtilities.when(() -> ContractUtilities.getJumpPath(eq(campaign), eq(contract), eq(currentLocation)))
+                  .thenReturn(jumpPath);
+            return payScheme.getTransportPay(campaign, DATE, contract, currentLocation);
+        }
+    }
+
+    @Test
+    void transportPayIsZeroWhenThereIsNoJourney() {
+        assertEquals(Money.zero(), transportPay(4, 0, 1.0, false, false, false));
+    }
+
+    @Test
+    void transportPayScalesWithScaleAndJumpCount() {
+        // 50 * scale(3) * jumps(2) = 300 support points, unconverted.
+        assertEquals(Money.of(300), transportPay(3, 2, 1.0, false, false, false));
+    }
+
+    @Test
+    void transportPayAppliesTheNegotiatedTransportMultiplier() {
+        // 50 * 2 * 1 = 100, rounded after the 1.5x multiplier -> 150 support points.
+        assertEquals(Money.of(150), transportPay(2, 1, 1.5, false, false, false));
+    }
+
+    @Test
+    void transportPayDoublesForTwoWayHiringHallPay() {
+        // 50 * 2 * 1 = 100, doubled by the hiring-hall return leg -> 200 support points.
+        assertEquals(Money.of(200), transportPay(2, 1, 1.0, true, true, false));
+    }
+
+    @Test
+    void transportPayIgnoresHiringHallReturnWhenTwoWayPayIsOff() {
+        assertEquals(Money.of(100), transportPay(2, 1, 1.0, true, false, false));
+    }
+
+    @Test
+    void transportPayConvertsSupportPointsToCBillsWhenEnabled() {
+        // 50 * 2 * 1 = 100 support points, converted at 10,000 C-bills each.
+        assertEquals(Money.of(1_000_000), transportPay(2, 1, 1.0, false, false, true));
+    }
+
+    // endregion transport pay
+}

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/CamOpsContractDeterminationPayTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/CamOpsContractDeterminationPayTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.mission.contract.contractGeneration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Accountant;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.mission.contract.AbstractContract;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the CamOps pay scheme: {@link CamOpsContractDeterminationPay#getMonthlyPay} grounds the retainer in the
+ * campaign's CamOps contract-base force value scaled by the negotiated base-pay multiplier, while
+ * {@link CamOpsContractDeterminationPay#getCombatPay} is always zero because CamOps folds combat compensation into the
+ * monthly retainer.
+ */
+class CamOpsContractDeterminationPayTest {
+    private final CamOpsContractDeterminationPay payScheme = new CamOpsContractDeterminationPay();
+
+    private static Campaign campaignWithContractBase(Money contractBase) {
+        Accountant accountant = mock(Accountant.class);
+        when(accountant.getContractBase()).thenReturn(contractBase);
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getAccountant()).thenReturn(accountant);
+        return campaign;
+    }
+
+    private static AbstractContract contractWithBasePayMultiplier(double basePayMultiplier) {
+        AbstractContract contract = mock(AbstractContract.class);
+        when(contract.getBasePayMultiplier()).thenReturn(basePayMultiplier);
+        return contract;
+    }
+
+    @Test
+    void monthlyPayIsTheContractBaseUnchangedAtAUnitMultiplier() {
+        assertEquals(Money.of(5_000_000),
+              payScheme.getMonthlyPay(campaignWithContractBase(Money.of(5_000_000)),
+                    contractWithBasePayMultiplier(1.0)));
+    }
+
+    @Test
+    void monthlyPayScalesTheContractBaseByTheNegotiatedMultiplier() {
+        // 5,000,000 force value * 1.5 negotiated base-pay multiplier.
+        assertEquals(Money.of(7_500_000),
+              payScheme.getMonthlyPay(campaignWithContractBase(Money.of(5_000_000)),
+                    contractWithBasePayMultiplier(1.5)));
+    }
+
+    @Test
+    void combatPayIsAlwaysZero() {
+        assertEquals(Money.zero(),
+              payScheme.getCombatPay(mock(Campaign.class), mock(AbstractContract.class)));
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationEmployerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationEmployerTest.java
@@ -48,7 +48,7 @@ import java.util.List;
 
 import megamek.common.compute.Compute;
 import mekhq.campaign.location.ILocation;
-import mekhq.campaign.mission.contract.contractGeneration.ChaosContractEmployerDetermination.EmployerFactions;
+import mekhq.campaign.mission.contract.contractGeneration.ChaosContractDeterminationEmployer.EmployerFactions;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.PlanetarySystem;
@@ -57,14 +57,14 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 /**
- * Covers the flavor/anchor/sponsor resolution in {@link ChaosContractEmployerDetermination#determineEmployerFactions}
+ * Covers the flavor/anchor/sponsor resolution in {@link ChaosContractDeterminationEmployer#determineEmployerFactions}
  * &mdash; in particular the rebel-sponsor rule: rebels always remain the visible employer, and a ComStar/Word of Blake
  * patron that would otherwise take over the contract instead becomes their covert backer on a mercenary search.
  *
  * <p>The faction singletons, the random faction generator, and the dice are all stubbed so these tests are fully
  * deterministic and need no loaded universe.</p>
  */
-class ChaosContractEmployerDeterminationTest {
+class ChaosContractDeterminationEmployerTest {
 
     private static final int YEAR = 3050;
     private static final LocalDate DATE = LocalDate.of(YEAR, 1, 1);
@@ -121,7 +121,7 @@ class ChaosContractEmployerDeterminationTest {
             // A roll of 0 opens the ComStar override, which is checked before Word of Blake.
             compute.when(() -> Compute.randomInt(anyInt())).thenReturn(0);
 
-            EmployerFactions result = ChaosContractEmployerDetermination.determineEmployerFactions(
+            EmployerFactions result = ChaosContractDeterminationEmployer.determineEmployerFactions(
                   ChaosEmployerType.CIVILIAN_ORGANIZATION_REBELS, DATE, locationOwnedByHouse(), true);
 
             assertSame(rebels, result.flavor(), "rebels remain the visible employer");
@@ -143,7 +143,7 @@ class ChaosContractEmployerDeterminationTest {
             // A non-zero roll misses both the ComStar and Word of Blake override windows.
             compute.when(() -> Compute.randomInt(anyInt())).thenReturn(1);
 
-            EmployerFactions result = ChaosContractEmployerDetermination.determineEmployerFactions(
+            EmployerFactions result = ChaosContractDeterminationEmployer.determineEmployerFactions(
                   ChaosEmployerType.CIVILIAN_ORGANIZATION_REBELS, DATE, locationOwnedByHouse(), true);
 
             assertSame(rebels, result.flavor());
@@ -162,7 +162,7 @@ class ChaosContractEmployerDeterminationTest {
         try (MockedStatic<Factions> factionsStatic = mockStatic(Factions.class)) {
             stubFactions(factionsStatic, rebels, house, comStar, wordOfBlake);
 
-            EmployerFactions result = ChaosContractEmployerDetermination.determineEmployerFactions(
+            EmployerFactions result = ChaosContractDeterminationEmployer.determineEmployerFactions(
                   ChaosEmployerType.CIVILIAN_ORGANIZATION_REBELS, DATE, locationOwnedByHouse(), false);
 
             assertSame(rebels, result.flavor());
@@ -181,7 +181,7 @@ class ChaosContractEmployerDeterminationTest {
         try (MockedStatic<Factions> factionsStatic = mockStatic(Factions.class)) {
             stubFactions(factionsStatic, rebels, house, comStar, wordOfBlake);
 
-            EmployerFactions result = ChaosContractEmployerDetermination.determineEmployerFactions(
+            EmployerFactions result = ChaosContractDeterminationEmployer.determineEmployerFactions(
                   ChaosEmployerType.LOCAL_SYSTEM_OWNER, DATE, locationOwnedByHouse(), false);
 
             assertSame(house, result.flavor(), "a local system owner is the current system's controller");
@@ -209,7 +209,7 @@ class ChaosContractEmployerDeterminationTest {
             // Resolves the fronting corporation's flavor faction.
             when(generator.getRandomEmployerFaction(eq(location), eq(DATE), eq(true), any())).thenReturn(house);
 
-            EmployerFactions result = ChaosContractEmployerDetermination.determineEmployerFactions(
+            EmployerFactions result = ChaosContractDeterminationEmployer.determineEmployerFactions(
                   ChaosEmployerType.CORPORATION, DATE, location, true);
 
             assertEquals(ChaosEmployerType.CORPORATION, result.type(),
@@ -240,7 +240,7 @@ class ChaosContractEmployerDeterminationTest {
             generatorStatic.when(RandomFactionGenerator::getInstance).thenReturn(generator);
             when(generator.getRandomEmployerFaction(eq(location), eq(DATE), eq(true), any())).thenReturn(house);
 
-            EmployerFactions result = ChaosContractEmployerDetermination.determineEmployerFactions(
+            EmployerFactions result = ChaosContractDeterminationEmployer.determineEmployerFactions(
                   ChaosEmployerType.CORPORATION, DATE, location, true);
 
             assertEquals(ChaosEmployerType.CORPORATION, result.type(), "Word of Blake keeps the rolled employer type");

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationIntensityTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationIntensityTest.java
@@ -40,16 +40,16 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 /**
- * Tests the roll-to-track-count tables in {@link ChaosContractDetermineIntensity}. The 2d6 roll is stubbed so each
+ * Tests the roll-to-track-count tables in {@link ChaosContractDeterminationIntensity}. The 2d6 roll is stubbed so each
  * branch of every objective family is pinned, including the boundary rolls (2 and 12) where an off-by-one in the switch
  * would show up.
  */
-class ChaosContractDetermineIntensityTest {
+class ChaosContractDeterminationIntensityTest {
 
     private static int trackCountForRoll(final ChaosObjectiveType objectiveType, final int roll) {
         try (MockedStatic<Compute> compute = mockStatic(Compute.class)) {
             compute.when(() -> Compute.d6(2)).thenReturn(roll);
-            return ChaosContractDetermineIntensity.determineTrackCount(objectiveType);
+            return ChaosContractDeterminationIntensity.determineTrackCount(objectiveType);
         }
     }
 

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationObjectiveTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationObjectiveTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 /**
- * Tests {@link ChaosContractObjectiveDetermination#determineContractObjectiveType(int)} - which bracket the 2d6 roll
+ * Tests {@link ChaosContractDeterminationObjective#determineContractObjectiveType(int)} - which bracket the 2d6 roll
  * (plus a generation modifier, clamped to 1..13) lands in, and the follow-up roll that picks the opposing objective.
  *
  * <p>Each call rolls d6 more than once, so the stub feeds a sequence: the first value is the bracket roll and the rest
@@ -53,14 +53,14 @@ import org.mockito.MockedStatic;
  * map back to a category (e.g. RAID -> Recon Raid or Diversionary Raid), so the concrete variant is not deterministic
  * across two independent invocations.</p>
  */
-class ChaosContractObjectiveDeterminationTest {
+class ChaosContractDeterminationObjectiveTest {
 
     /** The first roll is the bracket; any further rolls feed the sub-objective picks in call order. */
     private static ContractObjectiveData determine(final int modifier, final Integer firstRoll,
           final Integer... furtherRolls) {
         try (MockedStatic<Compute> compute = mockStatic(Compute.class)) {
             compute.when(() -> Compute.d6(2)).thenReturn(firstRoll, furtherRolls);
-            return ChaosContractObjectiveDetermination.determineContractObjectiveType(modifier);
+            return ChaosContractDeterminationObjective.determineContractObjectiveType(modifier);
         }
     }
 

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationPayTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationPayTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.mission.contract.contractGeneration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import mekhq.campaign.Campaign;
+import mekhq.campaign.campaignOptions.CampaignOption;
+import mekhq.campaign.campaignOptions.CampaignOptions;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.mission.contract.AbstractContract;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the Chaos pay scheme's two scale-derived components: {@link ChaosContractDeterminationPay#getMonthlyPay} (500
+ * support points per scale, scaled by the negotiated base-pay multiplier) and
+ * {@link ChaosContractDeterminationPay#getCombatPay} (500 support points per scale). Both optionally convert support
+ * points to C-bills at 10,000 each; the tests leave conversion off so the raw support-point arithmetic is visible.
+ */
+class ChaosContractDeterminationPayTest {
+    private final ChaosContractDeterminationPay payScheme = new ChaosContractDeterminationPay();
+
+    private static Campaign campaignWithConversion(boolean convertSupportPoints) {
+        CampaignOptions options = mock(CampaignOptions.class);
+        when(options.get(CampaignOption.USE_CHAOS_SUPPORT_POINT_CONVERSION)).thenReturn(convertSupportPoints);
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getCampaignOptions()).thenReturn(options);
+        return campaign;
+    }
+
+    private static AbstractContract contract(int scale, double basePayMultiplier) {
+        AbstractContract contract = mock(AbstractContract.class);
+        when(contract.getScale()).thenReturn(scale);
+        when(contract.getBasePayMultiplier()).thenReturn(basePayMultiplier);
+        return contract;
+    }
+
+    @Test
+    void monthlyPayIsScaleTimesTheMultiplierInSupportPoints() {
+        // 500 * scale(2) * basePay(1.0) = 1000 support points, unconverted.
+        assertEquals(Money.of(1_000),
+              payScheme.getMonthlyPay(campaignWithConversion(false), contract(2, 1.0)));
+    }
+
+    @Test
+    void monthlyPayAppliesTheNegotiatedBasePayMultiplier() {
+        // 500 * 2 = 1000, scaled by 1.5 -> 1500 support points.
+        assertEquals(Money.of(1_500),
+              payScheme.getMonthlyPay(campaignWithConversion(false), contract(2, 1.5)));
+    }
+
+    @Test
+    void monthlyPayConvertsSupportPointsToCBillsWhenEnabled() {
+        // 1000 support points converted at 10,000 C-bills each.
+        assertEquals(Money.of(10_000_000),
+              payScheme.getMonthlyPay(campaignWithConversion(true), contract(2, 1.0)));
+    }
+
+    @Test
+    void combatPayIsScaleInSupportPointsAndIgnoresTheBasePayMultiplier() {
+        // 500 * scale(3) = 1500 support points; the base-pay multiplier does not affect combat pay.
+        assertEquals(Money.of(1_500),
+              payScheme.getCombatPay(campaignWithConversion(false), contract(3, 2.0)));
+    }
+
+    @Test
+    void combatPayConvertsSupportPointsToCBillsWhenEnabled() {
+        assertEquals(Money.of(15_000_000),
+              payScheme.getCombatPay(campaignWithConversion(true), contract(3, 1.0)));
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationTermsTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationTermsTest.java
@@ -50,7 +50,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 /**
- * Tests the roll-to-step tables in {@link ChaosContractDetermineTerms}.
+ * Tests the roll-to-step tables in {@link ChaosContractDeterminationTerms}.
  *
  * <p>Every clause rolls the same stubbed 2d6, then shifts the base step by (objective modifier + employer modifier).
  * The cases below pair {@link ChaosObjectiveType#RAID} with {@link ChaosEmployerType#NOBLE}: NOBLE is neutral on every
@@ -58,12 +58,13 @@ import org.mockito.MockedStatic;
  * tables directly and only salvage carries a one-step drop. That keeps the roll tables - the typo-prone part - pinned
  * without re-deriving the modifier arithmetic.</p>
  */
-class ChaosContractDetermineTermsTest {
+class ChaosContractDeterminationTermsTest {
 
     private static ContractTermsData termsForRoll(final int roll) {
         try (MockedStatic<Compute> compute = mockStatic(Compute.class)) {
             compute.when(() -> Compute.d6(2)).thenReturn(roll);
-            return ChaosContractDetermineTerms.determineInitialTerms(ChaosObjectiveType.RAID, ChaosEmployerType.NOBLE,
+            return ChaosContractDeterminationTerms.determineInitialTerms(ChaosObjectiveType.RAID,
+                    ChaosEmployerType.NOBLE,
                   null, false);
         }
     }
@@ -92,7 +93,7 @@ class ChaosContractDetermineTermsTest {
             compute.when(() -> Compute.d6(2)).thenReturn(2);
             // CORPORATION carries a +2 pay-rate modifier; RAID adds nothing to pay, so base STEP_THREE climbs to
             // STEP_FIVE. This proves the employer modifier reaches influenceStep rather than being dropped.
-            ContractTermsData terms = ChaosContractDetermineTerms.determineInitialTerms(ChaosObjectiveType.RAID,
+            ContractTermsData terms = ChaosContractDeterminationTerms.determineInitialTerms(ChaosObjectiveType.RAID,
                   ChaosEmployerType.CORPORATION, null, false);
 
             assertEquals(STEP_FIVE, terms.payRate());


### PR DESCRIPTION
# Requires #9821
# Requires #9823
# Requires #9824
# Requires #9825
# Requires https://github.com/MegaMek/mm-data/pull/532

## What this changes

Negotiations edge trigger previously affected initial contract terms. That no longer functions. Now this edge trigger influences contract re-negotiations.

## Testing
- Manual testing

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result