### PR TITLE
Fix Command Generator tooltip text loss, dead scroll wheel and window name (Fixes #9860)

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -579,11 +579,11 @@ btnNewQuinquennial.toolTipText=<html>Advance to the first day of the next quinqu
 ### StoryArcSelectionDialog Class
 StoryArcSelectionDialog.title=Select a Story Arc
 ### CommandGenerationDialog Class
-CommandGenerationDialog.title=Command Designer
+CommandGenerationDialog.title=Command Generator
 CommandGenerationDialog.btnAccept.text=Accept & Build Command
 CommandGenerationDialog.btnAccept.toolTipText=Generates support and adds this command to your campaign TOE.
 CommandGenerationDialog.btnCancel.text=Close Without Building
-CommandGenerationDialog.btnCancel.toolTipText=Closes the Command Designer without building anything. The rolls and the settings on the tabs are discarded; your campaign is not changed.
+CommandGenerationDialog.btnCancel.toolTipText=Closes the Command Generator without building anything. The rolls and the settings on the tabs are discarded; your campaign is not changed.
 CommandGenerationDialog.banner.text=<html><b>DESIGN STAGE</b> &mdash; this is a model. Nothing is added to your campaign until you <b>Accept &amp; Build Command</b>.</html>
 CommandGenerationDialog.confirmBuild.title=Build Command
 CommandGenerationDialog.confirmBuild.text=Build this command? {0} combat unit(s) plus generated support will be added to your campaign TOE.

--- a/MekHQ/src/mekhq/gui/commandGeneration/CommandGenerationDialog.java
+++ b/MekHQ/src/mekhq/gui/commandGeneration/CommandGenerationDialog.java
@@ -75,7 +75,6 @@ import megamek.client.ui.preferences.PreferencesNode;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.Gender;
 import megamek.common.enums.SkillLevel;
-import megamek.common.ui.FastJScrollPane;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -98,7 +97,7 @@ import mekhq.gui.campaignOptions.optionChangeDialogs.AdvancedScoutingCampaignOpt
 import mekhq.gui.dialog.factionStanding.factionJudgment.FactionJudgmentDialog;
 
 /**
- * Top-level dialog for the Command Generator (Command Designer). Hosts a
+ * Top-level dialog for the Command Generator. Hosts a
  * {@link CommandGenerationPane} with three tabs (Personnel &amp; Officers, Force Generator,
  * Spares &amp; Finances) and runs the ratgen pipeline on Accept &amp; Build.
  *
@@ -185,7 +184,13 @@ public class CommandGenerationDialog extends AbstractMHQValidationButtonDialog {
               BorderFactory.createMatteBorder(0, 0, 1, 0, separatorColor),
               BorderFactory.createEmptyBorder(6, 10, 6, 10)));
         content.add(designBanner, BorderLayout.NORTH);
-        content.add(new FastJScrollPane(pane), BorderLayout.CENTER);
+        // The tabbed pane is added directly rather than inside a scroll pane of its own: each tab
+        // already scrolls its own content, and a scroll pane wrapped around them gave the inner ones
+        // all the height they asked for. They then had nothing to scroll but still swallowed every
+        // mouse-wheel event, so the wheel did nothing anywhere in the dialog. Adding it directly
+        // bounds each tab's viewport to the dialog and puts the wheel back to work, and keeps the tab
+        // strip in place instead of letting it scroll off the top.
+        content.add(pane, BorderLayout.CENTER);
         return content;
     }
 

--- a/MekHQ/src/mekhq/gui/commandGeneration/CommandGenerationPane.java
+++ b/MekHQ/src/mekhq/gui/commandGeneration/CommandGenerationPane.java
@@ -43,6 +43,7 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 
 import megamek.client.ratgenerator.FactionRecord;
+import megamek.common.ui.FastJScrollPane;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.universe.enums.ForceNamingMethod;
 import mekhq.campaign.universe.commandGeneration.CommandGenerationOptions;
@@ -66,7 +67,7 @@ import mekhq.gui.commandGeneration.contents.SparesAndFinancesTab;
  * </ol>
  *
  * <p>This Pane is the spiritual counterpart of {@code CampaignOptionsPane}, scaled down to the three
- * tabs the Command Designer needs. The Tab classes themselves live in
+ * tabs the Command Generator needs. The Tab classes themselves live in
  * {@link mekhq.gui.commandGeneration.contents} and are plain Java classes following the same
  * "constructor + {@code createTab()} + {@code loadValuesFromOptions()}" convention used in the
  * Campaign Options package.</p>
@@ -231,8 +232,9 @@ public class CommandGenerationPane extends AbstractMHQTabbedPane {
     }
 
     private static JScrollPane wrap(JPanel content) {
-        JScrollPane scroll = new JScrollPane(content);
-        scroll.getVerticalScrollBar().setUnitIncrement(16);
+        // FastJScrollPane rather than a plain JScrollPane so the scroll step follows the UI scale,
+        // as it does everywhere else in the suite.
+        JScrollPane scroll = new FastJScrollPane(content);
         scroll.setBorder(null);
         return scroll;
     }

--- a/MekHQ/src/mekhq/gui/commandGeneration/components/CommandGenerationCheckBox.java
+++ b/MekHQ/src/mekhq/gui/commandGeneration/components/CommandGenerationCheckBox.java
@@ -32,10 +32,9 @@
  */
 package mekhq.gui.commandGeneration.components;
 
-import static megamek.client.ui.WrapLayout.wordWrap;
 import static megamek.client.ui.util.FlatLafStyleBuilder.setFontScaling;
-import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.processWrapSize;
 import static mekhq.gui.commandGeneration.components.CommandGenerationUtilities.getCommandGenerationResourceBundle;
+import static mekhq.gui.commandGeneration.components.CommandGenerationUtilities.wrapTooltip;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import javax.swing.JCheckBox;
@@ -75,7 +74,7 @@ public class CommandGenerationCheckBox extends JCheckBox {
 
         String tooltipText = getTextAt(getCommandGenerationResourceBundle(), "lbl" + name + ".tooltip");
         if (!tooltipText.isEmpty()) {
-            setToolTipText(wordWrap(tooltipText, processWrapSize(customWrapSize)));
+            setToolTipText(wrapTooltip(tooltipText, customWrapSize));
         }
 
         setFontScaling(this, false, 1);

--- a/MekHQ/src/mekhq/gui/commandGeneration/components/CommandGenerationLabel.java
+++ b/MekHQ/src/mekhq/gui/commandGeneration/components/CommandGenerationLabel.java
@@ -32,10 +32,9 @@
  */
 package mekhq.gui.commandGeneration.components;
 
-import static megamek.client.ui.WrapLayout.wordWrap;
 import static megamek.client.ui.util.FlatLafStyleBuilder.setFontScaling;
-import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.processWrapSize;
 import static mekhq.gui.commandGeneration.components.CommandGenerationUtilities.getCommandGenerationResourceBundle;
+import static mekhq.gui.commandGeneration.components.CommandGenerationUtilities.wrapTooltip;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import javax.swing.JLabel;
@@ -84,7 +83,7 @@ public class CommandGenerationLabel extends JLabel {
         if (!noTooltip) {
             String tooltipText = getTextAt(getCommandGenerationResourceBundle(), "lbl" + name + ".tooltip");
             if (!tooltipText.isEmpty()) {
-                setToolTipText(wordWrap(tooltipText, processWrapSize(customWrapSize)));
+                setToolTipText(wrapTooltip(tooltipText, customWrapSize));
             }
         }
 

--- a/MekHQ/src/mekhq/gui/commandGeneration/components/CommandGenerationSpinner.java
+++ b/MekHQ/src/mekhq/gui/commandGeneration/components/CommandGenerationSpinner.java
@@ -32,9 +32,9 @@
  */
 package mekhq.gui.commandGeneration.components;
 
-import static megamek.client.ui.WrapLayout.wordWrap;
 import static megamek.client.ui.util.FlatLafStyleBuilder.setFontScaling;
 import static mekhq.gui.commandGeneration.components.CommandGenerationUtilities.getCommandGenerationResourceBundle;
+import static mekhq.gui.commandGeneration.components.CommandGenerationUtilities.wrapTooltip;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import javax.swing.JComponent;
@@ -85,7 +85,7 @@ public class CommandGenerationSpinner extends JSpinner {
 
         String tooltipText = getTextAt(getCommandGenerationResourceBundle(), "lbl" + name + ".tooltip");
         if (!tooltipText.isEmpty()) {
-            setToolTipText(wordWrap(tooltipText));
+            setToolTipText(wrapTooltip(tooltipText, null));
         }
 
         setName("spn" + name);

--- a/MekHQ/src/mekhq/gui/commandGeneration/components/CommandGenerationStandardPanel.java
+++ b/MekHQ/src/mekhq/gui/commandGeneration/components/CommandGenerationStandardPanel.java
@@ -32,9 +32,8 @@
  */
 package mekhq.gui.commandGeneration.components;
 
-import static megamek.client.ui.WrapLayout.wordWrap;
-import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.processWrapSize;
 import static mekhq.gui.commandGeneration.components.CommandGenerationUtilities.getCommandGenerationResourceBundle;
+import static mekhq.gui.commandGeneration.components.CommandGenerationUtilities.wrapTooltip;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import javax.swing.JPanel;
@@ -90,7 +89,7 @@ public class CommandGenerationStandardPanel extends JPanel {
                 // controls inside keep their own tooltips.
                 String titleTooltip = getTextAt(getCommandGenerationResourceBundle(), "lbl" + borderTitle + ".tooltip");
                 if (!titleTooltip.isBlank()) {
-                    setToolTipText(wordWrap(titleTooltip, processWrapSize(null)));
+                    setToolTipText(wrapTooltip(titleTooltip, null));
                 }
             }
         }

--- a/MekHQ/src/mekhq/gui/commandGeneration/components/CommandGenerationUtilities.java
+++ b/MekHQ/src/mekhq/gui/commandGeneration/components/CommandGenerationUtilities.java
@@ -99,10 +99,12 @@ public final class CommandGenerationUtilities {
     }
 
     /**
-     * Removes a surrounding {@code <html>} / {@code </html>} pair, if the text has one.
+     * Removes the outer {@code <html>} wrapper from a tooltip, if it has one.
      *
-     * <p>Only the outermost pair is touched: markup inside the tooltip is left alone. Text without
-     * the wrapper is returned unchanged.</p>
+     * <p>The opening tag is removed when the text starts with it, and the closing tag when the text
+     * ends with it, so a tooltip its author left unclosed is still unwrapped rather than kept with a
+     * stray opening tag. Only the outermost tags are touched: markup inside the tooltip is left
+     * alone, and text carrying no wrapper is returned unchanged.</p>
      *
      * @param text the text to unwrap
      *

--- a/MekHQ/src/mekhq/gui/commandGeneration/components/CommandGenerationUtilities.java
+++ b/MekHQ/src/mekhq/gui/commandGeneration/components/CommandGenerationUtilities.java
@@ -32,6 +32,13 @@
  */
 package mekhq.gui.commandGeneration.components;
 
+import static megamek.client.ui.WrapLayout.wordWrap;
+import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.processWrapSize;
+
+import java.util.Locale;
+
+import megamek.common.annotations.Nullable;
+
 /**
  * Shared helpers for the Command Generation dialog's styled components.
  *
@@ -49,6 +56,9 @@ public final class CommandGenerationUtilities {
      */
     private static final String RESOURCE_BUNDLE = "mekhq.resources.CommandGenerationDialog";
 
+    private static final String HTML_OPENING_TAG = "<html>";
+    private static final String HTML_CLOSING_TAG = "</html>";
+
     private CommandGenerationUtilities() {
         // utility class
     }
@@ -61,5 +71,53 @@ public final class CommandGenerationUtilities {
      */
     public static String getCommandGenerationResourceBundle() {
         return RESOURCE_BUNDLE;
+    }
+
+    /**
+     * Word-wraps a bundle tooltip for display, tolerating text that is already wrapped in
+     * {@code <html>} tags.
+     *
+     * <p>{@link megamek.client.ui.WrapLayout#wordWrap(String, int)} adds its own {@code <html>}
+     * wrapper. Handing it a tooltip that already carries one - as any tooltip using {@code <br>} or
+     * {@code <b>} must - leaves a stray {@code <html>} tag inside the document, and Swing's renderer
+     * then silently drops everything from that tag to the next line break. The visible result is a
+     * tooltip missing its opening line, or opening with a blank one. Stripping the outer tags here
+     * keeps the markup inside the tooltip working while leaving exactly one wrapper on the result.</p>
+     *
+     * @param tooltipText    the tooltip text from the bundle, with or without surrounding
+     *                       {@code <html>} tags; {@code null} is returned unchanged
+     * @param customWrapSize maximum line length, or {@code null} for the default
+     *
+     * @return the wrapped tooltip, ready for {@code setToolTipText}
+     */
+    public static @Nullable String wrapTooltip(@Nullable String tooltipText,
+          @Nullable Integer customWrapSize) {
+        if (tooltipText == null) {
+            return null;
+        }
+        return wordWrap(stripHtmlWrapper(tooltipText), processWrapSize(customWrapSize));
+    }
+
+    /**
+     * Removes a surrounding {@code <html>} / {@code </html>} pair, if the text has one.
+     *
+     * <p>Only the outermost pair is touched: markup inside the tooltip is left alone. Text without
+     * the wrapper is returned unchanged.</p>
+     *
+     * @param text the text to unwrap
+     *
+     * @return the text with its outer {@code <html>} tags removed
+     */
+    private static String stripHtmlWrapper(String text) {
+        String trimmed = text.trim();
+        String lowerCase = trimmed.toLowerCase(Locale.ROOT);
+        if (!lowerCase.startsWith(HTML_OPENING_TAG)) {
+            return text;
+        }
+        trimmed = trimmed.substring(HTML_OPENING_TAG.length());
+        if (lowerCase.endsWith(HTML_CLOSING_TAG)) {
+            trimmed = trimmed.substring(0, trimmed.length() - HTML_CLOSING_TAG.length());
+        }
+        return trimmed;
     }
 }

--- a/MekHQ/src/mekhq/gui/commandGeneration/contents/SetupTab.java
+++ b/MekHQ/src/mekhq/gui/commandGeneration/contents/SetupTab.java
@@ -35,9 +35,8 @@ package mekhq.gui.commandGeneration.contents;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import megamek.client.ui.util.UIUtil;
-import static megamek.client.ui.WrapLayout.wordWrap;
-import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.processWrapSize;
 import static mekhq.gui.commandGeneration.components.CommandGenerationUtilities.getCommandGenerationResourceBundle;
+import static mekhq.gui.commandGeneration.components.CommandGenerationUtilities.wrapTooltip;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import java.awt.Component;
@@ -471,7 +470,7 @@ public class SetupTab {
         button.setName("rdo" + name);
         String tooltip = getTextAt(getCommandGenerationResourceBundle(), "lbl" + name + ".tooltip");
         if (tooltip != null && !tooltip.isEmpty()) {
-            button.setToolTipText(wordWrap(tooltip, processWrapSize(null)));
+            button.setToolTipText(wrapTooltip(tooltip, null));
         }
         return button;
     }
@@ -534,8 +533,8 @@ public class SetupTab {
           MMComboBox<SortDirection> directionCombo) {
         CommandGenerationLabel label = new CommandGenerationLabel(labelName);
         factorCombo.setToolTipText(label.getToolTipText());
-        directionCombo.setToolTipText(wordWrap(getTextAt(getCommandGenerationResourceBundle(),
-              "cmbTechAssignmentDirection.tooltip"), processWrapSize(null)));
+        directionCombo.setToolTipText(wrapTooltip(getTextAt(getCommandGenerationResourceBundle(),
+              "cmbTechAssignmentDirection.tooltip"), null));
         indentAsSubOption(label);
         constraints.gridy = row;
         constraints.gridx = 0;

--- a/MekHQ/unittests/mekhq/gui/commandGeneration/components/CommandGenerationUtilitiesTest.java
+++ b/MekHQ/unittests/mekhq/gui/commandGeneration/components/CommandGenerationUtilitiesTest.java
@@ -150,7 +150,7 @@ class CommandGenerationUtilitiesTest {
         if (text.toLowerCase(Locale.ROOT).startsWith(HTML_OPENING_TAG)) {
             text = text.substring(HTML_OPENING_TAG.length());
         }
-        return text.trim().split("\s+")[0];
+        return text.trim().split("\\s+")[0];
     }
 
     /**

--- a/MekHQ/unittests/mekhq/gui/commandGeneration/components/CommandGenerationUtilitiesTest.java
+++ b/MekHQ/unittests/mekhq/gui/commandGeneration/components/CommandGenerationUtilitiesTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.commandGeneration.components;
+
+import static mekhq.gui.commandGeneration.components.CommandGenerationUtilities.getCommandGenerationResourceBundle;
+import static mekhq.gui.commandGeneration.components.CommandGenerationUtilities.wrapTooltip;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Enumeration;
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the Command Generator's tooltips against the double-{@code <html>} defect reported in MekHQ
+ * issue #9860.
+ *
+ * <p>A tooltip written with {@code <html>} tags so that it can use {@code <br>} used to be handed
+ * straight to {@code WrapLayout.wordWrap}, which adds a wrapper of its own. The stray inner
+ * {@code <html>} tag made Swing drop everything up to the next line break, so "Generate Captains"
+ * opened with "lance)." and "Assign Best Officers" opened with a blank line.</p>
+ */
+class CommandGenerationUtilitiesTest {
+
+    private static final String HTML_OPENING_TAG = "<html>";
+
+    /**
+     * The tooltip from the "Generate Captains" checkbox, which showed the defect most plainly: its
+     * first line is 105 characters once the stray tag is counted, so the wrap fell just before
+     * "lance)." and everything ahead of that was lost.
+     */
+    private static final String GENERATE_CAPTAINS_TOOLTIP =
+          "<html>Creates a Captain for every company after the first (or every company when using a "
+                + "mercenary company command lance).<br>Captains receive two officer skill increases.</html>";
+
+    @Test
+    void anAlreadyHtmlTooltipKeepsItsOpeningWords() {
+        String wrapped = wrapTooltip(GENERATE_CAPTAINS_TOOLTIP, null);
+
+        assertTrue(wrapped.startsWith("<html>Creates a Captain for every company"),
+              "the opening of the tooltip must survive wrapping, got: " + wrapped);
+    }
+
+    @Test
+    void anAlreadyHtmlTooltipIsWrappedExactlyOnce() {
+        String wrapped = wrapTooltip(GENERATE_CAPTAINS_TOOLTIP, null);
+
+        assertEquals(1, countOpeningHtmlTags(wrapped),
+              "a second <html> tag inside the document is what made Swing drop the first line");
+    }
+
+    @Test
+    void markupInsideTheTooltipIsLeftAlone() {
+        String wrapped = wrapTooltip("<html>Costed at the <b>purchase cost</b>.<br>Not the resale value.</html>",
+              null);
+
+        assertTrue(wrapped.contains("<b>purchase cost</b>"), "inline markup must be preserved");
+        assertTrue(wrapped.contains("Not the resale value."), "text after a line break must be preserved");
+    }
+
+    @Test
+    void aPlainTooltipIsStillWrapped() {
+        String wrapped = wrapTooltip("Generates 4 medics for every doctor created above.", null);
+
+        assertEquals(1, countOpeningHtmlTags(wrapped));
+        assertTrue(wrapped.startsWith("<html>Generates 4 medics"), "got: " + wrapped);
+    }
+
+    @Test
+    void aCustomWrapSizeIsHonoured() {
+        String wrapped = wrapTooltip("one two three four five", 8);
+
+        assertTrue(wrapped.contains("<br>"), "a short wrap size must break the line, got: " + wrapped);
+    }
+
+    @Test
+    void aNullTooltipStaysNull() {
+        assertNull(wrapTooltip(null, null));
+    }
+
+    /**
+     * Sweeps the live bundle so a tooltip added or translated later cannot reintroduce the defect: every
+     * tooltip in the Command Generator must come out of the wrap with a single {@code <html>} tag and
+     * with its own first word still in front.
+     */
+    @Test
+    void everyTooltipInTheBundleSurvivesWrapping() {
+        ResourceBundle bundle = ResourceBundle.getBundle(getCommandGenerationResourceBundle(), Locale.ROOT);
+
+        int tooltipsChecked = 0;
+        Enumeration<String> keys = bundle.getKeys();
+        while (keys.hasMoreElements()) {
+            String key = keys.nextElement();
+            if (!key.endsWith(".tooltip")) {
+                continue;
+            }
+            String tooltipText = bundle.getString(key).trim();
+            if (tooltipText.isEmpty()) {
+                continue;
+            }
+            tooltipsChecked++;
+
+            String wrapped = wrapTooltip(tooltipText, null);
+            assertEquals(1, countOpeningHtmlTags(wrapped), key + " must be wrapped in html exactly once");
+            assertTrue(wrapped.startsWith(HTML_OPENING_TAG + firstWordOf(tooltipText)),
+                  key + " lost its opening word; got: " + wrapped);
+        }
+
+        assertTrue(tooltipsChecked > 0, "the bundle should hold tooltips to check");
+    }
+
+    /**
+     * @return the first word the reader should see, ignoring an {@code <html>} wrapper the author added
+     */
+    private static String firstWordOf(String tooltipText) {
+        String text = tooltipText;
+        if (text.toLowerCase(Locale.ROOT).startsWith(HTML_OPENING_TAG)) {
+            text = text.substring(HTML_OPENING_TAG.length());
+        }
+        return text.trim().split("\s+")[0];
+    }
+
+    /**
+     * @return how many {@code <html>} opening tags the wrapped tooltip carries; the closing tag reads as
+     *       {@code </html>} and is not counted
+     */
+    private static int countOpeningHtmlTags(String wrapped) {
+        int count = 0;
+        int index = wrapped.indexOf(HTML_OPENING_TAG);
+        while (index >= 0) {
+            count++;
+            index = wrapped.indexOf(HTML_OPENING_TAG, index + HTML_OPENING_TAG.length());
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
## What was broken

Three separate problems in the Command Generator, all reported together.

**Tooltips lost their opening line.** Hovering "Generate Captains" showed a tooltip that began "lance)." Hovering "Assign Best Officers" showed a blank line where the first sentence should have been. Nine tooltips were affected; the reporter caught six of them.

Those nine are written with `<html>` tags in the properties file so they can use `<br>` line breaks. The components handed that text straight to `WrapLayout.wordWrap`, which adds an `<html>` wrapper of its own, leaving a stray second `<html>` tag buried in the middle of the document. Swing's renderer then dropped everything from that tag to the next line break. Where the first line was long enough to wrap it took half a sentence with it; where it was short the whole line vanished and left the blank space.

**The mouse wheel did nothing, on any tab.** The tabbed pane sat inside a scroll pane of its own (`CommandGenerationDialog`), which meant each tab's scroll pane was handed as much height as it asked for. Those inner panes then had nothing to scroll — but a Swing scroll pane consumes the wheel event whether or not it can act on it, so the wheel was swallowed before the outer pane ever saw it. Dragging the scrollbar worked; the wheel never did.

**The window said "Command Designer"** while the menu item that opens it says "Quick Start Command Generator".

## Changes

- Added `CommandGenerationUtilities.wrapTooltip`, which strips an outer `<html>` wrapper before word-wrapping, and routed all six tooltip call sites through it. Fixing it in the component rather than editing the nine strings means a translator or a new tooltip cannot reintroduce it.
- Removed the outer scroll pane so each tab's viewport is bounded by the dialog and scrolls itself. This also keeps the tab strip in place instead of letting it scroll off the top.
- Switched the per-tab wrapping to `FastJScrollPane`, replacing a hardcoded 16px scroll step with one that follows the user's GUI scale.
- Renamed the window title and the Close button's tooltip to "Command Generator" so the dialog matches the menu entry that opens it.

## Testing

Seven new tests in `CommandGenerationUtilitiesTest`. Alongside the specific cases, one sweeps the live resource bundle and asserts that every tooltip in it comes out of the wrap with exactly one `<html>` tag and its own first word still leading — that is the test that fails if someone adds or translates a tooltip the old way.

Full `:MekHQ:test` green (586 test classes) and `checkstyleMain` clean.

Playtested in-game: the affected tooltips read in full, and the wheel scrolls all three tabs.

## What is NOT proven yet

The starting-cash tooltips (`lblStartingCashPercent`, `lblStartingCashPreview`) are two of the nine and carry `<b>` markup as well as `<br>`. The bundle sweep covers them, but they were not among the ones hovered by eye.

Campaign Options has one tooltip with the same defect — `lblSkillLevel.tooltip` in `CampaignOptionsDialog.properties` — which is outside this fix and untouched here.

Fixes #9860
