### PR TITLE
Close #9693: Pregnant Combatant Nag Now Includes Hyperlinked Names of Pregnant Combatants

### DIFF
--- a/MekHQ/resources/mekhq/resources/NagDialogs.properties
+++ b/MekHQ/resources/mekhq/resources/NagDialogs.properties
@@ -196,9 +196,10 @@ OutstandingScenariosNagDialog.ooc=If using <a href=''GLOSSARY:STRATCON''>StratCo
   \ <a href=''GLOSSARY:CRISIS_SCENARIO''>Crisis</a>. Withdrawal is free for all other scenarios.\
   <p>If you accidentally suppress this warning, you can re-enable it in MekHQ Client Options.</p>
 # Pregnant Combatant
-PregnantCombatantNagDialog.ic={0}, our records indicate that there are pregnant personnel assigned\
-  \ to combat duties. This presents a significant risk to both the individuals and their unborn\
-  \ children.\
+PregnantCombatantNagDialog.ic={0}, our records indicate that the following personnel are pregnant and\
+  \ assigned to combat duties. This presents a significant risk to both the individuals and their\
+  \ unborn children:\
+  {1}\
   <p>I recommend that these personnel be reassigned to non-combat roles immediately to protect their\
   \ health and ensure compliance with medical and operational guidelines. Please advise on how you''d\
   \ like to proceed.</p>

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1075,7 +1075,7 @@ public class Campaign implements ITechManager {
      * hasActiveContract based on that check. This value should not be set elsewhere
      */
     public void setHasActiveContract() {
-        hasActiveContract = getActiveContracts().size() > 0;
+        hasActiveContract = !getActiveContracts().isEmpty();
     }
     // endregion Missions/Contracts
 

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/PregnantCombatantNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/PregnantCombatantNagDialog.java
@@ -34,7 +34,9 @@ package mekhq.gui.dialog.nagDialogs;
 
 import static mekhq.MHQConstants.NAG_PREGNANT_COMBATANT;
 
+import static mekhq.gui.dialog.nagDialogs.nagLogic.PregnantCombatantNagLogic.getPregnantCombatants;
 import static mekhq.gui.dialog.nagDialogs.nagLogic.PregnantCombatantNagLogic.hasActivePregnantCombatant;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 import java.util.List;
 
@@ -65,6 +67,21 @@ public class PregnantCombatantNagDialog extends ImmersiveDialogNag {
      */
     public PregnantCombatantNagDialog(final Campaign campaign) {
         super(campaign, NAG_PREGNANT_COMBATANT, "PregnantCombatantNagDialog");
+    }
+
+    @Override
+    protected String getInCharacterMessage(Campaign campaign, String key, String commanderAddress) {
+        final String RESOURCE_BUNDLE = "mekhq.resources.NagDialogs";
+
+        List<Person> pregnantCombatants = getPregnantCombatants(campaign.hasActiveContract(),
+              campaign.getPlayerForce().getHumanResources().getActivePersonnel(false, false));
+
+        StringBuilder pregnantCombatantNames = new StringBuilder();
+        for (Person person : pregnantCombatants) {
+            pregnantCombatantNames.append("<p>- ").append(person.getHyperlinkedFullTitle()).append("</p>");
+        }
+
+        return getFormattedTextAt(RESOURCE_BUNDLE, key + ".ic", commanderAddress, pregnantCombatantNames.toString());
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/nagLogic/PregnantCombatantNagLogic.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/nagLogic/PregnantCombatantNagLogic.java
@@ -32,6 +32,7 @@
  */
 package mekhq.gui.dialog.nagDialogs.nagLogic;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import mekhq.campaign.force.Formation;
@@ -60,8 +61,28 @@ public class PregnantCombatantNagLogic {
      * @return {@code true} if there are pregnant personnel assigned to a combat force; {@code false} otherwise.
      */
     public static boolean hasActivePregnantCombatant(boolean hasActiveContract, List<Person> activePersonnel) {
+        return !getPregnantCombatants(hasActiveContract, activePersonnel).isEmpty();
+    }
+
+    /**
+     * Collects all personnel who are pregnant and actively assigned to a combat force.
+     *
+     * <p>The conditions mirror those used by {@link #hasActivePregnantCombatant(boolean, List)}: the campaign must
+     * have
+     * an active contract, and each returned person must be pregnant and assigned to a unit that belongs to a combat
+     * force (i.e., a force with an ID other than {@link Formation#FORMATION_NONE}).</p>
+     *
+     * @param hasActiveContract A flag indicating whether the campaign currently has an active contract.
+     * @param activePersonnel   A list of {@link Person} objects representing the active personnel in the campaign.
+     *
+     * @return a list of pregnant personnel assigned to a combat force; an empty list if there are none or if there is
+     *       no active contract.
+     */
+    public static List<Person> getPregnantCombatants(boolean hasActiveContract, List<Person> activePersonnel) {
+        List<Person> pregnantCombatants = new ArrayList<>();
+
         if (!hasActiveContract) {
-            return false;
+            return pregnantCombatants;
         }
 
         // There is no reason to use a stream here, as there won't be enough iterations to warrant it.
@@ -71,12 +92,12 @@ public class PregnantCombatantNagLogic {
 
                 if (unit != null) {
                     if (unit.getFormationId() != Formation.FORMATION_NONE) {
-                        return true;
+                        pregnantCombatants.add(person);
                     }
                 }
             }
         }
 
-        return false;
+        return pregnantCombatants;
     }
 }


### PR DESCRIPTION
Close #9693

## What this changes

<img width="751" height="651" alt="image" src="https://github.com/user-attachments/assets/d58c75e8-3806-4ea6-b61d-334064d0a30c" />

## Testing

- Manual testing

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result