### PR TITLE
Fix #9911: Fixed Astech Nag Missing Text

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientAsTechsNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientAsTechsNagDialog.java
@@ -60,14 +60,14 @@ public class InsufficientAsTechsNagDialog extends ImmersiveDialogNag {
      *
      * <p>This constructor initializes the dialog with preconfigured parameters, such as the
      * {@code NAG_INSUFFICIENT_AS_TECHS} constant, to manage dialog suppression and the
-     * {@code "InsufficientAsTechsNagDialog"} message key for retrieving localized dialog content. No specialized
+     * {@code "InsufficientAstechsNagDialog"} message key for retrieving localized dialog content. No specialized
      * speaker is provided, triggering the fallback logic to determine the appropriate speaker for the dialog.</p>
      *
      * @param campaign The {@link Campaign} instance associated with this dialog. Provides access to campaign data and
      *                 settings required for constructing the dialog.
      */
     public InsufficientAsTechsNagDialog(final Campaign campaign) {
-        super(campaign, NAG_INSUFFICIENT_AS_TECHS, "InsufficientAsTechsNagDialog");
+        super(campaign, NAG_INSUFFICIENT_AS_TECHS, "InsufficientAstechsNagDialog");
     }
 
     /**


### PR DESCRIPTION
Fix #9911

## What this changes

Fixed spelling of nag calls.

## Testing

- Manual testing

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result