### PR TITLE
Fix #9909: Fixed Systems with Residual Populations, but No Government, Outlawing Players

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionStandingUtilities.java
+++ b/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionStandingUtilities.java
@@ -426,6 +426,8 @@ public class FactionStandingUtilities {
      * <p>The rules for entry are as follows:</p>
      * <ol>
      *   <li>If the target system is empty (population zero), entry is always permitted.</li>
+     *   <li>If the target system has no controlling faction (uncolonized or abandoned), entry is always permitted, even
+     *   if it retains a residual population. There is no government present to bar entry.</li>
      *   <li>If the target system is owned by any faction that is either an employer or a contract target, entry is
      *   allowed.</li>
      *   <li>If the player is outlawed in their current system, they may always exit to another system (unless {@code
@@ -458,6 +460,12 @@ public class FactionStandingUtilities {
         }
 
         Set<Faction> systemFactions = targetSystem.getFactionSet(when);
+
+        // Always allowed in systems with no controlling faction.
+        if (systemFactions.isEmpty()) {
+            LOGGER.debug("Target system has no controlling faction, access granted");
+            return true;
+        }
 
         Set<Faction> contractEmployers = new HashSet<>();
         Set<Faction> contractTargets = new HashSet<>();
@@ -521,8 +529,15 @@ public class FactionStandingUtilities {
      */
     private static boolean isOutlawedInSystem(FactionStandings factionStandings, PlanetarySystem targetSystem,
           LocalDate when) {
+        Set<Faction> systemFactions = targetSystem.getFactionSet(when);
+
+        // A system with no controlling faction cannot outlaw anyone.
+        if (systemFactions.isEmpty()) {
+            return false;
+        }
+
         double highestRegard = FactionStandingLevel.STANDING_LEVEL_0.getMinimumRegard();
-        for (Faction faction : targetSystem.getFactionSet(when)) {
+        for (Faction faction : systemFactions) {
             double currentRegard = factionStandings.getRegardForFaction(faction.getShortName(), true);
             if (currentRegard > highestRegard) {
                 highestRegard = currentRegard;

--- a/MekHQ/unittests/mekhq/campaign/universe/factionStanding/FactionStandingUtilitiesTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/factionStanding/FactionStandingUtilitiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -34,9 +34,18 @@ package mekhq.campaign.universe.factionStanding;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
 import java.util.stream.Stream;
 
+import mekhq.campaign.universe.Faction;
+import mekhq.campaign.universe.PlanetarySystem;
+import mekhq.campaign.universe.factionHints.FactionHints;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -90,6 +99,33 @@ class FactionStandingUtilitiesTest {
         for (double regard : new double[] { Double.MIN_VALUE, 0.0, 1.0, -1.0, 100000, -100000, Double.NaN }) {
             assertNotNull(FactionStandingUtilities.calculateFactionStandingLevel(regard));
         }
+    }
+
+    @Test
+    @DisplayName("An empty system (no population) is always enterable")
+    void testCanEnterTargetSystem_emptySystem_grantsAccess() {
+        LocalDate when = LocalDate.of(3021, 4, 17);
+        PlanetarySystem targetSystem = mock(PlanetarySystem.class);
+        when(targetSystem.getPopulation(when)).thenReturn(0L);
+
+        assertTrue(FactionStandingUtilities.canEnterTargetSystem(mock(Faction.class),
+              mock(FactionStandings.class), null, targetSystem, when, List.of(), mock(FactionHints.class)));
+    }
+
+    @Test
+    @DisplayName("An uncolonized system with a residual population but no controlling faction is enterable")
+    void testCanEnterTargetSystem_uncolonizedWithResidualPopulation_grantsAccess() {
+        // Regression test for issue #9909: dying/uncolonized worlds (e.g. Nuncavoy, Sacromonte) still report a
+        // residual population but have no faction events, so getFactionSet() is empty. Previously the outlaw check
+        // (highest regard defaults to the minimum) and the at-war check (allMatch on an empty stream is vacuously
+        // true) both flagged such systems as inaccessible.
+        LocalDate when = LocalDate.of(3021, 4, 17);
+        PlanetarySystem targetSystem = mock(PlanetarySystem.class);
+        when(targetSystem.getPopulation(when)).thenReturn(88_154L);
+        when(targetSystem.getFactionSet(when)).thenReturn(Collections.emptySet());
+
+        assertTrue(FactionStandingUtilities.canEnterTargetSystem(mock(Faction.class),
+              mock(FactionStandings.class), null, targetSystem, when, List.of(), mock(FactionHints.class)));
     }
 
 }


### PR DESCRIPTION
Fix #9909

## What this changes

A system with no government but a lingering population incorrectly considered itself outlawed to the player.

## Testing

- Manual testing
- AI regression tests

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result