### PR TITLE
Fix #9938: Command Generator options explain themselves on hover

### DIFF
--- a/MekHQ/resources/mekhq/resources/CommandGenerationDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CommandGenerationDialog.properties
@@ -48,105 +48,101 @@ sparesAndFinancesTab.title=Spares & Finances
 
 # ---- Setup tab section captions
 lblSupportPersonnel.text=Support Personnel
-lblSupportPersonnel.tooltip=The techs, doctors and administrators generated to keep the command running. Coverage is a percentage of what CamOps says the force needs, counting the support vehicles the build adds; Skill sets their experience, or Random rolls it for each person.
+lblSupportPersonnel.tooltip=The techs, doctors and administrators hired to keep the command running. Coverage is a percentage of the number the force needs; Skill sets their experience, and Random rolls a level for each person. Vehicles the build adds itself, such as the logistics trucks, are counted.
 lblAssistants.text=Assistants
-lblAssistants.tooltip=Astechs and medics: six per tech and four per doctor. Either as anonymous pool counts or as named people, plus an optional reserve of spare MekWarriors held back as injury replacements.
+lblAssistants.tooltip=The helpers behind the techs and doctors: six astechs per tech and four medics per doctor. They can be an anonymous pool or named people. A medical reserve of spare MekWarriors can be added as injury replacements.
 lblTechAssignment.text=Tech Assignment
-lblTechAssignment.tooltip=Which generated tech maintains which unit. Units are ordered by the sort keys below and techs are handed out down the list, so the first key decides who gets the best tech.
+lblTechAssignment.tooltip=Which tech looks after which unit. Units are put in order by the choices below and the best techs are handed out down the list, so the first choice decides who gets the best tech.
 lblOfficerSelection.text=Officer Selection
-lblOfficerSelection.tooltip=Who ends up in charge. Picks company commanders and officers from the people generated, by skill or by combat record, and decides whether the most skilled pilots go to the primary lances.
+lblOfficerSelection.tooltip=Who ends up in charge. The generator promotes the first combat person in each formation; the choices below are saved but not yet used to pick officers by skill.
 lblNamingAndRanks.text=Naming & Ranks
-lblNamingAndRanks.tooltip=How the command is named and ranked: the alphabet its formations are designated by, whether regiments are numbered, and whether the people generated get ranks, callsigns and founder status.
+lblNamingAndRanks.tooltip=How the command is named and ranked: the alphabet its formations are named by, whether regiments are numbered, and whether the people generated get ranks, callsigns and founder status.
 lblRandomOrigin.text=Random Origin
-lblRandomOrigin.tooltip=Where the generated people come from. Randomises birth planets around the command's home system, with separate settings for dependents and for Clan-born personnel.
+lblRandomOrigin.tooltip=Where the people generated were born. Rolls a home planet for each person around the command's home system, with separate settings for dependents and for Clan-born personnel.
 
 # ---- Setup: Force Shape
 lblGenerateMercenaryCompanyCommandLance.text=Generate Company Command Lance
-lblGenerateMercenaryCompanyCommandLance.tooltip=<html>Generates a separate command lance for the company commander.<br>When off, the commander leads the first generated lance instead.</html>
+lblGenerateMercenaryCompanyCommandLance.tooltip=Gives the company commander a separate command lance of their own. When off, the commander leads the first lance generated instead.
 lblForceNamingMethod.text=Formation Naming Method
-lblForceNamingMethod.tooltip=<html>The alphabet used to designate formations at every level of the command.<br>A regiment's battalions are named Alpha, Beta, Gamma; each battalion's companies start again at Alpha, and so on down to lances.<br>Examples: "Baker Company", "Bravo Company", "Beta Company".<br>Clan galaxies and ComStar Level III/IV formations keep their canon names and ignore this setting.</html>
+lblForceNamingMethod.tooltip=The alphabet used to name formations at every level of the command. A regiment's battalions are named Alpha, Beta, Gamma; each battalion's companies start again at Alpha, and so on down to the lances.
 lblAlwaysNumberRegiments.text=Always Number Regiments
-lblAlwaysNumberRegiments.tooltip=<html>When checked, regiments are numbered instead of taking the naming alphabet: "1st Mek Regiment", "2nd Mek Regiment".<br>Each type of regiment counts separately, so an armor regiment alongside two Mek regiments is the "1st Armor Regiment", not the third.<br>Everything below regiment level still uses the Formation Naming Method above.</html>
+lblAlwaysNumberRegiments.tooltip=Regiments are numbered instead of lettered: 1st Mek Regiment, 2nd Mek Regiment. Each kind of regiment counts on its own, so an armor regiment alongside two Mek regiments is the 1st Armor Regiment.
 
 # ---- Setup: Support Personnel
 # Spinner and skill-dropdown tooltips share a template; the single ``%s`` is replaced with the role's display name at runtime.
-supportCoveragePercent.toolTipText=Coverage percentage for %s. 100%% generates the canonical number needed to fully maintain the force; below under-staffs; above adds redundancy.
-supportSkillLevel.toolTipText=Experience level applied to every %s the generator creates. Random rolls each person's own level.
+supportCoveragePercent.toolTipText=How many %s to hire, as a percentage of the number needed to keep every unit maintained. 100%% hires the full number, less leaves some units without one, more gives spare hands.
+supportSkillLevel.toolTipText=The experience level every %s starts with. Random rolls a different level for each person.
 lblSupportPersonnelColumnRole.text=Role
 lblSupportPersonnelColumnPercent.text=Coverage %
 lblSupportPersonnelColumnSkill.text=Skill
 
 # ---- Setup: Assistants (astech / medic generation)
 lblGenerateAstechs.text=Generate Astechs (6 per Tech)
-lblGenerateAstechs.tooltip=Generates 6 astechs for every technician (Mek Tech, Mechanic, Aero Tek, BA Tech) created above. Astechs assist techs to bring per-team maintenance capacity up to the full 480-minute team output.
+lblGenerateAstechs.tooltip=Hires six astechs for every tech generated above. A tech with a full astech team gets through their maintenance and repair work at full speed.
 lblAstechsAsPool.text=Add to Astech pool
-lblAstechsAsPool.tooltip=Adds astechs as anonymous pool entries. Faster generation; pool astechs don't appear in the Personnel list.
+lblAstechsAsPool.tooltip=Astechs are counted in the astech pool rather than created as people. Quicker to generate, and they do not appear in the personnel list.
 lblAstechsAsPersonnel.text=Generate as individual personnel
-lblAstechsAsPersonnel.tooltip=Creates each astech as a named Person with their own rank and skill. Best for small-to-medium forces where you want astechs visible in the roster. NOTE: at battalion scale or larger this can produce hundreds of personnel; consider the pool option for fast-paced campaigns.
+lblAstechsAsPersonnel.tooltip=Each astech is created as a named person with a rank and a skill level. Good for a small command where you want to see them. For a battalion or larger this can mean hundreds of people; the pool is the better choice there.
+lblAstechSkillLevel.tooltip=The experience level of the astechs when they are created as named people. Random rolls a level for each one. Astechs in the pool have no skill level.
 lblGenerateMedics.text=Generate Medics (4 per Doctor)
-lblGenerateMedics.tooltip=Generates 4 medics for every doctor created above. Medics assist doctors to bring per-team medical capacity up to the full 480-minute team output.
+lblGenerateMedics.tooltip=Hires four medics for every doctor generated above. A doctor with a full medic team treats patients at full speed.
 lblGenerateMedicalReserve.text=Medical Reserve (% of combatants)
