### PR TITLE
When Adding a New Base the Base Picker Updates to Include the New Base as an Option

### DIFF
--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -2013,6 +2013,20 @@ public class CampaignGUI extends JPanel {
     }
 
     /**
+     * Rebuilds the Active Location dropdown when the set of player bases changes, so a newly added (or removed) base
+     * appears in the location filter picker without waiting for the next new day.
+     *
+     * <p><b>Important:</b> This method is not directly evoked, so IDEA will tell you it has no uses. IDEA is
+     * wrong.</p>
+     *
+     * @param locationEvent the event signalling that a tracked location (player base) was added or removed
+     */
+    @Subscribe
+    public void handleLocationSetChanged(LocationEvent locationEvent) {
+        refreshActiveLocation();
+    }
+
+    /**
      * Handles the transition to a new day in the campaign.
      *
      * <p>Refreshes the calendar, location, funds, parts availability, and all relevant UI tabs to ensure the user


### PR DESCRIPTION
## What this changes

As per title

## Testing

- Manual testing

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result