### PR TITLE
Fix #9866: Fixed Saving & Loading of Required Victory Points & Required Combat Elements

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/contract/io/ContractXmlCodec.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/io/ContractXmlCodec.java
@@ -111,8 +111,11 @@ public final class ContractXmlCodec {
         writeStringIfPresent(printWriter, indent, "contractName", contract.getName());
         writeStringIfPresent(printWriter, indent, "description", contract.getDescription());
         MHQXMLUtility.writeSimpleXMLTag(printWriter, indent, "scale", contract.getScale());
+        MHQXMLUtility.writeSimpleXMLTag(printWriter, indent, "requiredCombatElements",
+              contract.getRequiredCombatElements());
+        MHQXMLUtility.writeSimpleXMLTag(printWriter, indent, "requiredVictoryPoints",
+              contract.getRequiredVictoryPoints());
         MHQXMLUtility.writeSimpleXMLTag(printWriter, indent, "trackCount", contract.getTrackCount());
-        // The scenario schedule carries a random roll's result, so it is persisted rather than re-derived on load.
         if (!contract.getScenarioSchedule().isEmpty()) {
             MHQXMLUtility.writeSimpleXMLTag(printWriter, indent, "scenarioSchedule",
                   contract.getScenarioSchedule()
@@ -417,6 +420,10 @@ public final class ContractXmlCodec {
         readers.put("contractName", (contract, node, campaign, version) -> contract.setContractName(text(node)));
         readers.put("description", (contract, node, campaign, version) -> contract.setDescription(text(node)));
         readers.put("scale", (contract, node, campaign, version) -> contract.setScale(parseInt(node)));
+        readers.put("requiredCombatElements",
+              (contract, node, campaign, version) -> contract.setRequiredCombatElements(parseInt(node)));
+        readers.put("requiredVictoryPoints",
+              (contract, node, campaign, version) -> contract.setRequiredVictoryPoints(parseInt(node)));
         readers.put("trackCount", (contract, node, campaign, version) -> contract.setTrackCount(parseInt(node)));
         readers.put("scenarioSchedule",
               (contract, node, campaign, version) -> contract.setScenarioSchedule(parseScenarioSchedule(node)));


### PR DESCRIPTION
Fix #9866

## What this changes

The contract overhaul project IO was missing codecs for these values, now it isn't.

This fix isn't retroactive.

## Testing

- Manual testing

## What is not proven yet

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result