### PR TITLE
Fix: campaign load stalled by orphaned personnel market units and a duplicate market block

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3824,10 +3824,7 @@ public class Campaign implements ITechManager {
             storyArc.writeToXml(writer, indent);
         }
 
-        // Markets
-        if (getPlayerForce().getHumanResources().getPersonnelMarket() != null) {
-            getPlayerForce().getHumanResources().getPersonnelMarket().writeToXML(writer, indent, this);
-        }
+        // The personnel market is written inside <humanResources>; writing it here as well doubled the load time
 
         // Windchild: implicit DEPENDS-ON to the <campaignOptions> node, do not move
         // this above it

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -2278,6 +2278,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                           campaign,
                           version);
                     campaign.getPlayerForce().setHumanResources(humanResources);
+                    foundPersonnelMarket = foundPersonnelMarket || (humanResources.getPersonnelMarket() != null);
                 } else if (nodeName.equalsIgnoreCase("parts")) {
                     processPartNodes(campaign, workingNode, version);
                 } else if (nodeName.equalsIgnoreCase("personnel")) {
@@ -2324,11 +2325,17 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                     ForceShoppingList sl = ForceShoppingList.generateInstanceFromXML(workingNode, campaign, version);
                     campaign.getPlayerForce().setShoppingList(sl);
                 } else if (nodeName.equalsIgnoreCase("personnelMarket")) {
-                    final PersonnelMarket personnelMarket = PersonnelMarket.generateInstanceFromXML(workingNode,
-                          campaign,
-                          version);
-                    campaign.getPlayerForce().getHumanResources().setPersonnelMarket(personnelMarket);
-                    foundPersonnelMarket = true;
+                    if (foundPersonnelMarket) {
+                        // Saves written between the human-resources refactor and the fix that stopped the second
+                        // write carry the market twice; the copy inside <humanResources> has already been loaded.
+                        LOGGER.info("[PersonnelMarket] Skipping the duplicate top-level personnelMarket node");
+                    } else {
+                        final PersonnelMarket personnelMarket = PersonnelMarket.generateInstanceFromXML(workingNode,
+                              campaign,
+                              version);
+                        campaign.getPlayerForce().getHumanResources().setPersonnelMarket(personnelMarket);
+                        foundPersonnelMarket = true;
+                    }
                 } else if (nodeName.equalsIgnoreCase("unitMarket")) {
                     // Windchild: implicit DEPENDS ON to the <campaignOptions> nodes
                     campaign.setUnitMarket(campaign.getCampaignOptions().get(CampaignOption.UNIT_MARKET_METHOD).getUnitMarket());

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -2278,7 +2278,9 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                           campaign,
                           version);
                     campaign.getPlayerForce().setHumanResources(humanResources);
