### PR TITLE
Fix #9593: Allowed Empty Systems to Be Selected as Birthplace if They Had Population at Date of Birth

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/CreateCharacterDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CreateCharacterDialog.java
@@ -1180,7 +1180,7 @@ public class CreateCharacterDialog extends JDialog implements DialogOptionListen
         // A world is a valid birthworld if it either has a real owner faction at the character's date of birth OR
         // still had a recorded population then. The population fallback admits ABN (Abandoned) systems that retained
         // inhabitants — a character can be born on a world that no faction claims, so long as someone lived there.
-        LocalDate birthDate = (person.getDateOfBirth() != null) ? person.getDateOfBirth() : campaign.getLocalDate();
+        LocalDate birthDate = person.getDateOfBirth();
         List<PlanetarySystem> orderedSystems = campaign.getSystems()
                                                      .stream()
                                                      .filter(a -> !a.isConnector())

--- a/MekHQ/src/mekhq/gui/dialog/CreateCharacterDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CreateCharacterDialog.java
@@ -58,6 +58,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.ResourceBundle;
+import java.util.Set;
 import javax.swing.*;
 
 import megamek.client.generator.RandomCallsignGenerator;
@@ -1176,14 +1177,46 @@ public class CreateCharacterDialog extends JDialog implements DialogOptionListen
     private DefaultComboBoxModel<PlanetarySystem> getPlanetarySystemsComboBoxModel() {
         DefaultComboBoxModel<PlanetarySystem> model = new DefaultComboBoxModel<>();
 
+        // A world is a valid birthworld if it either has a real owner faction at the character's date of birth OR
+        // still had a recorded population then. The population fallback admits ABN (Abandoned) systems that retained
+        // inhabitants — a character can be born on a world that no faction claims, so long as someone lived there.
+        LocalDate birthDate = (person.getDateOfBirth() != null) ? person.getDateOfBirth() : campaign.getLocalDate();
         List<PlanetarySystem> orderedSystems = campaign.getSystems()
                                                      .stream()
+                                                     .filter(a -> !a.isConnector())
+                                                     .filter(a -> isSelectableBirthworld(a, birthDate))
                                                      .sorted(Comparator.comparing(a -> a.getName(campaign.getLocalDate())))
                                                      .toList();
         for (PlanetarySystem system : orderedSystems) {
             model.addElement(system);
         }
         return model;
+    }
+
+    /**
+     * @return {@code true} if {@code system} is a valid birthworld at {@code when} — it either has a real (non-ABN)
+     *       owner faction then, or still had a recorded population then. The population fallback admits abandoned
+     *       (ABN-only) worlds that retained inhabitants: a character can be born on a world no faction claims, so long
+     *       as people were living there. A {@code null} date is treated as selectable rather than over-filtering.
+     */
+    private static boolean isSelectableBirthworld(PlanetarySystem system, LocalDate when) {
+        if (when == null) {
+            return true;
+        }
+        if (system.getPopulation(when) > 0) {
+            return true;
+        }
+        // getFactionSet already drops the ABN marker when other factions are present, so an ABN-only world comes back
+        // as a single ABN entry; reject that case explicitly.
+        Set<Faction> owners = system.getFactionSet(when);
+        if (owners.isEmpty()) {
+            return false;
+        }
+        if (owners.size() == 1) {
+            Faction only = owners.iterator().next();
+            return only != null && !"ABN".equals(only.getShortName());
+        }
+        return true;
     }
 
     private DefaultComboBoxModel<PlanetarySystem> getPlanetarySystemsComboBoxModel(Faction faction) {

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -1538,7 +1538,11 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
         List<PlanetarySystem> orderedSystems = campaign.getSystems()
                                                      .stream()
                                                      .filter(a -> !a.isConnector())
-                                                     .filter(a -> isInhabitedAt(cachedOwnersAt(a)))
+                                                     // A world counts as a valid birth world if it either has a real
+                                                     // owner faction at the birthdate OR still had a recorded
+                                                     // population then.
+                                                     .filter(a -> isInhabitedAt(cachedOwnersAt(a)) ||
+                                                                        hadPopulationAt(a))
                                                      .sorted(Comparator.comparing(a -> a.getName(birthDate)))
                                                      .toList();
         for (PlanetarySystem system : orderedSystems) {
@@ -1865,6 +1869,17 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
             return only != null && !"ABN".equals(only.getShortName());
         }
         return true;
+    }
+
+    /**
+     * @return {@code true} if {@code system} had a recorded population greater than zero on the dialog's current
+     *       {@code birthdate}. Used as a fallback to {@link #isInhabitedAt(Set)} so an abandoned world (owner set is
+     *       {@code ABN}-only, which {@code isInhabitedAt} rejects) is still offered as a birthworld when people were
+     *       actually living there. Returns {@code false} when {@code birthdate} is unset, since population is
+     *       date-scoped.
+     */
+    private boolean hadPopulationAt(PlanetarySystem system) {
+        return birthdate != null && system.getPopulation(birthdate) > 0;
     }
 
     private void filterPlanetarySystemsForOurFaction(boolean onlyOurFaction) {

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -1541,8 +1541,8 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
                                                      // A world counts as a valid birth world if it either has a real
                                                      // owner faction at the birthdate OR still had a recorded
                                                      // population then.
-                                                     .filter(a -> isInhabitedAt(cachedOwnersAt(a)) ||
-                                                                        hadPopulationAt(a))
+                                                       .filter(a -> hadPopulationAt(a) ||
+                                                                            isInhabitedAt(cachedOwnersAt(a)))
                                                      .sorted(Comparator.comparing(a -> a.getName(birthDate)))
                                                      .toList();
         for (PlanetarySystem system : orderedSystems) {


### PR DESCRIPTION
Fix #9593

## What this changes

As per title

## Testing

- Manual testing

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result