### PR TITLE
Fix #9814: Fixed Legacy Contract Handling of Prisoners

### DIFF
--- a/MekHQ/resources/mekhq/resources/ContractAutomation.properties
+++ b/MekHQ/resources/mekhq/resources/ContractAutomation.properties
@@ -54,5 +54,6 @@ acceptContract.signingBonus.report=Signing bonus for {0}.
 completeContract.completionBonus.report=Completion bonus for {0}.
 legacyContract.defaultName={0} Contract
 legacyContract.settlement=Outstanding payout for {0} (legacy contract closeout).
+legacyContract.prisonerRansom=Ransom of held prisoners (legacy contract closeout).
 legacyContract.report=<b>{0}</b> used the old contract format, which is not compatible with the new system. It has \
   been closed out as a complete success and any outstanding payouts have been settled.

--- a/MekHQ/src/mekhq/campaign/mission/contract/AbstractContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/AbstractContract.java
@@ -135,6 +135,14 @@ public abstract class AbstractContract {
     private transient int cachedContractDifficulty;
 
     /**
+     * Marks a legacy contract that was still active when converted on load, and therefore force-closed by the legacy
+     * handler. Transient; set during legacy conversion and consumed by the post-load pass, which uses it to
+     * auto-resolve any prisoners still held once the closed-out contracts are settled. See
+     * {@link #wasClosedOutActiveOnLoad()}.
+     */
+    private transient boolean closedOutActiveOnLoad;
+
+    /**
      * The id of {@link #playerNegotiator} as read from a save, held until it can be resolved.
      *
      * <p>Contracts are written inside {@code <info>}, which the loader parses before the personnel roster exists, so
@@ -539,6 +547,24 @@ public abstract class AbstractContract {
      */
     public void setPendingLegacySettlementMultiplier(final @Nullable Double pendingLegacySettlementMultiplier) {
         this.pendingLegacySettlementMultiplier = pendingLegacySettlementMultiplier;
+    }
+
+    /**
+     * @return {@code true} if this contract was still active when converted on load and was therefore force-closed by
+     *       the legacy handler. Used by the post-load pass to decide whether held prisoners should be auto-resolved.
+     */
+    public boolean wasClosedOutActiveOnLoad() {
+        return closedOutActiveOnLoad;
+    }
+
+    /**
+     * Marks whether this legacy contract was force-closed while active on load. Set during legacy conversion and read
+     * by the post-load pass; not for general use.
+     *
+     * @param closedOutActiveOnLoad {@code true} if the contract was still active when converted and was force-closed
+     */
+    public void setClosedOutActiveOnLoad(final boolean closedOutActiveOnLoad) {
+        this.closedOutActiveOnLoad = closedOutActiveOnLoad;
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/mission/contract/io/LegacyContractConverter.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/io/LegacyContractConverter.java
@@ -39,6 +39,7 @@ import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.UUID;
 
 import jakarta.annotation.Nullable;
@@ -50,6 +51,7 @@ import megamek.common.enums.SkillLevel;
 import megamek.common.icons.Camouflage;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.ForceHumanResources;
 import mekhq.campaign.digitalGM.stratCon.StratConCampaignState;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.enums.TransactionType;
@@ -60,6 +62,7 @@ import mekhq.campaign.mission.contract.contractGeneration.ChaosEmployerType;
 import mekhq.campaign.mission.scenarios.Scenario;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRole;
+import mekhq.campaign.personnel.enums.PersonnelStatus;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.PlanetarySystem;
@@ -294,6 +297,9 @@ public final class LegacyContractConverter {
         // Only a contract that was still running needs settling and an advisory; one that had already concluded was
         // settled when it ended.
         if (wasActive) {
+            // Flag the force-closure so the post-load pass can auto-resolve any prisoners still held once the force is
+            // populated (prisoner ransom needs the same force data the deferred settlement does).
+            contract.setClosedOutActiveOnLoad(true);
             campaign.addReport(GENERAL,
                   getFormattedTextAt(RESOURCE_BUNDLE, "legacyContract.report", contract.getName()));
             if (routedPayout.isPositive()) {
@@ -327,12 +333,20 @@ public final class LegacyContractConverter {
      * {@code contractBase * paymentMultiplier}, written onto the contract's finance record (the legacy amounts were
      * never persisted, so it reads zero without this), and its remaining months are paid to the player as a lump sum.
      *
+     * <p>Once the closed-out contracts are settled, any prisoners the player is still holding are auto-resolved (see
+     * {@link #ransomHeldPrisoners(Campaign)}), but only when at least one contract was force-closed while active - a save
+     * whose contracts had all already concluded closed out nothing and leaves its prisoners alone.</p>
+     *
      * @param campaign the loaded campaign whose converted legacy contracts are settled
      */
     public static void settlePendingLegacyContracts(final Campaign campaign) {
         final Money contractBase = campaign.getAccountant().getContractBase();
 
+        boolean anyClosedOutActive = false;
         for (final AbstractContract contract : campaign.getContractHistoryAsMap().values()) {
+            anyClosedOutActive |= contract.wasClosedOutActiveOnLoad();
+            contract.setClosedOutActiveOnLoad(false);
+
             final Double paymentMultiplier = contract.getPendingLegacySettlementMultiplier();
             if (paymentMultiplier == null) {
                 continue;
@@ -355,6 +369,51 @@ public final class LegacyContractConverter {
                             settlementAmount,
                             getFormattedTextAt(RESOURCE_BUNDLE, "legacyContract.settlement", contract.getName()));
             }
+        }
+
+        if (anyClosedOutActive) {
+            ransomHeldPrisoners(campaign);
+        }
+    }
+
+    /**
+     * Auto-resolves every prisoner still held when the legacy handler force-closes an active contract on load.
+     *
+     * <p>Enemy prisoners the player is holding are ransomed back to the enemy: the player is credited their combined
+     * ransom value and they are released. The player's own captured personnel (friendly PoWs) are freed and restored to
+     * active duty at no cost.</p>
+     *
+     * @param campaign the loaded campaign whose held prisoners are resolved
+     */
+    private static void ransomHeldPrisoners(final Campaign campaign) {
+        final ForceHumanResources humanResources = campaign.getPlayerForce().getHumanResources();
+        final LocalDate today = campaign.getLocalDate();
+
+        // Enemy prisoners the player holds: ransom them back for money, then release them.
+        final List<Person> enemyPrisoners = humanResources.getCurrentPrisoners();
+        if (!enemyPrisoners.isEmpty()) {
+            Money ransom = Money.zero();
+            for (final Person prisoner : enemyPrisoners) {
+                ransom = ransom.plus(prisoner.getRansomValue(campaign));
+            }
+
+            if (ransom.isPositive()) {
+                campaign.getPlayerForce()
+                      .getFinances()
+                      .credit(TransactionType.RANSOM,
+                            today,
+                            ransom,
+                            getFormattedTextAt(RESOURCE_BUNDLE, "legacyContract.prisonerRansom"));
+            }
+
+            for (final Person prisoner : enemyPrisoners) {
+                humanResources.removePerson(campaign, prisoner);
+            }
+        }
+
+        // The player's own captured personnel: freed and returned to active duty at no cost.
+        for (final Person prisoner : humanResources.getFriendlyPrisoners()) {
+            prisoner.changeStatus(campaign, today, PersonnelStatus.ACTIVE);
         }
     }
 

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/io/LegacyContractConverterTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/io/LegacyContractConverterTest.java
@@ -58,7 +58,10 @@ import mekhq.campaign.mission.contract.contractData.ChaosContractStepsTable;
 import mekhq.campaign.mission.contract.contractData.ContractMoraleLevel;
 import mekhq.campaign.mission.contract.contractData.ContractObjectiveType;
 import mekhq.campaign.mission.contract.contractData.MissionStatus;
+import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.backgrounds.RandomCompanyNameGenerator;
+import mekhq.campaign.personnel.enums.PersonnelStatus;
+import mekhq.campaign.randomEvents.prisoners.PrisonerStatus;
 import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.Systems;
 import mekhq.campaign.universe.TestSystems;
@@ -220,6 +223,76 @@ class LegacyContractConverterTest {
 
     // endregion close-out rule
 
+    // region prisoner resolution
+
+    /**
+     * Closing out a running contract on load ransoms every enemy prisoner the player is holding: the player is credited
+     * their combined ransom value and the prisoners are released.
+     */
+    @Test
+    void closingOutAnActiveContractRansomsEnemyPrisonersHeld() throws Exception {
+        Person prisoner = addEnemyPrisoner();
+        Money expectedRansom = prisoner.getRansomValue(campaign);
+        assertTrue(expectedRansom.isPositive(), "the prisoner must be worth something for the credit to be meaningful");
+
+        importActiveLegacyContractWithNoPayout();
+        Money before = campaign.getPlayerForce().getFinances().getBalance();
+
+        LegacyContractConverter.settlePendingLegacyContracts(campaign);
+
+        // Checked against the live roster rather than getCurrentPrisoners(): the active-personnel cache is invalidated
+        // in production by the event bus reacting to the removal, but that subscriber isn't wired up in this harness.
+        assertFalse(campaign.getPlayerForce().getHumanResources().getPersonnel().contains(prisoner),
+              "a closed-out contract releases the enemy prisoners the player held");
+        assertEquals(before.plus(expectedRansom), campaign.getPlayerForce().getFinances().getBalance(),
+              "the player is credited the ransom of every enemy prisoner released");
+    }
+
+    /**
+     * The player's own captured personnel are freed and restored to active duty when the contract closes out, and at no
+     * cost - only the enemy prisoners the player held are paid for.
+     */
+    @Test
+    void closingOutAnActiveContractFreesFriendlyPoWsAtNoCost() throws Exception {
+        Person captured = addFriendlyPoW();
+
+        importActiveLegacyContractWithNoPayout();
+        Money before = campaign.getPlayerForce().getFinances().getBalance();
+
+        LegacyContractConverter.settlePendingLegacyContracts(campaign);
+
+        assertEquals(PersonnelStatus.ACTIVE, captured.getStatus(),
+              "a closed-out contract returns the player's own captured personnel to active duty");
+        assertEquals(before, campaign.getPlayerForce().getFinances().getBalance(),
+              "freeing the player's own captured personnel costs nothing");
+    }
+
+    /**
+     * A save whose contracts had all already concluded closed out nothing, so its prisoners are left exactly as they
+     * were - no ransom, no release, no status change.
+     */
+    @Test
+    void prisonersAreLeftAloneWhenNoActiveContractWasClosedOut() throws Exception {
+        Person enemyPrisoner = addEnemyPrisoner();
+        Person captured = addFriendlyPoW();
+
+        // A concluded contract has nothing to close out, so it neither settles pay nor triggers prisoner resolution.
+        campaign.importMission(convert(legacyMission("<status>FAILED</status>")));
+        Money before = campaign.getPlayerForce().getFinances().getBalance();
+
+        LegacyContractConverter.settlePendingLegacyContracts(campaign);
+
+        assertTrue(campaign.getPlayerForce().getHumanResources().getCurrentPrisoners().contains(enemyPrisoner),
+              "with no active contract closed out, the enemy prisoners the player held are untouched");
+        assertEquals(PersonnelStatus.POW, captured.getStatus(),
+              "with no active contract closed out, the player's own captured personnel stay captured");
+        assertEquals(before,
+              campaign.getPlayerForce().getFinances().getBalance(),
+              "nothing is ransomed, so nothing is paid");
+    }
+
+    // endregion prisoner resolution
+
     // region placeholders and defaults
 
     @Test
@@ -367,6 +440,31 @@ class LegacyContractConverterTest {
     /** Wraps {@code body} in a legacy {@code <mission>} element of the retired {@code AtBContract} type. */
     private static String legacyMission(String body) {
         return "<mission id=\"1\" type=\"mekhq.campaign.mission.AtBContract\">" + body + "</mission>";
+    }
+
+    /**
+     * Converts and imports a still-running legacy contract whose payout reconstructs to nothing (a zero payment
+     * multiplier), so its close-out settles no pay and any balance change comes purely from prisoner ransoming.
+     */
+    private void importActiveLegacyContractWithNoPayout() throws Exception {
+        campaign.importMission(convert(legacyMission("<status>ACTIVE</status>"
+                                                           + "<paymentMultiplier>0</paymentMultiplier>")));
+    }
+
+    /** Registers an enemy combatant the player is holding as a prisoner. */
+    private Person addEnemyPrisoner() {
+        Person prisoner = new Person(campaign);
+        campaign.importPerson(prisoner);
+        prisoner.setPrisonerStatus(campaign, PrisonerStatus.PRISONER, false);
+        return prisoner;
+    }
+
+    /** Registers one of the player's own personnel as a captured prisoner of war. */
+    private Person addFriendlyPoW() {
+        Person captured = new Person(campaign);
+        campaign.importPerson(captured);
+        captured.setStatus(PersonnelStatus.POW);
+        return captured;
     }
 
     private AbstractContract convert(String missionXml) throws Exception {


### PR DESCRIPTION
Fix #9814

## What this changes
An oversight in the legacy contract handler meant old POWs (held by player or enemy) were not being processed when old contracts were resolved. Now POWs are automatically ransomed, and player personnel marked as POWs are freed.

## Testing
- AI unit tests

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result