-lblGenerateMedicalReserve.tooltip=Generate spare, unassigned MekWarriors as injury replacements, sized as a percentage of the generated combatants. Applies during generation only, independent of the campaign-wide Alternative Advanced Medical rule.
+lblGenerateMedicalReserve.tooltip=Adds spare MekWarriors with no unit of their own, ready to step in when a pilot is wounded. How many is this percentage of the combat personnel generated. This only affects generation; it is not the campaign's Alternative Advanced Medical rule.
 lblMedicsAsPool.text=Add to Medic pool
-lblMedicsAsPool.tooltip=Adds medics as anonymous pool entries. Faster generation; pool medics don't appear in the Personnel list.
+lblMedicsAsPool.tooltip=Medics are counted in the medic pool rather than created as people. Quicker to generate, and they do not appear in the personnel list.
 lblMedicsAsPersonnel.text=Generate as individual personnel
-lblMedicsAsPersonnel.tooltip=Creates each medic as a named Person with their own rank and skill.
+lblMedicsAsPersonnel.tooltip=Each medic is created as a named person with a rank and a skill level.
+lblMedicSkillLevel.tooltip=The experience level of the medics when they are created as named people. Random rolls a level for each one. Medics in the pool have no skill level.
 
 # ---- Setup: Tech Assignment (which units get the best techs first)
 lblAssignTechsToUnits.text=Assign Techs to Units
-lblAssignTechsToUnits.tooltip=When on, units are sorted by the three slots below and matched with the best available technician from the appropriate role pool. Each technician can take multiple units up to a 480 min/day workload cap.
+lblAssignTechsToUnits.tooltip=Gives every unit a tech from the people generated. Units are sorted by the three choices below and matched with the best available tech of the right kind. A tech can look after several units up to a full working day of 480 minutes.
 lblTechAssignmentPrimary.text=First by
-lblTechAssignmentPrimary.tooltip=The most important sort key. Officers' units, heavier units, or skilled pilots get the first pick of techs depending on the factor here.
+lblTechAssignmentPrimary.tooltip=What matters most when handing out techs: the pilot's rank, the unit's weight, or the pilot's skill. The units highest in this order get the best techs.
 lblTechAssignmentSecondary.text=Then by
-lblTechAssignmentSecondary.tooltip=Tiebreaker for units that match on the primary sort. Set to (none) to keep ties unordered.
+lblTechAssignmentSecondary.tooltip=Breaks ties between units that match on the first choice. Choose (none) to leave ties in no particular order.
 lblTechAssignmentTertiary.text=Then by
-lblTechAssignmentTertiary.tooltip=Second tiebreaker. Set to (none) to ignore.
+lblTechAssignmentTertiary.tooltip=Breaks any ties left after the first two choices. Choose (none) to ignore.
 lblTechAssignmentDirection.descending=Highest first
 lblTechAssignmentDirection.ascending=Lowest first
 
 # ---- Setup: Officer Selection
 lblAssignBestCompanyCommander.text=Assign Best Company Commander
-lblAssignBestCompanyCommander.tooltip=Picks the highest-skilled person as Company Commander based on Tactical Genius, combined command skill levels, then combat skill level.
+lblAssignBestCompanyCommander.tooltip=Not in use yet: the Command Generator saves this setting but does not act on it. It is meant to make the most skilled person the company commander, judged by Tactical Genius, then command skills, then combat skills.
 lblPrioritizeCompanyCommanderCombatSkills.text=Prioritize Commander Combat Skills Over Command Skills
-lblPrioritizeCompanyCommanderCombatSkills.tooltip=When picking the Company Commander, weight combat skill experience over combined command skill levels.
+lblPrioritizeCompanyCommanderCombatSkills.tooltip=Not in use yet: the Command Generator saves this setting but does not act on it. It is meant to weigh combat skills above command skills when choosing the company commander.
 lblAssignBestOfficers.text=Assign Best Officers
-lblAssignBestOfficers.tooltip=<html>Picks the highest-skilled personnel as officers using the same sort as Company Commander.<br>When Assign Best Company Commander is off, this sort also selects the Company Commander.</html>
+lblAssignBestOfficers.tooltip=Not in use yet: the Command Generator saves this setting but does not act on it. It is meant to fill the officer posts with the most skilled people, using the same order as the company commander.
 lblPrioritizeOfficerCombatSkills.text=Prioritize Officer Combat Skills Over Command Skills
-lblPrioritizeOfficerCombatSkills.tooltip=When assigning officers, weight combat skill experience over combined command skill levels.
+lblPrioritizeOfficerCombatSkills.tooltip=Not in use yet: the Command Generator saves this setting but does not act on it. It is meant to weigh combat skills above command skills when choosing officers.
 lblAssignMostSkilledToPrimaryLances.text=Assign Most Skilled to Primary Lances
-lblAssignMostSkilledToPrimaryLances.tooltip=<html>Sorts the most skilled personnel into the highest lances in the TO&E.<br>When Assign Best Company Commander and Assign Best Officers are both off, this sort applies to all generated personnel.</html>
+lblAssignMostSkilledToPrimaryLances.tooltip=Not in use yet: the Command Generator saves this setting but does not act on it. It is meant to put the most skilled pilots into the first lances of the TO&E.
 lblGenerateCaptains.text=Generate Captains
-lblGenerateCaptains.tooltip=<html>Creates a Captain for every company after the first (or every company when using a mercenary company command lance).<br>Captains receive two officer skill increases.</html>
+lblGenerateCaptains.tooltip=Not in use yet: the Command Generator saves this setting but does not act on it. It is meant to create a Captain for every company after the first, or every company when the command has a separate command lance, each with two extra officer skill increases.
 lblAssignCompanyCommanderFlag.text=Assign Commander Flag
-lblAssignCompanyCommanderFlag.tooltip=Marks the generated Company Commander as the overall commander for the mercenary company.
+lblAssignCompanyCommanderFlag.tooltip=Makes the person promoted at the top of the command your campaign's commanding officer, and appoints a second in command.
 lblApplyOfficerStatBonusToWorstSkill.text=Apply Officer Stat Bonus to Weakest Skill
-lblApplyOfficerStatBonusToWorstSkill.tooltip=Applies the officer stat bonus to the weakest of the officer's primary skills (usually piloting).
+lblApplyOfficerStatBonusToWorstSkill.tooltip=Not in use yet: the Command Generator saves this setting but does not act on it. It is meant to give an officer's skill bonus to their weakest main skill, usually piloting, instead of their best.
 
 # ---- Setup: Naming & Ranks
 lblAutomaticallyAssignRanks.text=Automatically Assign Ranks
-lblAutomaticallyAssignRanks.tooltip=<html>Assigns ranks to all hired personnel based on the campaign's faction.<br>Officers get officer ranks scaled to the size of the force they command. MekWarriors get Sergeant ranks; support personnel get Corporal ranks.</html>
+lblAutomaticallyAssignRanks.tooltip=Gives everyone generated a rank from the faction's rank system. Officers get officer ranks sized to the formation they command. MekWarriors get sergeant ranks and support staff get corporal ranks.
 lblUseSpecifiedFactionToAssignRanks.text=Use Specified Faction to Assign Ranks
-lblUseSpecifiedFactionToAssignRanks.tooltip=Uses the Force Generator faction for rank assignment instead of the campaign's faction.
+lblUseSpecifiedFactionToAssignRanks.tooltip=Ranks follow the faction chosen on the Force Generator tab instead of your campaign's faction. Use it when a mercenary campaign generates a House or Clan command.
 lblAssignMekWarriorsCallSigns.text=Assign MekWarrior Callsigns
