### PR TITLE
Fix #9616: Fixed New Contract Market Rarely Generating Raid Contracts of Type 'Undefined'

### DIFF
--- a/MekHQ/src/mekhq/campaign/digitalGM/stratCon/StratConContractDefinition.java
+++ b/MekHQ/src/mekhq/campaign/digitalGM/stratCon/StratConContractDefinition.java
@@ -87,8 +87,15 @@ public class StratConContractDefinition {
      */
     public static StratConContractDefinition getContractDefinition(final ContractObjectiveType contractObjectiveType) {
         if (!loadedDefinitions.containsKey(contractObjectiveType)) {
-            String filePath = Paths.get(MHQConstants.STRAT_CON_CONTRACT_PATH,
-                  getContractDefinitionManifest().definitionFileNames.get(contractObjectiveType)).toString();
+            String fileName = getContractDefinitionManifest().definitionFileNames.get(contractObjectiveType);
+            if (fileName == null) {
+                // No manifest entry (e.g. the UNDEFINED sentinel). Guard against a null path segment, which would
+                // otherwise crash Paths.get. Callers treat a null definition as "skip StratCon seeding".
+                LOGGER.error("No contract definition is mapped for objective type {}", contractObjectiveType);
+                return null;
+            }
+
+            String filePath = Paths.get(MHQConstants.STRAT_CON_CONTRACT_PATH, fileName).toString();
             StratConContractDefinition def = Deserialize(new File(filePath));
 
             if (def == null) {

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractData/ContractObjectiveType.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractData/ContractObjectiveType.java
@@ -295,6 +295,16 @@ public enum ContractObjectiveType {
         return this == OBSERVATION_RAID;
     }
 
+    /**
+     * @return {@code true} if this is the {@link #UNDEFINED} sentinel value. UNDEFINED is a placeholder (used, for
+     *       example, as the opposing objective of a blank GM-created contract or when converting legacy saves) and is
+     *       never a real, playable objective. It must not be produced by contract generation, as it has no StratCon
+     *       contract definition and would crash on contract acceptance.
+     */
+    public boolean isUndefined() {
+        return this == UNDEFINED;
+    }
+
     public boolean isGarrisonType() {
         return isGarrisonDuty() || isCadreDuty() || isSecurityDuty() || isRiotDuty() || isRetainer();
     }

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosObjectiveType.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/ChaosObjectiveType.java
@@ -159,6 +159,11 @@ public enum ChaosObjectiveType {
     public ContractObjectiveType getCamOpsObjectiveType() {
         List<ContractObjectiveType> candidates = new ArrayList<>();
         for (ContractObjectiveType type : ContractObjectiveType.values()) {
+            // UNDEFINED is a sentinel/placeholder tagged with RAID; it is not a real objective and has no StratCon
+            // contract definition, so it must never be produced by generation (it would crash on contract acceptance).
+            if (type.isUndefined()) {
+                continue;
+            }
             if (type.getChaosObjectiveType() == this) {
                 candidates.add(type);
             }

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationObjectiveTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/contractGeneration/ChaosContractDeterminationObjectiveTest.java
@@ -33,6 +33,7 @@
 package mekhq.campaign.mission.contract.contractGeneration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mockStatic;
 
 import megamek.common.compute.Compute;
@@ -107,5 +108,19 @@ class ChaosContractDeterminationObjectiveTest {
 
         assertEquals(ChaosObjectiveType.EXPEDITION, data.playerObjectiveType().getChaosObjectiveType());
         assertEquals(ChaosObjectiveType.RAID, data.opposingObjectiveType().getChaosObjectiveType());
+    }
+
+    /**
+     * Regression test for issue #9921: UNDEFINED is tagged with the RAID chaos category but is a sentinel with no
+     * StratCon contract definition. Generation must never emit it - doing so crashed contract acceptance. The RAID
+     * category has the most concrete variants and is the only one UNDEFINED maps to, so drawing it many times exercises
+     * the exclusion.
+     */
+    @Test
+    void generationNeverProducesTheUndefinedSentinel() {
+        for (int i = 0; i < 1000; i++) {
+            assertFalse(ChaosObjectiveType.RAID.getCamOpsObjectiveType().isUndefined(),
+                  "RAID.getCamOpsObjectiveType() must never return the UNDEFINED sentinel");
+        }
     }
 }


### PR DESCRIPTION
Fix #9616

## What this changes

This fixes a small oversight which made 'Undefined' a sub-type of 'Raid', resulting in some raids generating as Undefined contract types.

## Testing

- Manual testing for around 100 contracts
- AI regression test

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result