### PR TITLE
Fix #9725: Standardized CVP Definition; Updated Glossary Entry

### DIFF
--- a/MekHQ/resources/mekhq/resources/AtBStratCon.properties
+++ b/MekHQ/resources/mekhq/resources/AtBStratCon.properties
@@ -151,9 +151,9 @@ stratConTab.editSupportPoints.text=Edit SP
 stratConTab.editSupportPoints.tooltip=Sets the contract's Support Point total.
 stratConTab.editSupportPoints.prompt=Set the contract's Support Points:
 stratConTab.editVictoryPoints.text=Edit CVP
-stratConTab.editVictoryPoints.tooltip=Sets the contract's Campaign Victory Point total.
-stratConTab.editVictoryPoints.prompt=Set the contract's Campaign Victory Points:
-stratConTab.status.victoryPointsBarFallback=<html><b>Campaign Victory Points:</b> {0} / {1}</html>
+stratConTab.editVictoryPoints.tooltip=Sets the contract's Contract Victory Point total.
+stratConTab.editVictoryPoints.prompt=Set the contract's Contract Victory Points:
+stratConTab.status.victoryPointsBarFallback=<html><b>Contract Victory Points:</b> {0} / {1}</html>
 ### GM terrain painting
 terrainPaint.title=Change Terrain (GM)
 terrainPaint.instructions=<html>Pick a terrain, then click or drag on the map to paint.\

--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -2431,7 +2431,7 @@ lblMissionXpSuccess.tooltip=How much experience is awarded for a successful cont
   \ granted to all active personnel.
 lblMissionXpOutstandingSuccess.text=Outstanding Success (StratCon)
 lblMissionXpOutstandingSuccess.tooltip=Experience points awarded when successfully concluding a\
-  \ mission with 3+ campaign victory points.
+  \ mission with 3+ contract victory points.
 # createAdministratorsPanel
 lblAdministratorsXpPanel.text=Administrators (Deprecated)
 lblAdministratorsXpPanel.summary=Deprecated administrator periodic XP and contract negotiation XP awards.

--- a/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
+++ b/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
@@ -594,7 +594,7 @@ COMMAND_RIGHTS.definition=Command Rights are used to dictate the level of contro
   an officer from Allied Command.</p>\
   <p><b>Independent</b> A contract with Independent command rights is operating, as the name suggests, independently.\
   \ No employer <a href='GLOSSARY:RESUPPLY'>Resupplies</a> will take place. Furthermore, Turning Point scenarios will\
-  \ only spawn if your <a href='GLOSSARY:STRATCON_SCENARIOS'>Campaign Victory Points</a> are below 1. This gives you \
+  \ only spawn if your <a href='GLOSSARY:STRATCON_SCENARIOS'>Contract Victory Points</a> are below 1. This gives you \
   the power to dictate when you engage the enemy, but without support from Allied Command you are more vulnerable to \
   sudden crisis.</p>
 CONNECTIONS.title=Connections
@@ -660,11 +660,13 @@ CONTRACTS_AND_MISSIONS.definition=MekHQ groups scenarios together under one of t
   \ with the most. \
   <p>Additional information on mission types can be found at <a href='GLOSSARY:MISSION_TYPES'>Mission Types</a></p>
 CONTRACT_VICTORY_POINTS.title=Contract Victory Points