-lblAssignMekWarriorsCallSigns.tooltip=Generates random callsigns for MekWarriors (Clan MekWarriors are skipped).
+lblAssignMekWarriorsCallSigns.tooltip=Gives every MekWarrior a random callsign. Skipped in Clan campaigns, where warriors carry bloodnames instead.
 lblAssignFounderFlag.text=Assign Founder Flag
-lblAssignFounderFlag.tooltip=Marks all generated personnel as founders (affects CamOps reputation tracking).
+lblAssignFounderFlag.tooltip=Marks everyone generated as a founding member of the command. Founders are shown as such in the personnel list, and with the Founder Plot Armor campaign option each gains a point of Edge.
 
 # ---- Spares & Finances tab section captions
-lblContracts.text=Contracts
 lblFinances.text=Finances
+lblFinances.tooltip=The money the command starts with. Starting cash is a share of what its units cost, or a dice roll, and can have the cost of setting up the command taken out of it.
 lblStartingSimulation.text=Starting Simulation
-lblSurprises.text=Surprises
-
-# ---- Spares & Finances: Contracts
-lblSelectStartingContract.text=Select Starting Contract
-lblSelectStartingContract.tooltip=Generate a starting contract for the new force.
-lblStartCourseToContractPlanet.text=Start Course to Contract Planet
-lblStartCourseToContractPlanet.tooltip=Plot a JumpShip course to the starting contract's planet automatically.
+lblStartingSimulation.tooltip=Running the campaign forward before play starts. None of these settings are in use yet: the Command Generator saves them but does not act on them.
 
 # ---- Spares & Finances: Finances
 lblProcessFinances.text=Process Finances
-lblProcessFinances.tooltip=When on, the generated command receives starting cash sized by the percentage below (or the dice roll when randomized), with optional setup-cost debits and a starting loan. Turn off to skip all financial setup.
+lblProcessFinances.tooltip=Gives the command starting cash: a percentage of what its rolled units cost to buy, or a dice roll when Randomize Starting Cash is on. The setup costs below can then be taken out of it. Off leaves the campaign's money untouched.
 lblStartingCashPercent.text=Starting Cash (% of unit value)
 lblStartingCashPercent.tooltip=<html>Starting cash as a percentage of the rolled units' total <b>purchase cost</b> — what buying them new would cost, not the roughly-half resale value the Net Worth report lists as assets. 10% of a command whose units cost 500M to buy grants 50M C-Bills. The ships and support vehicles the build adds after the rolls are not in the base.<br>Ignored when Randomize Starting Cash is on.</html>
 lblStartingCashPreview.text=Estimated Starting Cash
@@ -155,69 +151,70 @@ startingCashPreview.value={0} ({1}% of {2})
 startingCashPreview.random={0}d6 million C-Bills, rolled at build
 startingCashPreview.empty=Generate a command first
 lblRandomizeStartingCash.text=Randomize Starting Cash
-lblRandomizeStartingCash.tooltip=Roll the starting cash from a dice pool ({dice count}d6 million C-Bills) instead of the percentage of unit value.
+lblRandomizeStartingCash.tooltip=Rolls the starting cash with dice instead of taking a percentage of unit value. The dice count below is how many d6 are rolled, in millions of C-Bills.
 lblRandomStartingCashDiceCount.text=Dice Count
-lblRandomStartingCashDiceCount.tooltip=Number of d6 rolled (in millions of C-Bills) when Randomize Starting Cash is on.
+lblRandomStartingCashDiceCount.tooltip=How many six-sided dice are rolled for starting cash when Randomize Starting Cash is on. Each die is one million C-Bills.
 lblMinimumStartingFloat.text=Minimum Starting Float
-lblMinimumStartingFloat.tooltip=Minimum cash on hand after all setup debits are applied. The generator floors cash at this value, taking the shortfall as a loan when Generate Starting Loan is on.
+lblMinimumStartingFloat.tooltip=The least cash the command keeps after the setup costs are taken out. If the costs would leave less than this, cash stops here and the rest is borrowed when Generate Starting Loan is on.
 lblStartingLoan.text=Generate Starting Loan
-lblStartingLoan.tooltip=When setup costs exceed the starting cash, the shortfall is taken as a two-year 15% loan with monthly payments.
+lblStartingLoan.tooltip=When the setup costs come to more than the starting cash, the difference is borrowed as a two-year loan at 15% with monthly payments.
 lblPayForSetup.text=Pay for Initial Setup
-lblPayForSetup.tooltip=Master switch: debit the command's generation costs (chosen below) from the starting cash. Off grants the command free with its working capital untouched.
+lblPayForSetup.tooltip=Takes the cost of setting up the command out of its starting cash. Tick below which costs count. Off gives the command everything for free with its cash untouched.
 lblPayForPersonnel.text=Pay for Personnel
-lblPayForPersonnel.tooltip=Debits a hiring cost of twice the salary for every generated person.
+lblPayForPersonnel.tooltip=Charges a hiring fee of two months' salary for every person generated.
 lblPayForUnits.text=Pay for Units
-lblPayForUnits.tooltip=Debits the purchase value of every generated unit.
+lblPayForUnits.tooltip=Charges the full purchase price of every unit generated, ships included.
 lblPayForParts.text=Pay for Parts
-lblPayForParts.tooltip=Debits the value of the spare parts stocked into the warehouse.
+lblPayForParts.tooltip=Charges for the spare parts stocked into the warehouse.
 lblPayForArmour.text=Pay for Armour
-lblPayForArmour.tooltip=Debits the value of the spare armor stocked into the warehouse.
+lblPayForArmour.tooltip=Charges for the spare armor stocked into the warehouse.
 lblPayForAmmunition.text=Pay for Ammunition
-lblPayForAmmunition.tooltip=Debits the value of the spare ammunition stocked into the warehouse.
+lblPayForAmmunition.tooltip=Charges for the spare ammunition stocked into the warehouse.
 
 # ---- Spares & Finances: Starting Simulation
 lblRunStartingSimulation.text=Run Starting Simulation
-lblRunStartingSimulation.tooltip=Simulate the unit forward in time before play starts, advancing the campaign clock by the duration below and processing optional random events.
+lblRunStartingSimulation.tooltip=Not in use yet: the Command Generator saves this setting but does not act on it. It is meant to run the campaign forward for the months below before play starts.
 lblSimulationDuration.text=Simulation Duration (months)
-lblSimulationDuration.tooltip=Number of months to simulate forward before play begins.
+lblSimulationDuration.tooltip=Not in use yet: the Command Generator saves this setting but does not act on it. It is meant to be how many months the campaign runs forward before play starts.
 lblSimulateRandomMarriages.text=Simulate Random Marriages
-lblSimulateRandomMarriages.tooltip=Run random marriage events during the starting simulation.
+lblSimulateRandomMarriages.tooltip=Not in use yet: the Command Generator saves this setting but does not act on it. It is meant to let random marriages happen during the starting simulation.
 lblSimulateRandomProcreation.text=Simulate Random Procreation
-lblSimulateRandomProcreation.tooltip=Run random procreation events during the starting simulation.
+lblSimulateRandomProcreation.tooltip=Not in use yet: the Command Generator saves this setting but does not act on it. It is meant to let random births happen during the starting simulation.
 
 # ---- Spares & Finances: Spares section captions
 lblSparesPercentages.text=Spare Parts Restock %
