### PR TITLE
fix: SpotBugs code logic cleanup

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3173,8 +3173,6 @@ public class Campaign implements ITechManager {
                                                                  getLocalDate()),
                   "HELLO", chosenFaction,
                   FactionStandingJudgmentType.WELCOME, ImmersiveDialogWidth.MEDIUM, null, null);
-        } else if (chosenFaction == null) {
-            LOGGER.warn("Unable to find a suitable faction for a new mercenary organization start up");
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/mission/scenarios/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/scenarios/AtBDynamicScenarioFactory.java
@@ -2701,28 +2701,26 @@ public class AtBDynamicScenarioFactory {
         }
 
         UnitGeneratorParameters newParams = params.clone();
-        if (newParams != null) {
-            newParams.setUnitType(BATTLE_ARMOR);
-            newParams.getMovementModes().addAll(IUnitGenerator.ALL_BATTLE_ARMOR_MODES);
+        newParams.setUnitType(BATTLE_ARMOR);
+        newParams.getMovementModes().addAll(IUnitGenerator.ALL_BATTLE_ARMOR_MODES);
 
-            // Set the parameters to filter out types that are too heavy for the provided
-            // bay space, or those that cannot use mechanized BA travel
-            if (bayCapacity != IUnitGenerator.NO_WEIGHT_LIMIT) {
-                if (filterOutClanTech(campaign, isFactionClan(params.getFaction()))) {
-                    params.setFilter(mekSummary -> !mekSummary.isClan() && mekSummary.getTons() <= bayCapacity);
-                } else {
-                    params.setFilter(mekSummary -> mekSummary.getTons() <= bayCapacity);
-                }
+        // Set the parameters to filter out types that are too heavy for the provided
+        // bay space, or those that cannot use mechanized BA travel
+        if (bayCapacity != IUnitGenerator.NO_WEIGHT_LIMIT) {
+            if (filterOutClanTech(campaign, isFactionClan(params.getFaction()))) {
+                params.setFilter(mekSummary -> !mekSummary.isClan() && mekSummary.getTons() <= bayCapacity);
             } else {
-                newParams.addMissionRole(MECHANIZED_BA);
+                params.setFilter(mekSummary -> mekSummary.getTons() <= bayCapacity);
             }
+        } else {
+            newParams.addMissionRole(MECHANIZED_BA);
         }
 
         MekSummary unitData = campaign.getUnitGenerator().generate(newParams);
 
         // If generating for an internal bay fails, try again as mechanized if the flag is set
         if (unitData == null) {
-            if (newParams != null && bayCapacity != IUnitGenerator.NO_WEIGHT_LIMIT && retryAsMechanized) {
+            if (bayCapacity != IUnitGenerator.NO_WEIGHT_LIMIT && retryAsMechanized) {
                 if (filterOutClanTech(campaign, isFactionClan(params.getFaction()))) {
                     params.setFilter(mekSummary -> !mekSummary.isClan());
                 } else {
@@ -2739,11 +2737,7 @@ public class AtBDynamicScenarioFactory {
         }
 
         // Add an appropriate crew
-        if (newParams != null) {
-            return createEntityWithCrew(newParams.getFaction(), skill, campaign, unitData);
-        } else {
-            return null;
-        }
+        return createEntityWithCrew(newParams.getFaction(), skill, campaign, unitData);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/unit/TowTransportedUnitsSummary.java
+++ b/MekHQ/src/mekhq/campaign/unit/TowTransportedUnitsSummary.java
@@ -221,7 +221,7 @@ public class TowTransportedUnitsSummary extends AbstractTransportedUnitsSummary 
 
         // Update Transport Capacities
         if (!Objects.equals(oldTractor, transport)) {
-            if (transport.getEntity() != null & !transport.getEntity().isTrailer() &&
+            if (transport.getEntity() != null && !transport.getEntity().isTrailer() &&
                       transport.getEntity() instanceof Tank tank) {
                 recalculateTransportCapacity(tank);
             } else {


### PR DESCRIPTION
This addresses a couple minor items from the static analysis tool SpotBugs 4.10.4.

* A logical AND check
* Some logging that will never be reached
* Cloning will always return a non null object so some code cleanup to simplify

## What this changes

<!-- The effect someone actually sees, in plain language. One or two sentences is fine. -->

<!-- Keep this line as well as the number in the title. GitHub only closes an issue from a
     keyword in the description - a number in the title alone does not close anything.

     Any of these close an issue when this merges:
         Close / Closes / Closed
         Fix / Fixes / Fixed
         Resolve / Resolves / Resolved

     Closing more than one needs the keyword repeated in front of each number:
         Fixes #1234, fixes #5678          closes both
         Fixes #1234, #5678                closes only #1234

     For an issue in another repository, qualify it: Fixes MegaMek/mekhq#1234 -->


## Testing

Gradle tests

## What is not proven yet

<!-- What you did not test, or could not. "Nothing" is a valid answer - say so explicitly. -->

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text

No AI used.