-CONTRACT_VICTORY_POINTS.definition=Contract Victory Points (CVP) represent an abstract measure of your contract's overall\
-  \ strategic success. Most contracts require a positive CVP to be considered\
-  \ <a href='GLOSSARY:MISSION_CONCLUSION_HELP'>successful</a>.\
-  <p>Even if all other <a href='GLOSSARY:STRATEGIC_OBJECTIVES'>objectives</a> are met, having a neutral or negative CVP\
-  \ will result in a failure or, at best, a Partial Success.</p>\
+CONTRACT_VICTORY_POINTS.definition=Contract Victory Points (CVP) represent an abstract measure of your contract's \
+  overall strategic success. Most contracts set a required CVP target, and you must finish the contract with a CVP \
+  score that meets or exceeds it to be considered <a href='GLOSSARY:MISSION_CONCLUSION_HELP'>successful</a>. Most \
+  contracts carry this target as a <a href='GLOSSARY:STRATEGIC_OBJECTIVES'>Strategic Objective</a> and require a \
+  positive CVP score; the rest simply require a non-negative score, meaning you must not end the contract below zero.\
+  <p>Falling short of the required CVP target will result in a failure or, at best, a Partial Success, even if all\
+  \ other <a href='GLOSSARY:STRATEGIC_OBJECTIVES'>objectives</a> are met.</p>\
  <p>CVP should not be confused with <a href='GLOSSARY:SCENARIO_VICTORY_POINTS'>Scenario Victory Points (SVP)</a>.
 CRISIS_SCENARIO.title=Crisis Scenarios
 CRISIS_SCENARIO.definition=<b>Crisis</b> are special scenarios that require your immediate attention. They represent\
@@ -1975,7 +1977,7 @@ STRATCON_SCENARIOS.definition=Each scenario represents a strategic opportunity i
   <p>If you've already deployed formations to a scenario but then refuse to fight, it only counts as a <b>normal \
   defeat</b>. This is because the enemy must still account for your presence, limiting their strategic options - a \
   concept known as a "fleet in being."</p>\
-  <h2>Campaign Victory Points (CVP)</h2>\
+  <h2>Contract Victory Points (CVP)</h2>\
   In <b>StratCon</b>, you must end a contract with a positive CVP score. Even if all other objectives are met, finishing \
   with 0 or negative CVP results in only a <b>Partial Success</b>.\
   <ul><li>+1 CVP for each successful <b>Turning Point</b> scenario.</li>\

--- a/MekHQ/resources/mekhq/resources/Mission.properties
+++ b/MekHQ/resources/mekhq/resources/Mission.properties
@@ -211,7 +211,7 @@ ContractCommandRights.INTEGRATED.text=Integrated
 ContractCommandRights.INTEGRATED.toolTipText=Integrated command rights, standard for government forces, streamline command\
   \ and control, particularly in large-scale operations involving multiple forces, ensuring effective collaboration\
   \ without inter-service rivalry or confusion over command authority.\
-  <br>- Keep your Campaign Victory Points (CVP) positive by completing Turning Point and Crisis scenarios.\
+  <br>- Keep your Contract Victory Points (CVP) positive by completing Turning Point and Crisis scenarios.\
   <br>- Allies will join you in all scenarios.\
   <br>- Most scenarios are considered Turning Points.
 ContractCommandRights.INTEGRATED.stratConText=Complete <b>Turning Point</b> scenarios to fulfill contract conditions.
@@ -219,7 +219,7 @@ ContractCommandRights.HOUSE.text=House
 ContractCommandRights.HOUSE.toolTipText=House command rights empower noble scions and military leaders with autonomy over\
   \ allied forces, enabling them to strategize and expand their House's power while balancing loyalty to their lineage\
   \ and House interests.\
-  <br>- Keep your Campaign Victory Points (CVP) positive by completing Turning Point and Crisis scenarios.\
+  <br>- Keep your Contract Victory Points (CVP) positive by completing Turning Point and Crisis scenarios.\
   <br>- Allies will join you in scenarios around a third of the time.\
   <br>- Roughly a third of scenarios are considered Turning Points.
 ContractCommandRights.HOUSE.stratConText=Complete Turning Point scenarios to fulfill contract conditions.
@@ -227,7 +227,7 @@ ContractCommandRights.LIAISON.text=Liaison
 ContractCommandRights.LIAISON.toolTipText=Liaison command rights empower trusted officers to coordinate cooperation\
   \ between allied factions, streamlining communication and joint operations on the battlefield. These officers serve as\
   \ crucial links between factions, enhancing unity and effectiveness against shared adversaries.\
