### PR TITLE
Fixed Text Display For Certain Morale Conditions

### DIFF
--- a/MekHQ/resources/mekhq/resources/AtBContract.properties
+++ b/MekHQ/resources/mekhq/resources/AtBContract.properties
@@ -47,19 +47,3 @@ stratCon.earlyContractEnd.objectives=You have completely broken the OpFor in <b>
   any remaining objectives at their leisure. Though failed objectives will still count against you.\
   <p>The contract will end tomorrow. If the contract was successful, any outstanding payments will be rendered once \
   the contract has concluded.</p>
-# Rout Ended
-routEnded.reinforcements={0}, it looks like the lull is over.\
-  <p>We''re seeing signs of hostile movement across all sectors. {1} has rearmed and is hitting the field in numbers.\
-  \ Get ready for a tough fight.</p>
-routEnded.aNewChallenger={0}, this is an emergency broadcast!\
-  <p>We''ve detected multiple DropShips approaching from the star. They appear to be from {1}. I don''t know why our \
-  long-range sensors didn''t pick them up sooner, but they''re on a hard burn and will make planetfall imminently. We\
-  \ don''t know the strength of their forces, so prepare for anything.</p>
-# Emergency Salvage Clause
-emergencySalvageClause.message={0}, we have received confirmed intelligence reports indicating that the opposition is \
-  fielding sensitive materials of strategic concern. Due to the nature of these assets, we are invoking <i>Special \
-  Salvage Clause 7-C, The Recovery & Ownership of Strategically Sensitive Assets.</i>\
-  <p>Effective immediately, all battlefield salvage recovered by your forces during this operation is to be turned over\
-  \ to Allied Command for secure handling. You will be suitably compensated for all recovered materials.</p>\
-  <p>We recognize the impact this may have on your unit''s logistical planning and appreciate your cooperation in this \
-  matter.</p>

--- a/MekHQ/resources/mekhq/resources/MHQMorale.properties
+++ b/MekHQ/resources/mekhq/resources/MHQMorale.properties
@@ -47,3 +47,19 @@ stratCon.earlyContractEnd.objectives=You have completely broken the OpFor in <b>
   any remaining objectives at their leisure. Though failed objectives will still count against you.\
   <p>The contract will end tomorrow. If the contract was successful, any outstanding payments will be rendered once \
   the contract has concluded.</p>
+# Rout Ended
+routEnded.reinforcements={0}, it looks like the lull is over.\
+  <p>We''re seeing signs of hostile movement across all sectors. {1} has rearmed and is hitting the field in numbers.\
+  \ Get ready for a tough fight.</p>
+routEnded.aNewChallenger={0}, this is an emergency broadcast!\
+  <p>We''ve detected multiple DropShips approaching from the star. They appear to be from {1}. I don''t know why our \
+  long-range sensors didn''t pick them up sooner, but they''re on a hard burn and will make planetfall imminently. We\
+  \ don''t know the strength of their forces, so prepare for anything.</p>
+# Emergency Salvage Clause
+emergencySalvageClause.message={0}, we have received confirmed intelligence reports indicating that the opposition is \
+  fielding sensitive materials of strategic concern. Due to the nature of these assets, we are invoking <i>Special \
+  Salvage Clause 7-C, The Recovery & Ownership of Strategically Sensitive Assets.</i>\
+  <p>Effective immediately, all battlefield salvage recovered by your forces during this operation is to be turned over\
+  \ to Allied Command for secure handling. You will be suitably compensated for all recovered materials.</p>\
+  <p>We recognize the impact this may have on your unit''s logistical planning and appreciate your cooperation in this \
+  matter.</p>


### PR DESCRIPTION
## What this changes

Certain rout conditions were showing a missing text value. Now they work correctly.

## Testing

- None needed

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result