### PR TITLE
Fix #9695: Fixed Cargo Double-Dipping in Cargo Statistics

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignSummary.java
+++ b/MekHQ/src/mekhq/campaign/CampaignSummary.java
@@ -249,12 +249,12 @@ public class CampaignSummary {
 
         // cargo capacity
         CargoStatistics cargoStats = campaign.getCargoStatistics();
-        cargoCapacity = cargoStats.getTotalCombinedCargoCapacity();
+        cargoCapacity = cargoStats.getTotalCargoCapacity();
 
         double tetrisMasterMultiplier = 1.0;
         for (Person person : campaign.getPlayerForce().getHumanResources().getActivePersonnel(false, false)) {
             PersonnelOptions options = person.getOptions();
-            if (options.booleanOption(ADMIN_TETRIS_MASTER)) {
+            if (person.isAdministrator() && options.booleanOption(ADMIN_TETRIS_MASTER)) {
                 tetrisMasterMultiplier += 0.05;
             }
         }

--- a/MekHQ/src/mekhq/campaign/unit/CargoStatistics.java
+++ b/MekHQ/src/mekhq/campaign/unit/CargoStatistics.java
@@ -87,10 +87,16 @@ public record CargoStatistics(Campaign campaign) {
                      .sum();
     }
 
-    // Liquid not included
+    /**
+     * Returns the total cargo capacity across every bay type that can hold general cargo, plus livestock. Liquid cargo
+     * capacity is deliberately excluded.
+     *
+     * <p>Note that {@link #getTotalCargoCapacity()} already folds in refrigerated and insulated bay capacity - the
+     * convoy calculation treats both as usable general cargo space - so they must not be added again here. Only
+     * livestock capacity is added on top; adding refrigerated and insulated would double-count them.</p>
+     */
     public double getTotalCombinedCargoCapacity() {
-        return getTotalCargoCapacity() + getTotalLivestockCargoCapacity()
-                     + getTotalInsulatedCargoCapacity() + getTotalRefrigeratedCargoCapacity();
+        return getTotalCargoCapacity() + getTotalLivestockCargoCapacity();
     }
 
     public double getCargoTonnage(boolean inTransit) {


### PR DESCRIPTION
Fix #9695

## What this changes

Cargo statistics - the method used in the command center - was using the wrong cargo size fetcher. Furthermore, the one used was incorrectly double-dipping refrigerating and insulated cargo capacity. This meant the command center was showing higher capacity than it should.

Finally, fixed non-Admin personnel contributing Tetris Master.

## Testing

- Manual eyeballing

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result