### PR TITLE
fix: move null check before referencing unit object to prevent NPE

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/missing/MissingKFChargingSystem.java
+++ b/MekHQ/src/mekhq/campaign/parts/missing/MissingKFChargingSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2019-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -100,14 +100,16 @@ public class MissingKFChargingSystem extends MissingPart {
         Part replacement = findReplacement(false);
         if (null != replacement) {
             Part actualReplacement = replacement.clone();
-            unit.addPart(actualReplacement);
-            if (null != unit && unit.getEntity() instanceof Jumpship js) {
-                // Also repair your KF Drive integrity - +1 point if you have other components to fix
-                // Otherwise, fix it all.
-                if (js.isKFDriveDamaged()) {
-                    js.setKFIntegrity(Math.min((js.getKFIntegrity() + 1), js.getOKFIntegrity()));
-                } else {
-                    js.setKFIntegrity(js.getOKFIntegrity());
+            if (unit != null) {
+                unit.addPart(actualReplacement);
+                if (unit.getEntity() instanceof Jumpship js) {
+                    // Also repair your KF Drive integrity - +1 point if you have other components to fix
+                    // Otherwise, fix it all.
+                    if (js.isKFDriveDamaged()) {
+                        js.setKFIntegrity(Math.min((js.getKFIntegrity() + 1), js.getOKFIntegrity()));
+                    } else {
+                        js.setKFIntegrity(js.getOKFIntegrity());
+                    }
                 }
             }
             campaign.getQuartermaster().addPart(actualReplacement, 0, false);

--- a/MekHQ/src/mekhq/campaign/parts/missing/MissingKFDriveCoil.java
+++ b/MekHQ/src/mekhq/campaign/parts/missing/MissingKFDriveCoil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2019-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -100,14 +100,16 @@ public class MissingKFDriveCoil extends MissingPart {
         Part replacement = findReplacement(false);
         if (null != replacement) {
             Part actualReplacement = replacement.clone();
-            unit.addPart(actualReplacement);
-            if (null != unit && unit.getEntity() instanceof Jumpship js) {
-                //Also repair your KF Drive integrity - +1 point if you have other components to fix
-                //Otherwise, fix it all.
-                if (js.isKFDriveDamaged()) {
-                    js.setKFIntegrity(Math.min((js.getKFIntegrity() + 1), js.getOKFIntegrity()));
-                } else {
-                    js.setKFIntegrity(js.getOKFIntegrity());
+            if (unit != null) {
+                unit.addPart(actualReplacement);
+                if (unit.getEntity() instanceof Jumpship js) {
+                    //Also repair your KF Drive integrity - +1 point if you have other components to fix
+                    //Otherwise, fix it all.
+                    if (js.isKFDriveDamaged()) {
+                        js.setKFIntegrity(Math.min((js.getKFIntegrity() + 1), js.getOKFIntegrity()));
+                    } else {
+                        js.setKFIntegrity(js.getOKFIntegrity());
+                    }
                 }
             }
             campaign.getQuartermaster().addPart(actualReplacement, 0, false);

--- a/MekHQ/src/mekhq/campaign/parts/missing/MissingKFDriveController.java
+++ b/MekHQ/src/mekhq/campaign/parts/missing/MissingKFDriveController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2019-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -100,14 +100,16 @@ public class MissingKFDriveController extends MissingPart {
         Part replacement = findReplacement(false);
         if (null != replacement) {
             Part actualReplacement = replacement.clone();
-            unit.addPart(actualReplacement);
-            if (null != unit && unit.getEntity() instanceof Jumpship js) {
-                // Also repair your KF Drive integrity - +1 point if you have other components to fix
-                // Otherwise, fix it all.
-                if (js.isKFDriveDamaged()) {
-                    js.setKFIntegrity(Math.min((js.getKFIntegrity() + 1), js.getOKFIntegrity()));
-                } else {
-                    js.setKFIntegrity(js.getOKFIntegrity());
+            if (unit != null) {
+                unit.addPart(actualReplacement);
+                if (unit.getEntity() instanceof Jumpship js) {
+                    // Also repair your KF Drive integrity - +1 point if you have other components to fix
+                    // Otherwise, fix it all.
+                    if (js.isKFDriveDamaged()) {
+                        js.setKFIntegrity(Math.min((js.getKFIntegrity() + 1), js.getOKFIntegrity()));
+                    } else {
+                        js.setKFIntegrity(js.getOKFIntegrity());
+                    }
                 }
             }
             campaign.getQuartermaster().addPart(actualReplacement, 0, false);

--- a/MekHQ/src/mekhq/campaign/parts/missing/MissingKFFieldInitiator.java
+++ b/MekHQ/src/mekhq/campaign/parts/missing/MissingKFFieldInitiator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2019-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -102,14 +102,16 @@ public class MissingKFFieldInitiator extends MissingPart {
         Part replacement = findReplacement(false);
         if (null != replacement) {
             Part actualReplacement = replacement.clone();
-            unit.addPart(actualReplacement);
-            if (null != unit && unit.getEntity() instanceof Jumpship js) {
-                // Also repair your KF Drive integrity - +1 point if you have other components to fix
-                // Otherwise, fix it all.
-                if (js.isKFDriveDamaged()) {
-                    js.setKFIntegrity(Math.min((js.getKFIntegrity() + 1), js.getOKFIntegrity()));
-                } else {
-                    js.setKFIntegrity(js.getOKFIntegrity());
+            if (unit != null) {
+                unit.addPart(actualReplacement);
+                if (unit.getEntity() instanceof Jumpship js) {
+                    // Also repair your KF Drive integrity - +1 point if you have other components to fix
+                    // Otherwise, fix it all.
+                    if (js.isKFDriveDamaged()) {
+                        js.setKFIntegrity(Math.min((js.getKFIntegrity() + 1), js.getOKFIntegrity()));
+                    } else {
+                        js.setKFIntegrity(js.getOKFIntegrity());
+                    }
                 }
             }
             campaign.getQuartermaster().addPart(actualReplacement, 0, false);

--- a/MekHQ/src/mekhq/campaign/parts/missing/MissingKFHeliumTank.java
+++ b/MekHQ/src/mekhq/campaign/parts/missing/MissingKFHeliumTank.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2019-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -102,15 +102,17 @@ public class MissingKFHeliumTank extends MissingPart {
         Part replacement = findReplacement(false);
         if (null != replacement) {
             Part actualReplacement = replacement.clone();
-            unit.addPart(actualReplacement);
-            if (null != unit && unit.getEntity() instanceof Jumpship js) {
-                //Also repair your KF Drive integrity - up to 2/3 of the total if you have other components to fix
-                //Otherwise, fix it all.
-                if (js.isKFDriveDamaged()) {
-                    js.setKFIntegrity(Math.min((js.getKFIntegrity() + js.getKFHeliumTankIntegrity()),
-                          js.getOKFIntegrity()));
-                } else {
-                    js.setKFIntegrity(js.getOKFIntegrity());
+            if (unit != null) {
+                unit.addPart(actualReplacement);
+                if (unit.getEntity() instanceof Jumpship js) {
+                    //Also repair your KF Drive integrity - up to 2/3 of the total if you have other components to fix
+                    //Otherwise, fix it all.
+                    if (js.isKFDriveDamaged()) {
+                        js.setKFIntegrity(Math.min((js.getKFIntegrity() + js.getKFHeliumTankIntegrity()),
+                            js.getOKFIntegrity()));
+                    } else {
+                        js.setKFIntegrity(js.getOKFIntegrity());
+                    }
                 }
             }
             campaign.getQuartermaster().addPart(actualReplacement, 0, false);

--- a/MekHQ/src/mekhq/campaign/parts/missing/MissingLFBattery.java
+++ b/MekHQ/src/mekhq/campaign/parts/missing/MissingLFBattery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2019-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -99,14 +99,16 @@ public class MissingLFBattery extends MissingPart {
         Part replacement = findReplacement(false);
         if (null != replacement) {
             Part actualReplacement = replacement.clone();
-            unit.addPart(actualReplacement);
-            if (null != unit && unit.getEntity() instanceof Jumpship js) {
-                //Also repair your KF Drive integrity - +1 point if you have other components to fix
-                //Otherwise, fix it all.
-                if (js.isKFDriveDamaged()) {
-                    js.setKFIntegrity(Math.min((js.getKFIntegrity() + 1), js.getOKFIntegrity()));
-                } else {
-                    js.setKFIntegrity(js.getOKFIntegrity());
+            if (unit != null) {
+                unit.addPart(actualReplacement);
+                if (unit.getEntity() instanceof Jumpship js) {
+                    //Also repair your KF Drive integrity - +1 point if you have other components to fix
+                    //Otherwise, fix it all.
+                    if (js.isKFDriveDamaged()) {
+                        js.setKFIntegrity(Math.min((js.getKFIntegrity() + 1), js.getOKFIntegrity()));
+                    } else {
+                        js.setKFIntegrity(js.getOKFIntegrity());
+                    }
                 }
             }
             campaign.getQuartermaster().addPart(actualReplacement, 0, false);


### PR DESCRIPTION
This fixes and prevents a potential Null Pointer Exception on the `unit` variable/object as the check was done after it is used.  This moves the null check out into it's own block to prevent this.  Based on `Part.java`, null `unit` values are valid and denote parts not attached to a unit.

Things to check:
* For the reviewer: double-check to make sure we don't need to extend the `unit != null` check further to encompass additional parts of the code in the block.

These were found via the static code analysis tool [SpotBugs](https://github.com/spotbugs/spotbugs) version 4.10.4.

## What this changes

<!-- The effect someone actually sees, in plain language. One or two sentences is fine. -->

<!-- Keep this line as well as the number in the title. GitHub only closes an issue from a
     keyword in the description - a number in the title alone does not close anything.

     Any of these close an issue when this merges:
         Close / Closes / Closed
         Fix / Fixes / Fixed
         Resolve / Resolves / Resolved

     Closing more than one needs the keyword repeated in front of each number:
         Fixes #1234, fixes #5678          closes both
         Fixes #1234, #5678                closes only #1234

     For an issue in another repository, qualify it: Fixes MegaMek/mekhq#1234 -->


## Testing

Ran Gradle unit tests, did not run smoketest.

## What is not proven yet

<!-- What you did not test, or could not. "Nothing" is a valid answer - say so explicitly. -->

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text

No AI leveraged.