### PR TITLE
Fix #9828: Fixed Fluff Images Displaying with a Size of 0x0

### DIFF
--- a/MekHQ/src/mekhq/gui/utilities/ImgLabel.java
+++ b/MekHQ/src/mekhq/gui/utilities/ImgLabel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2019-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -48,10 +48,52 @@ import javax.swing.JLabel;
  */
 public class ImgLabel extends JLabel {
     Image image;
+    private final int maxWidth;
+    private final int maxHeight;
 
-    public ImgLabel(Image i) {
+    /**
+     * Creates a label that paints the given image without an upper bound on its preferred size, so it reports the
+     * image's natural dimensions and grows to whatever space a stretching layout gives it.
+     *
+     * @param image the image to paint
+     */
+    public ImgLabel(Image image) {
+        this(image, Integer.MAX_VALUE, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Creates a label that paints the given image, reporting a preferred size that fits the image (aspect ratio
+     * preserved) within the given bounds. The bounds matter for layouts that size a component to its preferred size
+     * (e.g. {@code GridBagConstraints.fill == NONE}); without a non-zero preferred size such layouts collapse the label
+     * to nothing and the image is never seen.
+     *
+     * @param i         the image to paint
+     * @param maxWidth  the maximum preferred width, in pixels
+     * @param maxHeight the maximum preferred height, in pixels
+     */
+    public ImgLabel(Image i, int maxWidth, int maxHeight) {
         super();
         this.image = i;
+        this.maxWidth = maxWidth;
+        this.maxHeight = maxHeight;
+    }
+
+    /**
+     * Reports the image's dimensions scaled to fit within the configured maximum bounds, preserving aspect ratio. This
+     * gives the label a non-zero footprint so that layouts which honor the preferred size still show the image.
+     *
+     * @return the preferred size for this label
+     */
+    @Override
+    public Dimension getPreferredSize() {
+        int imageWidth = image.getWidth(this);
+        int imageHeight = image.getHeight(this);
+        // If the image's dimensions are not yet known, defer to the default preferred size.
+        if ((imageWidth <= 0) || (imageHeight <= 0)) {
+            return super.getPreferredSize();
+        }
+        double scale = Math.min(1.0, Math.min((double) maxWidth / imageWidth, (double) maxHeight / imageHeight));
+        return new Dimension((int) Math.round(imageWidth * scale), (int) Math.round(imageHeight * scale));
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
@@ -69,6 +69,7 @@ import megamek.common.units.Entity;
 import megamek.utilities.ImageUtilities;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.campaignOptions.CampaignOption;
 import mekhq.campaign.log.LogEntry;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.baseComponents.JScrollablePanel;
@@ -78,7 +79,6 @@ import mekhq.gui.model.UnitTableModel;
 import mekhq.gui.utilities.ImgLabel;
 import mekhq.gui.utilities.MarkdownRenderer;
 import mekhq.gui.utilities.MultiLineTooltip;
-import mekhq.campaign.campaignOptions.CampaignOption;
 
 /**
  * A custom panel that gets filled in with goodies from a unit record
@@ -194,8 +194,9 @@ public class UnitViewPanel extends JScrollablePanel {
         Image image = isSpritesOnly ? null : FluffImageHelper.getFluffImage(entity);
 
         if (null != image) {
-            // fluff image exists so use custom ImgLabel to get full mek porn
-            return new ImgLabel(image);
+            // fluff image exists so use custom ImgLabel to get full mek porn; cap it so it stays prominent without
+            // crowding out the stats panel beside it (the image label is laid out to its preferred size).
+            return new ImgLabel(image, UIUtil.scaleForGUI(240), UIUtil.scaleForGUI(360));
         }
 
         // no fluff image, so just use image icon from top-down view


### PR DESCRIPTION
Fix #9828

## What this changes

The image for fluff images were generating using a preferred size of 0, meaning they were being created as 0x0 images. This fixes that error.

## Testing

- The reporter didn't include any fluff images, but I was able to confirm with random images from the internet

## What is not proven yet

- Whether this fix works for the bug reporter's specific use case, but it should.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result