### PR TITLE
Fixed Admin Personnel Not Being Migrated from Deprecated Roles

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
@@ -1473,7 +1473,7 @@ public enum PersonnelRole {
 
         // Parse from name
         try {
-            return PersonnelRole.valueOf(text.toUpperCase().replace(" ", "_"));
+            return migrateDeprecatedRole(PersonnelRole.valueOf(text.toUpperCase().replace(" ", "_")));
         } catch (Exception ignored) {
         }
 
@@ -1481,11 +1481,11 @@ public enum PersonnelRole {
         try {
             for (PersonnelRole personnelRole : PersonnelRole.values()) {
                 if (personnelRole.getLabel(false).equalsIgnoreCase(text)) {
-                    return personnelRole;
+                    return migrateDeprecatedRole(personnelRole);
                 }
 
                 if (personnelRole.getLabel(true).equalsIgnoreCase(text)) {
-                    return personnelRole;
+                    return migrateDeprecatedRole(personnelRole);
                 }
             }
         } catch (Exception ignored) {
@@ -1493,12 +1493,34 @@ public enum PersonnelRole {
 
         // Parse from ordinal
         try {
-            return PersonnelRole.values()[MathUtility.parseInt(text, NONE.ordinal())];
+            return migrateDeprecatedRole(PersonnelRole.values()[MathUtility.parseInt(text, NONE.ordinal())]);
         } catch (Exception ignored) {
         }
 
         logger.error("Unable to parse {} into a PersonnelRole. Returning NONE", text);
         return NONE;
+    }
+
+    /**
+     * Migrates a parsed role to its current equivalent when the original role has since been deprecated.
+     *
+     * <p>The Administrator specializations (Command, Logistics, Transport, and HR) were deprecated in 0.51.01 and
+     * consolidated into the single {@link #ADMINISTRATOR} role. Any character loading with one of these roles is
+     * automatically reassigned to {@link #ADMINISTRATOR}.</p>
+     *
+     * @param role the freshly parsed role
+     *
+     * @return the role the character should actually be assigned
+     *
+     * @author Illiani
+     * @since 0.51.01
+     */
+    private static PersonnelRole migrateDeprecatedRole(final PersonnelRole role) {
+        return switch (role) {
+            case ADMINISTRATOR_COMMAND, ADMINISTRATOR_LOGISTICS, ADMINISTRATOR_TRANSPORT, ADMINISTRATOR_HR ->
+                  ADMINISTRATOR;
+            default -> role;
+        };
     }
     // endregion File I/O
 


### PR DESCRIPTION
## What this changes

Admin personnel weren't correctly transitioning from the old deprecated admin roles to the new Administrator role. Now they are.

## Testing
- manual testing

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result