### PR TITLE
Improved UX When Upgrading Campaign from Old Contract Market

### DIFF
--- a/MekHQ/resources/mekhq/resources/ChaosContractMarketDialog.properties
+++ b/MekHQ/resources/mekhq/resources/ChaosContractMarketDialog.properties
@@ -38,6 +38,10 @@ empty.contractMarket.title=No contracts available
 empty.contractMarket.body=There is no work on offer here right now. Contracts are drawn from the local hiring hall \
   each month, so a busier world means more offers - travel to a system with a stronger hiring hall, or for government \
   work to one of your own faction's worlds. Then advance the calendar and check back after the next monthly report.
+empty.contractMarket.disabled.title=Contract market disabled
+empty.contractMarket.disabled.body=The contract market is switched off, so no offers will appear here. To receive \
+  contract offers, enable the contract market under Campaign Options, or use this \
+  screen's Create button to add a contract by hand.
 card.contractMarket.months={0, choice, 1#{0} month|1<{0} months}
 dossier.contractMarket.eyebrow=Briefing Dossier
 dossier.contractMarket.batchall=Batchall

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionCodecs.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionCodecs.java
@@ -160,7 +160,7 @@ final class CampaignOptionCodecs {
         register(CampaignOption.FINANCIAL_YEAR_DURATION, enumCodec(FinancialYearDuration::parseFromString));
         register(CampaignOption.PERSONNEL_MARKET_STYLE, enumCodec(PersonnelMarketStyle::fromString));
         register(CampaignOption.UNIT_MARKET_METHOD, enumCodec(UnitMarketMethod::valueOf));
-        register(CampaignOption.CONTRACT_MARKET_METHOD, enumCodec(ContractMarketMethod::valueOf));
+        register(CampaignOption.CONTRACT_MARKET_METHOD, enumCodec(ContractMarketMethod::fromString));
         register(CampaignOption.SKILL_LEVEL, enumCodec(SkillLevel::parseFromString));
         register(CampaignOption.MINIMUM_CALLSIGN_SKILL_LEVEL, enumCodec(SkillLevel::parseFromString));
         register(CampaignOption.AUTO_RESOLVE_METHOD, enumCodec(AutoResolveMethod::valueOf));

--- a/MekHQ/src/mekhq/campaign/market/enums/ContractMarketMethod.java
+++ b/MekHQ/src/mekhq/campaign/market/enums/ContractMarketMethod.java
@@ -34,6 +34,7 @@ package mekhq.campaign.market.enums;
 
 import java.util.ResourceBundle;
 
+import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 
 public enum ContractMarketMethod {
@@ -71,6 +72,32 @@ public enum ContractMarketMethod {
         return this == CHAOS_CAMPAIGN;
     }
     //endregion Boolean Comparison Methods
+
+    //region File I/O
+
+    /**
+     * Parses a {@link ContractMarketMethod} from its {@link Enum#name()}, falling back to {@link #CHAOS_CAMPAIGN} when
+     * the text cannot be matched. Unrecognized values default to the active market rather than a disabled one, so a bad
+     * or outdated save still loads with a working contract market.
+     *
+     * @param text the persisted enum name
+     *
+     * @return the matching method, or {@link #CHAOS_CAMPAIGN} if {@code text} does not match a known value
+     *
+     * @author Illiani
+     * @since 0.51.01
+     */
+    public static ContractMarketMethod fromString(final String text) {
+        try {
+            return valueOf(text);
+        } catch (Exception ignored) {
+        }
+
+        MMLogger.create(ContractMarketMethod.class)
+              .error("Unable to parse {} into a ContractMarketMethod. Returning CHAOS_CAMPAIGN.", text);
+        return CHAOS_CAMPAIGN;
+    }
+    //endregion File I/O
 
     @Override
     public String toString() {

--- a/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ChaosContractMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ChaosContractMarketDialog.java
@@ -552,7 +552,13 @@ public class ChaosContractMarketDialog extends JDialog implements ContractMarket
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
         panel.setBorder(BorderFactory.createEmptyBorder(scaleForGUI(48), PADDING, scaleForGUI(48), PADDING));
 
-        JLabel title = new JLabel(getTextAt(RESOURCE_BUNDLE, "empty.contractMarket.title"), SwingConstants.CENTER);
+        // When the market is disabled advancing the calendar will never populate the board, so the standard
+        // "check back next month" advice would be misleading - point the player at the option instead.
+        boolean marketDisabled = campaign.getCampaignOptions().get(CampaignOption.CONTRACT_MARKET_METHOD).isNone();
+        String titleKey = marketDisabled ? "empty.contractMarket.disabled.title" : "empty.contractMarket.title";
+        String bodyKey = marketDisabled ? "empty.contractMarket.disabled.body" : "empty.contractMarket.body";
+
+        JLabel title = new JLabel(getTextAt(RESOURCE_BUNDLE, titleKey), SwingConstants.CENTER);
         title.setAlignmentX(JLabel.CENTER_ALIGNMENT);
         title.setFont(title.getFont().deriveFont(title.getFont().getSize2D() + 2f));
 
@@ -560,7 +566,7 @@ public class ChaosContractMarketDialog extends JDialog implements ContractMarket
                                        scaleForGUI(360)
                                        +
                                        "px; text-align:center'>" +
-                                       getTextAt(RESOURCE_BUNDLE, "empty.contractMarket.body") +
+                                       getTextAt(RESOURCE_BUNDLE, bodyKey) +
                                        "</body></html>",
               SwingConstants.CENTER);
         body.setAlignmentX(JLabel.CENTER_ALIGNMENT);


### PR DESCRIPTION
## What this changes

It is now clearer what actions the player must take when upgrading an existing campaign to the new market system.

## Testing

- Manual testing

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result