### PR TITLE
Fix #9746: Fixed Refitting Battle Armor Causing Save Corruption

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingBattleArmorEquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingBattleArmorEquipmentPart.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2009 Jay Lawson (jaylawson39 at yahoo.com). All rights reserved.
- * Copyright (C) 2013-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2013-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -35,6 +35,7 @@ package mekhq.campaign.parts.equipment;
 
 import java.io.PrintWriter;
 
+import megamek.common.battleArmor.BattleArmor;
 import megamek.common.equipment.EquipmentType;
 import megamek.common.equipment.MiscType;
 import megamek.common.equipment.Mounted;
@@ -151,6 +152,13 @@ public class MissingBattleArmorEquipmentPart extends MissingEquipmentPart {
 
     @Override
     public void fix() {
+        // Never install a replacement for a Missing part that has lost a valid trooper assignment. Copying this onto
+        // the replacement below would attach an out-of-range part to the unit, which then crashes the next campaign
+        // load. We have other protections that should prevent this from being any issue, but I added this guard just
+        // in case. Illiani - Aug/31/26
+        if ((unit == null) || (trooper < BattleArmor.LOC_TROOPER_1)) {
+            return;
+        }
         Part replacement = findReplacement(false);
         if (null != replacement) {
             Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -3659,25 +3659,33 @@ public class Unit implements ITechnology, ILocatable {
             } else if (part instanceof MissingJumpJet) {
                 jumpJets.put(((MissingJumpJet) part).getEquipmentNum(), part);
             } else if (part instanceof BattleArmorEquipmentPart) {
-                if (!(entity instanceof BattleArmor)) {
+                int trooperIndex = ((BattleArmorEquipmentPart) part).getTrooper() - BattleArmor.LOC_TROOPER_1;
+                if (!(entity instanceof BattleArmor) || (trooperIndex < 0) ||
+                          (trooperIndex >= ((BattleArmor) entity).getSquadSize())) {
+                    // A detached BA equipment part reports a trooper of -1, which would index the squad array
+                    // out of bounds. Drop it rather than crashing the load.
                     partsToRemove.add(part);
                 } else {
                     Part[] parts = baEquipParts.get(((BattleArmorEquipmentPart) part).getEquipmentNum());
                     if (null == parts) {
                         parts = new Part[((BattleArmor) entity).getSquadSize()];
                     }
-                    parts[((BattleArmorEquipmentPart) part).getTrooper() - BattleArmor.LOC_TROOPER_1] = part;
+                    parts[trooperIndex] = part;
                     baEquipParts.put(((BattleArmorEquipmentPart) part).getEquipmentNum(), parts);
                 }
             } else if (part instanceof MissingBattleArmorEquipmentPart) {
-                if (!(entity instanceof BattleArmor)) {
+                int trooperIndex = ((MissingBattleArmorEquipmentPart) part).getTrooper() - BattleArmor.LOC_TROOPER_1;
+                if (!(entity instanceof BattleArmor) || (trooperIndex < 0) ||
+                          (trooperIndex >= ((BattleArmor) entity).getSquadSize())) {
+                    // A detached BA equipment part reports a trooper of -1, which would index the squad array
+                    // out of bounds. Drop it rather than crashing the load.
                     partsToRemove.add(part);
                 } else {
                     Part[] parts = baEquipParts.get(((MissingBattleArmorEquipmentPart) part).getEquipmentNum());
                     if (null == parts) {
                         parts = new Part[((BattleArmor) entity).getSquadSize()];
                     }
-                    parts[((MissingBattleArmorEquipmentPart) part).getTrooper() - BattleArmor.LOC_TROOPER_1] = part;
+                    parts[trooperIndex] = part;
                     baEquipParts.put(((MissingBattleArmorEquipmentPart) part).getEquipmentNum(), parts);
                 }
             } else if (part instanceof EquipmentPart) {

--- a/MekHQ/src/mekhq/campaign/unit/cleanup/BattleArmorEquipmentUnscrambler.java
+++ b/MekHQ/src/mekhq/campaign/unit/cleanup/BattleArmorEquipmentUnscrambler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2021-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -32,6 +32,7 @@
  */
 package mekhq.campaign.unit.cleanup;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -108,15 +109,35 @@ public class BattleArmorEquipmentUnscrambler extends EquipmentUnscrambler {
                     }
                 }
 
+                // Same-type parts that were never assigned an equipment number - e.g. fresh parts materialized by a
+                // refit, which arrive with equipmentNum == -1 and trooper == -1.
+                final List<BattleArmorEquipmentPart> unassigned = new ArrayList<>();
+                for (final EquipmentPart part : tempParts) {
+                    if ((part instanceof BattleArmorEquipmentPart)
+                              && part.getType().getInternalName().equals(m.getType().getInternalName())
+                              && (part.getEquipmentNum() < 0)) {
+                        unassigned.add((BattleArmorEquipmentPart) part);
+                    }
+                }
+
                 // Assign a part to any empty position and set the trooper field
                 for (int t = 0; t < perTrooper.length; t++) {
                     if (perTrooper[t] == null) {
+                        BattleArmorEquipmentPart chosen = null;
                         for (final Part part : parts) {
                             if (((BattleArmorEquipmentPart) part).getTrooper() < 1) {
-                                ((BattleArmorEquipmentPart) part).setTrooper(t + 1);
-                                perTrooper[t] = part;
+                                chosen = (BattleArmorEquipmentPart) part;
                                 break;
                             }
+                        }
+                        // Fall back to an unassigned same-type part if no eqNum-matched part is free for this slot.
+                        if ((chosen == null) && !unassigned.isEmpty()) {
+                            chosen = unassigned.removeFirst();
+                            chosen.setEquipmentNum(eqNum);
+                        }
+                        if (chosen != null) {
+                            chosen.setTrooper(t + 1);
+                            perTrooper[t] = chosen;
                         }
                     }
                 }


### PR DESCRIPTION
Fix #9746

## What this changes

When a BA refit ends it attaches the equipment to the unit with no trooper set. It then relies on later processes to assign troopers. Unfortunately that process was bugged causing it to not properly resolve. This meant that some BA parts were stuck with a trooper assignment of -1. When that was loaded by the save it immediately broke. Now it doesn't.

## Testing

- I ran a few refits and didn't run into any problems

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result