### PR TITLE
Fixed Clan Skill Parsing for Chaos Contracts

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationDifficulty.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationDifficulty.java
@@ -36,7 +36,7 @@ import static java.lang.Math.round;
 import static megamek.client.ratgenerator.ModelRecord.NETWORK_NONE;
 import static megamek.client.ratgenerator.UnitTable.findTable;
 import static megamek.common.enums.SkillLevel.ELITE;
-import static megamek.common.enums.SkillLevel.parseFromInteger;
+import static megamek.common.enums.SkillLevel.changeByDelta;
 import static megamek.common.units.UnitType.MEK;
 
 import java.time.LocalDate;
@@ -137,7 +137,9 @@ public class ChaosContractDeterminationDifficulty {
         }
 
         if (Factions.getInstance().getFaction(factionCode).isClan()) {
-            return parseFromInteger(skillLevel.ordinal() + 1);
+            // Clan forces fight one skill level above their nominal rating, clamped so an already-top-tier faction
+            // (LEGENDARY) does not overflow the enum.
+            return changeByDelta(skillLevel, 1);
         }
 
         return skillLevel;


### PR DESCRIPTION
## What this changes

<!-- The effect someone actually sees, in plain language. One or two sentences is fine. -->

This fixes a potential parse failure if a legendary Clan force is generated as the OpFor for a contract.

## Testing

- Manual testing

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result