### PR TITLE
Fixed Copy-Paste Error in Phenotype Enum Declaration

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/enums/Phenotype.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/Phenotype.java
@@ -69,8 +69,8 @@ public enum Phenotype {
      * Individual internal phenotypes.
      */
     // Internal Phenotypes
-    NONE(false, false, 0, 0, 0, 0, new Attributes(8, 8, 8, 8, 8, 8, 9, 8, 0), new ArrayList<>()),
-    GENERAL(false, false, 0, 0, 0, 0, new Attributes(8, 8, 8, 8, 8, 8, 9, 8, 0), new ArrayList<>());
+    NONE(),
+    GENERAL();
     // endregion Enum Declarations
 
     // region Variable Declarations
@@ -91,7 +91,6 @@ public enum Phenotype {
     // endregion Variable Declarations
 
     // region Constructors
-    @Deprecated(since = "0.51.0", forRemoval = true)
     Phenotype() {
         this(false, false, 0, 0, 0, 0, new Attributes(8, 8, 8, 8, 8, 8, 9, 8, 0), new ArrayList<>());
     }
@@ -151,9 +150,8 @@ public enum Phenotype {
      * @author Illiani
      * @since 0.50.05
      */
-    @Deprecated(since = "0.51.0", forRemoval = true)
     public boolean isTrueborn() {
-        return external;
+        return isTrueborn;
     }
 
     /**


### PR DESCRIPTION
## What this changes
- Fixed copy-paste error in `isTrueborn`
- Updated GENERAL and NONE initialization
- Removed unnecessary deprecations

## Testing

- None needed

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result