+lblSparesPercentages.tooltip=The spare parts the command starts with, as a percentage of what its units carry. These are the same restock percentages as Campaign Options, Acquisition & Delivery, and the tab opens with the values set there.
 
 # ---- Spares & Finances: per-category restock percentages
 # Mirrors the AutoLogistics grid on Campaign Options' Acquisition & Delivery page: same thirteen
 # categories, same order, same wording. Values load from and write back to the campaign's
 # autoLogistics* options directly.
 lblSparesMekHead.text=Mek Head
-lblSparesMekHead.tooltip=autoLogistics counts the number of each 'Mek head type in use and then automatically orders replacement spares equal to the percentage set in this option.
+lblSparesMekHead.tooltip=How many spare Mek heads to stock, as a percentage of the Mek heads in use across the command. 100 stocks one spare for every head in use.
 lblSparesMekLocation.text=Mek Location
-lblSparesMekLocation.tooltip=autoLogistics counts the number of each 'Mek location in use and then automatically orders replacement spares equal to the percentage set in this option.
+lblSparesMekLocation.tooltip=How many spare Mek limbs and torsos to stock, as a percentage of each location in use across the command.
 lblSparesNonRepairableLocation.text=Special Location
-lblSparesNonRepairableLocation.tooltip=autoLogistics counts the number of each special location in use and then automatically orders replacement spares equal to the percentage set in this option. Special locations are locations you would not normally want to restock such as vehicle locations, or 'Mek center torsos.
+lblSparesNonRepairableLocation.tooltip=How many spares to stock of the locations you would not normally restock, such as vehicle locations and Mek center torsos, as a percentage of those in use.
 lblSparesArmor.text=Armor
-lblSparesArmor.tooltip=autoLogistics counts the tonnage of armor in use and then automatically orders replacement spares equal to the percentage set in this option.
+lblSparesArmor.tooltip=How much spare armor to stock, as a percentage of the armor tonnage the command's units carry.
 lblSparesAmmunition.text=Ammunition
-lblSparesAmmunition.tooltip=autoLogistics counts the tonnage of ammo in use and then automatically orders replacement spares equal to the percentage set in this option.
+lblSparesAmmunition.tooltip=How much spare ammunition to stock, as a percentage of the ammunition tonnage the command's units carry.
 lblSparesHeatSink.text=Heat Sink
-lblSparesHeatSink.tooltip=autoLogistics counts the number of heat sinks in use and then automatically orders replacement spares equal to the percentage set in this option.
+lblSparesHeatSink.tooltip=How many spare heat sinks to stock, as a percentage of the heat sinks in use across the command.
 lblSparesWeapons.text=Weapon
-lblSparesWeapons.tooltip=autoLogistics counts the number of weapons in use and then automatically orders replacement spares equal to the percentage set in this option.
+lblSparesWeapons.tooltip=How many spare weapons to stock, as a percentage of each weapon in use across the command.
 lblSparesActuators.text=Actuators
-lblSparesActuators.tooltip=autoLogistics counts the number of 'Mek actuators in use and then automatically orders replacement spares equal to the percentage set in this option.
+lblSparesActuators.tooltip=How many spare Mek actuators to stock, as a percentage of the actuators in use across the command.
 lblSparesJumpJets.text=Jump Jets
-lblSparesJumpJets.tooltip=autoLogistics counts the number of jump jets in use and then automatically orders replacement spares equal to the percentage set in this option.
+lblSparesJumpJets.tooltip=How many spare jump jets to stock, as a percentage of the jump jets in use across the command.
 lblSparesHeadComponents.text=Mek Head Component
-lblSparesHeadComponents.tooltip=autoLogistics counts how many cockpits, sensors, and life support equipment are in use and then automatically orders replacement spares equal to the percentage set in this option.
+lblSparesHeadComponents.tooltip=How many spare cockpits, sensors and life support systems to stock, as a percentage of those in use across the command.
 lblSparesEngines.text=Engine
-lblSparesEngines.tooltip=autoLogistics counts the number of engines in use and then automatically orders replacement spares equal to the percentage set in this option.
+lblSparesEngines.tooltip=How many spare engines to stock, as a percentage of the engines in use across the command.
 lblSparesGyros.text=Mek Gyro
-lblSparesGyros.tooltip=autoLogistics counts the number of gyros in use and then automatically orders replacement spares equal to the percentage set in this option.
+lblSparesGyros.tooltip=How many spare gyros to stock, as a percentage of the gyros in use across the command.
 lblSparesOther.text=Other
-lblSparesOther.tooltip=autoLogistics counts each part in use, that is not covered by one of the other options, and automatically orders replacement spares equal to the percentage set in this option.
+lblSparesOther.tooltip=How many spares to stock of every part not covered above, as a percentage of those in use across the command.
 
 # ---- Spares & Finances: Spares help text
 # The fixed body width forces the label to wrap. Without it an HTML JLabel computes its preferred
@@ -235,13 +232,13 @@ warningDefaultsOnlyRuleset.continue=Continue?
 # Augmentation (cybernetics). All three are off in a new campaign; they are repeated here because
 # they must be set before generating and cannot be applied to warriors afterwards.
 lblAugmentation.text=Augmentation
-lblAugmentation.tooltip=Cybernetic implants for the generated warriors. Requires the campaign to track implants; the Manei Domini and neural interface rules are MegaMek game options, written to the campaign when the command is built.
+lblAugmentation.tooltip=Cybernetic implants for the warriors generated. The campaign has to track implants first; the Manei Domini and neural interface rules are MegaMek game options and are written to the campaign when the command is built.
 lblUseImplants.text=Track Cybernetic Implants
-lblUseImplants.tooltip=Lets the campaign record cybernetic implants. Required before any augmentation can be generated, and saved with the campaign.
+lblUseImplants.tooltip=Lets the campaign record cybernetic implants. Needed before any augmentation can be generated, and saved with the campaign.
 lblUseManeiDomini.text=Manei Domini Rules
-lblUseManeiDomini.tooltip=Turns on MegaMek's Manei Domini rules, without which a generated Word of Blake Shadow Division's implants do nothing. Saved with the campaign's game options.
+lblUseManeiDomini.tooltip=Turns on MegaMek's Manei Domini rules. Without them the implants of a generated Word of Blake Shadow Division do nothing. Saved with the campaign's game options.
 lblNeuralInterfaceMode.text=Neural Interface
-lblNeuralInterfaceMode.tooltip=Which of MegaMek's neural interface rules apply. Off means no implant does anything; Pilot Abilities Only needs only the implant; Full Tracking also requires interface equipment in the unit. Clan enhanced imaging warriors are only generated when this is not Off. Saved with the campaign's game options.
+lblNeuralInterfaceMode.tooltip=Which of MegaMek's neural interface rules apply. Off means no implant does anything. Pilot Abilities Only needs only the implant. Full Tracking also needs interface equipment fitted in the unit.
 
 # Temporary Crew (Personnel & Officers tab). The toggle labels are the campaign options dialog's, so the same
 # setting reads the same in both places.
@@ -270,5 +267,5 @@ lblUseBlobVesselCrew.tooltip=Allow large aerospace vessels to use temporary crew
 btnClearRolls.text=Clear Rolls
 btnClearRolls.tooltip=Empties the Command Model - every roll accumulated with Generate - and the organisation tree. Your settings on the tabs are kept, so you can roll again straight away.
 
-cmbTechAssignmentDirection.tooltip=Highest first hands the best techs to the top of this ordering; Lowest first reverses it.
+cmbTechAssignmentDirection.tooltip=Highest first gives the best techs to the top of this ordering, for example the heaviest units. Lowest first turns it round.
 GenerationProgressDialog.initializing.text=Initializing...

