### PR TITLE
Close #9648: Added Small Craft to Unit Market

### DIFF
--- a/MekHQ/resources/mekhq/resources/Market.properties
+++ b/MekHQ/resources/mekhq/resources/Market.properties
@@ -1,4 +1,4 @@
-# Copyright (C) 2005-2025 The MegaMek Team. All Rights Reserved.
+# Copyright (C) 2005-2026 The MegaMek Team. All Rights Reserved.
 #
 # This file is part of MekHQ.
 #
@@ -57,6 +57,7 @@ UnitMarketRarity.COMMON.name=Common
 UnitMarketRarity.VERY_COMMON.name=Very Common
 UnitMarketRarity.UBIQUITOUS.name=Ubiquitous
 # AtBMonthlyUnitMarket
+AtBMonthlyUnitMarket.smallCraft.report=A {0}<b>Small Craft</b>{1} has appeared in the <b>Unit Market</b>.
 AtBMonthlyUnitMarket.dropShip.report=A {0}<b>DropShip</b>{1} has appeared in the <b>Unit Market</b>.
 AtBMonthlyUnitMarket.jumpShip.report=A {0}<b>JumpShip</b>{1} has appeared in the <b>Unit Market</b>.
 ## Market Classes

--- a/MekHQ/src/mekhq/campaign/againstTheBot/AtBStaticWeightGenerator.java
+++ b/MekHQ/src/mekhq/campaign/againstTheBot/AtBStaticWeightGenerator.java
@@ -36,8 +36,8 @@ import megamek.common.compute.Compute;
 import megamek.common.units.EntityWeightClass;
 import megamek.common.units.UnitType;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.universe.Faction;
 import mekhq.campaign.campaignOptions.CampaignOption;
+import mekhq.campaign.universe.Faction;
 
 public class AtBStaticWeightGenerator {
     /**
@@ -63,6 +63,8 @@ public class AtBStaticWeightGenerator {
           final boolean regionVariations) {
         if (unitType == UnitType.AEROSPACE_FIGHTER) {
             return getRandomAerospaceWeight();
+        } else if (unitType == UnitType.SMALL_CRAFT) {
+            return EntityWeightClass.WEIGHT_SMALL_CRAFT;
         } else if (unitType == UnitType.DROPSHIP) {
             return getRandomDropShipWeight();
         } else if (unitType == UnitType.JUMPSHIP) {

--- a/MekHQ/src/mekhq/campaign/market/unitMarket/AtBMonthlyUnitMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/unitMarket/AtBMonthlyUnitMarket.java
@@ -135,6 +135,9 @@ public class AtBMonthlyUnitMarket extends AbstractUnitMarket {
         addOffers(campaign, getMarketItemCount(campaign, UBIQUITOUS, rarityModifier),
               UnitMarketType.OPEN, UnitType.INFANTRY, faction, DragoonRating.DRAGOON_F.getRating(), 1);
 
+        addOffers(campaign, getMarketItemCount(campaign, RARE, rarityModifier),
+              UnitMarketType.OPEN, UnitType.SMALL_CRAFT, faction, DragoonRating.DRAGOON_F.getRating(), 2);
+
         addOffers(campaign, getMarketItemCount(campaign, VERY_RARE, rarityModifier),
               UnitMarketType.OPEN, UnitType.DROPSHIP, faction, DragoonRating.DRAGOON_F.getRating(), 4);
 
@@ -301,6 +304,9 @@ public class AtBMonthlyUnitMarket extends AbstractUnitMarket {
             addOffers(campaign, getMarketItemCount(campaign, UBIQUITOUS, rarityModifier),
                   UnitMarketType.FACTORY, UnitType.INFANTRY, faction, DragoonRating.DRAGOON_A.getRating(), -4);
 
+            addOffers(campaign, getMarketItemCount(campaign, RARE, rarityModifier),
+                  UnitMarketType.FACTORY, UnitType.SMALL_CRAFT, faction, DragoonRating.DRAGOON_A.getRating(), 0);
+
             addOffers(campaign, getMarketItemCount(campaign, VERY_RARE, rarityModifier),
                   UnitMarketType.FACTORY, UnitType.DROPSHIP, faction, DragoonRating.DRAGOON_A.getRating(), 0);
 
@@ -410,7 +416,12 @@ public class AtBMonthlyUnitMarket extends AbstractUnitMarket {
                   missionRoles,
                   getPricePercentage(priceModifier));
             if (unitName != null) {
-                if (unitType == UnitType.DROPSHIP) {
+                if (unitType == UnitType.SMALL_CRAFT) {
+                    String key = "AtBMonthlyUnitMarket.smallCraft.report";
+                    String report = getFormattedTextAt(RESOURCE_BUNDLE, key,
+                          spanOpeningWithCustomColor(getPositiveColor()), CLOSING_SPAN_TAG);
+                    campaign.addReport(GENERAL, report);
+                } else if (unitType == UnitType.DROPSHIP) {
                     String key = "AtBMonthlyUnitMarket.dropShip.report";
                     String report = getFormattedTextAt(RESOURCE_BUNDLE, key,
                           spanOpeningWithCustomColor(getPositiveColor()), CLOSING_SPAN_TAG);


### PR DESCRIPTION
Close #9648

## What this changes

Small Craft can now appear in the unit market

## Testing

- Manual testing

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result