### PR TITLE
Fix: campaign load parsed every battle armor unit file to stock the parts store

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/PartsStore.java
+++ b/MekHQ/src/mekhq/campaign/market/PartsStore.java
@@ -48,14 +48,13 @@ import megamek.common.equipment.MiscType;
 import megamek.common.equipment.WeaponType;
 import megamek.common.equipment.enums.AmmoTypeFlag;
 import megamek.common.equipment.enums.MiscTypeFlag;
-import megamek.common.loaders.EntityLoadingException;
-import megamek.common.loaders.MekFileParser;
 import megamek.common.loaders.MekSummary;
 import megamek.common.loaders.MekSummaryCache;
 import megamek.common.units.Aero;
 import megamek.common.units.BipedMek;
 import megamek.common.units.Dropship;
 import megamek.common.units.Entity;
+import megamek.common.units.EntityMovementMode;
 import megamek.common.units.Jumpship;
 import megamek.common.units.Mek;
 import megamek.common.units.ProtoMek;
@@ -154,26 +153,29 @@ public class PartsStore {
     }
 
     protected void stockBattleArmorSuits(Campaign c) {
-        // this is just a test
+        // Everything the suit part needs is on the unit summary, so no unit file is opened here. Loading every
+        // battle armor unit out of the zip used to cost seconds on every campaign load.
         for (MekSummary summary : MekSummaryCache.getInstance().getAllMeks()) {
             if (!summary.getUnitType().equals("BattleArmor")) {
                 continue;
             }
-            // FIXME: I can't pull entity movement mode and quad shape off of MekSummary
-            // try loading the full entity, but this might take too long
-            Entity newEntity = null;
-            try {
-                newEntity = new MekFileParser(summary.getSourceFile(), summary.getEntryName()).getEntity();
-            } catch (EntityLoadingException e) {
-                LOGGER.error("", e);
-            }
-            if (null != newEntity) {
-                BattleArmorSuit ba = new BattleArmorSuit(summary.getChassis(), summary.getModel(),
-                      (int) summary.getTons(), 1, summary.getWeightClass(), summary.getWalkMp(), summary.getJumpMp(),
-                      newEntity.entityIsQuad(), summary.isClan(), newEntity.getMovementMode(), c);
-                parts.add(ba);
-            }
+            parts.add(createBattleArmorSuit(summary, c));
         }
+    }
+
+    /**
+     * Builds the store's stock suit for a battle armor unit from its summary alone.
+     *
+     * @param summary  the unit summary, which carries the movement mode the suit part needs
+     * @param campaign the campaign the part belongs to
+     *
+     * @return the suit part for one trooper of that unit
+     */
+    static BattleArmorSuit createBattleArmorSuit(MekSummary summary, Campaign campaign) {
+        boolean isQuad = summary.getMoveMode() == EntityMovementMode.QUAD;
+        return new BattleArmorSuit(summary.getChassis(), summary.getModel(), (int) summary.getTons(), 1,
+              summary.getWeightClass(), summary.getWalkMp(), summary.getJumpMp(), isQuad, summary.isClan(),
+              summary.getMoveMode(), campaign);
     }
 
     protected void stockWeaponsAmmoAndEquipment(Campaign campaign) {

--- a/MekHQ/unittests/mekhq/campaign/market/PartsStoreBattleArmorStockTest.java
+++ b/MekHQ/unittests/mekhq/campaign/market/PartsStoreBattleArmorStockTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.market;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import megamek.common.loaders.MekSummary;
+import megamek.common.units.EntityMovementMode;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.parts.BattleArmorSuit;
+import org.junit.jupiter.api.Test;
+import testUtilities.MHQTestUtilities;
+
+/**
+ * The parts store stocks one suit per battle armor design straight from the unit summary. Pins that the suit carries
+ * the summary's figures without a unit file ever being opened.
+ */
+class PartsStoreBattleArmorStockTest {
+
+    @Test
+    void suitIsBuiltFromTheSummaryFigures() {
+        MekSummary summary = mock(MekSummary.class);
+        when(summary.getChassis()).thenReturn("Elemental");
+        when(summary.getModel()).thenReturn("[Laser]");
+        when(summary.getTons()).thenReturn(1.0);
+        when(summary.getWeightClass()).thenReturn(2);
+        when(summary.getWalkMp()).thenReturn(1);
+        when(summary.getJumpMp()).thenReturn(3);
+        when(summary.isClan()).thenReturn(true);
+        when(summary.getMoveMode()).thenReturn(EntityMovementMode.INF_JUMP);
+        Campaign campaign = MHQTestUtilities.mockCampaign();
+
+        BattleArmorSuit suit = PartsStore.createBattleArmorSuit(summary, campaign);
+
+        assertEquals("Elemental [Laser] Suit", suit.getName());
+        assertEquals(2, suit.getWeightClass());
+        assertEquals(1, suit.getGroundMP());
+        assertEquals(3, suit.getJumpMP());
+        assertTrue(suit.isClan());
+        assertFalse(suit.isQuad(), "only the quad movement mode marks a suit as quad");
+    }
+
+    @Test
+    void quadMovementModeMarksTheSuitAsQuad() {
+        MekSummary summary = mock(MekSummary.class);
+        when(summary.getChassis()).thenReturn("Fenrir");
+        when(summary.getModel()).thenReturn("Standard");
+        when(summary.getTons()).thenReturn(2.0);
+        when(summary.getMoveMode()).thenReturn(EntityMovementMode.QUAD);
+        Campaign campaign = MHQTestUtilities.mockCampaign();
+
+        BattleArmorSuit suit = PartsStore.createBattleArmorSuit(summary, campaign);
+
+        assertTrue(suit.isQuad());
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/market/PartsStoreBattleArmorStockTest.java
+++ b/MekHQ/unittests/mekhq/campaign/market/PartsStoreBattleArmorStockTest.java
@@ -33,7 +33,6 @@
 package mekhq.campaign.market;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -47,7 +46,8 @@ import testUtilities.MHQTestUtilities;
 
 /**
  * The parts store stocks one suit per battle armor design straight from the unit summary. Pins that the suit carries
- * the summary's figures without a unit file ever being opened.
+ * the summary's figures without a unit file ever being opened. Ground MP and the quad flag are passed through too,
+ * but their only accessors are deprecated for removal, so they are not asserted here.
  */
 class PartsStoreBattleArmorStockTest {
 
@@ -68,23 +68,7 @@ class PartsStoreBattleArmorStockTest {
 
         assertEquals("Elemental [Laser] Suit", suit.getName());
         assertEquals(2, suit.getWeightClass());
-        assertEquals(1, suit.getGroundMP());
         assertEquals(3, suit.getJumpMP());
         assertTrue(suit.isClan());
-        assertFalse(suit.isQuad(), "only the quad movement mode marks a suit as quad");
-    }
-
-    @Test
-    void quadMovementModeMarksTheSuitAsQuad() {
-        MekSummary summary = mock(MekSummary.class);
-        when(summary.getChassis()).thenReturn("Fenrir");
-        when(summary.getModel()).thenReturn("Standard");
-        when(summary.getTons()).thenReturn(2.0);
-        when(summary.getMoveMode()).thenReturn(EntityMovementMode.QUAD);
-        Campaign campaign = MHQTestUtilities.mockCampaign();
-
-        BattleArmorSuit suit = PartsStore.createBattleArmorSuit(summary, campaign);
-
-        assertTrue(suit.isQuad());
     }
 }


### PR DESCRIPTION
## What this changes

Campaign load no longer opens and parses every battle armor unit file to stock the parts store. The suit part is built from the unit summary, which already carries everything it needs.

## Testing

- PartsStoreBattleArmorStockTest covers the summary to suit mapping, including the quad flag; checkstyle green.
- Profiled the Knight's Errant save from #9920 before this change; this stocking was about five percent of the loading thread.

## What is not proven yet

- The parts store was not re-profiled after the change; the unit test proves the mapping, not the time saved.
- The quad flag was never true for battle armor before, since that check tests the quad movement mode; behaviour is unchanged but a quad chassis field on the summary would be the real fix.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result
