### PR TITLE
Match warehouse Retractable Blades to the blade they replace (Fixes #9756)

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/PartsStore.java
+++ b/MekHQ/src/mekhq/campaign/market/PartsStore.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2011 Jay Lawson (jaylawson39 at yahoo.com). All rights reserved.
- * Copyright (C) 2013-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2013-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -53,6 +53,7 @@ import megamek.common.loaders.MekFileParser;
 import megamek.common.loaders.MekSummary;
 import megamek.common.loaders.MekSummaryCache;
 import megamek.common.units.Aero;
+import megamek.common.units.BipedMek;
 import megamek.common.units.Dropship;
 import megamek.common.units.Entity;
 import megamek.common.units.Jumpship;
@@ -97,6 +98,11 @@ import mekhq.campaign.parts.protomeks.ProtoMekSensor;
 public class PartsStore {
     private static final MMLogger LOGGER = MMLogger.create(PartsStore.class);
     private static final int EXPECTED_SIZE = 50000;
+
+    /** The lightest, heaviest and step size of BattleMek chassis weights, used to stock per-chassis equipment. */
+    private static final int MIN_MEK_TONNAGE = 20;
+    private static final int MAX_MEK_TONNAGE = 100;
+    private static final int MEK_TONNAGE_STEP = 5;
 
     private final ArrayList<Part> parts;
     private final Map<String, Part> nameAndDetailMap;
@@ -261,7 +267,9 @@ public class PartsStore {
                                        || equipmentType.hasFlag(WeaponType.F_AERO_WEAPON))
                                       && !((WeaponType) equipmentType).isCapital();
                 }
-                if (EquipmentPart.hasVariableTonnage(equipmentType)) {
+                if (isRetractableBlade(equipmentType)) {
+                    stockRetractableBlades(campaign, equipmentType, poddable);
+                } else if (EquipmentPart.hasVariableTonnage(equipmentType)) {
                     EquipmentPart equipmentPart;
                     for (double ton = EquipmentPart.getStartingTonnage(equipmentType);
                           ton <= EquipmentPart
@@ -302,6 +310,65 @@ public class PartsStore {
         hs = new AeroHeatSink(0, AeroHeatSink.CLAN_HEAT_DOUBLE, false, campaign);
         parts.add(new OmniPod(hs, campaign));
         parts.add(new AeroHeatSink(0, AeroHeatSink.CLAN_HEAT_DOUBLE, true, campaign));
+    }
+
+    /**
+     * @param equipmentType the equipment type to test
+     *
+     * @return {@code true} if the given equipment is a Retractable Blade
+     */
+    private static boolean isRetractableBlade(EquipmentType equipmentType) {
+        return (equipmentType instanceof MiscType) &&
+                     equipmentType.hasFlag(MiscType.F_CLUB) &&
+                     equipmentType.hasFlag(MiscTypeFlag.S_RETRACTABLE_BLADE);
+    }
+
+    /**
+     * Stocks Retractable Blades with one entry per unit tonnage, rather than one entry per item weight the way other
+     * variable-weight equipment is stocked.
+     *
+     * <p>A blade is built for a specific chassis and is not interchangeable between chassis of different weights, so
+     * {@link Part#isUnitTonnageMatters()} is {@code true} for it. Stocking by item weight left every loose blade with a
+     * unit tonnage of zero, which could never match the blade it was meant to replace, so warehouse stock was reported
+     * as unavailable. This mirrors how jump jets and MASC are already stocked.</p>
+     *
+     * @param campaign  the campaign the parts belong to
+     * @param bladeType the Retractable Blade equipment type
+     * @param poddable  {@code true} if omnipod variants should be stocked alongside the fixed ones
+     */
+    private void stockRetractableBlades(Campaign campaign, EquipmentType bladeType, boolean poddable) {
+        for (int unitTonnage = MIN_MEK_TONNAGE; unitTonnage <= MAX_MEK_TONNAGE; unitTonnage += MEK_TONNAGE_STEP) {
+            // Ask MegaMek what the blade weighs on a chassis of this weight rather than repeating the formula here.
+            Entity referenceChassis = new BipedMek();
+            referenceChassis.setWeight(unitTonnage);
+            double itemTonnage = bladeType.getTonnage(referenceChassis, 1.0);
+
+            parts.add(retractableBladeFor(campaign, bladeType, unitTonnage, itemTonnage, false));
+            if (poddable) {
+                parts.add(retractableBladeFor(campaign, bladeType, unitTonnage, itemTonnage, true));
+                parts.add(new OmniPod(retractableBladeFor(campaign, bladeType, unitTonnage, itemTonnage, false),
+                      campaign));
+            }
+        }
+    }
+
+    /**
+     * Builds a single loose Retractable Blade carrying both the tonnage of the chassis it was built for and its own
+     * resulting weight.
+     *
+     * @param campaign    the campaign the part belongs to
+     * @param bladeType   the Retractable Blade equipment type
+     * @param unitTonnage the weight of the chassis the blade was built for
+     * @param itemTonnage the weight of the blade itself
+     * @param omniPodded  {@code true} if the blade is omnipod mounted
+     *
+     * @return the stocked blade
+     */
+    private EquipmentPart retractableBladeFor(Campaign campaign, EquipmentType bladeType, int unitTonnage,
+          double itemTonnage, boolean omniPodded) {
+        EquipmentPart blade = new EquipmentPart(unitTonnage, bladeType, -1, 1.0, omniPodded, campaign);
+        blade.setEquipTonnage(itemTonnage);
+        return blade;
     }
 
     protected void stockMekActuators(Campaign c) {

--- a/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
@@ -71,6 +71,12 @@ import mekhq.campaign.campaignOptions.CampaignOption;
 public class EquipmentPart extends Part {
     private static final MMLogger LOGGER = MMLogger.create(EquipmentPart.class);
 
+    /**
+     * The weight of a Retractable Blade's retraction mechanism, in tons. A blade's total weight is this mechanism plus
+     * one ton of blade per twenty tons of the unit carrying it.
+     */
+    private static final double RETRACTABLE_BLADE_MECHANISM_TONNAGE = 0.5;
+
     // crap EquipmentType is not serialized!
     protected transient EquipmentType type;
     protected String typeName;
@@ -575,7 +581,11 @@ public class EquipmentPart extends Part {
             } else if (type.hasFlag(MiscType.F_CLUB) && type.hasFlag(MiscTypeFlag.S_SWORD)) {
                 varCost = Money.of(getTonnage() * 10000);
             } else if (type.hasFlag(MiscType.F_CLUB) && type.hasFlag(MiscTypeFlag.S_RETRACTABLE_BLADE)) {
-                varCost = Money.of((1 + getTonnage()) * 10000);
+                // A blade costs 10,000 per ton of blade, plus a flat 10,000 for the retraction mechanism. The
+                // mechanism is also half a ton of the item's total weight, so the blade itself weighs half a ton
+                // less than the part does. Charging (1 + total weight) would bill the mechanism twice.
+                double bladeTonnage = getTonnage() - RETRACTABLE_BLADE_MECHANISM_TONNAGE;
+                varCost = Money.of((1 + bladeTonnage) * 10000);
             } else if (type.hasFlag(MiscType.F_TRACKS)) {
                 // TODO: Handle this through subtyping
             } else if (type.hasFlag(MiscType.F_TALON)) {

--- a/MekHQ/unittests/mekhq/campaign/market/PartsStoreRetractableBladeTest.java
+++ b/MekHQ/unittests/mekhq/campaign/market/PartsStoreRetractableBladeTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.market;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static testUtilities.MHQTestUtilities.mockCampaign;
+
+import java.util.List;
+
+import megamek.common.equipment.EquipmentType;
+import megamek.common.units.BipedMek;
+import megamek.common.units.Entity;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.parts.Part;
+import mekhq.campaign.parts.equipment.EquipmentPart;
+import mekhq.campaign.parts.equipment.MissingEquipmentPart;
+import mekhq.campaign.unit.Unit;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end tests for issue #9756. The parts store used to stock Retractable Blades with no unit tonnage, so a loose
+ * blade could never be matched against the damaged blade it was meant to replace.
+ */
+class PartsStoreRetractableBladeTest {
+
+    private static final String RETRACTABLE_BLADE = "Retractable Blade";
+    private static final int REPORTED_CHASSIS_TONNAGE = 80;
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    private List<EquipmentPart> stockedBlades(Campaign campaign) {
+        PartsStore partsStore = new PartsStore();
+        partsStore.stockWeaponsAmmoAndEquipment(campaign);
+
+        EquipmentType bladeType = EquipmentType.get(RETRACTABLE_BLADE);
+        return partsStore.getInventory()
+                     .stream()
+                     .filter(EquipmentPart.class::isInstance)
+                     .map(EquipmentPart.class::cast)
+                     .filter(part -> bladeType.equals(part.getType()))
+                     .filter(part -> !part.isOmniPodded())
+                     .toList();
+    }
+
+    /**
+     * Every stocked blade must know which chassis weight it was built for, otherwise it can never be matched to the
+     * blade it replaces.
+     */
+    @Test
+    void everyStockedBladeCarriesAChassisTonnage() {
+        List<EquipmentPart> blades = stockedBlades(mockCampaign());
+
+        assertTrue(!blades.isEmpty(), "The parts store must stock Retractable Blades");
+        for (EquipmentPart blade : blades) {
+            assertTrue(blade.getUnitTonnage() > 0,
+                  "Stocked Retractable Blades must record the chassis tonnage they were built for");
+        }
+    }
+
+    /**
+     * The reported case: with a damaged blade on an 80-ton chassis, the matching blade in the store must both be
+     * counted as stock and be usable as the replacement.
+     */
+    @Test
+    void stockedBladeMatchesADamagedBladeOnTheReportedChassis() {
+        Campaign campaign = mockCampaign();
+        EquipmentType bladeType = EquipmentType.get(RETRACTABLE_BLADE);
+
+        Entity chassis = new BipedMek();
+        chassis.setWeight(REPORTED_CHASSIS_TONNAGE);
+        Unit unit = mock(Unit.class);
+        when(unit.getEntity()).thenReturn(chassis);
+
+        MissingEquipmentPart damagedBlade = new MissingEquipmentPart(REPORTED_CHASSIS_TONNAGE,
+              bladeType,
+              -1,
+              campaign,
+              bladeType.getTonnage(chassis, 1.0),
+              1.0,
+              false);
+        damagedBlade.setUnit(unit);
+        Part requiredBlade = damagedBlade.getNewPart();
+
+        EquipmentPart storeBlade = stockedBlades(campaign).stream()
+                                         .filter(part -> part.getUnitTonnage() == REPORTED_CHASSIS_TONNAGE)
+                                         .findFirst()
+                                         .orElse(null);
+
+        assertNotNull(storeBlade, "The parts store must stock a blade for an 80-ton chassis");
+        assertEquals(bladeType.getCost(chassis, false, Entity.LOC_NONE, 1.0),
+              storeBlade.getStickerPrice().getAmount().doubleValue(),
+              0.001,
+              "The stocked blade must cost the same as the blade it replaces");
+        assertTrue(requiredBlade.isSamePartType(storeBlade),
+              "The stocked blade must be counted as available stock");
+        assertTrue(damagedBlade.isAcceptableReplacement(storeBlade, false),
+              "The stocked blade must be usable to repair the damaged blade");
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/RetractableBladeWarehouseTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/RetractableBladeWarehouseTest.java
@@ -84,7 +84,7 @@ class RetractableBladeWarehouseTest {
 
     /**
      * A loose blade must carry the same sticker price as the same blade mounted on a unit. Before the fix MekHQ
-     * charged for the half-ton retraction mechanism twice, leaving every loose blade 10,000 C-bills too expensive.
+     * charged for the half-ton retraction mechanism twice, leaving every loose blade 5,000 C-bills too expensive.
      */
     @ParameterizedTest
     @ValueSource(doubles = { 20.0, 35.0, 55.0, 80.0, 100.0 })

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/RetractableBladeWarehouseTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/RetractableBladeWarehouseTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.parts.equipment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static testUtilities.MHQTestUtilities.mockCampaign;
+
+import megamek.common.equipment.EquipmentType;
+import megamek.common.units.BipedMek;
+import megamek.common.units.Entity;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.unit.Unit;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Regression tests for issue #9756: a Retractable Blade sitting in the warehouse was not recognised as a replacement
+ * for a damaged blade, so the unit could not be repaired.
+ *
+ * <p>These tests deliberately use real {@link EquipmentType} instances rather than mocks. The defect lived in the
+ * interaction between MekHQ's own pricing formula for unit-less parts and MegaMek's pricing formula for mounted
+ * equipment, so a mocked equipment type cannot exercise it.</p>
+ */
+class RetractableBladeWarehouseTest {
+
+    private static final String RETRACTABLE_BLADE = "Retractable Blade";
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    private Entity mekOfWeight(double weightInTons) {
+        Entity mek = new BipedMek();
+        mek.setWeight(weightInTons);
+        return mek;
+    }
+
+    /**
+     * Builds a loose warehouse part the way {@code PartsStore} stocks variable-tonnage equipment: no owning unit, and
+     * the item weight set explicitly.
+     */
+    private EquipmentPart looseWarehousePart(Campaign campaign, EquipmentType equipmentType, double itemTonnage) {
+        EquipmentPart loosePart = new EquipmentPart(0, equipmentType, -1, 1.0, false, campaign);
+        loosePart.setEquipTonnage(itemTonnage);
+        return loosePart;
+    }
+
+    /**
+     * A loose blade must carry the same sticker price as the same blade mounted on a unit. Before the fix MekHQ
+     * charged for the half-ton retraction mechanism twice, leaving every loose blade 10,000 C-bills too expensive.
+     */
+    @ParameterizedTest
+    @ValueSource(doubles = { 20.0, 35.0, 55.0, 80.0, 100.0 })
+    void looseBladeCostsTheSameAsAMountedBlade(double unitTonnage) {
+        Campaign campaign = mockCampaign();
+        EquipmentType bladeType = EquipmentType.get(RETRACTABLE_BLADE);
+        Entity mek = mekOfWeight(unitTonnage);
+
+        double mountedTonnage = bladeType.getTonnage(mek, 1.0);
+        double mountedCost = bladeType.getCost(mek, false, Entity.LOC_NONE, 1.0);
+        EquipmentPart loosePart = looseWarehousePart(campaign, bladeType, mountedTonnage);
+
+        assertEquals(mountedCost,
+              loosePart.getStickerPrice().getAmount().doubleValue(),
+              0.001,
+              "A loose Retractable Blade must cost the same as the identical mounted blade");
+    }
+
+    /**
+     * The reported failure: a damaged blade on the reporter's 80-ton chassis could not be repaired from warehouse
+     * stock. The store already carries a blade of the correct weight, so the replacement must be accepted.
+     */
+    @Test
+    void warehouseBladeIsAcceptedAsAReplacementForADamagedBlade() {
+        Campaign campaign = mockCampaign();
+        EquipmentType bladeType = EquipmentType.get(RETRACTABLE_BLADE);
+        Entity mek = mekOfWeight(80.0);
+        Unit unit = mock(Unit.class);
+        when(unit.getEntity()).thenReturn(mek);
+
+        double mountedTonnage = bladeType.getTonnage(mek, 1.0);
+        MissingEquipmentPart damagedBlade =
+              new MissingEquipmentPart(80, bladeType, -1, campaign, mountedTonnage, 1.0, false);
+        damagedBlade.setUnit(unit);
+
+        EquipmentPart warehouseBlade = looseWarehousePart(campaign, bladeType, mountedTonnage);
+
+        assertTrue(damagedBlade.isAcceptableReplacement(warehouseBlade, false),
+              "Warehouse stock of the correct weight must be usable to repair a damaged Retractable Blade");
+    }
+
+    /**
+     * A blade built for a heavier unit is a different item and must not be substituted.
+     */
+    @Test
+    void warehouseBladeOfTheWrongWeightIsRejected() {
+        Campaign campaign = mockCampaign();
+        EquipmentType bladeType = EquipmentType.get(RETRACTABLE_BLADE);
+        Entity mek = mekOfWeight(80.0);
+        Unit unit = mock(Unit.class);
+        when(unit.getEntity()).thenReturn(mek);
+
+        MissingEquipmentPart damagedBlade =
+              new MissingEquipmentPart(80, bladeType, -1, campaign, bladeType.getTonnage(mek, 1.0), 1.0, false);
+        damagedBlade.setUnit(unit);
+
+        EquipmentPart oversizedBlade =
+              looseWarehousePart(campaign, bladeType, bladeType.getTonnage(mekOfWeight(100.0), 1.0));
+
+        assertFalse(damagedBlade.isAcceptableReplacement(oversizedBlade, false),
+              "A blade built for a 100-ton unit must not repair an 80-ton unit's blade");
+    }
+
+    /**
+     * The blade fix changes a branch shared by every physical weapon, so the other clubs must keep pricing correctly.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = { "Hatchet", "Sword", "Mace", "Talons" })
+    void otherPhysicalWeaponsStillPriceCorrectly(String equipmentName) {
+        Campaign campaign = mockCampaign();
+        EquipmentType clubType = EquipmentType.get(equipmentName);
+
+        for (double unitTonnage : new double[] { 20.0, 55.0, 80.0, 100.0 }) {
+            Entity mek = mekOfWeight(unitTonnage);
+            double mountedCost = clubType.getCost(mek, false, Entity.LOC_NONE, 1.0);
+            EquipmentPart loosePart = looseWarehousePart(campaign, clubType, clubType.getTonnage(mek, 1.0));
+
+            assertEquals(mountedCost,
+                  loosePart.getStickerPrice().getAmount().doubleValue(),
+                  0.001,
+                  equipmentName + " pricing must be unchanged at " + unitTonnage + " tons");
+        }
+    }
+}


### PR DESCRIPTION
## What was broken

A Retractable Blade sitting in the warehouse was never offered as a replacement for a damaged one, so the unit could not be repaired even with the right blade in stock.

Take the reporter's 80-ton chassis. Its blade weighs 4.5 tons and costs 50,000 C-bills. Buy the identical blade for the warehouse and MekHQ prices it at 55,000. When the repair code looks for a replacement it compares the two prices, sees 55,000 against 50,000, decides they are different items, and reports no stock available.

Two separate things went wrong, and both had to be fixed:

A blade costs 10,000 C-bills per ton of *blade*, plus a flat 10,000 for the retraction mechanism. The mechanism is also half a ton of the item's total weight. MekHQ's own pricing formula for a part with no owning unit charged `(1 + total weight) * 10,000`, which bills that half-ton mechanism a second time - 5,000 C-bills too much at every chassis weight. Other physical weapons priced correctly because only the blade carries a fixed mechanism weight on top of the blade itself (`EquipmentPart.resolveVariableCost`).

Separately, the parts store stocked blades the way it stocks other variable-weight gear: one entry per *item* weight, with the chassis weight left at zero. A blade is built for a specific chassis and is not interchangeable, so it is flagged as caring about unit tonnage - but with that field zero it could never match anything (`PartsStore.stockWeaponsAmmoAndEquipment`).

## Changes

- Subtract the retraction mechanism's half ton before applying the per-ton blade price, so a loose blade costs exactly what the same blade mounted on a unit costs.
- Stock Retractable Blades by chassis weight, 20 to 100 tons in 5-ton steps, the way jump jets and MASC are already stocked, so each stocked blade records the chassis it was built for.
- Ask MegaMek for the resulting blade weight via `getTonnage(chassis, 1.0)` rather than repeating the weight formula in MekHQ, so the two cannot drift apart.
- The stocking logic lives in two small private helpers rather than being added inline to the already-long equipment loop.

## Testing

Thirteen unit tests across two new classes, all using real `EquipmentType` data rather than mocks - the defect lived in the interaction between MekHQ's pricing formula and MegaMek's, so a mocked equipment type cannot exercise it.

`RetractableBladeWarehouseTest` checks that a loose blade costs the same as the identical mounted blade at 20, 35, 55, 80 and 100 tons; that a warehouse blade of the correct weight is accepted to repair a damaged one; that a blade built for a 100-ton unit is still rejected for an 80-ton unit; and that Hatchet, Sword, Mace and Talons pricing is unchanged, since the fix touches a branch shared by every physical weapon.

`PartsStoreRetractableBladeTest` drives the real parts store and asserts every stocked blade records a chassis weight, and that the store's 80-ton blade both counts as stock and repairs the reporter's damaged blade.

Each test was proven non-vacuous by reverting the matching production change and confirming it fails: the pricing fix drops six tests, the parts store fix drops both store tests. Full `./gradlew :MekHQ:build` is green, checkstyle and javadoc included.

## What is NOT proven yet

This has not been run in a live campaign. MekHQ was never launched, the reporter's save was never loaded, and no one has watched the repair succeed in the Warehouse tab. The behaviour is covered end to end by tests that call the real parts store and the real replacement-matching code, but an in-game confirmation is still wanted before merge.

The pricing change also affects the sale value of loose blades, which now drop by 5,000 C-bills each. That is the correct price, but any existing campaign holding blades in stock will see their value change on load.

This is an alternative to #9809, which targets the same issue.

Fixes #9756
