### PR TITLE
Fix #9761, #9762: Fixed Non-Persistent Damage to Torso Mounts and Autocannons

### DIFF
--- a/MekHQ/resources/mekhq/resources/Parts.properties
+++ b/MekHQ/resources/mekhq/resources/Parts.properties
@@ -56,6 +56,8 @@ PartRepairType.UNKNOWN_LOCATION.text=Error: Unknown Repair Type
 # Modifier descriptions
 Part.modifier.obsolete=obsolete
 Part.damaged.beyond.repair=This part is damaged beyond repair
+EquipmentPart.directionalMountLocked=Rotation Mount Locked
+EquipmentPart.autocannonHit=Autocannon Damaged
 # Fabrication
 MissingPart.noUnit=No Attached Unit
 MissingPart.complex.maintenance=Too Complex: needs a maintenance facility or better

--- a/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
@@ -33,6 +33,8 @@
  */
 package mekhq.campaign.parts.equipment;
 
+import static mekhq.utilities.MHQInternationalization.getTextAt;
+
 import java.io.PrintWriter;
 
 import jakarta.annotation.Nonnull;
@@ -51,13 +53,13 @@ import megamek.common.units.Entity;
 import megamek.common.weapons.bayWeapons.BayWeapon;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.campaignOptions.CampaignOption;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.unit.Unit;
 import mekhq.utilities.MHQXMLUtility;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import mekhq.campaign.campaignOptions.CampaignOption;
 
 /**
  * This part covers most of the equipment types in WeaponType, AmmoType, and MiscType It can robustly handle all
@@ -83,6 +85,16 @@ public class EquipmentPart extends Part {
     protected int equipmentNum;
     protected double equipTonnage;
     protected double size;
+
+    /**
+     * Whether the weapon's Directional Torso Mount rotation mechanism has been destroyed in combat.
+     */
+    protected boolean directionalMountLocked = false;
+
+    /**
+     * Whether an autocannon has absorbed its first critical hit (Core rules only).
+     */
+    protected boolean autocannonHit = false;
 
     public EquipmentType getType() {
         return type;
@@ -145,6 +157,8 @@ public class EquipmentPart extends Part {
         EquipmentPart clone = new EquipmentPart(getUnitTonnage(), type, equipmentNum, size, omniPodded, campaign);
         clone.copyBaseData(this);
         clone.setEquipTonnage(equipTonnage);
+        clone.directionalMountLocked = directionalMountLocked;
+        clone.autocannonHit = autocannonHit;
         return clone;
     }
 
@@ -195,6 +209,12 @@ public class EquipmentPart extends Part {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "typeName", type.getInternalName());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "size", size);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "equipTonnage", equipTonnage);
+        if (directionalMountLocked) {
+            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "directionalMountLocked", true);
+        }
+        if (autocannonHit) {
+            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "autocannonHit", true);
+        }
         writeToXMLEnd(pw, indent);
     }
 
@@ -212,6 +232,10 @@ public class EquipmentPart extends Part {
                 size = Double.parseDouble(wn2.getTextContent());
             } else if (wn2.getNodeName().equalsIgnoreCase("equipTonnage")) {
                 equipTonnage = Double.parseDouble(wn2.getTextContent());
+            } else if (wn2.getNodeName().equalsIgnoreCase("directionalMountLocked")) {
+                directionalMountLocked = Boolean.parseBoolean(wn2.getTextContent());
+            } else if (wn2.getNodeName().equalsIgnoreCase("autocannonHit")) {
+                autocannonHit = Boolean.parseBoolean(wn2.getTextContent());
             }
         }
         restore();