-  <br>- Keep your Campaign Victory Points (CVP) positive by completing Turning Point and Crisis scenarios.\
+  <br>- Keep your Contract Victory Points (CVP) positive by completing Turning Point and Crisis scenarios.\
   <br>- Complete any additional objectives listed in the Area of Operations tab.\
   <br>- Allies will join you in scenarios around a third of the time.\
   <br>- Roughly a third of scenarios are considered Turning Points.
@@ -237,7 +237,7 @@ ContractCommandRights.INDEPENDENT.text=Independent
 ContractCommandRights.INDEPENDENT.toolTipText=Independent command rights afford skilled commanders autonomy over their\
   \ forces, enabling them to make critical decisions and adapt swiftly to achieve objectives efficiently. However, this\
   \ autonomy necessitates balancing personal discretion with the employer's broader goals.\
-  <br>- Keep your Campaign Victory Points (CVP) positive by completing Turning Point and Crisis scenarios.\
+  <br>- Keep your Contract Victory Points (CVP) positive by completing Turning Point and Crisis scenarios.\
   <br>- Complete any additional objectives listed in the Area of Operations tab.\
   <br>- Allies will only rarely join you on scenarios.\
   <br>- Roughly a third of scenarios are considered Turning Points.

--- a/MekHQ/src/mekhq/campaign/mission/scenarios/ScenarioObjectiveProcessor.java
+++ b/MekHQ/src/mekhq/campaign/mission/scenarios/ScenarioObjectiveProcessor.java
@@ -445,7 +445,7 @@ public class ScenarioObjectiveProcessor {
                     int scoreEffect = effect.howMuch * effectMultiplier;
 
                     if (dryRun) {
-                        return String.format("%d Contract Score/Campaign Victory Points", scoreEffect);
+                        return String.format("%d Contract Score/Contract Victory Points", scoreEffect);
                     } else {
                         tracker.getMission().getStratConCampaignState().changeVictoryPoints(scoreEffect);
                     }

--- a/MekHQ/src/mekhq/gui/StratConTab.java
+++ b/MekHQ/src/mekhq/gui/StratConTab.java
@@ -347,7 +347,7 @@ public class StratConTab extends CampaignGuiTab {
         btnEditSupportPoints.setEnabled(isGM);
         btnEditSupportPoints.addActionListener(this::editSupportPoints);
 
-        // "Edit CVP" - set the contract's Campaign Victory Point total (GM only)
+        // "Edit CVP" - set the contract's Contract Victory Point total (GM only)
         btnEditVictoryPoints = new RoundedJButton(getTextAt(RESOURCE_BUNDLE, "stratConTab.editVictoryPoints.text"));
         btnEditVictoryPoints.setToolTipText(getTextAt(RESOURCE_BUNDLE, "stratConTab.editVictoryPoints.tooltip"));
         btnEditVictoryPoints.setEnabled(isGM);
@@ -389,7 +389,7 @@ public class StratConTab extends CampaignGuiTab {
     }
 
     /**
-     * GM action: prompts for and sets the current contract's Campaign Victory Point total.
+     * GM action: prompts for and sets the current contract's Contract Victory Point total.
      */
     private void editVictoryPoints(ActionEvent e) {
         if (currentContract == null) {
@@ -582,7 +582,7 @@ public class StratConTab extends CampaignGuiTab {
 
     /**
      * Refreshes the victory-point progress bar shown above the objectives list. Mirrors the Briefing Room's contract
-     * gauge: a {@link ContractMeterBar} charting current-versus-required Campaign Victory Points when a positive target
+     * gauge: a {@link ContractMeterBar} charting current-versus-required Contract Victory Points when a positive target
      * exists, falling back to a plain current/required label when it does not.
      *
      * @param campaignState the StratCon state of the currently selected contract


### PR DESCRIPTION
Fix #9725

## What this changes

CVP stands for Contract Victory Points but sometimes Campaign Victory Points, depending on who you ask. Now it is always _Contract_ Victory Points.

## Testing

- Text changes only

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result