### PR TITLE
Fix #9902: Fixed Ransoming Prisoners Causing Errors

### DIFF
--- a/MekHQ/src/mekhq/gui/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/PersonnelTab.java
@@ -543,25 +543,33 @@ public final class PersonnelTab extends CampaignGuiTab {
     public void refreshPersonnelList() {
         UUID selectedUUID = null;
         int selectedRow = personnelTable.getSelectedRow();
-        if (selectedRow != -1) {
+        if (selectedRow >= 0 && selectedRow < personnelTable.getRowCount()) {
             Person person = getPersonnelTableModel().getRow(personnelTable.convertRowIndexToModel(selectedRow));
             if (null != person) {
                 selectedUUID = person.getId();
             }
         }
 
+        personnelTable.clearSelection();
+
         LocationFilterItem locationFilter = getCampaignGui().getActiveLocation();
 
         List<Person> people = locationFilter.selectPersonnel(getCampaign());
         getPersonnelTableModel().setData(people);
 
+        boolean reselected = false;
         for (int row = 0; row < personnelTable.getRowCount(); row++) {
             Person person = getPersonnelTableModel().getRow(personnelTable.convertRowIndexToModel(row));
             if (person != null && person.getId().equals(selectedUUID)) {
                 personnelTable.setRowSelectionInterval(row, row);
                 refreshPersonnelView();
+                reselected = true;
                 break;
             }
+        }
+
+        if (!reselected) {
+            refreshPersonnelView();
         }
         filterPersonnel();
     }


### PR DESCRIPTION
Fix #9902

## What this changes

Fixes a potential out of bounds error when removing personnel from the personnel tab table.

## Testing

- Manual testing

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result