### PR TITLE
Fix: unit tech progression recalculated from every unit file on each campaign load

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/UnitTechProgression.java
+++ b/MekHQ/src/mekhq/campaign/unit/UnitTechProgression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2017-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/campaign/unit/UnitTechProgression.java
+++ b/MekHQ/src/mekhq/campaign/unit/UnitTechProgression.java
@@ -33,14 +33,11 @@
 package mekhq.campaign.unit;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import megamek.common.enums.Faction;
 import megamek.common.interfaces.ITechnology;
@@ -176,10 +173,10 @@ public class UnitTechProgression {
             MekSummary[] allUnits = MekSummaryCache.getInstance().getAllMeks();
             UnitTechProgressionCache.Fingerprint fingerprint = UnitTechProgressionCache.currentFingerprint(allUnits);
             File cacheFile = UnitTechProgressionCache.cacheFile(techFaction);
-            Map<String, MekSummary> unitsByName = Arrays.stream(allUnits)
-                                                        .collect(Collectors.toMap(MekSummary::getName,
-                                                              Function.identity(),
-                                                              (first, duplicate) -> first));
+            Map<String, MekSummary> unitsByName = new HashMap<>(allUnits.length * 2);
+            for (MekSummary unit : allUnits) {
+                unitsByName.putIfAbsent(unit.getName(), unit);
+            }
             Map<MekSummary, ITechnology> cached = UnitTechProgressionCache.load(cacheFile, fingerprint, unitsByName);
             if (cached != null) {
                 return cached;

--- a/MekHQ/src/mekhq/campaign/unit/UnitTechProgression.java
+++ b/MekHQ/src/mekhq/campaign/unit/UnitTechProgression.java
@@ -32,11 +32,15 @@
  */
 package mekhq.campaign.unit;
 
+import java.io.File;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import megamek.common.enums.Faction;
 import megamek.common.interfaces.ITechnology;
@@ -165,14 +169,30 @@ public class UnitTechProgression {
      */
     private record BuildMapTask(Faction techFaction) implements Callable<Map<MekSummary, ITechnology>> {
 
-        // Load all the Entities in the MekSummaryCache and calculate the tech level for
-        // the given faction.
+        // Reuse the map kept on disk from an earlier session when it was built from the same unit data; otherwise
+        // load every entity in the MekSummaryCache, calculate the tech level for the given faction, and keep it.
         @Override
         public Map<MekSummary, ITechnology> call() {
+            MekSummary[] allUnits = MekSummaryCache.getInstance().getAllMeks();
+            UnitTechProgressionCache.Fingerprint fingerprint = UnitTechProgressionCache.currentFingerprint(allUnits);
+            File cacheFile = UnitTechProgressionCache.cacheFile(techFaction);
+            Map<String, MekSummary> unitsByName = Arrays.stream(allUnits)
+                                                        .collect(Collectors.toMap(MekSummary::getName,
+                                                              Function.identity(),
+                                                              (first, duplicate) -> first));
+            Map<MekSummary, ITechnology> cached = UnitTechProgressionCache.load(cacheFile, fingerprint, unitsByName);
+            if (cached != null) {
+                return cached;
+            }
+
+            long startMillis = System.currentTimeMillis();
             Map<MekSummary, ITechnology> map = new HashMap<>();
-            for (MekSummary mekSummary : MekSummaryCache.getInstance().getAllMeks()) {
+            for (MekSummary mekSummary : allUnits) {
                 map.put(mekSummary, calcTechProgression(mekSummary, techFaction));
             }
+            LOGGER.info("[TechProgression] Calculated {} units for {} in {} ms",
+                  map.size(), techFaction, System.currentTimeMillis() - startMillis);
+            UnitTechProgressionCache.save(cacheFile, fingerprint, map);
             return map;
         }
     }

--- a/MekHQ/src/mekhq/campaign/unit/UnitTechProgressionCache.java
+++ b/MekHQ/src/mekhq/campaign/unit/UnitTechProgressionCache.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.unit;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import megamek.common.Configuration;
+import megamek.common.annotations.Nullable;
+import megamek.common.enums.Faction;
+import megamek.common.interfaces.ITechnology;
+import megamek.common.loaders.MekSummary;
+import megamek.common.loaders.MekSummaryCache;
+import megamek.logging.MMLogger;
+import mekhq.MHQConstants;
+
+/**
+ * Keeps a faction's unit tech progression map on disk between sessions.
+ *
+ * <p>Working the map out means loading every unit file in the game, which costs several seconds of CPU on every
+ * campaign load. The result only changes when the unit data or the program version changes, so the map is written to
+ * {@code userdata/cache} together with a fingerprint of what it was computed from, and reused while that fingerprint
+ * still matches.</p>
+ */
+final class UnitTechProgressionCache {
+    private static final MMLogger LOGGER = MMLogger.create(UnitTechProgressionCache.class);
+
+    private static final String CACHE_DIRECTORY = "cache";
+    private static final String FILE_PREFIX = "techProgression-";
+    private static final String FILE_SUFFIX = ".cache";
+
+    private UnitTechProgressionCache() {
+    }
+
+    /**
+     * What a cached map was computed from. Any difference between the stored and the current fingerprint means the
+     * map is stale.
+     *
+     * @param suiteVersion      the MekHQ version that produced the map
+     * @param unitCacheModified last-modified time of MegaMek's unit cache file
+     * @param unitCacheLength   size in bytes of MegaMek's unit cache file
+     * @param unitCount         number of units in the unit cache
+     */
+    record Fingerprint(String suiteVersion, long unitCacheModified, long unitCacheLength, int unitCount)
+          implements Serializable {
+    }
+
+    /**
+     * @param allUnits every unit currently in the unit cache
+     *
+     * @return the fingerprint a map computed right now would carry
+     */
+    static Fingerprint currentFingerprint(MekSummary[] allUnits) {
+        File unitCache = new File(MekSummaryCache.getUnitCacheDir(), MekSummaryCache.FILENAME_UNITS_CACHE);
+        return new Fingerprint(MHQConstants.VERSION.toString(),
+              unitCache.lastModified(),
+              unitCache.length(),
+              allUnits.length);
+    }
+
+    /**
+     * @param techFaction the faction the map was computed for
+     *
+     * @return where that faction's map is kept
+     */
+    static File cacheFile(Faction techFaction) {
+        File cacheDirectory = new File(Configuration.userDataDir(), CACHE_DIRECTORY);
+        return new File(cacheDirectory, FILE_PREFIX + techFaction.name() + FILE_SUFFIX);
+    }
+
+    /**
+     * Reads a cached map back, provided it was computed from the same unit data and version.
+     *
+     * @param cacheFile   the file to read
+     * @param expected    the fingerprint the map must carry to be usable
+     * @param unitsByName the units currently in the unit cache, by their summary name
+     *
+     * @return the cached map, or {@code null} when there is no usable cache and the map must be recalculated
+     */
+    static @Nullable Map<MekSummary, ITechnology> load(File cacheFile, Fingerprint expected,
+          Map<String, MekSummary> unitsByName) {
+        if (!cacheFile.isFile()) {
+            LOGGER.info("[TechProgression] No cache at {}; calculating", cacheFile);
+            return null;
+        }
+
+        // The file stream is its own resource so it is closed even when the object stream refuses the file's header
+        try (FileInputStream fileInput = new FileInputStream(cacheFile);
+              ObjectInputStream input = new ObjectInputStream(new BufferedInputStream(fileInput))) {
+            Object storedFingerprint = input.readObject();
+            if (!expected.equals(storedFingerprint)) {
+                LOGGER.info("[TechProgression] {} was built from other unit data or another version; recalculating",
+                      cacheFile.getName());
+                return null;
+            }
+
+            int entryCount = input.readInt();
+            Map<MekSummary, ITechnology> map = new HashMap<>(entryCount * 2);
+            int unknownUnitCount = 0;
+            for (int index = 0; index < entryCount; index++) {
+                String unitName = input.readUTF();
+                ITechnology progression = (ITechnology) input.readObject();
+                MekSummary summary = unitsByName.get(unitName);
+                if (summary == null) {
+                    unknownUnitCount++;
+                    continue;
+                }
+                map.put(summary, progression);
+            }
+            LOGGER.info("[TechProgression] Loaded {} entries from {}; {} named units are no longer in the unit cache",
+                  map.size(), cacheFile.getName(), unknownUnitCount);
+            return map;
+        } catch (IOException | ClassNotFoundException | ClassCastException exception) {
+            LOGGER.warn(exception, "[TechProgression] Could not read {}; recalculating", cacheFile);
+            return null;
+        }
+    }
+
+    /**
+     * Writes a map out for the next session. Units whose progression could not be calculated are left out, so they
+     * are tried again next time.
+     *
+     * @param cacheFile   the file to write
+     * @param fingerprint what the map was computed from
+     * @param map         the map to keep
+     */
+    static void save(File cacheFile, Fingerprint fingerprint, Map<MekSummary, ITechnology> map) {
+        File directory = cacheFile.getParentFile();
+        boolean directoryMissing = (directory != null) && !directory.isDirectory();
+        if (directoryMissing && !directory.mkdirs()) {
+            LOGGER.warn("[TechProgression] Could not create {}; the map will be recalculated next time", directory);
+            return;
+        }
+
+        Map<String, ITechnology> storable = new HashMap<>();
+        for (Map.Entry<MekSummary, ITechnology> entry : map.entrySet()) {
+            if (entry.getValue() instanceof Serializable) {
+                storable.put(entry.getKey().getName(), entry.getValue());
+            }
+        }
+
+        try (FileOutputStream fileOutput = new FileOutputStream(cacheFile);
+              ObjectOutputStream output = new ObjectOutputStream(new BufferedOutputStream(fileOutput))) {
+            output.writeObject(fingerprint);
+            output.writeInt(storable.size());
+            for (Map.Entry<String, ITechnology> entry : storable.entrySet()) {
+                output.writeUTF(entry.getKey());
+                output.writeObject(entry.getValue());
+            }
+            LOGGER.info("[TechProgression] Wrote {} entries to {}", storable.size(), cacheFile);
+        } catch (IOException exception) {
+            LOGGER.warn(exception, "[TechProgression] Could not write {}", cacheFile);
+        }
+    }
+}

--- a/MekHQ/src/mekhq/campaign/unit/UnitTechProgressionCache.java
+++ b/MekHQ/src/mekhq/campaign/unit/UnitTechProgressionCache.java
@@ -38,6 +38,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.ObjectInputFilter;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
@@ -67,6 +68,16 @@ final class UnitTechProgressionCache {
     private static final String CACHE_DIRECTORY = "cache";
     private static final String FILE_PREFIX = "techProgression-";
     private static final String FILE_SUFFIX = ".cache";
+
+    /**
+     * The only classes a cache file may contain: the fingerprint, MegaMek's tech level types and the JDK collections
+     * and enums they are built from. Everything else is rejected before it is instantiated.
+     */
+    private static final String ALLOWED_CLASSES = "mekhq.campaign.unit.UnitTechProgressionCache$Fingerprint;"
+          + "megamek.common.**;java.util.**;java.lang.**;maxdepth=24;maxarray=100000;!*";
+
+    /** Far more units than the game ships with; a stored count above this is a corrupt or hostile file. */
+    private static final int MAX_ENTRIES = 250_000;
 
     private UnitTechProgressionCache() {
     }
@@ -126,6 +137,9 @@ final class UnitTechProgressionCache {
         // The file stream is its own resource so it is closed even when the object stream refuses the file's header
         try (FileInputStream fileInput = new FileInputStream(cacheFile);
               ObjectInputStream input = new ObjectInputStream(new BufferedInputStream(fileInput))) {
+            // The file sits in the user's own data directory, but it is still untrusted input: only the classes a
+            // progression map is made of may be deserialized, and nothing deeply nested or oversized.
+            input.setObjectInputFilter(ObjectInputFilter.Config.createFilter(ALLOWED_CLASSES));
             Object storedFingerprint = input.readObject();
             if (!expected.equals(storedFingerprint)) {
                 LOGGER.info("[TechProgression] {} was built from other unit data or another version; recalculating",
@@ -134,6 +148,11 @@ final class UnitTechProgressionCache {
             }
 
             int entryCount = input.readInt();
+            if ((entryCount < 0) || (entryCount > MAX_ENTRIES)) {
+                LOGGER.warn("[TechProgression] {} claims {} entries, which is not a plausible count; recalculating",
+                      cacheFile.getName(), entryCount);
+                return null;
+            }
             Map<MekSummary, ITechnology> map = new HashMap<>(entryCount * 2);
             int unknownUnitCount = 0;
             for (int index = 0; index < entryCount; index++) {
@@ -156,8 +175,8 @@ final class UnitTechProgressionCache {
     }
 
     /**
-     * Writes a map out for the next session. Units whose progression could not be calculated are left out, so they
-     * are tried again next time.
+     * Writes a map out for the next session. Units whose progression could not be calculated, or is of a type that
+     * cannot be serialized, are left out, so they are calculated again next time.
      *
      * @param cacheFile   the file to write
      * @param fingerprint what the map was computed from

--- a/MekHQ/unittests/mekhq/campaign/unit/UnitTechProgressionCacheTest.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/UnitTechProgressionCacheTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import megamek.common.CompositeTechLevel;
+import megamek.common.TechAdvancement;
+import megamek.common.enums.Faction;
+import megamek.common.enums.TechBase;
+import megamek.common.interfaces.ITechnology;
+import megamek.common.loaders.MekSummary;
+import mekhq.campaign.unit.UnitTechProgressionCache.Fingerprint;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The on-disk tech progression map is only ever a shortcut: it must come back exactly as written when the unit data
+ * is unchanged, and must be refused, never half-used, when anything it was built from has changed.
+ */
+class UnitTechProgressionCacheTest {
+    private static final Fingerprint FINGERPRINT = new Fingerprint("0.51.01", 1000L, 2000L, 3);
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void mapComesBackWhenTheFingerprintMatches() {
+        MekSummary atlas = summary("Atlas AS7-D");
+        Map<MekSummary, ITechnology> map = new HashMap<>();
+        map.put(atlas, progression(3025));
+        File cacheFile = tempDir.resolve("techProgression-IS.cache").toFile();
+
+        UnitTechProgressionCache.save(cacheFile, FINGERPRINT, map);
+        Map<MekSummary, ITechnology> loaded = UnitTechProgressionCache.load(cacheFile, FINGERPRINT,
+              Map.of("Atlas AS7-D", atlas));
+
+        assertNotNull(loaded);
+        assertEquals(3025, loaded.get(atlas).getIntroductionDate());
+    }
+
+    @Test
+    void mapIsRefusedWhenTheFingerprintDiffers() {
+        MekSummary atlas = summary("Atlas AS7-D");
+        File cacheFile = tempDir.resolve("techProgression-IS.cache").toFile();
+        UnitTechProgressionCache.save(cacheFile, FINGERPRINT, Map.of(atlas, progression(3025)));
+
+        Fingerprint newerUnitData = new Fingerprint("0.51.01", 1000L, 2001L, 3);
+
+        assertNull(UnitTechProgressionCache.load(cacheFile, newerUnitData, Map.of("Atlas AS7-D", atlas)));
+    }
+
+    @Test
+    void unitsNoLongerInTheUnitCacheAreDropped() {
+        MekSummary atlas = summary("Atlas AS7-D");
+        File cacheFile = tempDir.resolve("techProgression-IS.cache").toFile();
+        UnitTechProgressionCache.save(cacheFile, FINGERPRINT, Map.of(atlas, progression(3025)));
+
+        Map<MekSummary, ITechnology> loaded = UnitTechProgressionCache.load(cacheFile, FINGERPRINT, Map.of());
+
+        assertNotNull(loaded);
+        assertTrue(loaded.isEmpty());
+    }
+
+    @Test
+    void unitsThatCouldNotBeCalculatedAreNotWritten() {
+        MekSummary atlas = summary("Atlas AS7-D");
+        MekSummary broken = summary("Broken BRK-1");
+        Map<MekSummary, ITechnology> map = new HashMap<>();
+        map.put(atlas, progression(3025));
+        map.put(broken, null);
+        File cacheFile = tempDir.resolve("techProgression-IS.cache").toFile();
+
+        UnitTechProgressionCache.save(cacheFile, FINGERPRINT, map);
+        Map<MekSummary, ITechnology> loaded = UnitTechProgressionCache.load(cacheFile, FINGERPRINT,
+              Map.of("Atlas AS7-D", atlas, "Broken BRK-1", broken));
+
+        assertNotNull(loaded);
+        assertFalse(loaded.containsKey(broken), "a missing entry is recalculated on demand rather than cached as null");
+    }
+
+    @Test
+    void unreadableFileIsRefused() throws Exception {
+        File cacheFile = tempDir.resolve("techProgression-IS.cache").toFile();
+        Files.writeString(cacheFile.toPath(), "not a cache");
+
+        assertNull(UnitTechProgressionCache.load(cacheFile, FINGERPRINT, Map.of()));
+    }
+
+    @Test
+    void missingFileIsRefused() {
+        File cacheFile = tempDir.resolve("techProgression-IS.cache").toFile();
+
+        assertNull(UnitTechProgressionCache.load(cacheFile, FINGERPRINT, Map.of()));
+    }
+
+    @Test
+    void cacheFileIsNamedForTheFaction() {
+        assertEquals("techProgression-CLAN.cache", UnitTechProgressionCache.cacheFile(Faction.CLAN).getName());
+    }
+
+    private static MekSummary summary(String name) {
+        MekSummary summary = mock(MekSummary.class);
+        when(summary.getName()).thenReturn(name);
+        return summary;
+    }
+
+    private static CompositeTechLevel progression(int introYear) {
+        TechAdvancement advancement = new TechAdvancement(TechBase.IS)
+                                            .setAdvancement(introYear, introYear + 5, introYear + 10);
+        return new CompositeTechLevel(advancement, false, false, introYear, Faction.IS);
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/unit/UnitTechProgressionCacheTest.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/UnitTechProgressionCacheTest.java
@@ -41,6 +41,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.ObjectOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -134,6 +136,31 @@ class UnitTechProgressionCacheTest {
         File cacheFile = tempDir.resolve("techProgression-IS.cache").toFile();
 
         assertNull(UnitTechProgressionCache.load(cacheFile, FINGERPRINT, Map.of()));
+    }
+
+    @Test
+    void implausibleEntryCountIsRefusedBeforeAnythingIsAllocated() throws Exception {
+        File cacheFile = tempDir.resolve("techProgression-IS.cache").toFile();
+        try (ObjectOutputStream output = new ObjectOutputStream(new FileOutputStream(cacheFile))) {
+            output.writeObject(FINGERPRINT);
+            output.writeInt(Integer.MAX_VALUE);
+        }
+
+        assertNull(UnitTechProgressionCache.load(cacheFile, FINGERPRINT, Map.of()));
+    }
+
+    @Test
+    void entryOfAClassAProgressionIsNotMadeOfIsRefused() throws Exception {
+        MekSummary atlas = summary("Atlas AS7-D");
+        File cacheFile = tempDir.resolve("techProgression-IS.cache").toFile();
+        try (ObjectOutputStream output = new ObjectOutputStream(new FileOutputStream(cacheFile))) {
+            output.writeObject(FINGERPRINT);
+            output.writeInt(1);
+            output.writeUTF("Atlas AS7-D");
+            output.writeObject(new File("not a tech level"));
+        }
+
+        assertNull(UnitTechProgressionCache.load(cacheFile, FINGERPRINT, Map.of("Atlas AS7-D", atlas)));
     }
 
     @Test

--- a/MekHQ/unittests/mekhq/campaign/unit/UnitTechProgressionCacheTest.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/UnitTechProgressionCacheTest.java
@@ -141,7 +141,8 @@ class UnitTechProgressionCacheTest {
     @Test
     void implausibleEntryCountIsRefusedBeforeAnythingIsAllocated() throws Exception {
         File cacheFile = tempDir.resolve("techProgression-IS.cache").toFile();
-        try (ObjectOutputStream output = new ObjectOutputStream(new FileOutputStream(cacheFile))) {
+        try (FileOutputStream fileOutput = new FileOutputStream(cacheFile);
+              ObjectOutputStream output = new ObjectOutputStream(fileOutput)) {
             output.writeObject(FINGERPRINT);
             output.writeInt(Integer.MAX_VALUE);
         }
@@ -153,7 +154,8 @@ class UnitTechProgressionCacheTest {
     void entryOfAClassAProgressionIsNotMadeOfIsRefused() throws Exception {
         MekSummary atlas = summary("Atlas AS7-D");
         File cacheFile = tempDir.resolve("techProgression-IS.cache").toFile();
-        try (ObjectOutputStream output = new ObjectOutputStream(new FileOutputStream(cacheFile))) {
+        try (FileOutputStream fileOutput = new FileOutputStream(cacheFile);
+              ObjectOutputStream output = new ObjectOutputStream(fileOutput)) {
             output.writeObject(FINGERPRINT);
             output.writeInt(1);
             output.writeUTF("Atlas AS7-D");


### PR DESCRIPTION
## What this changes

The per-faction unit tech progression map, which loads every unit file in the game and ran on every campaign load, is now kept on disk under userdata/cache and reused until the unit data or the program version changes.

## Testing

- UnitTechProgressionCacheTest covers the round trip, a changed fingerprint, dropped units, unwritten failures, and unreadable files; checkstyle green.
- Loaded the Knight's Errant save from #9920 twice; the second load found the cache and skipped the calculation.

## What is not proven yet

- Not exercised with the faction intro date option on, which asks for a second faction's map.
- Nothing invalidates the cache if unit data changes without the unit cache file changing.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result
