### PR TITLE
Fix #9807: Contract Status Now Viewable on Left Not Right in Briefing Room Dropdown

### DIFF
--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -269,7 +269,7 @@ public final class BriefingTab extends CampaignGuiTab {
                 if (value instanceof AbstractContract contract) {
                     MissionStatus status = contract.getStatus();
                     if (status != null) {
-                        setText(getText() + " [" + status + "]");
+                        setText("[" + status + "] " + getText());
                     }
                 }
                 return this;


### PR DESCRIPTION
Fix #9807

## What this changes

The contract status in the Briefing Room dropdown had it placed on the right, which could get cut off in some guis. Now it lives on the left.

## Testing

- Manual testing

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result