### PR TITLE
Fix #9833: Fixed Clan Phenotype Bonus Not Universally Applying to Trueborn Characters

### DIFF
--- a/MekHQ/src/mekhq/Utilities.java
+++ b/MekHQ/src/mekhq/Utilities.java
@@ -1050,7 +1050,7 @@ public class Utilities {
      * @param person    the person whose skills should receive the bonus
      * @param phenotype the phenotype determining which skills are bonused
      */
-    private static void applyPhenotypeSkillBonus(Person person, Phenotype phenotype) {
+    static void applyPhenotypeSkillBonus(Person person, Phenotype phenotype) {
         for (String skillName : phenotype.getBonusSkills()) {
             Skill skill = person.getSkill(skillName);
             if (skill != null) {

--- a/MekHQ/src/mekhq/Utilities.java
+++ b/MekHQ/src/mekhq/Utilities.java
@@ -98,6 +98,7 @@ import mekhq.campaign.mission.scenarios.IPlayerSettings;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.enums.Phenotype;
+import mekhq.campaign.personnel.skills.Skill;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.unit.CrewType;
 import mekhq.campaign.unit.ITransportAssignment;
@@ -1022,7 +1023,9 @@ public class Utilities {
 
                 String phenotype = oldCrew.getExtraDataValue(crewIndex, Crew.MAP_PHENOTYPE);
                 if (phenotype != null) {
-                    person.setPhenotype(Phenotype.fromString(phenotype));
+                    Phenotype resolvedPhenotype = Phenotype.fromString(phenotype);
+                    person.setPhenotype(resolvedPhenotype);
+                    applyPhenotypeSkillBonus(person, resolvedPhenotype);
                 }
 
                 String bloodname = oldCrew.getExtraDataValue(crewIndex, Crew.MAP_BLOOD_NAME);
@@ -1032,6 +1035,26 @@ public class Utilities {
             // Only created crew can be assigned a portrait, so this is safe to put in here
             if (!oldCrew.getPortrait(crewIndex).isDefault()) {
                 person.setPortrait(oldCrew.getPortrait(crewIndex).clone());
+            }
+        }
+    }
+
+    /**
+     * Applies the Clan Trueborn {@code +1} "Misc bonus" to a person's phenotype-appropriate profession skills.
+     *
+     * <p>Personnel converted from an {@link megamek.common.Crew} (such as captured enemy pilots) have their skills
+     * seeded directly from the crew's gunnery and piloting, so they never pass through the skill generator that would
+     * otherwise apply this bonus. Without this, Trueborn prisoners and bondsmen were missing the {@code +1} bonus that
+     * hired and Ronin Trueborn personnel receive.</p>
+     *
+     * @param person    the person whose skills should receive the bonus
+     * @param phenotype the phenotype determining which skills are bonused
+     */
+    private static void applyPhenotypeSkillBonus(Person person, Phenotype phenotype) {
+        for (String skillName : phenotype.getBonusSkills()) {
+            Skill skill = person.getSkill(skillName);
+            if (skill != null) {
+                skill.setBonus(skill.getBonus() + 1);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/personnel/enums/Phenotype.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/Phenotype.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -41,6 +41,7 @@ import megamek.codeUtilities.MathUtility;
 import megamek.logging.MMLogger;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.skills.Attributes;
+import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.personnel.skills.enums.SkillAttribute;
 
 /**
@@ -201,6 +202,39 @@ public enum Phenotype {
      */
     public List<String> getBonusTraits() {
         return bonusTraits;
+    }
+
+    /**
+     * Retrieves the profession skills that receive the Trueborn {@code +1} "Misc bonus" for this phenotype.
+     *
+     * <p>Each Clan Trueborn is bred for a specific profession and carries a {@code +1} bonus on the skills tied to
+     * that phenotype. This is the authoritative mapping of phenotype to bonused skills; a phenotype that grants no such
+     * bonus (for example {@link #NONE} or {@link #GENERAL}) returns an empty list.</p>
+     *
+     * @return the {@link SkillType} names that receive the phenotype bonus, or an empty list if none apply.
+     *
+     * @author Illiani
+     * @since 0.51.0
+     */
+    public List<String> getBonusSkills() {
+        return switch (this) {
+            case MEKWARRIOR -> List.of(SkillType.S_GUN_MEK, SkillType.S_PILOT_MEK);
+            case ELEMENTAL -> List.of(SkillType.S_GUN_BA, SkillType.S_ANTI_MEK);
+            case AEROSPACE -> List.of(SkillType.S_GUN_AERO,
+                  SkillType.S_PILOT_AERO,
+                  SkillType.S_GUN_JET,
+                  SkillType.S_PILOT_JET);
+            case VEHICLE -> List.of(SkillType.S_GUN_VEE,
+                  SkillType.S_PILOT_GVEE,
+                  SkillType.S_PILOT_NVEE,
+                  SkillType.S_PILOT_VTOL);
+            case PROTOMEK -> List.of(SkillType.S_GUN_PROTO);
+            case NAVAL -> List.of(SkillType.S_TECH_VESSEL,
+                  SkillType.S_GUN_SPACE,
+                  SkillType.S_PILOT_SPACE,
+                  SkillType.S_NAVIGATION);
+            case NONE, GENERAL -> List.of();
+        };
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/enums/Phenotype.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/Phenotype.java
@@ -208,10 +208,10 @@ public enum Phenotype {
      * Retrieves the profession skills that receive the Trueborn {@code +1} "Misc bonus" for this phenotype.
      *
      * <p>Each Clan Trueborn is bred for a specific profession and carries a {@code +1} bonus on the skills tied to
-     * that phenotype. This is the authoritative mapping of phenotype to bonused skills; a phenotype that grants no such
-     * bonus (for example {@link #NONE} or {@link #GENERAL}) returns an empty list.</p>
+     * that phenotype. This method centralizes the phenotype-to-skill mapping; phenotypes that grant no such bonus
+     * (for example {@link #NONE} or {@link #GENERAL}) return an empty list.</p>
      *
-     * @return the {@link SkillType} names that receive the phenotype bonus, or an empty list if none apply.
+     * @return the {@link SkillType} name strings that receive the phenotype bonus, or an empty list if none apply.
      *
      * @author Illiani
      * @since 0.51.0

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -73,6 +73,7 @@ import megamek.common.units.Entity;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.campaignOptions.CampaignOption;
 import mekhq.campaign.personnel.Bloodname;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
@@ -101,7 +102,6 @@ import mekhq.gui.control.EditLogControl.LogType;
 import mekhq.gui.control.EditScenarioLogControl;
 import mekhq.gui.utilities.MarkdownEditorPanel;
 import mekhq.gui.utilities.OriginFactionPickerHelper;
-import mekhq.campaign.campaignOptions.CampaignOption;
 
 /**
  * This dialog is used to both hire new pilots and to edit existing ones
@@ -2413,72 +2413,12 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
         final Phenotype newPhenotype = (Phenotype) choicePhenotype.getSelectedItem();
         if ((chkClan.isSelected()) || (Objects.requireNonNull(newPhenotype).isNone())) {
             if ((newPhenotype != null) && (newPhenotype != selectedPhenotype)) {
-                switch (selectedPhenotype) {
-                    case MEKWARRIOR:
-                        decreasePhenotypeBonus(SkillType.S_GUN_MEK);
-                        decreasePhenotypeBonus(SkillType.S_PILOT_MEK);
-                        break;
-                    case ELEMENTAL:
-                        decreasePhenotypeBonus(SkillType.S_GUN_BA);
-                        decreasePhenotypeBonus(SkillType.S_ANTI_MEK);
-                        break;
-                    case AEROSPACE:
-                        decreasePhenotypeBonus(SkillType.S_GUN_AERO);
-                        decreasePhenotypeBonus(SkillType.S_PILOT_AERO);
-                        decreasePhenotypeBonus(SkillType.S_GUN_JET);
-                        decreasePhenotypeBonus(SkillType.S_PILOT_JET);
-                        break;
-                    case VEHICLE:
-                        decreasePhenotypeBonus(SkillType.S_GUN_VEE);
-                        decreasePhenotypeBonus(SkillType.S_PILOT_GVEE);
-                        decreasePhenotypeBonus(SkillType.S_PILOT_NVEE);
-                        decreasePhenotypeBonus(SkillType.S_PILOT_VTOL);
-                        break;
-                    case PROTOMEK:
-                        decreasePhenotypeBonus(SkillType.S_GUN_PROTO);
-                        break;
-                    case NAVAL:
-                        decreasePhenotypeBonus(SkillType.S_TECH_VESSEL);
-                        decreasePhenotypeBonus(SkillType.S_GUN_SPACE);
-                        decreasePhenotypeBonus(SkillType.S_PILOT_SPACE);
-                        decreasePhenotypeBonus(SkillType.S_NAVIGATION);
-                        break;
-                    default:
-                        break;
+                for (String skillType : selectedPhenotype.getBonusSkills()) {
+                    decreasePhenotypeBonus(skillType);
                 }
 
-                switch (newPhenotype) {
-                    case MEKWARRIOR:
-                        increasePhenotypeBonus(SkillType.S_GUN_MEK);
-                        increasePhenotypeBonus(SkillType.S_PILOT_MEK);
-                        break;
-                    case ELEMENTAL:
-                        increasePhenotypeBonus(SkillType.S_GUN_BA);
-                        increasePhenotypeBonus(SkillType.S_ANTI_MEK);
-                        break;
-                    case AEROSPACE:
-                        increasePhenotypeBonus(SkillType.S_GUN_AERO);
-                        increasePhenotypeBonus(SkillType.S_PILOT_AERO);
-                        increasePhenotypeBonus(SkillType.S_GUN_JET);
-                        increasePhenotypeBonus(SkillType.S_PILOT_JET);
-                        break;
-                    case VEHICLE:
-                        increasePhenotypeBonus(SkillType.S_GUN_VEE);
-                        increasePhenotypeBonus(SkillType.S_PILOT_GVEE);
-                        increasePhenotypeBonus(SkillType.S_PILOT_NVEE);
-                        increasePhenotypeBonus(SkillType.S_PILOT_VTOL);
-                        break;
-                    case PROTOMEK:
-                        increasePhenotypeBonus(SkillType.S_GUN_PROTO);
-                        break;
-                    case NAVAL:
-                        increasePhenotypeBonus(SkillType.S_TECH_VESSEL);
-                        increasePhenotypeBonus(SkillType.S_GUN_SPACE);
-                        increasePhenotypeBonus(SkillType.S_PILOT_SPACE);
-                        increasePhenotypeBonus(SkillType.S_NAVIGATION);
-                        break;
-                    default:
-                        break;
+                for (String skillType : newPhenotype.getBonusSkills()) {
+                    increasePhenotypeBonus(skillType);
                 }
 
                 selectedPhenotype = newPhenotype;

--- a/MekHQ/unittests/mekhq/UtilitiesTest.java
+++ b/MekHQ/unittests/mekhq/UtilitiesTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq;
+
+import static mekhq.campaign.personnel.skills.SkillType.EXP_REGULAR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import mekhq.campaign.Campaign;
+import mekhq.campaign.force.PlayerForce;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.enums.Phenotype;
+import mekhq.campaign.personnel.skills.SkillType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link Utilities#applyPhenotypeSkillBonus(Person, Phenotype)}, which restores the Clan Trueborn {@code +1}
+ * "Misc bonus" for personnel converted from a crew (for example captured enemy pilots) — see MekHQ issue 9833.
+ */
+class UtilitiesTest {
+    private Campaign mockCampaign;
+
+    @BeforeEach
+    void setUp() {
+        SkillType.initializeTypes();
+        mockCampaign = mock(Campaign.class);
+        // Person construction reads campaign.getPlayerForce().getRankSystem(); the force just needs to be non-null.
+        when(mockCampaign.getPlayerForce()).thenReturn(mock(PlayerForce.class));
+    }
+
+    private Person newPersonWithSkills(String... skillNames) {
+        Person person = new Person(mockCampaign, "MERC");
+        for (String skillName : skillNames) {
+            person.addSkill(skillName, EXP_REGULAR, 0);
+        }
+        return person;
+    }
+
+    @Test
+    void appliesBonusToAllMappedSkillsForMekWarriorPhenotype() {
+        Person person = newPersonWithSkills(SkillType.S_GUN_MEK, SkillType.S_PILOT_MEK);
+
+        Utilities.applyPhenotypeSkillBonus(person, Phenotype.MEKWARRIOR);
+
+        assertEquals(1, person.getSkill(SkillType.S_GUN_MEK).getBonus());
+        assertEquals(1, person.getSkill(SkillType.S_PILOT_MEK).getBonus());
+    }
+
+    @Test
+    void appliesBonusToAllMappedSkillsForNavalPhenotype() {
+        Person person = newPersonWithSkills(SkillType.S_TECH_VESSEL,
+              SkillType.S_GUN_SPACE,
+              SkillType.S_PILOT_SPACE,
+              SkillType.S_NAVIGATION);
+
+        Utilities.applyPhenotypeSkillBonus(person, Phenotype.NAVAL);
+
+        assertEquals(1, person.getSkill(SkillType.S_TECH_VESSEL).getBonus());
+        assertEquals(1, person.getSkill(SkillType.S_GUN_SPACE).getBonus());
+        assertEquals(1, person.getSkill(SkillType.S_PILOT_SPACE).getBonus());
+        assertEquals(1, person.getSkill(SkillType.S_NAVIGATION).getBonus());
+    }
+
+    @Test
+    void doesNotTouchSkillsOutsideThePhenotypeMapping() {
+        Person person = newPersonWithSkills(SkillType.S_GUN_MEK, SkillType.S_SMALL_ARMS);
+
+        Utilities.applyPhenotypeSkillBonus(person, Phenotype.MEKWARRIOR);
+
+        assertEquals(1, person.getSkill(SkillType.S_GUN_MEK).getBonus());
+        assertEquals(0, person.getSkill(SkillType.S_SMALL_ARMS).getBonus());
+    }
+
+    @Test
+    void addsToAnyExistingBonusRatherThanOverwriting() {
+        Person person = new Person(mockCampaign, "MERC");
+        person.addSkill(SkillType.S_GUN_MEK, EXP_REGULAR, 2);
+
+        Utilities.applyPhenotypeSkillBonus(person, Phenotype.MEKWARRIOR);
+
+        assertEquals(3, person.getSkill(SkillType.S_GUN_MEK).getBonus());
+    }
+
+    @Test
+    void ignoresMappedSkillsThePersonDoesNotHave() {
+        // A MekWarrior phenotype maps to both gunnery and piloting; a person with only one should not gain the other.
+        Person person = newPersonWithSkills(SkillType.S_GUN_MEK);
+
+        Utilities.applyPhenotypeSkillBonus(person, Phenotype.MEKWARRIOR);
+
+        assertEquals(1, person.getSkill(SkillType.S_GUN_MEK).getBonus());
+        assertFalse(person.hasSkill(SkillType.S_PILOT_MEK));
+    }
+
+    @Test
+    void internalPhenotypesApplyNoBonus() {
+        Person person = newPersonWithSkills(SkillType.S_GUN_MEK, SkillType.S_PILOT_MEK);
+
+        Utilities.applyPhenotypeSkillBonus(person, Phenotype.NONE);
+        Utilities.applyPhenotypeSkillBonus(person, Phenotype.GENERAL);
+
+        assertEquals(0, person.getSkill(SkillType.S_GUN_MEK).getBonus());
+        assertEquals(0, person.getSkill(SkillType.S_PILOT_MEK).getBonus());
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/PhenotypeTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/PhenotypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2022-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -40,6 +40,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import mekhq.campaign.personnel.skills.SkillType;
 import org.junit.jupiter.api.Test;
 
 class PhenotypeTest {
@@ -86,6 +87,38 @@ class PhenotypeTest {
             String shortName = phenotype.getShortName();
             boolean isValid = isResourceKeyValid(shortName);
             assertTrue(isValid, "Invalid resource key: " + shortName);
+        }
+    }
+
+    @Test
+    void testGetBonusSkills() {
+        assertEquals(List.of(SkillType.S_GUN_MEK, SkillType.S_PILOT_MEK), Phenotype.MEKWARRIOR.getBonusSkills());
+        assertEquals(List.of(SkillType.S_GUN_BA, SkillType.S_ANTI_MEK), Phenotype.ELEMENTAL.getBonusSkills());
+        assertEquals(List.of(SkillType.S_GUN_AERO, SkillType.S_PILOT_AERO, SkillType.S_GUN_JET, SkillType.S_PILOT_JET),
+              Phenotype.AEROSPACE.getBonusSkills());
+        assertEquals(List.of(SkillType.S_GUN_VEE,
+              SkillType.S_PILOT_GVEE,
+              SkillType.S_PILOT_NVEE,
+              SkillType.S_PILOT_VTOL), Phenotype.VEHICLE.getBonusSkills());
+        assertEquals(List.of(SkillType.S_GUN_PROTO), Phenotype.PROTOMEK.getBonusSkills());
+        assertEquals(List.of(SkillType.S_TECH_VESSEL,
+              SkillType.S_GUN_SPACE,
+              SkillType.S_PILOT_SPACE,
+              SkillType.S_NAVIGATION), Phenotype.NAVAL.getBonusSkills());
+    }
+
+    @Test
+    void testGetBonusSkillsInternalPhenotypesHaveNone() {
+        assertTrue(Phenotype.NONE.getBonusSkills().isEmpty());
+        assertTrue(Phenotype.GENERAL.getBonusSkills().isEmpty());
+    }
+
+    @Test
+    void testGetBonusSkillsOnlyExternalPhenotypesGrantBonus() {
+        for (final Phenotype phenotype : phenotypes) {
+            assertEquals(phenotype.isExternal(),
+                  !phenotype.getBonusSkills().isEmpty(),
+                  "Bonus skills should be present only for external phenotypes: " + phenotype);
         }
     }
 


### PR DESCRIPTION
Fix #9833

## What this changes

This fixes a shortcutting issue caused by the method in which MegaMek only characters (i.e. those from scenarios) are converted into MekHQ people. This unique path meant that the phenotype skill bonus wasn't being applied. Now it is.

## Testing
- Manual testing
- AI Unit tests

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result