### PR TITLE
Fix #9853: Fixed Crash in Unit Market When Entity Fails to Load

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/unitMarket/UnitMarketOffer.java
+++ b/MekHQ/src/mekhq/campaign/market/unitMarket/UnitMarketOffer.java
@@ -42,8 +42,8 @@ import megamek.common.loaders.MekSummaryCache;
 import megamek.common.units.Entity;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.campaignOptions.CampaignOption;
+import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.market.enums.UnitMarketType;
 import mekhq.utilities.MHQXMLUtility;
@@ -140,9 +140,16 @@ public class UnitMarketOffer {
     public Money getPrice() {
         Money cost = Money.of((double) getUnit().getCost()).multipliedBy(getPercent()).dividedBy(100);
 
-        if (getEntity().isMixedTech()) {
+        final Entity entity = getEntity();
+        if (entity == null) {
+            // The unit failed to load; skip the tech-based price multiplier rather than crashing the market display.
+            // We should be dropping it elsewhere, so this is just added security.
+            return cost;
+        }
+
+        if (entity.isMixedTech()) {
             cost = cost.multipliedBy(campaignOptions.get(CampaignOption.MIXED_TECH_UNIT_PRICE_MULTIPLIER));
-        } else if (getEntity().isClan()) {
+        } else if (entity.isClan()) {
             cost = cost.multipliedBy(campaignOptions.get(CampaignOption.CLAN_UNIT_PRICE_MULTIPLIER));
         } else { // Inner Sphere Entity
             cost = cost.multipliedBy(campaignOptions.get(CampaignOption.INNER_SPHERE_UNIT_PRICE_MULTIPLIER));
@@ -193,6 +200,15 @@ public class UnitMarketOffer {
             }
         } catch (Exception ex) {
             LOGGER.error("", ex);
+            return null;
+        }
+
+        // The MekSummary can be present in the cache index while the underlying file no longer parses
+        // (stale/broken custom, moved or corrupt file). Such an offer is unpurchasable, so drop it here
+        // rather than let it linger as a phantom row that crashes the market display and cannot be bought.
+        if (retVal.getEntity() == null) {
+            LOGGER.error("Failed to load entity for unit {}, removing the offer from the market.",
+                  retVal.getUnit().getName());
             return null;
         }
 

--- a/MekHQ/src/mekhq/gui/panes/UnitMarketPane.java
+++ b/MekHQ/src/mekhq/gui/panes/UnitMarketPane.java
@@ -63,6 +63,7 @@ import megamek.common.units.UnitType;
 import megamek.common.util.sorter.NaturalOrderComparator;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.campaignOptions.CampaignOption;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.enums.TransactionType;
 import mekhq.campaign.market.enums.UnitMarketType;
@@ -73,7 +74,6 @@ import mekhq.gui.model.UnitMarketTableModel;
 import mekhq.gui.sorter.FormattedNumberSorter;
 import mekhq.gui.sorter.WeightClassSorter;
 import mekhq.utilities.ReportingUtilities;
-import mekhq.campaign.campaignOptions.CampaignOption;
 
 public class UnitMarketPane extends AbstractMHQSplitPane {
     private static final MMLogger LOGGER = MMLogger.create(UnitMarketPane.class);
@@ -541,10 +541,19 @@ public class UnitMarketPane extends AbstractMHQSplitPane {
      */
     private void finalizeEntityAcquisition(final List<UnitMarketOffer> offers, final boolean instantDelivery) {
         for (final UnitMarketOffer offer : offers) {
+            final Entity entity = offer.getEntity();
+            if (entity == null) {
+                // The unit failed to load. It cannot be acquired, so drop it instead of passing a null entity into
+                // addNewUnit.
+                LOGGER.error("Cannot acquire a null entity; removing the offer from the market.");
+                getCampaign().getUnitMarket().getOffers().remove(offer);
+                continue;
+            }
+
             boolean isEmployerMarket = offer.getMarketType().isEmployer();
             int transitDuration = instantDelivery || isEmployerMarket ? 0 : offer.getTransitDuration();
 
-            getCampaign().addNewUnit(offer.getEntity(),
+            getCampaign().addNewUnit(entity,
                   false,
                   transitDuration,
                   UnitMarketType.getQuality(campaign, offer.getMarketType()),


### PR DESCRIPTION
Fix #9853

## What this changes

Adds null protection for when a null entity is returned by the unit market. I wasn't able to track down the root cause here, potentially it was caused by a custom unit that no longer exists. But, really, all I can do is cure the symptom without a lot more information.

## Testing

- Hard to test due to not knowing the root cause.

## What is not proven yet

- Why the unit failed to load it's entity.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result