--- a/MekHQ/src/mekhq/gui/commandGeneration/contents/SetupTab.java
+++ b/MekHQ/src/mekhq/gui/commandGeneration/contents/SetupTab.java
@@ -362,6 +362,8 @@ public class SetupTab {
         astechGroup.add(rdoAstechsAsPersonnel);
         rdoAstechsAsPool.setSelected(true);
         cmbAstechSkillLevel = buildSkillLevelCombo("cmbAstechSkillLevel");
+        cmbAstechSkillLevel.setToolTipText(wrapTooltip(
+              getTextAt(getCommandGenerationResourceBundle(), "lblAstechSkillLevel.tooltip"), null));
 
         // Medic block
         chkGenerateMedics = new CommandGenerationCheckBox("GenerateMedics");
@@ -372,6 +374,8 @@ public class SetupTab {
         medicGroup.add(rdoMedicsAsPersonnel);
         rdoMedicsAsPool.setSelected(true);
         cmbMedicSkillLevel = buildSkillLevelCombo("cmbMedicSkillLevel");
+        cmbMedicSkillLevel.setToolTipText(wrapTooltip(
+              getTextAt(getCommandGenerationResourceBundle(), "lblMedicSkillLevel.tooltip"), null));
 
         // Enable/disable wiring: parent checkbox controls the radios + skill dropdown;
         // "as Personnel" radio controls whether the skill dropdown is live.

--- a/MekHQ/src/mekhq/gui/commandGeneration/contents/SparesAndFinancesTab.java
+++ b/MekHQ/src/mekhq/gui/commandGeneration/contents/SparesAndFinancesTab.java
@@ -79,7 +79,6 @@ import mekhq.gui.commandGeneration.components.CommandGenerationStandardPanel;
  *
  * <p><b>Right column</b> - the post-generation rule sections:</p>
  * <ol>
- *   <li><b>Contracts</b> - Select Starting Contract, Start Course to Contract Planet</li>
  *   <li><b>Finances</b> - Process Finances toggle plus the starting-cash percentage: the command
  *       is granted free, and starting cash is working capital sized as a percentage of the
  *       generated units' total purchase cost (default 10%)</li>
@@ -100,10 +99,6 @@ public class SparesAndFinancesTab {
 
     /** Ordered map: bundle-key suffix (also the lbl{key}.text key) → spares spinner. */
     private final Map<String, JSpinner> spinners = new LinkedHashMap<>();
-
-    // Contracts
-    private CommandGenerationCheckBox chkSelectStartingContract;
-    private CommandGenerationCheckBox chkStartCourseToContractPlanet;
 
     // Finances
     private CommandGenerationCheckBox chkProcessFinances;
@@ -162,11 +157,10 @@ public class SparesAndFinancesTab {
         constraints.weighty = 1.0;
         panel.add(leftColumn, constraints);
 
-        // Right column: Contracts (2 rows) + Finances (the tallest section) + Starting Simulation.
+        // Right column: Finances (the tallest section) + Starting Simulation. The starting-contract options
+        // are not shown: the generator does not act on them yet, and a box that does nothing misleads.
         JPanel rightColumn = new JPanel();
         rightColumn.setLayout(new BoxLayout(rightColumn, BoxLayout.Y_AXIS));
-        rightColumn.add(buildContractsSection());
-        rightColumn.add(Box.createVerticalStrut(UIUtil.scaleForGUI(6)));
         rightColumn.add(buildFinancesSection());
         rightColumn.add(Box.createVerticalStrut(UIUtil.scaleForGUI(6)));
         rightColumn.add(buildStartingSimulationSection());
@@ -225,6 +219,7 @@ public class SparesAndFinancesTab {
 
             JLabel label = new CommandGenerationLabel(key);
             label.setLabelFor(spinner);
+            spinner.setToolTipText(label.getToolTipText());
 
             boolean leftColumn = index < perColumn;
             constraints.gridy = 1 + (leftColumn ? index : index - perColumn);
@@ -242,26 +237,6 @@ public class SparesAndFinancesTab {
 
     // region Finances column
 
-    private JPanel buildContractsSection() {
-        CommandGenerationStandardPanel section = new CommandGenerationStandardPanel(
-              "Contracts", true, "Contracts");
-        section.setLayout(new GridBagLayout());
-        GridBagConstraints constraints = sectionConstraints();
-
-        chkSelectStartingContract = new CommandGenerationCheckBox("SelectStartingContract");
-        chkStartCourseToContractPlanet = new CommandGenerationCheckBox("StartCourseToContractPlanet");
-        chkSelectStartingContract.addActionListener(event ->
-              chkStartCourseToContractPlanet.setEnabled(chkSelectStartingContract.isSelected()));
-
-        constraints.gridy = 0;
-        section.add(chkSelectStartingContract, constraints);
-        constraints.gridy = 1;
-        section.add(chkStartCourseToContractPlanet, constraints);
-
-        addFillers(section);
-        return section;
-    }
-
     private JPanel buildFinancesSection() {
         CommandGenerationStandardPanel section = new CommandGenerationStandardPanel(
               "Finances", true, "Finances");
@@ -269,15 +244,24 @@ public class SparesAndFinancesTab {
         GridBagConstraints constraints = sectionConstraints();
 
         chkProcessFinances = new CommandGenerationCheckBox("ProcessFinances");
+        // Each spinner shares the tooltip of the label beside it, so the help shows whichever is hovered.
+        CommandGenerationLabel startingCashPercentLabel = new CommandGenerationLabel("StartingCashPercent");
         spnStartingCashPercent = new JSpinner(new SpinnerNumberModel(10, 0, 1000, 1));
         spnStartingCashPercent.setName("spnStartingCashPercent");
+        spnStartingCashPercent.setToolTipText(startingCashPercentLabel.getToolTipText());
+        CommandGenerationLabel startingCashPreviewLabel = new CommandGenerationLabel("StartingCashPreview");
         lblStartingCashPreviewValue = new JLabel();
         lblStartingCashPreviewValue.setName("lblStartingCashPreviewValue");
+        lblStartingCashPreviewValue.setToolTipText(startingCashPreviewLabel.getToolTipText());
         chkRandomizeStartingCash = new CommandGenerationCheckBox("RandomizeStartingCash");
+        CommandGenerationLabel diceCountLabel = new CommandGenerationLabel("RandomStartingCashDiceCount");
         spnRandomStartingCashDiceCount = new JSpinner(new SpinnerNumberModel(18, 1, 100, 1));
         spnRandomStartingCashDiceCount.setName("spnRandomStartingCashDiceCount");
+        spnRandomStartingCashDiceCount.setToolTipText(diceCountLabel.getToolTipText());
+        CommandGenerationLabel minimumFloatLabel = new CommandGenerationLabel("MinimumStartingFloat");
         spnMinimumStartingFloat = new JSpinner(new SpinnerNumberModel(0, 0, 100_000_000, 100_000));
         spnMinimumStartingFloat.setName("spnMinimumStartingFloat");
+        spnMinimumStartingFloat.setToolTipText(minimumFloatLabel.getToolTipText());
         chkStartingLoan = new CommandGenerationCheckBox("StartingLoan");
 
         chkProcessFinances.addActionListener(event -> refreshFinanceEnablement());
@@ -295,14 +279,14 @@ public class SparesAndFinancesTab {
         constraints.gridwidth = 1;
         constraints.gridy = row;
         constraints.gridx = 0;
-        section.add(new CommandGenerationLabel("StartingCashPercent"), constraints);
+        section.add(startingCashPercentLabel, constraints);
         constraints.gridx = 1;
         section.add(spnStartingCashPercent, constraints);
         row++;
 
         constraints.gridy = row;
         constraints.gridx = 0;
-        section.add(new CommandGenerationLabel("StartingCashPreview"), constraints);
+        section.add(startingCashPreviewLabel, constraints);
         constraints.gridx = 1;
         section.add(lblStartingCashPreviewValue, constraints);
         row++;
@@ -315,14 +299,14 @@ public class SparesAndFinancesTab {
         constraints.gridwidth = 1;
         constraints.gridy = row;
         constraints.gridx = 0;
-        section.add(new CommandGenerationLabel("RandomStartingCashDiceCount"), constraints);
+        section.add(diceCountLabel, constraints);
         constraints.gridx = 1;
         section.add(spnRandomStartingCashDiceCount, constraints);
         row++;
 
         constraints.gridy = row;
         constraints.gridx = 0;
-        section.add(new CommandGenerationLabel("MinimumStartingFloat"), constraints);
+        section.add(minimumFloatLabel, constraints);
         constraints.gridx = 1;
         section.add(spnMinimumStartingFloat, constraints);
         row++;
@@ -406,8 +390,10 @@ public class SparesAndFinancesTab {
         GridBagConstraints constraints = sectionConstraints();
 
         chkRunStartingSimulation = new CommandGenerationCheckBox("RunStartingSimulation");
+        CommandGenerationLabel simulationDurationLabel = new CommandGenerationLabel("SimulationDuration");
         spnSimulationDuration = new JSpinner(new SpinnerNumberModel(12, 1, 600, 1));
         spnSimulationDuration.setName("spnSimulationDuration");
+        spnSimulationDuration.setToolTipText(simulationDurationLabel.getToolTipText());
         chkSimulateRandomMarriages = new CommandGenerationCheckBox("SimulateRandomMarriages");
         chkSimulateRandomProcreation = new CommandGenerationCheckBox("SimulateRandomProcreation");
 
@@ -426,7 +412,7 @@ public class SparesAndFinancesTab {
         constraints.gridwidth = 1;
         constraints.gridy = row;
         constraints.gridx = 0;
-        section.add(new CommandGenerationLabel("SimulationDuration"), constraints);
+        section.add(simulationDurationLabel, constraints);
         constraints.gridx = 1;
         section.add(spnSimulationDuration, constraints);
         row++;
@@ -482,7 +468,7 @@ public class SparesAndFinancesTab {
 
     /**
      * Reads values into the tab's controls. The spares spinners load from the campaign's
-     * {@link CampaignOptions} (their source of truth); the contract / finance / simulation controls
+     * {@link CampaignOptions} (their source of truth); the finance / simulation controls
      * load from the supplied {@code sourceOptions}.
      */
     public void loadValuesFromOptions(CommandGenerationOptions sourceOptions) {
@@ -493,10 +479,6 @@ public class SparesAndFinancesTab {
         if (sourceOptions == null) {
             return;
         }
-
-        chkSelectStartingContract.setSelected(sourceOptions.isSelectStartingContract());
-        chkStartCourseToContractPlanet.setSelected(sourceOptions.isStartCourseToContractPlanet());
-        chkStartCourseToContractPlanet.setEnabled(chkSelectStartingContract.isSelected());
 
         chkProcessFinances.setSelected(sourceOptions.isProcessFinances());
         spnStartingCashPercent.setValue(sourceOptions.getStartingCashPercent());
@@ -549,7 +531,7 @@ public class SparesAndFinancesTab {
     /**
      * Writes the tab's controls back out. The spares spinners write to the campaign's
      * {@link CampaignOptions} (making the dialog's selections effective immediately for both the
-     * initial spawn and ongoing resupply); the contract / finance / simulation controls write to the
+     * initial spawn and ongoing resupply); the finance / simulation controls write to the
      * supplied {@code targetOptions}.
      */
     public void writeValuesToOptions(CommandGenerationOptions targetOptions) {
@@ -559,9 +541,6 @@ public class SparesAndFinancesTab {
         if (targetOptions == null) {
             return;
         }
-
-        targetOptions.setSelectStartingContract(chkSelectStartingContract.isSelected());
-        targetOptions.setStartCourseToContractPlanet(chkStartCourseToContractPlanet.isSelected());
 
         targetOptions.setProcessFinances(chkProcessFinances.isSelected());
         targetOptions.setStartingCashPercent((Integer) spnStartingCashPercent.getValue());

--- a/MekHQ/unittests/mekhq/gui/commandGeneration/CommandGenerationTooltipsTest.java
+++ b/MekHQ/unittests/mekhq/gui/commandGeneration/CommandGenerationTooltipsTest.java
@@ -35,140 +35,86 @@ package mekhq.gui.commandGeneration;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.awt.Component;
-import java.awt.Container;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.TreeSet;
-import javax.swing.AbstractButton;
-import javax.swing.JComboBox;
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JSlider;
-import javax.swing.JSpinner;
-import javax.swing.JTextField;
 
-import megamek.common.equipment.EquipmentType;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.personnel.skills.SkillType;
-import mekhq.campaign.universe.Factions;
-import mekhq.campaign.universe.commandGeneration.CommandGenerationOptions;
-import mekhq.gui.commandGeneration.contents.SetupTab;
-import mekhq.gui.commandGeneration.contents.SparesAndFinancesTab;
+import mekhq.gui.commandGeneration.components.CommandGenerationUtilities;
 import mekhq.utilities.MHQInternationalization;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import testUtilities.MHQTestUtilities;
 
 /**
- * Every option a player can set in the Command Generator explains itself on hover (MekHQ issue 9938).
+ * Every option in the Command Generator has help text in its bundle (MekHQ issue 9938).
  *
- * <p>The tabs are built the way the dialog builds them and every control walked: check boxes, radio buttons,
- * drop-downs, spinners, text fields, sliders and buttons. Each must carry a tooltip that is not blank and is
- * not the {@code !key!} placeholder the bundle lookup returns for a missing key. A spinner's text field and a
- * drop-down's arrow button are checked as well: they are what the pointer actually rests on, and the look and
- * feel is expected to hand them the parent's tooltip. The Force Generator tab's controls come from MegaMek's
- * own panel, which sets its tooltips from MegaMek's bundle, so it is covered there.</p>
+ * <p>The tabs build their controls from {@code lbl<name>.text} keys and read the matching
+ * {@code lbl<name>.tooltip}; the two skill drop-downs and the tech assignment direction read a tooltip key of
+ * their own. This checks the bundle rather than the built dialog: every labelled entry carries a tooltip that is
+ * not blank and not the bundle's missing-key placeholder, apart from the few labels that are headings or body
+ * text rather than options.</p>
  */
 class CommandGenerationTooltipsTest {
 
-    private static Campaign campaign;
+    /** Labels that are not options: column headings and a paragraph of help, which explain nothing further. */
+    private static final Set<String> NOT_OPTIONS = Set.of(
+          "lblSupportPersonnelColumnRole",
+          "lblSupportPersonnelColumnPercent",
+          "lblSupportPersonnelColumnSkill",
+          "lblSparesHelpBody");
 
-    @BeforeAll
-    static void loadWhatTheTabsRead() {
-        EquipmentType.initializeTypes();
-        SkillType.initializeTypes();
-        Factions.setInstance(Factions.loadDefault(true));
-        campaign = MHQTestUtilities.getTestCampaign();
+    /** Tooltip keys read by controls that take their text from somewhere other than an {@code lbl} key. */
+    private static final List<String> TOOLTIP_ONLY_KEYS = List.of(
+          "lblAstechSkillLevel.tooltip",
+          "lblMedicSkillLevel.tooltip",
+          "cmbTechAssignmentDirection.tooltip",
+          "supportCoveragePercent.toolTipText",
+          "supportSkillLevel.toolTipText");
+
+    private static ResourceBundle bundle() {
+        return ResourceBundle.getBundle(CommandGenerationUtilities.getCommandGenerationResourceBundle());
     }
 
     @Test
-    void everyControlOnThePersonnelAndOfficersTabHasATooltip() {
-        JPanel tab = new SetupTab(campaign, new CommandGenerationOptions()).createTab();
-
-        assertEveryControlExplainsItself(tab, "Personnel & Officers");
-    }
-
-    @Test
-    void everyControlOnTheSparesAndFinancesTabHasATooltip() {
-        JPanel tab = new SparesAndFinancesTab(campaign, new CommandGenerationOptions(), () -> null).createTab();
-
-        assertEveryControlExplainsItself(tab, "Spares & Finances");
-    }
-
-    private static void assertEveryControlExplainsItself(Container tab, String tabName) {
-        List<JComponent> controls = new ArrayList<>();
-        collectControls(tab, controls);
-        assertFalse(controls.isEmpty(), tabName + " built no controls; the walk found nothing to check");
+    void everyLabelledOptionHasATooltip() {
+        ResourceBundle bundle = bundle();
+        Set<String> options = new TreeSet<>();
+        for (String key : bundle.keySet()) {
+            boolean isLabel = key.startsWith("lbl") && key.endsWith(".text");
+            if (isLabel) {
+                options.add(key.substring(0, key.length() - ".text".length()));
+            }
+        }
+        options.removeAll(NOT_OPTIONS);
+        assertFalse(options.isEmpty(), "the bundle names no options at all");
 
         Set<String> missing = new TreeSet<>();
-        for (JComponent control : controls) {
-            String tooltip = control.getToolTipText();
-            boolean isBlank = (tooltip == null) || tooltip.isBlank();
-            boolean isPlaceholder = (tooltip != null) && !MHQInternationalization.isResourceKeyValid(tooltip);
-            if (isBlank || isPlaceholder) {
-                missing.add(describe(control));
+        for (String option : options) {
+            if (!hasHelp(bundle, option + ".tooltip")) {
+                missing.add(option);
             }
         }
-        assertTrue(missing.isEmpty(), tabName + ": " + missing.size() + " control(s) have no tooltip: " + missing);
+        assertTrue(missing.isEmpty(), missing.size() + " option(s) have no tooltip: " + missing);
     }
 
-    /**
-     * Gathers the controls a player operates. A spinner is listed with its text field and a drop-down with its
-     * arrow button, since those are the parts the pointer rests on; the look and feel passes the parent's tooltip
-     * down to them, and this checks that it did.
-     */
-    private static void collectControls(Container container, List<JComponent> into) {
-        for (Component component : container.getComponents()) {
-            if (component instanceof JSpinner spinner) {
-                into.add(spinner);
-                if (spinner.getEditor() instanceof JSpinner.DefaultEditor editor) {
-                    into.add(named(editor.getTextField(), spinner.getName() + " text field"));
-                }
-                continue;
-            }
-            if (component instanceof JComboBox<?> dropDown) {
-                into.add(dropDown);
-                for (Component part : dropDown.getComponents()) {
-                    if (part instanceof AbstractButton arrowButton) {
-                        into.add(named(arrowButton, dropDown.getName() + " arrow button"));
-                    }
-                }
-                continue;
-            }
-            boolean isControl = (component instanceof AbstractButton)
-                  || (component instanceof JTextField)
-                  || (component instanceof JSlider);
-            if (isControl) {
-                into.add((JComponent) component);
-            }
-            if (component instanceof Container child) {
-                collectControls(child, into);
+    @Test
+    void controlsWithTheirOwnTooltipKeyHaveOne() {
+        ResourceBundle bundle = bundle();
+        Set<String> missing = new TreeSet<>();
+        for (String key : TOOLTIP_ONLY_KEYS) {
+            if (!hasHelp(bundle, key)) {
+                missing.add(key);
             }
         }
+        assertTrue(missing.isEmpty(), "tooltip key(s) missing or blank: " + missing);
     }
 
-    /** Gives a nameless part of a control a name that says which control it belongs to. */
-    private static JComponent named(JComponent part, String name) {
-        if ((part.getName() == null) || part.getName().isBlank()) {
-            part.setName(name);
+    private static boolean hasHelp(ResourceBundle bundle, String key) {
+        if (!bundle.containsKey(key)) {
+            return false;
         }
-        return part;
-    }
-
-    private static String describe(JComponent control) {
-        String name = control.getName();
-        if ((name != null) && !name.isBlank()) {
-            return name;
-        }
-        if (control instanceof AbstractButton button) {
-            return button.getClass().getSimpleName() + " '" + button.getText() + "'";
-        }
-        if (control instanceof JLabel label) {
-            return "label '" + label.getText() + "'";
-        }
-        return control.getClass().getSimpleName() + " (unnamed)";
+        String text = bundle.getString(key);
+        boolean isBlank = text.isBlank();
+        boolean isPlaceholder = !MHQInternationalization.isResourceKeyValid(text);
+        return !isBlank && !isPlaceholder;
     }
 }

--- a/MekHQ/unittests/mekhq/gui/commandGeneration/CommandGenerationTooltipsTest.java
+++ b/MekHQ/unittests/mekhq/gui/commandGeneration/CommandGenerationTooltipsTest.java
@@ -57,6 +57,7 @@ import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.commandGeneration.CommandGenerationOptions;
 import mekhq.gui.commandGeneration.contents.SetupTab;
 import mekhq.gui.commandGeneration.contents.SparesAndFinancesTab;
+import mekhq.utilities.MHQInternationalization;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import testUtilities.MHQTestUtilities;
@@ -66,9 +67,10 @@ import testUtilities.MHQTestUtilities;
  *
  * <p>The tabs are built the way the dialog builds them and every control walked: check boxes, radio buttons,
  * drop-downs, spinners, text fields, sliders and buttons. Each must carry a tooltip that is not blank and is
- * not the {@code !key!} placeholder the bundle lookup returns for a missing key. The Force Generator tab's
- * controls come from MegaMek's own panel, which sets its tooltips from MegaMek's bundle, so it is covered
- * there.</p>
+ * not the {@code !key!} placeholder the bundle lookup returns for a missing key. A spinner's text field and a
+ * drop-down's arrow button are checked as well: they are what the pointer actually rests on, and the look and
+ * feel is expected to hand them the parent's tooltip. The Force Generator tab's controls come from MegaMek's
+ * own panel, which sets its tooltips from MegaMek's bundle, so it is covered there.</p>
  */
 class CommandGenerationTooltipsTest {
 
@@ -105,7 +107,7 @@ class CommandGenerationTooltipsTest {
         for (JComponent control : controls) {
             String tooltip = control.getToolTipText();
             boolean isBlank = (tooltip == null) || tooltip.isBlank();
-            boolean isPlaceholder = (tooltip != null) && tooltip.startsWith("!");
+            boolean isPlaceholder = (tooltip != null) && !MHQInternationalization.isResourceKeyValid(tooltip);
             if (isBlank || isPlaceholder) {
                 missing.add(describe(control));
             }
@@ -114,17 +116,26 @@ class CommandGenerationTooltipsTest {
     }
 
     /**
-     * Gathers the controls a player operates. A spinner's own text field and a drop-down's arrow button are
-     * parts of their control and are not listed on their own; the spinner or drop-down carries the tooltip.
+     * Gathers the controls a player operates. A spinner is listed with its text field and a drop-down with its
+     * arrow button, since those are the parts the pointer rests on; the look and feel passes the parent's tooltip
+     * down to them, and this checks that it did.
      */
     private static void collectControls(Container container, List<JComponent> into) {
         for (Component component : container.getComponents()) {
             if (component instanceof JSpinner spinner) {
                 into.add(spinner);
+                if (spinner.getEditor() instanceof JSpinner.DefaultEditor editor) {
+                    into.add(named(editor.getTextField(), spinner.getName() + " text field"));
+                }
                 continue;
             }
             if (component instanceof JComboBox<?> dropDown) {
                 into.add(dropDown);
+                for (Component part : dropDown.getComponents()) {
+                    if (part instanceof AbstractButton arrowButton) {
+                        into.add(named(arrowButton, dropDown.getName() + " arrow button"));
+                    }
+                }
                 continue;
             }
             boolean isControl = (component instanceof AbstractButton)
@@ -137,6 +148,14 @@ class CommandGenerationTooltipsTest {
                 collectControls(child, into);
             }
         }
+    }
+
+    /** Gives a nameless part of a control a name that says which control it belongs to. */
+    private static JComponent named(JComponent part, String name) {
+        if ((part.getName() == null) || part.getName().isBlank()) {
+            part.setName(name);
+        }
+        return part;
     }
 
     private static String describe(JComponent control) {

--- a/MekHQ/unittests/mekhq/gui/commandGeneration/CommandGenerationTooltipsTest.java
+++ b/MekHQ/unittests/mekhq/gui/commandGeneration/CommandGenerationTooltipsTest.java
@@ -128,7 +128,6 @@ class CommandGenerationTooltipsTest {
                 continue;
             }
             boolean isControl = (component instanceof AbstractButton)
-                  || (component instanceof JComboBox<?>)
                   || (component instanceof JTextField)
                   || (component instanceof JSlider);
             if (isControl) {

--- a/MekHQ/unittests/mekhq/gui/commandGeneration/CommandGenerationTooltipsTest.java
+++ b/MekHQ/unittests/mekhq/gui/commandGeneration/CommandGenerationTooltipsTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.commandGeneration;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Component;
+import java.awt.Container;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import javax.swing.AbstractButton;
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JSlider;
+import javax.swing.JSpinner;
+import javax.swing.JTextField;
+
+import megamek.common.equipment.EquipmentType;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.personnel.skills.SkillType;
+import mekhq.campaign.universe.Factions;
+import mekhq.campaign.universe.commandGeneration.CommandGenerationOptions;
+import mekhq.gui.commandGeneration.contents.SetupTab;
+import mekhq.gui.commandGeneration.contents.SparesAndFinancesTab;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import testUtilities.MHQTestUtilities;
+
+/**
+ * Every option a player can set in the Command Generator explains itself on hover (MekHQ issue 9938).
+ *
+ * <p>The tabs are built the way the dialog builds them and every control walked: check boxes, radio buttons,
+ * drop-downs, spinners, text fields, sliders and buttons. Each must carry a tooltip that is not blank and is
+ * not the {@code !key!} placeholder the bundle lookup returns for a missing key. The Force Generator tab's
+ * controls come from MegaMek's own panel, which sets its tooltips from MegaMek's bundle, so it is covered
+ * there.</p>
+ */
+class CommandGenerationTooltipsTest {
+
+    private static Campaign campaign;
+
+    @BeforeAll
+    static void loadWhatTheTabsRead() {
+        EquipmentType.initializeTypes();
+        SkillType.initializeTypes();
+        Factions.setInstance(Factions.loadDefault(true));
+        campaign = MHQTestUtilities.getTestCampaign();
+    }
+
+    @Test
+    void everyControlOnThePersonnelAndOfficersTabHasATooltip() {
+        JPanel tab = new SetupTab(campaign, new CommandGenerationOptions()).createTab();
+
+        assertEveryControlExplainsItself(tab, "Personnel & Officers");
+    }
+
+    @Test
+    void everyControlOnTheSparesAndFinancesTabHasATooltip() {
+        JPanel tab = new SparesAndFinancesTab(campaign, new CommandGenerationOptions(), () -> null).createTab();
+
+        assertEveryControlExplainsItself(tab, "Spares & Finances");
+    }
+
+    private static void assertEveryControlExplainsItself(Container tab, String tabName) {
+        List<JComponent> controls = new ArrayList<>();
+        collectControls(tab, controls);
+        assertFalse(controls.isEmpty(), tabName + " built no controls; the walk found nothing to check");
+
+        Set<String> missing = new TreeSet<>();
+        for (JComponent control : controls) {
+            String tooltip = control.getToolTipText();
+            boolean isBlank = (tooltip == null) || tooltip.isBlank();
+            boolean isPlaceholder = (tooltip != null) && tooltip.startsWith("!");
+            if (isBlank || isPlaceholder) {
+                missing.add(describe(control));
+            }
+        }
+        assertTrue(missing.isEmpty(), tabName + ": " + missing.size() + " control(s) have no tooltip: " + missing);
+    }
+
+    /**
+     * Gathers the controls a player operates. A spinner's own text field and a drop-down's arrow button are
+     * parts of their control and are not listed on their own; the spinner or drop-down carries the tooltip.
+     */
+    private static void collectControls(Container container, List<JComponent> into) {
+        for (Component component : container.getComponents()) {
+            if (component instanceof JSpinner spinner) {
+                into.add(spinner);
+                continue;
+            }
+            if (component instanceof JComboBox<?> dropDown) {
+                into.add(dropDown);
+                continue;
+            }
+            boolean isControl = (component instanceof AbstractButton)
+                  || (component instanceof JComboBox<?>)
+                  || (component instanceof JTextField)
+                  || (component instanceof JSlider);
+            if (isControl) {
+                into.add((JComponent) component);
+            }
+            if (component instanceof Container child) {
+                collectControls(child, into);
+            }
+        }
+    }
+
+    private static String describe(JComponent control) {
+        String name = control.getName();
+        if ((name != null) && !name.isBlank()) {
+            return name;
+        }
+        if (control instanceof AbstractButton button) {
+            return button.getClass().getSimpleName() + " '" + button.getText() + "'";
+        }
+        if (control instanceof JLabel label) {
+            return "label '" + label.getText() + "'";
+        }
+        return control.getClass().getSimpleName() + " (unnamed)";
+    }
+}


### PR DESCRIPTION
## What this changes

Every option in the Command Generator now shows help on hover, written in plain language against what the code does. The two assistant skill drop-downs and all seventeen spinners on Spares & Finances had none. Nine options the generator does not act on yet say so; the two starting-contract options are no longer shown, since nothing reads them.

Fixes #9938

## Testing

- New CommandGenerationTooltipsTest builds both tabs headless and fails on any control without a tooltip.
- 279 tests across the command generation GUI and pipeline packages; checkstyle green.
- Each tooltip checked against the consuming code.

## What is not proven yet

- Not opened in a running campaign; the headless tab build is the check.
- Generate Captains, the issue's example, already had a tooltip on main and is never greyed out, so that exact report was not reproduced.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result
