### PR TITLE
fix: explicitly call out selectedScenario as not being Null

### DIFF
--- a/MekHQ/src/mekhq/gui/TOETab.java
+++ b/MekHQ/src/mekhq/gui/TOETab.java
@@ -248,7 +248,10 @@ public final class TOETab extends CampaignGuiTab {
      * @since 0.50.10
      */
     private void deployToRegularScenario(Scenario selectedScenario) {
-        Objects.requireNonNull(selectedScenario, "selectedScenario");
+        if (selectedScenario == null) {
+            LOGGER.warn("TOETab: Null selectedScenario in deployToRegularScenario()");
+            return;
+        }
 
         // Get available forces
         mekhq.campaign.Campaign campaign = getCampaign();

--- a/MekHQ/src/mekhq/gui/TOETab.java
+++ b/MekHQ/src/mekhq/gui/TOETab.java
@@ -45,6 +45,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Vector;
 import javax.swing.*;
 import javax.swing.tree.TreePath;
@@ -247,6 +248,8 @@ public final class TOETab extends CampaignGuiTab {
      * @since 0.50.10
      */
     private void deployToRegularScenario(Scenario selectedScenario) {
+        Objects.requireNonNull(selectedScenario, "selectedScenario");
+
         // Get available forces
         mekhq.campaign.Campaign campaign = getCampaign();
         List<Formation> formationOptions = campaign.getPlayerForce()
@@ -278,10 +281,8 @@ public final class TOETab extends CampaignGuiTab {
         } else {
             getCampaignGui().undeployForce(selectedFormation);
             selectedFormation.clearScenarioIds(getCampaign(), true);
-            if (selectedScenario != null) {
-                selectedScenario.addForces(selectedFormation.getId());
-                selectedFormation.setScenarioId(selectedScenario.getId(), getCampaign());
-            }
+            selectedScenario.addForces(selectedFormation.getId());
+            selectedFormation.setScenarioId(selectedScenario.getId(), getCampaign());
             MekHQ.triggerEvent(new DeploymentChangedEvent(selectedFormation, selectedScenario));
         }
     }

--- a/MekHQ/src/mekhq/gui/TOETab.java
+++ b/MekHQ/src/mekhq/gui/TOETab.java
@@ -45,7 +45,6 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Vector;
 import javax.swing.*;
 import javax.swing.tree.TreePath;
@@ -248,11 +247,6 @@ public final class TOETab extends CampaignGuiTab {
      * @since 0.50.10
      */
     private void deployToRegularScenario(Scenario selectedScenario) {
-        if (selectedScenario == null) {
-            LOGGER.warn("TOETab: Null selectedScenario in deployToRegularScenario()");
-            return;
-        }
-
         // Get available forces
         mekhq.campaign.Campaign campaign = getCampaign();
         List<Formation> formationOptions = campaign.getPlayerForce()
@@ -274,6 +268,13 @@ public final class TOETab extends CampaignGuiTab {
         }
 
         Formation selectedFormation = formationOptions.get(forcePicker.getComboBoxChoiceIndex());
+
+        if (selectedScenario == null) {
+            getCampaignGui().undeployForce(selectedFormation);
+            selectedFormation.clearScenarioIds(getCampaign(), true);
+            LOGGER.warn("TOETab: Null selectedScenario in deployToRegularScenario()");
+            return;
+        }
 
         // Deploy force to scenario
         if (selectedScenario instanceof AtBDynamicScenario dynamicScenario) {


### PR DESCRIPTION
fix: explicitly call out `selectedScenario` as not being Null, prevent potential Null being passed to constructor

`selectedScenario` is checked to make sure it's not Null.  However, at the end, it's used as a parameter to a constructor.  If it shouldn't ever be null, it seems more clear to spell that out up-front with `requireNonNull`.

Found via static analysis tool [SpotBugs](https://github.com/spotbugs/spotbugs) 4.10.4.

## What this changes

<!-- The effect someone actually sees, in plain language. One or two sentences is fine. -->

<!-- Keep this line as well as the number in the title. GitHub only closes an issue from a
     keyword in the description - a number in the title alone does not close anything.

     Any of these close an issue when this merges:
         Close / Closes / Closed
         Fix / Fixes / Fixed
         Resolve / Resolves / Resolved

     Closing more than one needs the keyword repeated in front of each number:
         Fixes #1234, fixes #5678          closes both
         Fixes #1234, #5678                closes only #1234

     For an issue in another repository, qualify it: Fixes MegaMek/mekhq#1234 -->


## Testing

Ran Gradle tests, no smoketests run.

## What is not proven yet

<!-- What you did not test, or could not. "Nothing" is a valid answer - say so explicitly. -->

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text

No AI usage.