@@ -231,11 +255,16 @@ public class EquipmentPart extends Part {
     public void fix() {
         super.fix();
 
+        directionalMountLocked = false;
+        autocannonHit = false;
+
         final Mounted<?> mounted = getMounted();
         if (mounted != null) {
             mounted.setHit(false);
             mounted.setMissing(false);
             mounted.setDestroyed(false);
+            mounted.setAutocannonHit(false);
+            mounted.setDirectionalMountLocked(false);
             unit.repairSystem(CriticalSlot.TYPE_EQUIPMENT, equipmentNum);
         }
 
@@ -317,6 +346,11 @@ public class EquipmentPart extends Part {
 
         setHits(newHits);
 
+        // These two states are combat damage that MegaMek does not model as a crit-slot hit, so they are tracked
+        // separately from hits
+        autocannonHit = mounted.isAutocannonHit();
+        directionalMountLocked = mounted.isDirectionalMountLocked();
+
         omniPodded = mounted.isOmniPodMounted();
 
         if (checkForDestruction &&
@@ -348,6 +382,10 @@ public class EquipmentPart extends Part {
             return 250;
         }
 
+        if (autocannonHit || directionalMountLocked) {
+            return 100;
+        }
+
         return 0;
     }
 
@@ -369,12 +407,16 @@ public class EquipmentPart extends Part {
         } else if (hits > 3) {
             return 2;
         }
+
+        if (autocannonHit || directionalMountLocked) {
+            return -3;
+        }
         return 0;
     }
 
     @Override
     public boolean needsFixing() {
-        return hits > 0;
+        return hits > 0 || directionalMountLocked || autocannonHit;
     }
 
     protected @Nullable Mounted<?> getMounted() {
@@ -406,6 +448,30 @@ public class EquipmentPart extends Part {
         return (mounted != null) && mounted.isRearMounted();
     }
 
+    public boolean isDirectionalMountLocked() {
+        return directionalMountLocked;
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
+        StringBuilder details = new StringBuilder(super.getDetails(includeRepairDetails));
+
+        if (autocannonHit) {
+            appendDetail(details, getTextAt("mekhq.resources.Parts", "EquipmentPart.autocannonHit"));
+        }
+        if (directionalMountLocked) {
+            appendDetail(details, getTextAt("mekhq.resources.Parts", "EquipmentPart.directionalMountLocked"));
+        }
+        return details.toString();
+    }
+
+    private static void appendDetail(StringBuilder details, String note) {
+        if (!details.isEmpty()) {
+            details.append(", ");
+        }
+        details.append(note);
+    }
+
     @Override
     public void updateConditionFromPart() {
         final Unit unit = getUnit();
@@ -427,6 +493,9 @@ public class EquipmentPart extends Part {
                 mounted.setRepairable(true);
                 unit.repairSystem(CriticalSlot.TYPE_EQUIPMENT, getEquipmentNum());
             }
+
+            mounted.setAutocannonHit(autocannonHit);
+            mounted.setDirectionalMountLocked(directionalMountLocked);
 
             setOmniPodded(mounted.isOmniPodMounted());
         }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
@@ -33,6 +33,8 @@
  */
 package mekhq.campaign.parts.equipment;
 
+import static mekhq.utilities.MHQInternationalization.getTextAt;
+
 import java.io.PrintWriter;
 
 import jakarta.annotation.Nonnull;
@@ -51,13 +53,13 @@ import megamek.common.units.Entity;
 import megamek.common.weapons.bayWeapons.BayWeapon;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.campaignOptions.CampaignOption;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.unit.Unit;
 import mekhq.utilities.MHQXMLUtility;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import mekhq.campaign.campaignOptions.CampaignOption;
 
 /**
  * This part covers most of the equipment types in WeaponType, AmmoType, and MiscType It can robustly handle all
@@ -83,6 +85,16 @@ public class EquipmentPart extends Part {
     protected int equipmentNum;
     protected double equipTonnage;
     protected double size;
+
+    /**
+     * Whether the weapon's Directional Torso Mount rotation mechanism has been destroyed in combat.
+     */
+    protected boolean directionalMountLocked = false;
+
+    /**
+     * Whether an autocannon has absorbed its first critical hit (Core rules only).
+     */
+    protected boolean autocannonHit = false;
 
     public EquipmentType getType() {
         return type;
@@ -145,6 +157,8 @@ public class EquipmentPart extends Part {
         EquipmentPart clone = new EquipmentPart(getUnitTonnage(), type, equipmentNum, size, omniPodded, campaign);
         clone.copyBaseData(this);
         clone.setEquipTonnage(equipTonnage);
+        clone.directionalMountLocked = directionalMountLocked;
+        clone.autocannonHit = autocannonHit;
         return clone;
     }
 
@@ -195,6 +209,12 @@ public class EquipmentPart extends Part {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "typeName", type.getInternalName());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "size", size);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "equipTonnage", equipTonnage);
+        if (directionalMountLocked) {
+            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "directionalMountLocked", true);
+        }
+        if (autocannonHit) {
+            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "autocannonHit", true);
+        }
         writeToXMLEnd(pw, indent);
     }
 
