### PR TITLE
fix: this adjusts a few places where variables should be set to final

### DIFF
--- a/MekHQ/src/mekhq/campaign/chaosCampaign/ChaosCampaignUtilities.java
+++ b/MekHQ/src/mekhq/campaign/chaosCampaign/ChaosCampaignUtilities.java
@@ -37,7 +37,7 @@ import java.math.BigDecimal;
 import mekhq.campaign.finances.Money;
 
 public class ChaosCampaignUtilities {
-    public static int SUPPORT_POINTS_TO_MONEY_CONVERSION = 10_000; // Chaos Campaign pg 28
+    public static final int SUPPORT_POINTS_TO_MONEY_CONVERSION = 10_000; // Chaos Campaign pg 28
 
     public static Money getMoneyFromChaosSupportPoints(int supportPoints) {
         return getMoneyFromChaosSupportPoints(supportPoints, true);

--- a/MekHQ/src/mekhq/campaign/personnel/InjuryType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/InjuryType.java
@@ -126,7 +126,7 @@ public class InjuryType {
     }
 
     /** Default injury type: reduction in hit points */
-    public static InjuryType BAD_HEALTH = new InjuryType();
+    public static final InjuryType BAD_HEALTH = new InjuryType();
 
     static {
         BAD_HEALTH.recoveryTime = 7;

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedical/InjuryTypes.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedical/InjuryTypes.java
@@ -94,11 +94,11 @@ public final class InjuryTypes {
     public static final InjuryType CATATONIA = new Catatonia();
 
     // Replacement Limbs
-    public static int REPLACEMENT_LIMB_MINIMUM_SKILL_REQUIRED_TYPES_3_4_5 = 5;
-    public static Money REPLACEMENT_LIMB_COST_ARM_TYPE_5 = Money.of(200000);
-    public static Money REPLACEMENT_LIMB_COST_HAND_TYPE_5 = Money.of(100000);
-    public static Money REPLACEMENT_LIMB_COST_LEG_TYPE_5 = Money.of(125000);
-    public static Money REPLACEMENT_LIMB_COST_FOOT_TYPE_5 = Money.of(50000);
+    public static final int REPLACEMENT_LIMB_MINIMUM_SKILL_REQUIRED_TYPES_3_4_5 = 5;
+    public static final Money REPLACEMENT_LIMB_COST_ARM_TYPE_5 = Money.of(200000);
+    public static final Money REPLACEMENT_LIMB_COST_HAND_TYPE_5 = Money.of(100000);
+    public static final Money REPLACEMENT_LIMB_COST_LEG_TYPE_5 = Money.of(125000);
+    public static final Money REPLACEMENT_LIMB_COST_FOOT_TYPE_5 = Money.of(50000);
 
     private static boolean registered = false;
 

--- a/MekHQ/src/mekhq/campaign/personnel/skills/Attributes.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Attributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -91,7 +91,7 @@ public class Attributes {
     /**
      * The default score assigned to all attributes during initialization.
      */
-    public static int DEFAULT_ATTRIBUTE_SCORE = 5;
+    public static final int DEFAULT_ATTRIBUTE_SCORE = 5;
 
     /**
      * The minimum allowable score for any attribute (other than Edge).
@@ -102,7 +102,7 @@ public class Attributes {
      * <p><b>Note:</b> ATOW allows attribute scores of 0. However, at that point the character is effectively dead
      * and outside the scope of MekHQ tracking (for now).</p>
      */
-    public static int MINIMUM_ATTRIBUTE_SCORE = 1;
+    public static final int MINIMUM_ATTRIBUTE_SCORE = 1;
 
     /**
      * The minimum allowable score for the Edge attribute.
@@ -110,7 +110,7 @@ public class Attributes {
      * <p>Edge values cannot be set below this limit, and any attempts to do so will result in clamping to this
      * value.</p>
      */
-    public static int MINIMUM_EDGE_SCORE = 0;
+    public static final int MINIMUM_EDGE_SCORE = 0;
 
     /**
      * The maximum allowable score for any attribute.
@@ -118,7 +118,7 @@ public class Attributes {
      * <p>Attribute values cannot be set above this limit, and any attempts to do so will result in clamping to this
      * value.</p>
      */
-    public static int MAXIMUM_ATTRIBUTE_SCORE = 10;
+    public static final int MAXIMUM_ATTRIBUTE_SCORE = 10;
 
     // Constructor
 

--- a/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
@@ -99,8 +99,8 @@ import org.w3c.dom.NodeList;
  * @author Jay Lawson (jaylawson39 at yahoo.com)
  */
 public class Skill {
-    public static int COUNT_UP_MAX_VALUE = 10;
-    public static int COUNT_DOWN_MIN_VALUE = 0;
+    public static final int COUNT_UP_MAX_VALUE = 10;
+    public static final int COUNT_DOWN_MIN_VALUE = 0;
 
     private static final String RESOURCE_BUNDLE = "mekhq.resources.Skill";
     private static final MMLogger logger = MMLogger.create(Skill.class);

--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillModifierData.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillModifierData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2025 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -66,5 +66,5 @@ public record SkillModifierData(PersonnelOptions characterOptions, Attributes at
      *
      * <p>The value {@code -1} is used as a sentinel and does not correspond to any valid chronological age.</p>
      */
-    public static int IGNORE_AGE = -1;
+    public static final int IGNORE_AGE = -1;
 }

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -144,9 +144,9 @@ public class CampaignGUI extends JPanel {
     private static final int MIN_WINDOW_WIDTH = 1024;
     private static final int MIN_WINDOW_HEIGHT = 768;
     private static final int TOP_PANEL_HEIGHT = 90;
-    public static int THIN_GAP = 2;
-    public static int SMALL_GAP = 4;
-    public static int MEDIUM_GAP = 8;
+    public static final int THIN_GAP = 2;
+    public static final int SMALL_GAP = 4;
+    public static final int MEDIUM_GAP = 8;
 
     // the max quantity when mass purchasing parts, hiring, etc. using the JSpinner
     public static final int MAX_QUANTITY_SPINNER = 10000;

--- a/MekHQ/src/mekhq/gui/panels/StartupScreenPanel.java
+++ b/MekHQ/src/mekhq/gui/panels/StartupScreenPanel.java
@@ -86,7 +86,7 @@ public class StartupScreenPanel extends AbstractMHQPanel {
     private BufferedImage backgroundIcon;
 
     // Save file filtering needs to avoid loading some special files
-    public static FilenameFilter saveFilter = (dir, name) -> {
+    public static final FilenameFilter saveFilter = (dir, name) -> {
         // Allow any .xml, .cpnx, and .cpnx.gz file that is not in the list of excluded
         // files
         List<String> toReject = List.of(PreferenceManager.DEFAULT_CFG_FILE_NAME.toLowerCase());


### PR DESCRIPTION
fix: this adjusts a few places where variables should be set to `final` to ensure they're not changed by accident or by another package

This was identified by [SpotBugs](https://github.com/spotbugs/spotbugs) 4.10.4

Details on the issue are here: https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#ms-field-isn-t-final-but-should-be-ms-should-be-final

SpotBugs isn't an AI tool but is a helpful static code analysis Java tool.

<!-- TITLE: include the issue number, and start with "Fix" for a bug fix or "Close" for
     anything else:

         Fix #1234: Cheese has the wrong colour gradient
         Close #1234: Added 6 new cheese gradients

     More than one issue is fine: "Close #111, #5329: Added unit history tracking".
     Release notes are generated automatically from pull request titles, so the title is
     what players end up reading. -->

## What this changes

<!-- The effect someone actually sees, in plain language. One or two sentences is fine. -->

<!-- Keep this line as well as the number in the title. GitHub only closes an issue from a
     keyword in the description - a number in the title alone does not close anything.

     Any of these close an issue when this merges:
         Close / Closes / Closed
         Fix / Fixes / Fixed
         Resolve / Resolves / Resolved

     Closing more than one needs the keyword repeated in front of each number:
         Fixes #1234, fixes #5678          closes both
         Fixes #1234, #5678                closes only #1234

     For an issue in another repository, qualify it: Fixes MegaMek/mekhq#1234 -->


## Testing

Ran gradle tests, did not perform smoketests.

## What is not proven yet

<!-- What you did not test, or could not. "Nothing" is a valid answer - say so explicitly. -->

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text

No AI usage

