### PR TITLE
Fix #9704: Hide 'Employ' Option in Personnel Tab for Unemployable Characters

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -2425,14 +2425,16 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
         JMenu changeStatusMenu = new JMenu(resources.getString("changeStatus.text"));
 
-        if (StaticChecks.areAllEmployed(selected)) {
+        boolean areAllEmployed = StaticChecks.areAllEmployed(selected);
+        if (areAllEmployed) {
             menuItem = new JMenuItem(resources.getString("sack.text"));
             menuItem.setActionCommand(CMD_SACK);
             menuItem.addActionListener(this);
             changeStatusMenu.add(menuItem);
         }
 
-        if (!StaticChecks.areAllEmployed(selected)) {
+        boolean areAllFree = StaticChecks.areAllFreeOrBondsman(selected);
+        if (!areAllEmployed && areAllFree) {
             menuItem = new JMenuItem(resources.getString("employ.text"));
             menuItem.setActionCommand(CMD_EMPLOY);
             menuItem.addActionListener(this);
@@ -2445,7 +2447,6 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
         changeStatusMenu.addSeparator();
 
-        boolean areAllFree = Stream.of(selected).allMatch(p -> p.getPrisonerStatus().isFreeOrBondsman());
         for (final PersonnelStatus status : PersonnelStatus.getImplementedStatuses(areAllFree, false)) {
             cbMenuItem = new JCheckBoxMenuItem(status.toString());
             cbMenuItem.setToolTipText(status.getToolTipText());

--- a/MekHQ/src/mekhq/gui/utilities/StaticChecks.java
+++ b/MekHQ/src/mekhq/gui/utilities/StaticChecks.java
@@ -443,6 +443,10 @@ public class StaticChecks {
         return true;
     }
 
+    public static boolean areAllFreeOrBondsman(Person... people) {
+        return Stream.of(people).allMatch(p -> p.getPrisonerStatus().isFreeOrBondsman());
+    }
+
     public static boolean areAllStudents(Person... people) {
         return Arrays.stream(people).allMatch(p -> p.getStatus().isStudent());
     }


### PR DESCRIPTION
Fix #9704

## What this changes

Players no longer have the 'employ' option in the personnel tab for personnel which cannot be employed.

## Testing

- Manual testing

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result