### PR TITLE
Fix #9591: Personnel Generated for Planets Now Based on Current & Historical Ownership

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketCamOpsRevised.java
+++ b/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketCamOpsRevised.java
@@ -39,8 +39,8 @@ import static mekhq.campaign.universe.Faction.PIRATE_FACTION_CODE;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
+import mekhq.campaign.campaignOptions.CampaignOption;
 import mekhq.campaign.market.personnelMarket.records.PersonnelMarketEntry;
 import mekhq.campaign.market.personnelMarket.yaml.PersonnelMarketLibraries;
 import mekhq.campaign.personnel.Person;
@@ -50,7 +50,6 @@ import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.factionHints.FactionHints;
 import mekhq.campaign.universe.factionStanding.FactionStandingUtilities;
 import mekhq.campaign.universe.factionStanding.FactionStandings;
-import mekhq.campaign.campaignOptions.CampaignOption;
 
 /**
  * Implements the personnel market logic using the Campaign Operations Revised ruleset.
@@ -110,7 +109,9 @@ public class PersonnelMarketCamOpsRevised extends NewPersonnelMarket {
      */
     @Override
     public ArrayList<Faction> getApplicantOriginFactions() {
-        Set<Faction> systemFactions = getCurrentSystem().getFactionSet(getToday());
+        // Faction -> tenure weight (years the faction held a world here within living memory). Weighting recruits by
+        // tenure makes long-standing rulers the dominant birth origin while recent or departed rulers still appear.
+        Map<Faction, Integer> systemFactions = getCurrentSystem().getPopulationFactions(getToday());
         ArrayList<Faction> interestedFactions = new ArrayList<>();
 
         if (getCampaign().getPlayerForce().isClanForce()) {
@@ -123,7 +124,10 @@ public class PersonnelMarketCamOpsRevised extends NewPersonnelMarket {
         Faction pirateFaction = factions.getFaction(PIRATE_FACTION_CODE);
         FactionStandings factionStandings = getCampaign().getPlayerForce().getFactionStandings();
 
-        for (Faction faction : systemFactions) {
+        for (Map.Entry<Faction, Integer> systemFaction : systemFactions.entrySet()) {
+            Faction faction = systemFaction.getKey();
+            int tenureWeight = systemFaction.getValue();
+
             if (FactionHints.getInstance().isAtWarWith(getCampaignFaction(), faction, getToday())) {
                 continue;
             }
@@ -140,7 +144,8 @@ public class PersonnelMarketCamOpsRevised extends NewPersonnelMarket {
                 factionStandingMultiplier *= 3;
             }
 
-            for (int i = 0; i < factionStandingMultiplier; i++) {
+            // Weight the applicant pool by how long the faction held a world here, on top of the standing multiplier.
+            for (int i = 0; i < factionStandingMultiplier * tenureWeight; i++) {
                 interestedFactions.add(faction);
             }
         }

--- a/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketMekHQ.java
+++ b/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketMekHQ.java
@@ -48,7 +48,6 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import megamek.common.compute.Compute;
 import megamek.common.enums.Gender;
@@ -154,7 +153,9 @@ public class PersonnelMarketMekHQ extends NewPersonnelMarket {
      */
     @Override
     public ArrayList<Faction> getApplicantOriginFactions() {
-        Set<Faction> systemFactions = getCurrentSystem().getFactionSet(getToday());
+        // Faction -> tenure weight (years the faction held a world here within living memory). Weighting recruits by
+        // tenure makes long-standing rulers the dominant birth origin while recent or departed rulers still appear.
+        Map<Faction, Integer> systemFactions = getCurrentSystem().getPopulationFactions(getToday());
         ArrayList<Faction> interestedFactions = new ArrayList<>();
 
         boolean filterOutLegalFactions = false;
@@ -180,7 +181,10 @@ public class PersonnelMarketMekHQ extends NewPersonnelMarket {
         Faction pirateFaction = factions.getFaction(PIRATE_FACTION_CODE);
         FactionStandings factionStandings = getCampaign().getPlayerForce().getFactionStandings();
 
-        for (Faction faction : systemFactions) {
+        for (Map.Entry<Faction, Integer> systemFaction : systemFactions.entrySet()) {
+            Faction faction = systemFaction.getKey();
+            int tenureWeight = systemFaction.getValue();
+
             if (filterOutLegalFactions) {
                 if (!faction.isPirate() && !faction.isMercenary()) {
                     continue;
@@ -203,7 +207,8 @@ public class PersonnelMarketMekHQ extends NewPersonnelMarket {
                 factionStandingMultiplier *= 3;
             }
 
-            for (int i = 0; i < factionStandingMultiplier; i++) {
+            // Weight the applicant pool by how long the faction held a world here, on top of the standing multiplier.
+            for (int i = 0; i < factionStandingMultiplier * tenureWeight; i++) {
                 interestedFactions.add(faction);
             }
         }

--- a/MekHQ/src/mekhq/campaign/universe/Faction.java
+++ b/MekHQ/src/mekhq/campaign/universe/Faction.java
@@ -73,6 +73,8 @@ public class Faction {
     public static final String INDEPENDENT_FACTION_CODE = "IND";
     public static final String CLAN_FACTION_CODE = "CLAN";
     public static final String REPUBLIC_OF_THE_SPHERE_FACTION_CODE = "ROS";
+    public static final String DISPUTED_FACTION_CODE = "DIS";
+    public static final String ABANDONED_FACTION_CODE = "ABN";
 
     private Faction2 faction2;
 

--- a/MekHQ/src/mekhq/campaign/universe/PlanetarySystem.java
+++ b/MekHQ/src/mekhq/campaign/universe/PlanetarySystem.java
@@ -381,10 +381,8 @@ public class PlanetarySystem {
             weights.put(entry.getKey(), weight);
         }
 
-        // ignore cases where abandoned (ABN) is given in addition to real factions
-        if (weights.size() > 1) {
-            weights.remove(Factions.getInstance().getFaction(ABANDONED_FACTION_CODE));
-        }
+        // Abandoned (ABN) is a pseudo-faction; it must never be treated as a valid birth origin.
+        weights.remove(Factions.getInstance().getFaction(ABANDONED_FACTION_CODE));
         return weights;
     }
 

--- a/MekHQ/src/mekhq/campaign/universe/PlanetarySystem.java
+++ b/MekHQ/src/mekhq/campaign/universe/PlanetarySystem.java
@@ -33,8 +33,12 @@
  */
 package mekhq.campaign.universe;
 
+import static mekhq.campaign.universe.Faction.ABANDONED_FACTION_CODE;
+import static mekhq.campaign.universe.Faction.DISPUTED_FACTION_CODE;
+
 import java.io.IOException;
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -59,12 +63,12 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.util.StdConverter;
 import megamek.codeUtilities.ObjectUtility;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.campaignOptions.CampaignOption;
 import mekhq.campaign.personnel.education.Academy;
 import mekhq.campaign.personnel.education.AcademyFactory;
 import mekhq.campaign.universe.enums.CapitalType;
 import mekhq.campaign.universe.enums.HPGRating;
 import mekhq.campaign.universe.enums.HiringHallLevel;
-import mekhq.campaign.campaignOptions.CampaignOption;
 
 /**
  * This is a PlanetarySystem object that will contain information about the system as well as an ArrayList of the Planet
@@ -330,12 +334,194 @@ public class PlanetarySystem {
         return factions;
     }
 
+    /**
+     * The look-back window, in years, over which prior rulers still count toward a world's living population. A native
+     * up to this old could have been born under a faction that has since lost the world, so those factions remain a
+     * plausible birth origin.
+     */
+    private static final int POPULATION_WINDOW_YEARS = 40;
+
+    /** Average days per year (accounting for leap years), for converting a tenure span into whole-year weights. */
+    private static final double DAYS_PER_YEAR = 365.25;
+
+    /**
+     * Returns the factions a person native to this system could plausibly have been born under, each weighted by how
+     * long it ruled within the last {@link #POPULATION_WINDOW_YEARS} years.
+     *
+     * <p>For every planet, this measures how much of the window each real faction held the world and credits it that
+     * many years of tenure. A faction that has held the world for the whole window weighs
+     * {@link #POPULATION_WINDOW_YEARS}; one that ruled only briefly weighs proportionally less (minimum 1). Tenure is
+     * summed across the system's planets, so a faction credited on several worlds accumulates their spans.</p>
+     *
+     * <p>Contested stretches are handled specially. {@link #getFactionSet(LocalDate)} reports a disputed world's owner
+     * as the aggregate {@code DIS} ("Disputed") pseudo-faction, which is not a real polity a person can belong to. The
+     * duration of each dispute is instead split evenly between the two sides fighting over it: the owner recorded
+     * immediately before the dispute and the one who eventually resolves it (which may lie in the future for a dispute
+     * still raging at {@code when}). This keeps both combatants in the pool, weighted by how long the world has been
+     * fought over.</p>
+     *
+     * <p>The {@code DIS} marker is never returned, and {@code ABN} (Abandoned) is dropped when other owners are
+     * present.</p>
+     *
+     * @param when the date to evaluate ownership at
+     *
+     * @return a map of birth-eligible factions to their tenure weight in whole years; may be empty if a disputed world
+     *       has no recorded owner before or after the dispute
+     */
+    public Map<Faction, Integer> getPopulationFactions(LocalDate when) {
+        Map<Faction, Double> tenureYears = new HashMap<>();
+        for (Planet planet : planets.values()) {
+            accumulatePopulationTenure(tenureYears, planet, when);
+        }
+
+        Map<Faction, Integer> weights = new HashMap<>();
+        for (Map.Entry<Faction, Double> entry : tenureYears.entrySet()) {
+            // Any faction that ruled at all is worth at least one ticket; longer and multi-world tenure weighs more.
+            int weight = (int) Math.max(1, Math.round(entry.getValue()));
+            weights.put(entry.getKey(), weight);
+        }
+
+        // ignore cases where abandoned (ABN) is given in addition to real factions
+        if (weights.size() > 1) {
+            weights.remove(Factions.getInstance().getFaction(ABANDONED_FACTION_CODE));
+        }
+        return weights;
+    }
+
+    /**
+     * Accumulates, into {@code tenureYears}, how long each real faction held {@code planet} within the last
+     * {@link #POPULATION_WINDOW_YEARS} years before {@code when}.
+     *
+     * <p>Walks the ownership timeline, crediting each owner the length of its reign clipped to the window. Future
+     * ownership (after {@code when}) is not part of the current population and is skipped, except that an ongoing
+     * dispute's eventual resolver is credited its share of the contested span (see {@link #creditContestants}).</p>
+     *
+     * @param tenureYears the running per-faction tenure total, in years
+     * @param planet      the planet whose ownership timeline is walked
+     * @param when        the date the population is evaluated at
+     */
+    private static void accumulatePopulationTenure(Map<Faction, Double> tenureYears, Planet planet, LocalDate when) {
+        List<Planet.PlanetaryEvent> events = planet.getEvents();
+        if (events == null) {
+            return;
+        }
+        LocalDate windowStart = when.minusYears(POPULATION_WINDOW_YEARS);
+
+        // Ownership snapshots (events that set a faction) in chronological order, across the whole timeline.
+        List<Planet.PlanetaryEvent> ownership = new ArrayList<>();
+        for (Planet.PlanetaryEvent event : events) {
+            if (event.date != null && event.faction != null && event.faction.getValue() != null) {
+                ownership.add(event);
+            }
+        }
+
+        for (int i = 0; i < ownership.size(); i++) {
+            Planet.PlanetaryEvent event = ownership.get(i);
+            if (!event.date.isBefore(when)) {
+                break; // this reign begins at or after the evaluation date — not part of the current population
+            }
+            // This owner holds from its own date until the next ownership change (or the evaluation date).
+            LocalDate segmentEnd = (i + 1 < ownership.size()) ? ownership.get(i + 1).date : when;
+            if (segmentEnd.isAfter(when)) {
+                segmentEnd = when;
+            }
+            // Clip the reign to the living-population window.
+            LocalDate segmentStart = event.date.isBefore(windowStart) ? windowStart : event.date;
+            if (!segmentStart.isBefore(segmentEnd)) {
+                continue; // reign falls entirely outside the window
+            }
+            double years = ChronoUnit.DAYS.between(segmentStart, segmentEnd) / DAYS_PER_YEAR;
+
+            if (isDisputedOnly(event.faction.getValue())) {
+                creditContestants(tenureYears, ownership, i, years);
+            } else {
+                creditCodes(tenureYears, event.faction.getValue(), years);
+            }
+        }
+    }
+
+    /**
+     * Credits {@code years} of tenure to each real faction named in {@code codes} (the Disputed marker and unknown
+     * codes are skipped). Co-owners each receive the full span rather than a split.
+     */
+    private static void creditCodes(Map<Faction, Double> tenureYears, List<String> codes, double years) {
+        Set<Faction> factions = new HashSet<>();
+        addFactionsFromCodes(factions, codes);
+        for (Faction faction : factions) {
+            tenureYears.merge(faction, years, Double::sum);
+        }
+    }
+
+    /**
+     * Splits a contested span evenly between the two sides fighting over the world: the last real owner recorded before
+     * the dispute at {@code disputeIndex} and the first real owner recorded after it (which may lie in the future for a
+     * dispute still ongoing at the evaluation date). If only one side is recorded, it takes the whole span.
+     *
+     * @param tenureYears  the running per-faction tenure total, in years
+     * @param ownership    the planet's chronological ownership snapshots
+     * @param disputeIndex the index of the disputed snapshot within {@code ownership}
+     * @param years        the length of the contested span, in years
+     */
+    private static void creditContestants(Map<Faction, Double> tenureYears, List<Planet.PlanetaryEvent> ownership,
+          int disputeIndex, double years) {
+        Set<Faction> contestants = new HashSet<>();
+        for (int j = disputeIndex - 1; j >= 0; j--) {
+            List<String> codes = ownership.get(j).faction.getValue();
+            if (!isDisputedOnly(codes)) {
+                addFactionsFromCodes(contestants, codes);
+                break;
+            }
+        }
+        for (int j = disputeIndex + 1; j < ownership.size(); j++) {
+            List<String> codes = ownership.get(j).faction.getValue();
+            if (!isDisputedOnly(codes)) {
+                addFactionsFromCodes(contestants, codes);
+                break;
+            }
+        }
+        if (contestants.isEmpty()) {
+            return;
+        }
+        double share = years / contestants.size();
+        for (Faction faction : contestants) {
+            tenureYears.merge(faction, share, Double::sum);
+        }
+    }
+
+    /**
+     * @return {@code true} if {@code codes} is non-empty and every code is the Disputed marker, i.e. the world is
+     *       actively contested with no real owner recorded at the queried date
+     */
+    private static boolean isDisputedOnly(List<String> codes) {
+        if (codes == null || codes.isEmpty()) {
+            return false;
+        }
+        for (String code : codes) {
+            if (!DISPUTED_FACTION_CODE.equals(code)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /** Resolves each faction code to a {@link Faction} and adds the non-null, non-disputed results to {@code sink}. */
+    private static void addFactionsFromCodes(Set<Faction> sink, List<String> codes) {
+        for (String code : codes) {
+            if (DISPUTED_FACTION_CODE.equals(code)) {
+                continue;
+            }
+            Faction faction = Factions.getInstance().getFaction(code);
+            if (faction != null) {
+                sink.add(faction);
+            }
+        }
+    }
+
     public long getPopulation(LocalDate when) {
         long pop = 0L;
         for (Planet planet : planets.values()) {
-            if (null != planet.getPopulation(when)) {
-                pop += planet.getPopulation(when);
-            }
+            planet.getPopulation(when);
+            pop += planet.getPopulation(when);
         }
         return pop;
     }

--- a/MekHQ/src/mekhq/campaign/universe/PlanetarySystem.java
+++ b/MekHQ/src/mekhq/campaign/universe/PlanetarySystem.java
@@ -518,7 +518,6 @@ public class PlanetarySystem {
     public long getPopulation(LocalDate when) {
         long pop = 0L;
         for (Planet planet : planets.values()) {
-            planet.getPopulation(when);
             pop += planet.getPopulation(when);
         }
         return pop;

--- a/MekHQ/unittests/mekhq/campaign/universe/PlanetarySystemPopulationFactionsTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/PlanetarySystemPopulationFactionsTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.universe;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link PlanetarySystem#getPopulationFactions(LocalDate)} &mdash; the tenure-weighted set of factions a native
+ * of a system could have been born under, including the resolution of the {@code DIS} ("Disputed") marker into the two
+ * sides fighting over a contested world.
+ */
+class PlanetarySystemPopulationFactionsTest {
+
+    /** Must match {@code PlanetarySystem.POPULATION_WINDOW_YEARS}. */
+    private static final int WINDOW_YEARS = 40;
+
+    private static final LocalDate WHEN = LocalDate.of(3000, 1, 1);
+
+    @AfterEach
+    void tearDown() {
+        Factions.setInstance(null);
+    }
+
+    @Test
+    @DisplayName("An owner holding the world across the whole window weighs the full window length")
+    void continuousOwnerFillsWindow() {
+        Faction federatedSuns = registerFactions("FS").get("FS");
+        // Acquired long before the window opened; only the in-window portion (40 years) is credited.
+        PlanetarySystem system = systemWith(planet(factionEvent(LocalDate.of(2800, 1, 1), "FS")));
+
+        assertEquals(Map.of(federatedSuns, WINDOW_YEARS), system.getPopulationFactions(WHEN));
+    }
+
+    @Test
+    @DisplayName("Two owners inside the window are each weighted by how long they held the world")
+    void ownersWeightedByTenure() {
+        Map<String, Faction> factions = registerFactions("FS", "DC");
+        // FS holds the window's first 25 years (2960-2985); DC the last 15 (2985-3000).
+        PlanetarySystem system = systemWith(planet(
+              factionEvent(LocalDate.of(2900, 1, 1), "FS"),
+              factionEvent(LocalDate.of(2985, 1, 1), "DC")));
+
+        assertEquals(Map.of(factions.get("FS"), 25, factions.get("DC"), 15),
+              system.getPopulationFactions(WHEN));
+    }
+
+    @Test
+    @DisplayName("An owner that left before the window opened is not part of the current population")
+    void ownerDepartedBeforeWindowExcluded() {
+        Map<String, Faction> factions = registerFactions("FS", "DC");
+        // FS ruled 2900-2950, entirely before the 2960 window start; DC has held it since.
+        PlanetarySystem system = systemWith(planet(
+              factionEvent(LocalDate.of(2900, 1, 1), "FS"),
+              factionEvent(LocalDate.of(2950, 1, 1), "DC")));
+
+        assertEquals(Map.of(factions.get("DC"), WINDOW_YEARS), system.getPopulationFactions(WHEN));
+    }
+
+    @Test
+    @DisplayName("A contested world splits the dispute's span between the pre-dispute and eventual owner")
+    void disputedWorldSplitsBetweenContestants() {
+        Map<String, Faction> factions = registerFactions("FS", "DC", "DIS");
+        // FS holds 2960-2980, the world is disputed 2980-3010, and DC takes it in 3010 (after the evaluation date).
+        // In-window: FS reigns 20 years, then a 20-year dispute is split 10/10 between FS (before) and DC (eventual).
+        PlanetarySystem system = systemWith(planet(
+              factionEvent(LocalDate.of(2900, 1, 1), "FS"),
+              factionEvent(LocalDate.of(2980, 1, 1), "DIS"),
+              factionEvent(LocalDate.of(3010, 1, 1), "DC")));
+
+        Map<Faction, Integer> result = system.getPopulationFactions(WHEN);
+
+        assertEquals(Map.of(factions.get("FS"), 30, factions.get("DC"), 10), result);
+        assertFalse(result.containsKey(factions.get("DIS")),
+              "the Disputed pseudo-faction must never be returned as a birth origin");
+    }
+
+    @Test
+    @DisplayName("Co-owners of a world each receive the full span rather than a split")
+    void coOwnersEachGetFullSpan() {
+        Map<String, Faction> factions = registerFactions("FS", "LA");
+        // A jointly held world (unlike a dispute) credits both owners the full tenure.
+        PlanetarySystem system = systemWith(planet(factionEvent(LocalDate.of(2900, 1, 1), "FS", "LA")));
+
+        assertEquals(Map.of(factions.get("FS"), WINDOW_YEARS, factions.get("LA"), WINDOW_YEARS),
+              system.getPopulationFactions(WHEN));
+    }
+
+    @Test
+    @DisplayName("A faction that ruled only briefly still weighs at least one")
+    void briefTenureFlooredToOne() {
+        Map<String, Faction> factions = registerFactions("FS", "DC");
+        // DC seized the world barely two months before the evaluation date — a fraction of a year, floored to 1.
+        PlanetarySystem system = systemWith(planet(
+              factionEvent(LocalDate.of(2900, 1, 1), "FS"),
+              factionEvent(LocalDate.of(2999, 11, 1), "DC")));
+
+        assertEquals(Map.of(factions.get("FS"), WINDOW_YEARS, factions.get("DC"), 1),
+              system.getPopulationFactions(WHEN));
+    }
+
+    @Test
+    @DisplayName("Abandoned (ABN) is dropped when a real owner is also present")
+    void abandonedDroppedAlongsideRealOwner() {
+        Map<String, Faction> factions = registerFactions("FS", "ABN");
+        // One inhabited world (FS) and one abandoned world in the same system.
+        PlanetarySystem system = systemWith(
+              planet(factionEvent(LocalDate.of(2900, 1, 1), "FS")),
+              planet(factionEvent(LocalDate.of(2900, 1, 1), "ABN")));
+
+        assertEquals(Map.of(factions.get("FS"), WINDOW_YEARS), system.getPopulationFactions(WHEN));
+    }
+
+    @Test
+    @DisplayName("Tenure accumulates across a faction's worlds in the system")
+    void tenureSumsAcrossPlanets() {
+        Faction federatedSuns = registerFactions("FS").get("FS");
+        // FS has held two worlds in this system for the whole window; person-years accumulate across both.
+        PlanetarySystem system = systemWith(
+              planet(factionEvent(LocalDate.of(2900, 1, 1), "FS")),
+              planet(factionEvent(LocalDate.of(2900, 1, 1), "FS")));
+
+        assertEquals(Map.of(federatedSuns, WINDOW_YEARS * 2), system.getPopulationFactions(WHEN));
+    }
+
+    @Test
+    @DisplayName("An uninhabited world with no ownership history yields no population factions")
+    void planetWithoutEventsYieldsEmpty() {
+        registerFactions("FS");
+        PlanetarySystem system = systemWith(new Planet("Barren"));
+
+        assertTrue(system.getPopulationFactions(WHEN).isEmpty());
+    }
+
+    // --- helpers ---------------------------------------------------------------------------------------------------
+
+    private static Map<String, Faction> registerFactions(String... codes) {
+        java.util.Map<String, Faction> byCode = new java.util.HashMap<>();
+        for (String code : codes) {
+            Faction faction = mock(Faction.class);
+            when(faction.getShortName()).thenReturn(code);
+            byCode.put(code, faction);
+        }
+        Factions registry = mock(Factions.class);
+        when(registry.getFaction(anyString())).thenAnswer(invocation -> byCode.get(invocation.getArgument(0)));
+        Factions.setInstance(registry);
+        return byCode;
+    }
+
+    private static Planet.PlanetaryEvent factionEvent(LocalDate date, String... factionCodes) {
+        Planet.PlanetaryEvent event = new Planet.PlanetaryEvent();
+        event.date = date;
+        event.faction = SourceableValue.of(List.of(factionCodes));
+        return event;
+    }
+
+    private static Planet planet(Planet.PlanetaryEvent... events) {
+        Planet planet = new Planet("Test World");
+        for (Planet.PlanetaryEvent event : events) {
+            planet.putEvent(event);
+        }
+        return planet;
+    }
+
+    private static PlanetarySystem systemWith(Planet... planets) {
+        PlanetarySystem system = new PlanetarySystem("Test System");
+        TreeMap<Integer, Planet> planetMap = new TreeMap<>();
+        int position = 1;
+        for (Planet planet : planets) {
+            planetMap.put(position++, planet);
+        }
+        try {
+            Field field = PlanetarySystem.class.getDeclaredField("planets");
+            field.setAccessible(true);
+            field.set(system, planetMap);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Could not inject planets into the test system", e);
+        }
+        return system;
+    }
+}


### PR DESCRIPTION
Fix #9591

## What this changes

When picking the personnel at a location, personnel will now peer back within the last 40 years and generate based on past and current factional owners. This is weighted by how long ago the faction owned the planet and for how long.

'Disputed' and 'Abandoned' factions can no longer generate personnel

## Testing

- Manual testing.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result