### PR TITLE
fix: adjust personnel market static variable names, getters, setters

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/NewPersonnelMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/NewPersonnelMarket.java
@@ -103,8 +103,8 @@ public class NewPersonnelMarket {
 
     @SuppressWarnings(value = "FieldCanBeLocal")
     private static final int RARE_PROFESSION_WEIGHT = 20;
-    private static int LOW_POPULATION_RECRUITMENT_DIVIDER = 1;
-    private static int UNIT_REPUTATION_RECRUITMENT_CUTOFF = Integer.MIN_VALUE;
+    private static int lowPopulationRecruitmentDivider = 1;
+    private static int unitReputationRecruitmentCutoff = Integer.MIN_VALUE;
     @SuppressWarnings(value = "FieldCanBeLocal")
     private static final int PROFESSION_EXTINCTION_IGNORE_VALUE = -1;
 
@@ -414,20 +414,20 @@ public class NewPersonnelMarket {
      * @author Illiani
      * @since 0.50.06
      */
-    public int getLowPopulationRecruitmentDivider() {
-        return LOW_POPULATION_RECRUITMENT_DIVIDER;
+    public static int getLowPopulationRecruitmentDivider() {
+        return lowPopulationRecruitmentDivider;
     }
 
     /**
      * Sets the recruitment divider for low population systems.
      *
-     * @param lowPopulationRecruitmentDivider recruitment divider to set
+     * @param divider recruitment divider to set
      *
      * @author Illiani
      * @since 0.50.06
      */
-    public void setLowPopulationRecruitmentDivider(int lowPopulationRecruitmentDivider) {
-        LOW_POPULATION_RECRUITMENT_DIVIDER = lowPopulationRecruitmentDivider;
+    public static void setLowPopulationRecruitmentDivider(int divider) {
+        lowPopulationRecruitmentDivider = divider;
     }
 
     /**
@@ -438,20 +438,20 @@ public class NewPersonnelMarket {
      * @author Illiani
      * @since 0.50.06
      */
-    public int getUnitReputationRecruitmentCutoff() {
-        return UNIT_REPUTATION_RECRUITMENT_CUTOFF;
+    public static int getUnitReputationRecruitmentCutoff() {
+        return unitReputationRecruitmentCutoff;
     }
 
     /**
      * Sets the cutoff value for unit reputation in recruitment eligibility.
      *
-     * @param unitReputationRecruitmentCutoff reputation cutoff to set
+     * @param cutoff reputation cutoff to set
      *
      * @author Illiani
      * @since 0.50.06
      */
-    public void setUnitReputationRecruitmentCutoff(int unitReputationRecruitmentCutoff) {
-        UNIT_REPUTATION_RECRUITMENT_CUTOFF = unitReputationRecruitmentCutoff;
+    public static void setUnitReputationRecruitmentCutoff(int cutoff) {
+        unitReputationRecruitmentCutoff = cutoff;
     }
 
     /**


### PR DESCRIPTION
fix: adjust personnel market static variable names and ensure getter and setter methods are static

This renames some static variables, uppercase is typically used for finals/constants.  It also adjusts the getter and setter methods so they are static to match the variables.

This was identified/found via the static analysis tool SpotBugs 4.10.4.

## What this changes

<!-- The effect someone actually sees, in plain language. One or two sentences is fine. -->

<!-- Keep this line as well as the number in the title. GitHub only closes an issue from a
     keyword in the description - a number in the title alone does not close anything.

     Any of these close an issue when this merges:
         Close / Closes / Closed
         Fix / Fixes / Fixed
         Resolve / Resolves / Resolved

     Closing more than one needs the keyword repeated in front of each number:
         Fixes #1234, fixes #5678          closes both
         Fixes #1234, #5678                closes only #1234

     For an issue in another repository, qualify it: Fixes MegaMek/mekhq#1234 -->


## Testing

Gradle test

## What is not proven yet

<!-- What you did not test, or could not. "Nothing" is a valid answer - say so explicitly. -->

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text

No AI usage