@@ -212,6 +232,10 @@ public class EquipmentPart extends Part {
                 size = Double.parseDouble(wn2.getTextContent());
             } else if (wn2.getNodeName().equalsIgnoreCase("equipTonnage")) {
                 equipTonnage = Double.parseDouble(wn2.getTextContent());
+            } else if (wn2.getNodeName().equalsIgnoreCase("directionalMountLocked")) {
+                directionalMountLocked = Boolean.parseBoolean(wn2.getTextContent());
+            } else if (wn2.getNodeName().equalsIgnoreCase("autocannonHit")) {
+                autocannonHit = Boolean.parseBoolean(wn2.getTextContent());
             }
         }
         restore();
@@ -231,11 +255,16 @@ public class EquipmentPart extends Part {
     public void fix() {
         super.fix();
 
+        directionalMountLocked = false;
+        autocannonHit = false;
+
         final Mounted<?> mounted = getMounted();
         if (mounted != null) {
             mounted.setHit(false);
             mounted.setMissing(false);
             mounted.setDestroyed(false);
+            mounted.setAutocannonHit(false);
+            mounted.setDirectionalMountLocked(false);
             unit.repairSystem(CriticalSlot.TYPE_EQUIPMENT, equipmentNum);
         }
 
@@ -317,6 +346,15 @@ public class EquipmentPart extends Part {
 
         setHits(newHits);
 
+        // These two states are combat damage that MegaMek does not model as a crit-slot hit, so they are tracked
+        // separately from hits (and read straight off the mount, which only carries them for the ruleset that was
+        // actually in play): a CORE-rules autocannon that has taken its first, non-destroying crit (#9761), and a
+        // destroyed Directional Torso Mount rotation mechanism that locks the still-firing weapon's arc (#9762). Keeping
+        // hits purely crit-slot based means a Total-Warfare-destroyed autocannon (hits == 1) is never confused with a
+        // still-firing CORE one.
+        autocannonHit = mounted.isAutocannonHit();
+        directionalMountLocked = mounted.isDirectionalMountLocked();
+
         omniPodded = mounted.isOmniPodMounted();
 
         if (checkForDestruction &&
@@ -348,6 +386,10 @@ public class EquipmentPart extends Part {
             return 250;
         }
 
+        if (autocannonHit || directionalMountLocked) {
+            return 100;
+        }
+
         return 0;
     }
 
@@ -369,12 +411,16 @@ public class EquipmentPart extends Part {
         } else if (hits > 3) {
             return 2;
         }
+
+        if (autocannonHit || directionalMountLocked) {
+            return -3;
+        }
         return 0;
     }
 
     @Override
     public boolean needsFixing() {
-        return hits > 0;
+        return hits > 0 || directionalMountLocked || autocannonHit;
     }
 
     protected @Nullable Mounted<?> getMounted() {
@@ -406,6 +452,30 @@ public class EquipmentPart extends Part {
         return (mounted != null) && mounted.isRearMounted();
     }
 
+    public boolean isDirectionalMountLocked() {
+        return directionalMountLocked;
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
+        StringBuilder details = new StringBuilder(super.getDetails(includeRepairDetails));
+
+        if (autocannonHit) {
+            appendDetail(details, getTextAt("mekhq.resources.Parts", "EquipmentPart.autocannonHit"));
+        }
+        if (directionalMountLocked) {
+            appendDetail(details, getTextAt("mekhq.resources.Parts", "EquipmentPart.directionalMountLocked"));
+        }
+        return details.toString();
+    }
+
+    private static void appendDetail(StringBuilder details, String note) {
+        if (!details.isEmpty()) {
+            details.append(", ");
+        }
+        details.append(note);
+    }
+
     @Override
     public void updateConditionFromPart() {
         final Unit unit = getUnit();
@@ -427,6 +497,9 @@ public class EquipmentPart extends Part {
                 mounted.setRepairable(true);
                 unit.repairSystem(CriticalSlot.TYPE_EQUIPMENT, getEquipmentNum());
             }
+
+            mounted.setAutocannonHit(autocannonHit);
+            mounted.setDirectionalMountLocked(directionalMountLocked);
 
             setOmniPodded(mounted.isOmniPodMounted());
         }

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/EquipmentPartTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/EquipmentPartTest.java
@@ -68,11 +68,12 @@ import megamek.common.units.Aero;
 import megamek.common.units.Entity;
 import megamek.common.units.Mek;
 import megamek.common.units.SmallCraft;
+import megamek.common.weapons.autoCannons.ACWeapon;
 import megamek.common.weapons.bayWeapons.BayWeapon;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.LocalWarehouse;
-import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.campaignOptions.CampaignOption;
+import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.unit.Unit;
 import mekhq.utilities.MHQXMLUtility;
@@ -1788,5 +1789,207 @@ public class EquipmentPartTest {
         verify(weaponBay, times(1)).setMissing(eq(false));
         verify(weaponBay, times(1)).setDestroyed(eq(false));
         verify(unit, times(1)).repairSystem(eq(CriticalSlot.TYPE_EQUIPMENT), eq(bayEqNum));
+    }
+
+    /**
+     * #9761: under CORE rules an autocannon's first critical hit does not damage a crit slot; it only sets the
+     * autocannon-hit flag while the weapon keeps firing. That intermediate state must carry over for repair without
+     * being folded into hits (which stays crit-slot based, so it cannot be confused with a Total-Warfare destroyed
+     * AC).
+     */
+    @Test
+    public void updateConditionFromEntityAutocannonFirstHitTest() {
+        Campaign mockCampaign = mockCampaign();
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        ACWeapon type = mock(ACWeapon.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+        int location = Mek.LOC_RIGHT_TORSO;
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.isMissing()).thenReturn(false);
+        when(mounted.getLocation()).thenReturn(location);
+        when(mounted.isAutocannonHit()).thenReturn(true);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+        // No damaged crit slots - the first AC crit does not mark one.
+        doReturn(0).when(entity).getDamagedCriticalSlots(anyInt(), anyInt(), anyInt());
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, 1.0, false, mockCampaign);
+        equipmentPart.setUnit(unit);
+
+        equipmentPart.updateConditionFromEntity(false);
+
+        // No crit-slot hit, but the flag flags it for repair.
+        assertEquals(0, equipmentPart.getHits());
+        assertTrue(equipmentPart.autocannonHit);
+        assertTrue(equipmentPart.needsFixing());
+        assertTrue(equipmentPart.getBaseTime() > 0);
+
+        // A second AC crit damages a crit slot as normal, destroying the weapon (hits == 1).
+        doReturn(1).when(entity)
+              .getDamagedCriticalSlots(eq(CriticalSlot.TYPE_EQUIPMENT), eq(equipmentNum), eq(location));
+        equipmentPart.updateConditionFromEntity(false);
+        assertEquals(1, equipmentPart.getHits());
+        assertTrue(equipmentPart.autocannonHit);
+    }
+
+    /**
+     * #9761 ruleset guard: under Total Warfare rules a single AC crit destroys the weapon (crit slot hit, no
+     * autocannon-hit flag). That hits == 1 state must round-trip through the entity as a genuine destroyed weapon,
+     * never as the CORE damaged-but-firing state.
+     */
+    @Test
+    public void updateConditionFromPartTotalWarfareAutocannonDestroyedTest() {
+        Campaign mockCampaign = mockCampaign();
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        ACWeapon type = mock(ACWeapon.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+        Mounted mounted = mock(Mounted.class);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, 1.0, false, mockCampaign);
+        equipmentPart.setUnit(unit);
+        // A crit-slot hit with no autocannon-hit flag: the Total Warfare "AC destroyed by one crit" case.
+        equipmentPart.setHits(1);
+
+        equipmentPart.updateConditionFromPart();
+
+        verify(mounted, times(1)).setDestroyed(eq(true));
+        verify(mounted, times(1)).setHit(eq(true));
+        verify(mounted, times(1)).setAutocannonHit(eq(false));
+        verify(unit, times(1)).damageSystem(eq(CriticalSlot.TYPE_EQUIPMENT), eq(equipmentNum), eq(1));
+    }
+
+    /**
+     * #9762: a destroyed Directional Torso Mount rotation mechanism locks the weapon's arc without destroying the
+     * weapon, so it must be flagged for repair even with no crit-slot hits.
+     */
+    @Test
+    public void updateConditionFromEntityDirectionalMountLockedTest() {
+        Campaign mockCampaign = mockCampaign();
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        WeaponType type = mock(WeaponType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.isMissing()).thenReturn(false);
+        when(mounted.getLocation()).thenReturn(Mek.LOC_LEFT_TORSO);
+        when(mounted.isDirectionalMountLocked()).thenReturn(true);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+        doReturn(0).when(entity).getDamagedCriticalSlots(anyInt(), anyInt(), anyInt());
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, 1.0, false, mockCampaign);
+        equipmentPart.setUnit(unit);
+
+        equipmentPart.updateConditionFromEntity(false);
+
+        assertEquals(0, equipmentPart.getHits());
+        assertTrue(equipmentPart.isDirectionalMountLocked());
+        assertTrue(equipmentPart.needsFixing());
+        assertTrue(equipmentPart.getBaseTime() > 0);
+
+        // Once the mount is un-locked in combat terms, the part no longer needs fixing.
+        when(mounted.isDirectionalMountLocked()).thenReturn(false);
+        equipmentPart.updateConditionFromEntity(false);
+        assertFalse(equipmentPart.isDirectionalMountLocked());
+        assertFalse(equipmentPart.needsFixing());
+    }
+
+    /**
+     * A first-crit CORE autocannon (flag set, no crit-slot hit) is pushed back onto the entity as the autocannon-hit
+     * flag rather than a destroyed crit slot, so the damaged-but-firing state survives a save/load round trip (#9761).
+     */
+    @Test
+    public void updateConditionFromPartAutocannonFirstHitTest() {
+        Campaign mockCampaign = mockCampaign();
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        ACWeapon type = mock(ACWeapon.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+        Mounted mounted = mock(Mounted.class);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, 1.0, false, mockCampaign);
+        equipmentPart.setUnit(unit);
+        equipmentPart.autocannonHit = true;
+
+        equipmentPart.updateConditionFromPart();
+
+        verify(mounted, times(1)).setAutocannonHit(eq(true));
+        verify(mounted, never()).setDestroyed(eq(true));
+        verify(unit, times(1)).repairSystem(eq(CriticalSlot.TYPE_EQUIPMENT), eq(equipmentNum));
+    }
+
+    /** fix() must clear both soft-damage states MegaMek does not model as crit slots (#9761, #9762). */
+    @Test
+    public void fixClearsAutocannonHitAndDirectionalMountLockTest() {
+        Campaign mockCampaign = mockCampaign();
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+        Mounted mounted = mock(Mounted.class);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, 1.0, false, mockCampaign);
+        equipmentPart.setId(25);
+        equipmentPart.setUnit(unit);
+        equipmentPart.setHits(1);
+
+        equipmentPart.fix();
+
+        verify(mounted, times(1)).setAutocannonHit(eq(false));
+        verify(mounted, times(1)).setDirectionalMountLocked(eq(false));
+    }
+
+    /** The Directional Torso Mount lock survives a serialization round trip (#9762). */
+    @Test
+    public void directionalMountLockedRoundTripTest() throws ParserConfigurationException, SAXException, IOException {
+        EquipmentType type = getEquipmentType(EquipmentTypeLookup.JUMP_JET);
+        Campaign mockCampaign = mockCampaign();
+        EquipmentPart equipmentPart = new EquipmentPart(65, type, 42, 18.0, false, mockCampaign);
+        equipmentPart.setId(25);
+        equipmentPart.directionalMountLocked = true;
+
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        equipmentPart.writeToXML(pw, 0);
+
+        String xml = sw.toString();
+        assertTrue(xml.contains("directionalMountLocked"));
+
+        DocumentBuilder db = MHQXMLUtility.newSafeDocumentBuilder();
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+        Element partElt = xmlDoc.getDocumentElement();
+
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version());
+        assertInstanceOf(EquipmentPart.class, deserializedPart);
+        assertTrue(((EquipmentPart) deserializedPart).isDirectionalMountLocked());
+        assertTrue(deserializedPart.needsFixing());
     }
 }


### PR DESCRIPTION
# Requires https://github.com/MegaMek/megamek/pull/8866

Fix #9761
Fix #9762

## What this changes

Adds flags to mhq equipment so that it can track damaged (but not Hit) auto cannons and locked torso mounts.

## Testing

- Manual tests (which were a pita)
- AI unit tests

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result