-                    foundPersonnelMarket = foundPersonnelMarket || (humanResources.getPersonnelMarket() != null);
+                    // The loaded object always carries a default market, so ask the save itself whether the block
+                    // held one; only then is a later top-level market node a duplicate rather than the real data.
+                    foundPersonnelMarket = foundPersonnelMarket || hasChildElement(workingNode, "personnelMarket");
                 } else if (nodeName.equalsIgnoreCase("parts")) {
                     processPartNodes(campaign, workingNode, version);
                 } else if (nodeName.equalsIgnoreCase("personnel")) {

--- a/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
@@ -44,9 +44,12 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import megamek.Version;
+import megamek.common.annotations.Nullable;
 import megamek.common.event.Subscribe;
 import megamek.common.loaders.EntityLoadingException;
 import megamek.common.loaders.MekFileParser;
@@ -154,6 +157,9 @@ public class PersonnelMarket {
         boolean isCapital = location.getFactionSet(today)
                                   .stream()
                                   .anyMatch(faction -> location.equals(faction.getStartingPlanet(campaign, today)));
+
+        // Units left behind by recruits that are already gone would otherwise sit in the save forever
+        purgeOrphanedEntities();
 
         // Remove existing personnel for the day
         if (!personnel.isEmpty()) {
@@ -377,6 +383,10 @@ public class PersonnelMarket {
             // Okay, now load Part-specific fields!
             NodeList nl = wn.getChildNodes();
 
+            // A saved unit is only worth loading for a recruit who is still in the market, and the recruits may
+            // follow the units in the file, so the unit nodes are held back until every recruit is known.
+            List<Node> attachedEntityNodes = new ArrayList<>();
+
             // Loop through the nodes and load our personnel
             for (int x = 0; x < nl.getLength(); x++) {
                 Node wn2 = nl.item(x);
@@ -393,20 +403,7 @@ public class PersonnelMarket {
                         retVal.personnel.add(p);
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("entity")) {
-                    UUID id = UUID.fromString(wn2.getAttributes().getNamedItem("id").getTextContent());
-                    MekSummary ms = MekSummaryCache.getInstance().getMek(wn2.getTextContent());
-                    Entity en = null;
-                    try {
-                        en = new MekFileParser(ms.getSourceFile(), ms.getEntryName()).getEntity();
-                    } catch (EntityLoadingException ex) {
-                        logger.error(ex, "Unable to load entity: {}: {}: {}",
-                              ms.getSourceFile(),
-                              ms.getEntryName(),
-                              ex.getMessage());
-                    }
-                    if (null != en) {
-                        retVal.attachedEntities.put(id, en);
-                    }
+                    attachedEntityNodes.add(wn2);
                 } else if (wn2.getNodeName().equalsIgnoreCase("paidRecruitment")) {
                     retVal.paidRecruitment = true;
                 } else if (wn2.getNodeName().equalsIgnoreCase("paidRecruitType")) {
@@ -419,6 +416,8 @@ public class PersonnelMarket {
                     logger.error("Unknown node type not loaded in Personnel nodes: {}", wn2.getNodeName());
                 }
             }
+
+            loadAttachedEntities(retVal, attachedEntityNodes);
 
             // All personnel need the rank reference fixed
             for (int x = 0; x < retVal.personnel.size(); x++) {
@@ -435,6 +434,74 @@ public class PersonnelMarket {
         }
 
         return retVal;
+    }
+
+    /**
+     * Loads the units saved alongside the market's recruits, skipping every unit whose recruit is no longer there.
+     *
+     * <p>Older versions left a unit behind each time a recruit was dropped, and a long campaign can carry tens of
+     * thousands of them. Each one costs a zip open and a unit-file parse, so an orphaned unit is not loaded at all and
+     * therefore never written back.</p>
+     *
+     * @param market              the market whose recruits have already been loaded
+     * @param attachedEntityNodes the {@code entity} nodes read from the save
+     */
+    private static void loadAttachedEntities(PersonnelMarket market, List<Node> attachedEntityNodes) {
+        Set<UUID> recruitIds = market.personnel.stream()
+                                     .map(Person::getId)
+                                     .collect(Collectors.toSet());
+        int orphanedUnitCount = 0;
+
+        for (Node entityNode : attachedEntityNodes) {
+            UUID recruitId = UUID.fromString(entityNode.getAttributes().getNamedItem("id").getTextContent());
+            if (!recruitIds.contains(recruitId)) {
+                orphanedUnitCount++;
+                continue;
+            }
+
+            Entity entity = loadAttachedEntity(entityNode.getTextContent());
+            if (entity != null) {
+                market.attachedEntities.put(recruitId, entity);
+            }
+        }
+
+        if (orphanedUnitCount > 0) {
+            logger.info("[PersonnelMarket] Skipped {} saved unit(s) with no matching recruit; they will not be kept",
+                  orphanedUnitCount);
+        }
+    }
+
+    /**
+     * @param unitName the unit's name as written in the save
+     *
+     * @return the loaded unit, or {@code null} if it is not in the unit cache or fails to load
+     */
+    private static @Nullable Entity loadAttachedEntity(String unitName) {
+        MekSummary summary = MekSummaryCache.getInstance().getMek(unitName);
+        if (summary == null) {
+            logger.error("[PersonnelMarket] Unit {} attached to a recruit is not in the unit cache", unitName);
+            return null;
+        }
+
+        try {
+            return new MekFileParser(summary.getSourceFile(), summary.getEntryName()).getEntity();
+        } catch (EntityLoadingException exception) {
+            logger.error(exception, "Unable to load entity: {}: {}: {}",
+                  summary.getSourceFile(),
+                  summary.getEntryName(),
+                  exception.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Drops every attached unit whose recruit is no longer in the market.
+     */
+    public void purgeOrphanedEntities() {
+        Set<UUID> recruitIds = personnel.stream()
+                                     .map(Person::getId)
+                                     .collect(Collectors.toSet());
+        attachedEntities.keySet().removeIf(recruitId -> !recruitIds.contains(recruitId));
     }
 
     public static String getTypeName(int type) {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -5370,16 +5370,37 @@ public class Person implements ILocatable {
 
         while (st.hasMoreTokens()) {
             String trigger = st.nextToken();
-            String triggerName = Crew.parseAdvantageName(trigger);
+            String savedTriggerName = Crew.parseAdvantageName(trigger);
             Object value = Crew.parseAdvantageValue(trigger);
 
-            try {
-                retVal.getOptions().getOption(triggerName).setValue(value);
-                edgeOptionList.remove(triggerName);
-            } catch (Exception e) {
-                LOGGER.error("Error restoring edge trigger: {}", trigger);
+            for (String triggerName : resolveEdgeTriggerNames(savedTriggerName)) {
+                try {
+                    retVal.getOptions().getOption(triggerName).setValue(value);
+                    edgeOptionList.remove(triggerName);
+                } catch (Exception exception) {
+                    LOGGER.error("Error restoring edge trigger: {}", trigger);
+                }
             }
         }
+    }
+
+    /**
+     * Maps an edge trigger name as it was saved to the option names it sets today.
+     *
+     * <p>The single "admin acquisition failed" trigger was split into three by how badly the roll missed. A save that
+     * still carries the old name applies its value to all three, which is what the old single switch did.</p>
+     *
+     * @param savedTriggerName the trigger name read from the save
+     *
+     * @return the current option names the saved value applies to
+     */
+    static List<String> resolveEdgeTriggerNames(String savedTriggerName) {
+        if (PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL_LEGACY.equals(savedTriggerName)) {
+            return List.of(PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL_OTHER,
+                  PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL_EIGHT,
+                  PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL_ELEVEN);
+        }
+        return List.of(savedTriggerName);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -61,6 +61,8 @@ public class PersonnelOptions extends PilotOptions {
     public static final String EDGE_ADVANCED_SURGERY = "edge_when_advanced_surgery_fail";
     public static final String EDGE_REPAIR_BREAK_PART = "edge_when_repair_break_part";
     public static final String EDGE_REPAIR_FAILED_REFIT = "edge_when_fail_refit_check";
+    /** The single admin acquisition trigger older saves carry; it maps onto the three triggers below on load. */
+    public static final String EDGE_ADMIN_ACQUIRE_FAIL_LEGACY = "edge_when_admin_acquire_fail";
     public static final String EDGE_ADMIN_ACQUIRE_FAIL_EIGHT = "edge_when_admin_acquire_fail_greater_than_eight";
     public static final String EDGE_ADMIN_ACQUIRE_FAIL_OTHER = "edge_when_admin_acquire_fail_other";
     public static final String EDGE_ADMIN_ACQUIRE_FAIL_ELEVEN = "edge_when_admin_acquire_fail_greater_than_eleven";

--- a/MekHQ/unittests/mekhq/campaign/market/PersonnelMarketTest.java
+++ b/MekHQ/unittests/mekhq/campaign/market/PersonnelMarketTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.market;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import megamek.Version;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.units.Entity;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.enums.PersonnelRole;
+import mekhq.campaign.personnel.skills.SkillType;
+import mekhq.campaign.universe.Factions;
+import mekhq.campaign.universe.Systems;
+import mekhq.campaign.universe.TestSystems;
+import mekhq.utilities.MHQXMLUtility;
+import org.apache.logging.log4j.LogManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import testUtilities.MHQTestUtilities;
+
+/**
+ * Pins the behaviour that keeps a long campaign's save from filling up with recruits' units nobody can hire any more:
+ * a saved unit with no matching recruit is skipped on load, dropped on the daily refresh, and the market itself is
+ * written into the save exactly once.
+ */
+class PersonnelMarketTest {
+    /** Any version at or above the current release; keeps the version-gated compatibility branches dormant. */
+    private static final Version VERSION = new Version(999, 0, 0);
+
+    private Campaign campaign;
+
+    @BeforeAll
+    static void initSingletons() {
+        EquipmentType.initializeTypes();
+        SkillType.initializeTypes();
+        try {
+            Factions.setInstance(Factions.loadDefault(true));
+            Systems.setInstance(TestSystems.loadDefault());
+        } catch (Exception exception) {
+            LogManager.getLogger().error("", exception);
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        campaign = MHQTestUtilities.getTestCampaign();
+    }
+
+    @Test
+    void savedUnitWithNoRecruitIsSkippedWithoutStoppingTheLoad() throws Exception {
+        UUID orphanId = UUID.randomUUID();
+        // The unit comes before the recruit type on purpose: the old loader tried to load it on the spot, and an
+        // unknown unit name threw and abandoned everything after it.
+        String xml = "<personnelMarket>"
+              + "<entity id=\"" + orphanId + "\">No Such Unit XYZ-1</entity>"
+              + "<paidRecruitType>ADMINISTRATOR</paidRecruitType>"
+              + "</personnelMarket>";
+        Document document = MHQXMLUtility.parseDocument(
+              new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+
+        PersonnelMarket market = PersonnelMarket.generateInstanceFromXML(document.getDocumentElement(),
+              campaign,
+              VERSION);
+
+        assertNotNull(market);
+        assertTrue(market.getPersonnel().isEmpty(), "no recruit was saved, so none is loaded");
+        assertNull(market.getAttachedEntity(orphanId), "a unit with no recruit is not loaded");
+        assertEquals(PersonnelRole.ADMINISTRATOR, market.getPaidRecruitRole(),
+              "the nodes after the orphaned unit are still read");
+    }
+
+    @Test
+    void purgeKeepsTheRecruitsUnitAndDropsTheOrphan() {
+        PersonnelMarket market = new PersonnelMarket();
+        UUID recruitId = UUID.randomUUID();
+        UUID orphanId = UUID.randomUUID();
+        Person recruit = mock(Person.class);
+        when(recruit.getId()).thenReturn(recruitId);
+        Entity recruitUnit = mock(Entity.class);
+        Entity orphanUnit = mock(Entity.class);
+        market.addPerson(recruit);
+        market.addAttachedEntity(recruitId, recruitUnit);
+        market.addAttachedEntity(orphanId, orphanUnit);
+
+        market.purgeOrphanedEntities();
+
+        assertSame(recruitUnit, market.getAttachedEntity(recruitId));
+        assertNull(market.getAttachedEntity(orphanId));
+    }
+
+    @Test
+    void campaignWritesThePersonnelMarketOnce() {
+        StringWriter output = new StringWriter();
+        campaign.writeToXML(new PrintWriter(output), false);
+
+        long marketBlocks = output.toString()
+                                  .lines()
+                                  .filter(line -> line.trim().equals("<personnelMarket>"))
+                                  .count();
+
+        assertEquals(1L, marketBlocks);
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/market/PersonnelMarketTest.java
+++ b/MekHQ/unittests/mekhq/campaign/market/PersonnelMarketTest.java
@@ -57,7 +57,6 @@ import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.Systems;
 import mekhq.campaign.universe.TestSystems;
 import mekhq.utilities.MHQXMLUtility;
-import org.apache.logging.log4j.LogManager;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -76,15 +75,11 @@ class PersonnelMarketTest {
     private Campaign campaign;
 
     @BeforeAll
-    static void initSingletons() {
+    static void initSingletons() throws Exception {
         EquipmentType.initializeTypes();
         SkillType.initializeTypes();
-        try {
-            Factions.setInstance(Factions.loadDefault(true));
-            Systems.setInstance(TestSystems.loadDefault());
-        } catch (Exception exception) {
-            LogManager.getLogger().error("", exception);
-        }
+        Factions.setInstance(Factions.loadDefault(true));
+        Systems.setInstance(TestSystems.loadDefault());
     }
 
     @BeforeEach

--- a/MekHQ/unittests/mekhq/campaign/personnel/PersonEdgeTriggerMigrationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/PersonEdgeTriggerMigrationTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.personnel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The edge trigger names a save carries must keep mapping onto live options after a trigger is renamed or split,
+ * otherwise every person in an old save logs an error on load and silently loses that setting.
+ */
+class PersonEdgeTriggerMigrationTest {
+
+    @Test
+    void currentTriggerNameMapsToItself() {
+        assertEquals(List.of(PersonnelOptions.EDGE_REPAIR_BREAK_PART),
+              Person.resolveEdgeTriggerNames(PersonnelOptions.EDGE_REPAIR_BREAK_PART));
+    }
+
+    @Test
+    void legacyAdminAcquisitionTriggerMapsToAllThreeReplacements() {
+        List<String> resolved = Person.resolveEdgeTriggerNames(PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL_LEGACY);
+
+        assertEquals(List.of(PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL_OTHER,
+              PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL_EIGHT,
+              PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL_ELEVEN), resolved);
+    }
+}


### PR DESCRIPTION
## What this changes

A campaign whose old personnel market left thousands of recruit units behind in the save loads in seconds instead of minutes, and the market is no longer written into the save twice. Old saves also stop logging an edge trigger error for every person.

Save from #9920 (Knight's Errant).

## Testing

- PersonnelMarketTest and PersonEdgeTriggerMigrationTest, five tests, plus checkstyle, green.
- Headless load of that save: 134 seconds down to 15, with 49,306 orphaned units skipped and zero edge trigger errors.
- Loaded the same save in the app and profiled it; the market parse is gone from the profile.

## What is not proven yet

- A market with live recruits and their units was not carried across a day change in game.
- Saves older than the humanResources wrapper still use the top-level market block; that fallback was not loaded by hand.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result
