### PR TITLE
Fix #9593: Allowed Empty Systems to Be Selected as Birthplace if They Had Population at Date of Birth

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -2213,6 +2213,13 @@ lblOpForLanceTypeVehicle.tooltip=What ratio of enemy forces should be vehicle fo
 lblUseDropShips.text=Use Player DropShips
 lblUseDropShips.tooltip=Some scenarios may require the player to deploy with a combat drop. If the\
   \ player doesn't have a DropShip, the employer will provide one.
+lblRestrictScenariosToFleetCapability.text=Restrict Scenarios to Fleet Capability
+lblRestrictScenariosToFleetCapability.tooltip=If enabled, StratCon only generates scenarios your combat teams can \
+  actually fight. A campaign whose combat teams are all airborne is never handed ground battles: an all-conventional-\
+  fighter outfit sees only low-atmosphere scenarios, while an outfit with space-capable units (aerospace fighters, \
+  small craft, DropShips, and so on) sees space and low-atmosphere scenarios. As soon as the campaign fields any \
+  ground unit ('Mechs, vehicles, infantry, and the like) the restriction lifts and the full range of scenarios \
+  returns. This is intended for dedicated aerospace companies.
 lblRegionalMekVariations.text=Faction Influences Mek Weights
 lblRegionalMekVariations.tooltip=Use alternate weight class distributions for some factions.
 lblAttachedPlayerCamouflage.text=Attached Units use Campaign Camouflage

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -771,6 +771,19 @@ public class CampaignNewDayManager {
     private void updateFacilities() {
         updateFieldKitchenCapacity();
         updateMASHTheatreCapacity();
+        updateFleetAltitudeCapability();
+    }
+
+    /**
+     * Refreshes the player force's cached {@link mekhq.campaign.force.FleetAltitudeCapability}.
+     *
+     * <p>This is a daily, roster-derived snapshot (mirroring {@link #updateMASHTheatreCapacity()}) so StratCon
+     * scenario generation can read the fleet's fightable altitudes in O(1) instead of rescanning every unit for each
+     * scenario it generates. It runs before scenario generation in the new-day sequence.</p>
+     */
+    private void updateFleetAltitudeCapability() {
+        campaign.getPlayerForce()
+              .setFleetAltitudeCapability(campaign.getPlayerForce().calculateFleetAltitudeCapability(campaign));
     }
 
     private void processAllArrivals() {

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOption.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOption.java
@@ -936,6 +936,8 @@ public final class CampaignOption<T> {
           of(Boolean.class, false, "useAdvancedScouting");
     public static final CampaignOption<Boolean> ESSENTIAL_SCENARIOS_ONLY =
           of(Boolean.class, false, "essentialScenariosOnly");
+    public static final CampaignOption<Boolean> RESTRICT_SCENARIOS_TO_FLEET_CAPABILITY =
+          of(Boolean.class, false, "restrictScenariosToFleetCapability");
     public static final CampaignOption<StratConSectorCountMethod> STRAT_CON_SECTOR_COUNT_METHOD =
           of(StratConSectorCountMethod.class,
                 StratConSectorCountMethod.ALTERNATE_REGIMENTAL,

--- a/MekHQ/src/mekhq/campaign/digitalGM/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/digitalGM/stratCon/StratConRulesManager.java
@@ -40,6 +40,7 @@ import static megamek.common.board.Coords.ALL_DIRECTIONS;
 import static megamek.common.compute.Compute.d6;
 import static megamek.common.compute.Compute.randomInt;
 import static megamek.common.enums.SkillLevel.REGULAR;
+import static megamek.common.units.UnitType.AEROSPACE_FIGHTER;
 import static megamek.common.units.UnitType.CONV_FIGHTER;
 import static megamek.common.units.UnitType.DROPSHIP;
 import static megamek.common.units.UnitType.JUMPSHIP;
@@ -2528,6 +2529,70 @@ public class StratConRulesManager {
     }
 
     /**
+     * Determines the set of {@link MapLocation map locations} that StratCon is allowed to generate scenarios in, given
+     * the composition of the campaign's fleet.
+     *
+     * <p>This implements the {@link CampaignOption#RESTRICT_SCENARIOS_TO_FLEET_CAPABILITY} option: an aerospace
+     * outfit should not be handed ground battles it has no units to fight. The rules are:</p>
+     *
+     * <ul>
+     *   <li>If the option is disabled, the campaign has no units, or it fields any ground-capable unit (a 'Mech,
+     *       vehicle, infantry, and so on), no restriction is applied and {@code null} is returned - the full range of
+     *       ground, low-atmosphere, and space scenarios remains available.</li>
+     *   <li>If every unit is airborne and at least one is space-capable (an aerospace fighter, small craft, DropShip,
+     *       and so on), scenarios are restricted to space and low atmosphere.</li>
+     *   <li>If every unit is airborne but none is space-capable (only conventional fighters), scenarios are restricted
+     *       to low atmosphere.</li>
+     * </ul>
+     *
+     * <p>This reads the player force's {@link mekhq.campaign.force.FleetAltitudeCapability}, a cached summary
+     * refreshed once per day in {@code CampaignNewDayManager} (before scenario generation), so this method is O(1) and
+     * safe to call for every scenario generated in a batch rather than rescanning the roster each time.</p>
+     *
+     * @param campaign the current {@link Campaign}
+     *
+     * @return a fresh {@link Set} of the allowed {@link MapLocation}s, or {@code null} if scenario generation should
+     *       not be restricted
+     */
+    public static @Nullable Set<MapLocation> getFleetRestrictedMapLocations(Campaign campaign) {
+        if (!campaign.getCampaignOptions().get(CampaignOption.RESTRICT_SCENARIOS_TO_FLEET_CAPABILITY)) {
+            return null;
+        }
+
+        return switch (campaign.getPlayerForce().getFleetAltitudeCapability()) {
+            case UNRESTRICTED -> null;
+            case ATMOSPHERE_ONLY -> EnumSet.of(LowAtmosphere);
+            case SPACE_AND_ATMOSPHERE -> EnumSet.of(Space, LowAtmosphere);
+        };
+    }
+
+    /**
+     * Selects a random, non-ambush scenario template for the given unit type, honoring the campaign's
+     * {@link CampaignOption#RESTRICT_SCENARIOS_TO_FLEET_CAPABILITY fleet-capability restriction}.
+     *
+     * <p>When the campaign is restricted to aerospace altitudes but the resolved {@code unitType} would only pull
+     * ground templates - most commonly because no deploying force was supplied, so it defaulted to
+     * {@link megamek.common.units.UnitType#MEK} - a representative aerospace unit type is substituted so a suitable
+     * scenario is still found instead of coming up empty.</p>
+     *
+     * @param campaign the current {@link Campaign}
+     * @param unitType the primary unit type of the deploying force, or {@code MEK} if none is available
+     *
+     * @return a suitable {@link ScenarioTemplate}, or {@code null} if none could be selected
+     */
+    private static @Nullable ScenarioTemplate getFleetAppropriateRandomScenario(Campaign campaign, int unitType) {
+        Set<MapLocation> allowedLocations = getFleetRestrictedMapLocations(campaign);
+
+        if ((allowedLocations != null) &&
+                  (convertSpecificUnitTypeToGeneral(unitType) !=
+                         ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_AERO_MIX)) {
+            unitType = allowedLocations.contains(Space) ? AEROSPACE_FIGHTER : CONV_FIGHTER;
+        }
+
+        return StratConScenarioFactory.getRandomScenario(unitType, false, false, allowedLocations);
+    }
+
+    /**
      * Generates a StratCon scenario at the specified coordinates for the given force on the specified track. The
      * scenario is determined based on a random template suitable for the unit type of the specified force, and it is
      * optionally configured with a deployment delay.
@@ -2562,7 +2627,7 @@ public class StratConRulesManager {
         // produces an ambush. Ambushes (a scenario spawning on top of an already-deployed force) are handled up
         // front by generateScenarioForExistingForces in deployForceToCoords and generateDailyScenariosForTrack,
         // which pass an explicit ambush template instead of the random one selected here.
-        ScenarioTemplate template = StratConScenarioFactory.getRandomScenario(unitType, false, false);
+        ScenarioTemplate template = getFleetAppropriateRandomScenario(campaign, unitType);
         // useful for debugging specific scenario types
         // template = StratConScenarioFactory.getSpecificScenario("Defend Grounded
         // Dropship.xml");
@@ -2619,7 +2684,7 @@ public class StratConRulesManager {
                 // This just means the player has no units
             }
 
-            template = StratConScenarioFactory.getRandomScenario(unitType, false, false);
+            template = getFleetAppropriateRandomScenario(campaign, unitType);
         }
 
         if (template == null) {

--- a/MekHQ/src/mekhq/campaign/digitalGM/stratCon/StratConScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/digitalGM/stratCon/StratConScenarioFactory.java
@@ -174,6 +174,30 @@ public class StratConScenarioFactory {
      */
     public static @Nullable ScenarioTemplate getRandomScenario(int unitType, boolean isAmbushed,
           boolean isBungledPatrol) {
+        return getRandomScenario(unitType, isAmbushed, isBungledPatrol, null);
+    }
+
+    /**
+     * Retrieves a random scenario template based on the given unit type and additional parameters, optionally
+     * constrained to a set of allowed {@link MapLocation map locations}.
+     *
+     * <p>This overload behaves exactly like {@link #getRandomScenario(int, boolean, boolean)}, but if
+     * {@code allowedLocations} is non-{@code null} the candidate templates are further filtered so that only those
+     * whose map location is contained in the set survive. This is used to keep StratCon from generating, for example,
+     * ground scenarios for a campaign whose combat teams cannot fight on the ground (see
+     * {@link StratConRulesManager#getFleetRestrictedMapLocations}).</p>
+     *
+     * @param unitType         The specific unit type that the scenario should be associated with.
+     * @param isAmbushed       A boolean flag indicating whether the unit is ambushed.
+     * @param isBungledPatrol  A boolean flag indicating whether the scenario involves a bungled patrol.
+     * @param allowedLocations The set of {@link MapLocation}s the scenario is allowed to take place in, or {@code null}
+     *                         to impose no location restriction.
+     *
+     * @return A randomly selected {@code ScenarioTemplate} that fits the specified criteria, or {@code null} if no
+     *       suitable scenarios are configured.
+     */
+    public static @Nullable ScenarioTemplate getRandomScenario(int unitType, boolean isAmbushed,
+          boolean isBungledPatrol, @Nullable Set<MapLocation> allowedLocations) {
         int generalUnitType = convertSpecificUnitTypeToGeneral(unitType);
 
         // if the specific unit type doesn't have any scenario templates for it
@@ -196,6 +220,11 @@ public class StratConScenarioFactory {
 
         // We don't want facilities spawning mid-contract; this stops facility count getting out of control
         jointList.removeIf(ScenarioTemplate::isFacilityScenario);
+
+        // Restrict to fleet-appropriate altitudes (ground / low atmosphere / space) when requested.
+        if (allowedLocations != null) {
+            jointList.removeIf(template -> !allowedLocations.contains(template.mapParameters.getMapLocation()));
+        }
 
         if (jointList.isEmpty()) {
             logger.warn("No scenarios configured for unit type {}, ({}) and ambushed status {}", unitType,

--- a/MekHQ/src/mekhq/campaign/force/AbstractForce.java
+++ b/MekHQ/src/mekhq/campaign/force/AbstractForce.java
@@ -147,6 +147,7 @@ public abstract class AbstractForce {
     // Capacity / facility state
     private int temporaryPrisonerCapacity = DEFAULT_TEMPORARY_CAPACITY;
     private int mashTheatreCapacity = 0;
+    private FleetAltitudeCapability fleetAltitudeCapability = FleetAltitudeCapability.UNRESTRICTED;
     private boolean fieldKitchenWithinCapacity = false;
     private int repairBaysRented = 0;
     private List<UUID> automatedMothballUnits = new ArrayList<>();
@@ -614,6 +615,75 @@ public abstract class AbstractForce {
         int rentedCapacity = FacilityRentals.getCapacityIncreaseFromRentals(campaign.getActiveContracts(),
               ContractRentalType.HOSPITAL_BEDS);
         return baseCapacity + rentedCapacity;
+    }
+
+    /**
+     * The force's cached {@link FleetAltitudeCapability}, describing the range of altitudes its units can fight at.
+     * This is refreshed once per day (see {@link #calculateFleetAltitudeCapability(Campaign)}) so consumers can read it
+     * in O(1) rather than rescanning the roster.
+     */
+    public FleetAltitudeCapability getFleetAltitudeCapability() {
+        return fleetAltitudeCapability;
+    }
+
+    public void setFleetAltitudeCapability(FleetAltitudeCapability fleetAltitudeCapability) {
+        this.fleetAltitudeCapability = fleetAltitudeCapability;
+    }
+
+    /**
+     * Determines the {@link FleetAltitudeCapability} of this force from the composition of its combat teams.
+     *
+     * <p>Only units organised into combat teams are considered, since those are the units that actually deploy to
+     * StratCon scenarios; unassigned or reserve units in the roster are ignored. A single ground-capable unit ('Mech,
+     * vehicle, infantry, and so on) among the combat teams - or having no combat-team units at all - yields
+     * {@link FleetAltitudeCapability#UNRESTRICTED}. An all-airborne set of combat teams yields
+     * {@link FleetAltitudeCapability#SPACE_AND_ATMOSPHERE} if any unit is space-capable (aerospace fighter, small
+     * craft, DropShip, and so on) and {@link FleetAltitudeCapability#ATMOSPHERE_ONLY} otherwise (conventional fighters
+     * only).</p>
+     *
+     * @param campaign the current {@link Campaign}
+     *
+     * @return the force's fleet altitude capability
+     */
+    public FleetAltitudeCapability calculateFleetAltitudeCapability(Campaign campaign) {
+        boolean hasSpaceCapable = false;
+        boolean hasAnyUnit = false;
+
+        for (CombatTeam combatTeam : getCombatTeamsAsList(campaign)) {
+            Formation formation = combatTeam.getFormation(campaign);
+            if (formation == null) {
+                continue;
+            }
+
+            for (UUID unitId : formation.getAllUnits(false)) {
+                Unit unit = campaign.getUnit(unitId);
+                if (unit == null) {
+                    continue;
+                }
+
+                Entity entity = unit.getEntity();
+                if (entity == null) {
+                    continue;
+                }
+
+                hasAnyUnit = true;
+
+                if (entity.isAerospace()) {
+                    hasSpaceCapable = true;
+                } else if (!entity.isConventionalFighter()) {
+                    // A single ground unit lifts every restriction, so there is nothing more to learn.
+                    return FleetAltitudeCapability.UNRESTRICTED;
+                }
+            }
+        }
+
+        if (!hasAnyUnit) {
+            return FleetAltitudeCapability.UNRESTRICTED;
+        }
+
+        return hasSpaceCapable ?
+                     FleetAltitudeCapability.SPACE_AND_ATMOSPHERE :
+                     FleetAltitudeCapability.ATMOSPHERE_ONLY;
     }
 
     public boolean getFieldKitchenWithinCapacity() {

--- a/MekHQ/src/mekhq/campaign/force/FleetAltitudeCapability.java
+++ b/MekHQ/src/mekhq/campaign/force/FleetAltitudeCapability.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.force;
+
+/**
+ * Describes the range of altitudes a force is able to fight at, derived from the composition of its units.
+ *
+ * <p>This is a cheap, cached summary computed once per day (see
+ * {@link AbstractForce#calculateFleetAltitudeCapability(mekhq.campaign.Campaign)}) so that consumers - most notably
+ * StratCon scenario generation - can restrict the scenarios they hand a dedicated aerospace outfit without rescanning
+ * the whole roster on every call.</p>
+ *
+ * @author Illiani
+ */
+public enum FleetAltitudeCapability {
+    /**
+     * The force fields at least one ground-capable unit ('Mech, vehicle, infantry, and so on), or has no units to
+     * reason about. No altitude restriction applies.
+     */
+    UNRESTRICTED,
+
+    /**
+     * Every unit is airborne and at least one is space-capable (an aerospace fighter, small craft, DropShip, and so
+     * on). Only space and low-atmosphere scenarios are appropriate.
+     */
+    SPACE_AND_ATMOSPHERE,
+
+    /**
+     * Every unit is airborne but none is space-capable - the force is made up solely of conventional fighters. Only
+     * low-atmosphere scenarios are appropriate.
+     */
+    ATMOSPHERE_ONLY
+}

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/RulesetsOptionsModel.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/RulesetsOptionsModel.java
@@ -50,6 +50,7 @@ class RulesetsOptionsModel {
     boolean autoGenerateOpForCallSigns;
     SkillLevel minimumCallsignSkillLevel;
     boolean useDropShips;
+    boolean restrictScenariosToFleetCapability;
     boolean regionalMekVariations;
     boolean attachedPlayerCamouflage;
     boolean playerControlsAttachedUnits;
@@ -97,6 +98,7 @@ class RulesetsOptionsModel {
         autoGenerateOpForCallSigns = options.get(CampaignOption.AUTO_GENERATE_OP_FOR_CALL_SIGNS);
         minimumCallsignSkillLevel = options.get(CampaignOption.MINIMUM_CALLSIGN_SKILL_LEVEL);
         useDropShips = options.get(CampaignOption.USE_DROP_SHIPS);
+        restrictScenariosToFleetCapability = options.get(CampaignOption.RESTRICT_SCENARIOS_TO_FLEET_CAPABILITY);
         regionalMekVariations = options.get(CampaignOption.REGIONAL_MEK_VARIATIONS);
         attachedPlayerCamouflage = options.get(CampaignOption.ATTACHED_PLAYER_CAMOUFLAGE);
         playerControlsAttachedUnits = options.get(CampaignOption.PLAYER_CONTROLS_ATTACHED_UNITS);
@@ -145,6 +147,7 @@ class RulesetsOptionsModel {
         options.set(CampaignOption.AUTO_GENERATE_OP_FOR_CALL_SIGNS, autoGenerateOpForCallSigns);
         options.set(CampaignOption.MINIMUM_CALLSIGN_SKILL_LEVEL, minimumCallsignSkillLevel);
         options.set(CampaignOption.USE_DROP_SHIPS, useDropShips);
+        options.set(CampaignOption.RESTRICT_SCENARIOS_TO_FLEET_CAPABILITY, restrictScenariosToFleetCapability);
         options.set(CampaignOption.REGIONAL_MEK_VARIATIONS, regionalMekVariations);
         options.set(CampaignOption.ATTACHED_PLAYER_CAMOUFLAGE, attachedPlayerCamouflage);
         options.set(CampaignOption.PLAYER_CONTROLS_ATTACHED_UNITS, playerControlsAttachedUnits);

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/StratConPage.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/StratConPage.java
@@ -114,6 +114,8 @@ class StratConPage {
 
     private JCheckBox chkUseDropShips;
 
+    private JCheckBox chkRestrictScenariosToFleetCapability;
+
     private JCheckBox chkRegionalMekVariations;
 
     private JCheckBox chkAttachedPlayerCamouflage;
@@ -408,6 +410,10 @@ class StratConPage {
         spnOpForLanceTypeVehicles = new CampaignOptionsSpinner("OpForLanceTypeVehicle", 0, 0, 10, 1);
 
         chkUseDropShips = new CampaignOptionsCheckBox("UseDropShips");
+        chkRestrictScenariosToFleetCapability = new CampaignOptionsCheckBox("RestrictScenariosToFleetCapability",
+              getMetadata(new Version(0, 51, 1)));
+        chkRestrictScenariosToFleetCapability.addMouseListener(
+              createTipPanelUpdater("RestrictScenariosToFleetCapability"));
         chkRegionalMekVariations = new CampaignOptionsCheckBox("RegionalMekVariations");
         chkAttachedPlayerCamouflage = new CampaignOptionsCheckBox("AttachedPlayerCamouflage");
         chkPlayerControlsAttachedUnits = new CampaignOptionsCheckBox("PlayerControlsAttachedUnits");
@@ -533,6 +539,7 @@ class StratConPage {
         panel.addRow(lblOpForLanceTypeVehicle, spnOpForLanceTypeVehicles);
         panel.addCheckBoxGrid(CHECKBOX_GRID_COLUMNS,
               chkUseDropShips,
+              chkRestrictScenariosToFleetCapability,
               chkRegionalMekVariations,
               chkAttachedPlayerCamouflage,
               chkPlayerControlsAttachedUnits,
@@ -629,6 +636,7 @@ class StratConPage {
         chkAutoGenerateOpForCallSigns.setSelected(model.autoGenerateOpForCallSigns);
         comboMinimumCallsignSkillLevel.setSelectedItem(model.minimumCallsignSkillLevel);
         chkUseDropShips.setSelected(model.useDropShips);
+        chkRestrictScenariosToFleetCapability.setSelected(model.restrictScenariosToFleetCapability);
         chkRegionalMekVariations.setSelected(model.regionalMekVariations);
         chkAttachedPlayerCamouflage.setSelected(model.attachedPlayerCamouflage);
         chkPlayerControlsAttachedUnits.setSelected(model.playerControlsAttachedUnits);
@@ -687,6 +695,7 @@ class StratConPage {
         model.autoGenerateOpForCallSigns = chkAutoGenerateOpForCallSigns.isSelected();
         model.minimumCallsignSkillLevel = comboMinimumCallsignSkillLevel.getSelectedItem();
         model.useDropShips = chkUseDropShips.isSelected();
+        model.restrictScenariosToFleetCapability = chkRestrictScenariosToFleetCapability.isSelected();
         model.regionalMekVariations = chkRegionalMekVariations.isSelected();
         model.attachedPlayerCamouflage = chkAttachedPlayerCamouflage.isSelected();
         model.playerControlsAttachedUnits = chkPlayerControlsAttachedUnits.isSelected();

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -1538,7 +1538,11 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
         List<PlanetarySystem> orderedSystems = campaign.getSystems()
                                                      .stream()
                                                      .filter(a -> !a.isConnector())
-                                                     .filter(a -> isInhabitedAt(cachedOwnersAt(a)))
+                                                     // A world counts as a valid birth world if it either has a real
+                                                     // owner faction at the birthdate OR still had a recorded
+                                                     // population then.
+                                                     .filter(a -> isInhabitedAt(cachedOwnersAt(a)) ||
+                                                                        hadPopulationAt(a))
                                                      .sorted(Comparator.comparing(a -> a.getName(birthDate)))
                                                      .toList();
         for (PlanetarySystem system : orderedSystems) {
@@ -1865,6 +1869,17 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
             return only != null && !"ABN".equals(only.getShortName());
         }
         return true;
+    }
+
+    /**
+     * @return {@code true} if {@code system} had a recorded population greater than zero on the dialog's current
+     *       {@code birthdate}. Used as a fallback to {@link #isInhabitedAt(Set)} so an abandoned world (owner set is
+     *       {@code ABN}-only, which {@code isInhabitedAt} rejects) is still offered as a birthworld when people were
+     *       actually living there. Returns {@code false} when {@code birthdate} is unset, since population is
+     *       date-scoped.
+     */
+    private boolean hadPopulationAt(PlanetarySystem system) {
+        return birthdate != null && system.getPopulation(birthdate) > 0;
     }
 
     private void filterPlanetarySystemsForOurFaction(boolean onlyOurFaction) {


### PR DESCRIPTION
Fix #9593

## What this changes

As per title

## Testing

- Manual testing

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result