### PR TITLE
Fix #9792: Fixed Infinite Loop When Repairing Podded Equipment in MRMS

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/PodSpace.java
+++ b/MekHQ/src/mekhq/campaign/parts/PodSpace.java
@@ -189,11 +189,22 @@ public class PodSpace implements IPartWork {
                 return unit.getEntity().getLocationName(location) + " is destroyed.";
             }
             if (repairInPlace) {
+                boolean hasMissingPart = false;
                 for (int id : childPartIds) {
                     final Part p = unit.getCampaign().getPlayerForce().getWarehouse().getPart(id);
-                    if (p instanceof MissingPart) {
-                        return null;
+                    if (p instanceof MissingPart missing) {
+                        hasMissingPart = true;
+                        // Only fixable if a replacement is actually in stock. This check prevents an infinite loop
+                        // in MRMS
+                        if (missing.isReplacementAvailable()) {
+                            return null;
+                        }
                     }
+                }
+                if (hasMissingPart) {
+                    return "There are no replacement parts available for " +
+                                 unit.getEntity().getLocationName(location) +
+                                 '.';
                 }
                 return unit.getEntity().getLocationName(location) + " is not missing any pod-mounted equipment.";
             } else {


### PR DESCRIPTION
Fix #9792:

## What this changes

This fix prevents an infinite loop caused by podded equipment being considered repairable, even if replacement parts aren't available. That repair would then be attempted, but fail because the replacement part wasn't available.

## Testing

- Manual testing
- AI verification of fix

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result