### PR TITLE
Close #9867: Separated Talent & Random Personality Campaign Options

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -977,9 +977,10 @@ lblBackgroundsPage.text=Background Options
 lblRandomBackgroundsPanel.text=Random Backgrounds
 lblRandomBackgroundsPanel.summary=Optional random personality, reputation, talent, and relationship history rules.
 lblUseRandomPersonalities.text=Assign Random Personalities
-lblUseRandomPersonalities.tooltip=Personnel are generated with random personality traits, quirks, and talent.\
-  <br>\
-  <br>Talent affects a character's ability to graduate from education module academies.
+lblUseRandomPersonalities.tooltip=Personnel are generated with random personality traits and quirks.
+lblUseRandomTalent.text=Assign Random Talent
+lblUseRandomTalent.tooltip=Personnel's Talent scores are taken into account. Talent affects a character's ability\
+  \ to graduate from education module academies.
 lblUsePersonalityTagsOnly.text=Show Personality Labels Only
 lblUsePersonalityTagsOnly.tooltip=Some players do not enjoy the random personality trait descriptions. Or they might \
   wish to just use the traits as a springboard for their own writing. This option will hide the descriptions and only\

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOption.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOption.java
@@ -442,6 +442,8 @@ public final class CampaignOption<T> {
           ofMutable(RandomOriginOptions.class, () -> new RandomOriginOptions(true), "randomOriginOptions");
     public static final CampaignOption<Boolean> USE_RANDOM_PERSONALITIES =
           of(Boolean.class, false, "useRandomPersonalities");
+    public static final CampaignOption<Boolean> USE_RANDOM_TALENT =
+          of(Boolean.class, false, "useRandomTalent");
     public static final CampaignOption<Boolean> USE_PERSONALITY_LABELS_ONLY =
           of(Boolean.class, false, "usePersonalityLabelsOnly");
     public static final CampaignOption<Boolean> USE_RANDOM_PERSONALITY_REPUTATION =

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
@@ -53,6 +53,8 @@ public class CampaignOptionsUnmarshaller {
         CampaignOptions campaignOptions = new CampaignOptions();
         NodeList childNodes = parentNod.getChildNodes();
 
+        boolean sawRandomTalent = false;
+
         for (int i = 0; i < childNodes.getLength(); i++) {
             Node childNode = childNodes.item(i);
 
@@ -68,11 +70,22 @@ public class CampaignOptionsUnmarshaller {
                 LOGGER.debug("{}\n\t{}", nodeName, nodeContents);
             }
 
+            if (CampaignOption.USE_RANDOM_TALENT.xmlTag().equals(nodeName)) {
+                sawRandomTalent = true;
+            }
+
             try {
                 parseNodeName(version, nodeName, campaignOptions, nodeContents, childNode);
             } catch (Exception ex) {
                 LOGGER.error(ex, "Exception parsing campaign option node: {}", nodeName);
             }
+        }
+
+        // Talent (Reasoning) was coupled to random personalities before it gained its own toggle. Saves written before
+        // that split carry no useRandomTalent tag, so inherit the personality setting to preserve their behavior.
+        if (!sawRandomTalent) {
+            campaignOptions.set(CampaignOption.USE_RANDOM_TALENT,
+                  campaignOptions.get(CampaignOption.USE_RANDOM_PERSONALITIES));
         }
 
         LOGGER.debug("Load Campaign Options Complete!");

--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -188,7 +188,7 @@ public class EducationController {
 
         // Calculate the roll based on Reasoning if necessary
         int roll = d6(2);
-        if (campaignOptions.get(CampaignOption.USE_RANDOM_PERSONALITIES)) {
+        if (campaignOptions.get(CampaignOption.USE_RANDOM_TALENT)) {
             roll += (person.getReasoning().getReasoningScore() / 4);
         }
         // Calculate the target number based on base target number and faculty skill
@@ -672,7 +672,6 @@ public class EducationController {
      *
      * @param campaign  The campaign the person is part of.
      * @param person    The person for whom the journey is being processed.
-     * @param resources The resource bundle containing localized strings.
      */
     private static void journeyToAcademy(Campaign campaign, Person person) {
         PlanetarySystem targetSystem = campaign.getSystemById(person.getEduAcademySystem());
@@ -1409,7 +1408,7 @@ public class EducationController {
             }
         }
 
-        if (campaign.getCampaignOptions().get(CampaignOption.USE_RANDOM_PERSONALITIES)) {
+        if (campaign.getCampaignOptions().get(CampaignOption.USE_RANDOM_TALENT)) {
             graduationRoll += person.getReasoning().getReasoningScore();
         }
 
@@ -1705,7 +1704,7 @@ public class EducationController {
             }
         }
 
-        if (campaign.getCampaignOptions().get(CampaignOption.USE_RANDOM_PERSONALITIES)) {
+        if (campaign.getCampaignOptions().get(CampaignOption.USE_RANDOM_TALENT)) {
             graduationRoll += person.getReasoning().ordinal() - 12;
         }
 
@@ -2325,8 +2324,8 @@ public class EducationController {
      *   <li>If the person's education reaches the doctorate level, they are granted the pre-nominal "Dr".</li>
      * </ul>
      *
-     * <p>The pass rate is influenced by the campaign's settings. When using random personalities, the person's
-     * reasoning modifies the base pass rate (defaulting to average reasoning if personalities are disabled).</p>
+     * <p>The pass rate is influenced by the campaign's settings. When using random talent, the person's
+     * reasoning modifies the base pass rate (defaulting to average reasoning if talent is disabled).</p>
      *
      * @param campaign the campaign context, used to retrieve the current date, options, and calculate the person's
      *                 experience.
@@ -2354,7 +2353,7 @@ public class EducationController {
 
         // We base passRate on US averages
         int passRate = 60 - (Reasoning.values().length / 2);
-        final int reasoningModifier = campaign.getCampaignOptions().get(CampaignOption.USE_RANDOM_PERSONALITIES) ?
+        final int reasoningModifier = campaign.getCampaignOptions().get(CampaignOption.USE_RANDOM_TALENT) ?
                                             person.getReasoning().getReasoningScore() :
                                             Reasoning.values().length / 2;
         passRate += reasoningModifier;

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -4646,7 +4646,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 personalityMenu.add(menuItem);
             }
 
-            if (getCampaignOptions().get(CampaignOption.USE_RANDOM_PERSONALITIES)) {
+            if (getCampaignOptions().get(CampaignOption.USE_RANDOM_PERSONALITIES) ||
+                      getCampaignOptions().get(CampaignOption.USE_RANDOM_TALENT)) {
                 menuItem = new JMenuItem(resources.getString("regeneratePersonality.text"));
                 menuItem.setActionCommand(CMD_PERSONALITY);
                 menuItem.addActionListener(this);

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/BackgroundsPage.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/BackgroundsPage.java
@@ -53,13 +53,13 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import megamek.Version;
 import megamek.client.ui.comboBoxes.MMComboBox;
+import megamek.client.ui.settings.SettingsFormPanel;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Planet;
 import mekhq.campaign.universe.PlanetarySystem;
 import mekhq.gui.campaignOptions.CampaignOptionFlag;
 import mekhq.gui.campaignOptions.components.CampaignOptionsCheckBox;
-import megamek.client.ui.settings.SettingsFormPanel;
 import mekhq.gui.campaignOptions.components.CampaignOptionsHeaderPanel;
 import mekhq.gui.campaignOptions.components.CampaignOptionsLabel;
 import mekhq.gui.campaignOptions.components.CampaignOptionsPagePanel;
@@ -89,6 +89,7 @@ class BackgroundsPage {
     private CampaignOptionsHeaderPanel backgroundHeader;
     private JPanel pnlRandomBackgrounds;
     private JCheckBox chkUseRandomPersonalities;
+    private JCheckBox chkUseRandomTalent;
     private JCheckBox chkUsePersonalityTagsOnly;
     private JCheckBox chkUseRandomPersonalityReputation;
     private JCheckBox chkUseReasoningXpMultiplier;
@@ -171,6 +172,9 @@ class BackgroundsPage {
         chkUseRandomPersonalities = new CampaignOptionsCheckBox("UseRandomPersonalities",
                 getMetadata(LEGACY_RULE_BEFORE_METADATA, CampaignOptionFlag.DOCUMENTED));
         chkUseRandomPersonalities.addMouseListener(createTipPanelUpdater("UseRandomPersonalities"));
+        chkUseRandomTalent = new CampaignOptionsCheckBox("UseRandomTalent",
+              getMetadata(new Version(0, 51, 1), CampaignOptionFlag.DOCUMENTED));
+        chkUseRandomTalent.addMouseListener(createTipPanelUpdater("UseRandomTalent"));
         chkUsePersonalityTagsOnly = new CampaignOptionsCheckBox("UsePersonalityTagsOnly",
                 getMetadata(new Version(0, 51, 1), CampaignOptionFlag.IMPORTANT));
         chkUsePersonalityTagsOnly.addMouseListener(createTipPanelUpdater("UsePersonalityTagsOnly"));
@@ -188,6 +192,7 @@ class BackgroundsPage {
             CONTROL_COLUMN_WIDTH);
         panel.addCheckBoxGrid(2,
                 chkUseRandomPersonalities,
+              chkUseRandomTalent,
                 chkUsePersonalityTagsOnly,
                 chkUseRandomPersonalityReputation,
                 chkUseReasoningXpMultiplier,
@@ -453,6 +458,7 @@ class BackgroundsPage {
         }
 
         chkUseRandomPersonalities.setSelected(model.useRandomPersonalities);
+        chkUseRandomTalent.setSelected(model.useRandomTalent);
         chkUsePersonalityTagsOnly.setSelected(model.usePersonalityLabelsOnly);
         chkUseRandomPersonalityReputation.setSelected(model.useRandomPersonalityReputation);
         chkUseReasoningXpMultiplier.setSelected(model.useReasoningXpMultiplier);
@@ -482,6 +488,7 @@ class BackgroundsPage {
         }
 
         model.useRandomPersonalities = chkUseRandomPersonalities.isSelected();
+        model.useRandomTalent = chkUseRandomTalent.isSelected();
         model.usePersonalityLabelsOnly = chkUsePersonalityTagsOnly.isSelected();
         model.useRandomPersonalityReputation = chkUseRandomPersonalityReputation.isSelected();
         model.useReasoningXpMultiplier = chkUseReasoningXpMultiplier.isSelected();

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyOptionsModel.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyOptionsModel.java
@@ -42,8 +42,8 @@ import jakarta.annotation.Nullable;
 import megamek.client.generator.RandomGenderGenerator;
 import megamek.client.generator.RandomNameGenerator;
 import mekhq.campaign.RandomOriginOptions;
-import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.campaignOptions.CampaignOption;
+import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.personnel.enums.AgeGroup;
 import mekhq.campaign.personnel.enums.FamilialRelationshipDisplayLevel;
 import mekhq.campaign.universe.Planet;
@@ -68,6 +68,7 @@ class BiographyOptionsModel {
     boolean rewardComingOfAgeAbilities;
     boolean rewardComingOfAgeRPSkills;
     boolean useRandomPersonalities;
+    boolean useRandomTalent;
     boolean usePersonalityLabelsOnly;
     boolean useRandomPersonalityReputation;
     boolean useReasoningXpMultiplier;
@@ -127,6 +128,7 @@ class BiographyOptionsModel {
         rewardComingOfAgeAbilities = options.get(CampaignOption.REWARD_COMING_OF_AGE_ABILITIES);
         rewardComingOfAgeRPSkills = options.get(CampaignOption.REWARD_COMING_OF_AGE_RP_SKILLS);
         useRandomPersonalities = options.get(CampaignOption.USE_RANDOM_PERSONALITIES);
+        useRandomTalent = options.get(CampaignOption.USE_RANDOM_TALENT);
         usePersonalityLabelsOnly = options.get(CampaignOption.USE_PERSONALITY_LABELS_ONLY);
         useRandomPersonalityReputation = options.get(CampaignOption.USE_RANDOM_PERSONALITY_REPUTATION);
         useReasoningXpMultiplier = options.get(CampaignOption.USE_REASONING_XP_MULTIPLIER);
@@ -187,6 +189,7 @@ class BiographyOptionsModel {
         options.set(CampaignOption.REWARD_COMING_OF_AGE_ABILITIES, rewardComingOfAgeAbilities);
         options.set(CampaignOption.REWARD_COMING_OF_AGE_RP_SKILLS, rewardComingOfAgeRPSkills);
         options.set(CampaignOption.USE_RANDOM_PERSONALITIES, useRandomPersonalities);
+        options.set(CampaignOption.USE_RANDOM_TALENT, useRandomTalent);
         options.set(CampaignOption.USE_PERSONALITY_LABELS_ONLY, usePersonalityLabelsOnly);
         options.set(CampaignOption.USE_RANDOM_PERSONALITY_REPUTATION, useRandomPersonalityReputation);
         options.set(CampaignOption.USE_REASONING_XP_MULTIPLIER, useReasoningXpMultiplier);

--- a/MekHQ/src/mekhq/gui/dialog/CreateCharacterDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CreateCharacterDialog.java
@@ -81,6 +81,7 @@ import megamek.common.units.Crew;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.campaignOptions.CampaignOption;
 import mekhq.campaign.personnel.Bloodname;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
@@ -102,7 +103,6 @@ import mekhq.campaign.universe.PlanetarySystem;
 import mekhq.gui.utilities.MarkdownEditorPanel;
 import mekhq.gui.utilities.MarkdownRenderer;
 import mekhq.gui.utilities.OriginFactionPickerHelper;
-import mekhq.campaign.campaignOptions.CampaignOption;
 
 /**
  * This dialog is used to create a character in story arcs from a pool of XP
@@ -1016,7 +1016,11 @@ public class CreateCharacterDialog extends JDialog implements DialogOptionListen
             gridBagConstraints.anchor = GridBagConstraints.WEST;
             gridBagConstraints.insets = new Insets(0, 5, 0, 0);
             demographicPanel.add(spnPersonalityQuirk, gridBagConstraints);
+        }
+        //endregion random personality
 
+        //region random talent
+        if (campaign.getCampaignOptions().get(CampaignOption.USE_RANDOM_TALENT)) {
             JLabel labelReasoning = new JLabel();
             labelReasoning.setText("Talent:");
             labelReasoning.setName("labelReasoning");
@@ -1037,6 +1041,7 @@ public class CreateCharacterDialog extends JDialog implements DialogOptionListen
             gridBagConstraints.insets = new Insets(0, 5, 0, 0);
             demographicPanel.add(comboReasoning, gridBagConstraints);
         }
+        //endregion random talent
 
         y++;
 
@@ -1762,10 +1767,12 @@ public class CreateCharacterDialog extends JDialog implements DialogOptionListen
             person.setPersonalityQuirk(comboPersonalityQuirk.getSelectedItem());
             person.setPersonalityQuirkDescriptionIndex((int) spnPersonalityQuirk.getValue());
 
-            person.setReasoning(comboReasoning.getSelectedItem());
-
             writePersonalityDescription(person);
             writeInterviewersNotes(person);
+        }
+
+        if (campaign.getCampaignOptions().get(CampaignOption.USE_RANDOM_TALENT)) {
+            person.setReasoning(comboReasoning.getSelectedItem());
         }
 
         person.setPortrait(portrait);

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -73,6 +73,7 @@ import megamek.common.units.Entity;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.campaignOptions.CampaignOption;
 import mekhq.campaign.personnel.Bloodname;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
@@ -101,7 +102,6 @@ import mekhq.gui.control.EditLogControl.LogType;
 import mekhq.gui.control.EditScenarioLogControl;
 import mekhq.gui.utilities.MarkdownEditorPanel;
 import mekhq.gui.utilities.OriginFactionPickerHelper;
-import mekhq.campaign.campaignOptions.CampaignOption;
 
 /**
  * This dialog is used to both hire new pilots and to edit existing ones
@@ -1266,7 +1266,11 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
             panDemographics.add(spnPersonalityQuirk, gridBagConstraints);
 
             y++;
+        }
+        // endregion random personality
 
+        // region random talent
+        if (campaign.getCampaignOptions().get(CampaignOption.USE_RANDOM_TALENT)) {
             JLabel labelReasoning = new JLabel();
             labelReasoning.setText("Talent:");
             labelReasoning.setName("labelReasoning");
@@ -1289,6 +1293,7 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
 
             y++;
         }
+        // endregion random talent
 
         if (person.hasDarkSecret()) {
             chkDarkSecretRevealed = new JCheckBox("Dark Secret Revealed");
@@ -1999,10 +2004,12 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
             person.setPersonalityQuirk(comboPersonalityQuirk.getSelectedItem());
             person.setPersonalityQuirkDescriptionIndex((int) spnPersonalityQuirk.getValue());
 
-            person.setReasoning(comboReasoning.getSelectedItem());
-
             writePersonalityDescription(person);
             writeInterviewersNotes(person);
+        }
+
+        if (campaign.getCampaignOptions().get(CampaignOption.USE_RANDOM_TALENT)) {
+            person.setReasoning(comboReasoning.getSelectedItem());
         }
 
         if (person.hasDarkSecret()) {

--- a/MekHQ/src/mekhq/gui/enums/PersonnelTabView.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTabView.java
@@ -104,7 +104,7 @@ public enum PersonnelTabView {
                 AMBITION, options -> options.get(CampaignOption.USE_RANDOM_PERSONALITIES),
                 GREED, options -> options.get(CampaignOption.USE_RANDOM_PERSONALITIES),
                 SOCIAL, options -> options.get(CampaignOption.USE_RANDOM_PERSONALITIES),
-                REASONING, options -> options.get(CampaignOption.USE_RANDOM_PERSONALITIES))),
+                REASONING, options -> options.get(CampaignOption.USE_RANDOM_TALENT))),
     SERVICE_RECORD("PersonnelTabView.SERVICE_RECORD.text", "PersonnelTabView.SERVICE_RECORD.toolTipText",
           Set.of(RANK, FIRST_NAME, LAST_NAME, PERSONNEL_ROLE, COMMAND_STATUS, FOUNDER, RECRUITMENT_DATE,
                 RETIREMENT_DATE, SALARY, KILLS, REPUTATION),


### PR DESCRIPTION
Close #9867

## What this changes

This PR breaks random talent rating out of random personality, so the two systems operate independently.

## Testing

- Manual testing
- AI testing

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result