### PR TITLE
Fix #9937: MASH trucks and recovery vehicles generated with the wrong crew

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/commandGeneration/SupportPersonnelToTOE.java
+++ b/MekHQ/src/mekhq/campaign/universe/commandGeneration/SupportPersonnelToTOE.java
@@ -303,8 +303,9 @@ public final class SupportPersonnelToTOE {
     /**
      * Creates each of {@code vehicle}'s crewless copies, crews it from the staff pool starting at
      * {@code startIndex} (up to the vehicle's full crew size, understaffed if the pool runs out), and
-     * files it under {@code parent} (the section's capability-vehicle company). Returns the number of
-     * people consumed as crew. Stops early once the pool is exhausted.
+     * files it under {@code parent} (the section's capability-vehicle company). The staff are seated
+     * into the vehicle's driver, gunner and vehicle-crew positions by {@link #seatVehicleCrew}.
+     * Returns the number of people consumed as crew. Stops early once the pool is exhausted.
      */
     private static int addCapabilityVehicles(Campaign campaign, Formation parent, VehicleSpec vehicle,
           List<Person> pool, int startIndex) {
@@ -319,22 +320,61 @@ public final class SupportPersonnelToTOE {
             try {
                 // allowNewPilots = false: crew comes from the generated staff, not fresh personnel.
                 Unit unit = campaign.addNewUnit(mekSummary.loadEntity(), false, 0);
-                int crewNeeded = Math.max(1, unit.getFullCrewSize());
-                int available = pool.size() - startIndex - consumed;
-                int crewSize = Math.min(crewNeeded, available);
-                for (int crewIndex = 0; crewIndex < crewSize; crewIndex++) {
-                    unit.addPilotOrSoldier(pool.get(startIndex + consumed + crewIndex));
-                }
+                int crewNeeded = unit.getFullCrewSize();
+                int crewSize = seatVehicleCrew(unit, pool, startIndex + consumed);
                 consumed += crewSize;
                 campaign.getPlayerForce().addUnitToFormation(unit, parent.getId(), campaign);
-                LOGGER.info("[CompanyGen][SupportTOE]     {} vehicle '{}' unitId={} crewed with {}/{} staff",
-                      parent.getName(), vehicle.unitName(), unit.getId(), crewSize, crewNeeded);
+                LOGGER.info("[CompanyGen][SupportTOE]     {} vehicle '{}' unitId={} crewed with {}/{} staff "
+                                  + "(drivers {}/{}, gunners {}/{}, vehicle crew {}/{})",
+                      parent.getName(), vehicle.unitName(), unit.getId(), crewSize, crewNeeded,
+                      unit.getDrivers().size(), unit.getTotalDriverNeeds(),
+                      unit.getGunners().size(), unit.getTotalGunnerNeeds(),
+                      unit.getVesselCrew().size(), unit.getTotalCrewNeeds());
             } catch (Exception exception) {
                 LOGGER.error(exception, "Unable to load capability vehicle {}: {}", vehicle.unitName(),
                       mekSummary.getSourceFile());
             }
         }
         return consumed;
+    }
+
+    /**
+     * Seats staff from {@code pool} into {@code unit}'s crew positions, filling drivers first, then
+     * gunners, then vehicle crew - the split MekHQ generates for a vehicle in
+     * {@code Utilities.genRandomCrewWithCombinedSkill}. Filling in that order leaves an understaffed
+     * vehicle with someone at the controls rather than a cabin full of gunners.
+     *
+     * <p>Seating every position through {@code Unit.addPilotOrSoldier} instead makes each person a
+     * driver <em>and</em> a gunner, because a vehicle's pilot and gunner crew positions are the same
+     * position. A four-seat recovery vehicle then holds four drivers where it has room for one, and
+     * {@code Unit.checkForOverCrewing} ejects the surplus the next time the campaign loads.</p>
+     *
+     * @param unit      the vehicle to crew
+     * @param pool      the section's staff, in the order they are handed out
+     * @param fromIndex the first person in {@code pool} still free to crew this vehicle
+     *
+     * @return the number of people seated, which is fewer than the vehicle's seats when the pool runs out
+     */
+    static int seatVehicleCrew(Unit unit, List<Person> pool, int fromIndex) {
+        int available = pool.size() - fromIndex;
+        int driverSeats = unit.getTotalDriverNeeds();
+        int gunnerSeats = unit.getTotalGunnerNeeds();
+        int vehicleCrewSeats = unit.getTotalCrewNeeds();
+        int seated = 0;
+
+        for (int seat = 0; (seat < driverSeats) && (seated < available); seat++) {
+            unit.addDriver(pool.get(fromIndex + seated));
+            seated++;
+        }
+        for (int seat = 0; (seat < gunnerSeats) && (seated < available); seat++) {
+            unit.addGunner(pool.get(fromIndex + seated));
+            seated++;
+        }
+        for (int seat = 0; (seat < vehicleCrewSeats) && (seated < available); seat++) {
+            unit.addVesselCrew(pool.get(fromIndex + seated));
+            seated++;
+        }
+        return seated;
     }
 
     /** A capability vehicle to place into a section, crewed from that section's staff. */

--- a/MekHQ/unittests/mekhq/campaign/universe/commandGeneration/SupportPersonnelToTOETest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/commandGeneration/SupportPersonnelToTOETest.java
@@ -35,7 +35,10 @@ package mekhq.campaign.universe.commandGeneration;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -45,6 +48,7 @@ import java.util.Map;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRole;
+import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.commandGeneration.SupportPersonnelToTOE.CarrierSpec;
 import mekhq.campaign.universe.commandGeneration.SupportPersonnelToTOE.EchelonProfile;
 import org.junit.jupiter.api.Test;
@@ -190,6 +194,105 @@ class SupportPersonnelToTOETest {
         assertEquals(5, grouped.get(PersonnelRole.ASTECH).size());
     }
 
+    // --- Seating a capability vehicle's crew (issue #9937) ---
+    //
+    // A vehicle's pilot and gunner crew positions are the same position, so Unit.addPilotOrSoldier
+    // seats one person as a driver AND a gunner. Filling every seat that way over-crews the vehicle
+    // and Unit.checkForOverCrewing ejects the surplus on the next campaign load. Seats must be
+    // filled per role instead.
+
+    @Test
+    void seatVehicleCrew_recoveryVehicle_oneDriverThreeGunners() {
+        // BattleMek Recovery Vehicle, 50t: full crew 4 = 1 driver + 3 gunners.
+        Unit unit = vehicle(1, 3, 0);
+        List<Person> pool = people(4);
+
+        assertEquals(4, SupportPersonnelToTOE.seatVehicleCrew(unit, pool, 0));
+
+        verify(unit).addDriver(pool.get(0));
+        verify(unit).addGunner(pool.get(1));
+        verify(unit).addGunner(pool.get(2));
+        verify(unit).addGunner(pool.get(3));
+        verify(unit, never()).addVesselCrew(any());
+        verify(unit, never()).addPilotOrSoldier(any());
+    }
+
+    @Test
+    void seatVehicleCrew_mashTruck_oneDriverFiveVehicleCrew() {
+        // MASH Truck (Small), 15t with one theatre: full crew 6 = 1 driver + 0 gunners + 5 crew
+        // (one doctor seat and four medic seats).
+        Unit unit = vehicle(1, 0, 5);
+        List<Person> pool = people(6);
+
+        assertEquals(6, SupportPersonnelToTOE.seatVehicleCrew(unit, pool, 0));
+
+        verify(unit).addDriver(pool.get(0));
+        verify(unit, never()).addGunner(any());
+        for (int index = 1; index < 6; index++) {
+            verify(unit).addVesselCrew(pool.get(index));
+        }
+        verify(unit, never()).addPilotOrSoldier(any());
+    }
+
+    @Test
+    void seatVehicleCrew_shortPool_fillsDriverBeforeTheRest() {
+        // The medical section commonly has fewer staff than a MASH truck has seats, so an
+        // understaffed truck must still have someone at the controls.
+        Unit unit = vehicle(1, 0, 5);
+        List<Person> pool = people(3);
+
+        assertEquals(3, SupportPersonnelToTOE.seatVehicleCrew(unit, pool, 0));
+
+        verify(unit).addDriver(pool.get(0));
+        verify(unit).addVesselCrew(pool.get(1));
+        verify(unit).addVesselCrew(pool.get(2));
+    }
+
+    @Test
+    void seatVehicleCrew_shortPool_gunnerSeatsYieldToTheDriver() {
+        Unit unit = vehicle(1, 3, 0);
+        List<Person> pool = people(2);
+
+        assertEquals(2, SupportPersonnelToTOE.seatVehicleCrew(unit, pool, 0));
+
+        verify(unit).addDriver(pool.get(0));
+        verify(unit).addGunner(pool.get(1));
+    }
+
+    @Test
+    void seatVehicleCrew_offsetPool_seatsOnlyTheStaffStillFree() {
+        // The second recovery vehicle in a batch starts where the first one stopped.
+        Unit unit = vehicle(1, 3, 0);
+        List<Person> pool = people(8);
+
+        assertEquals(4, SupportPersonnelToTOE.seatVehicleCrew(unit, pool, 4));
+
+        verify(unit).addDriver(pool.get(4));
+        verify(unit).addGunner(pool.get(5));
+        verify(unit).addGunner(pool.get(6));
+        verify(unit).addGunner(pool.get(7));
+    }
+
+    @Test
+    void seatVehicleCrew_exhaustedPool_seatsNobody() {
+        Unit unit = vehicle(1, 3, 0);
+        List<Person> pool = people(4);
+
+        assertEquals(0, SupportPersonnelToTOE.seatVehicleCrew(unit, pool, 4));
+
+        verify(unit, never()).addDriver(any());
+        verify(unit, never()).addGunner(any());
+        verify(unit, never()).addVesselCrew(any());
+    }
+
+    @Test
+    void seatVehicleCrew_neverSeatsMoreThanTheVehicleHolds() {
+        Unit unit = vehicle(1, 3, 0);
+        List<Person> pool = people(40);
+
+        assertEquals(4, SupportPersonnelToTOE.seatVehicleCrew(unit, pool, 0));
+    }
+
     // --- Guards ---
 
     @Test
@@ -217,6 +320,15 @@ class SupportPersonnelToTOETest {
             total += spec.crew().size();
         }
         return total;
+    }
+
+    /** A vehicle Unit mock with the given driver, gunner and vehicle-crew seat counts. */
+    private static Unit vehicle(int driverSeats, int gunnerSeats, int vehicleCrewSeats) {
+        Unit unit = mock(Unit.class);
+        when(unit.getTotalDriverNeeds()).thenReturn(driverSeats);
+        when(unit.getTotalGunnerNeeds()).thenReturn(gunnerSeats);
+        when(unit.getTotalCrewNeeds()).thenReturn(vehicleCrewSeats);
+        return unit;
     }
 
     /** A list of {@code count} distinct Person mocks; packPool only slices, so no stubbing needed. */


### PR DESCRIPTION
## What this changes

MASH trucks and recovery vehicles from the Company Generator were crewed as if every seat were the driver's seat. MekHQ threw the surplus crew off the vehicle the next time the campaign loaded, so the vehicle could not do its job. They now get the crew they actually have seats for, and keep it.

Fixes #9937

- A recovery vehicle gets 1 driver and 3 gunners. It used to get 4 of each.
- A MASH truck gets 1 driver and 5 vehicle crew. It used to get 6 drivers and 6 gunners.
- When the section has fewer staff than the vehicle has seats, the driver's seat is filled first.
- Support vehicles keep their maintenance tech. The ejected crew used to take it with them, which is the second half of the issue.
- The infantry carriers are unchanged. A Support Squad correctly lists every trooper as both driver and gunner.
- The Support Teams conversion in #9929 calls the same method, so it is fixed too.

## Testing

- `./gradlew :MekHQ:test :MekHQ:checkstyleMain :MekHQ:javadoc` green. 15,420 tests, 0 failures.
- 7 new tests in `SupportPersonnelToTOETest`, 27 in the class.
- Five of the seven fail with the fix reverted: the recovery-vehicle split, the MASH split, both short-pool cases, and the pool-offset case. The other two are invariants and pass either way.
- In game: new campaign, Company Generator, CamOps Salvage and MASH Theatres on. The log reads `crewed with 4/4 staff (drivers 1/1, gunners 3/3, vehicle crew 0/0)` for the recovery vehicles and `6/6 staff (drivers 1/1, gunners 0/0, vehicle crew 5/5)` for the MASH truck.
- Saved and reloaded that campaign. Every support vehicle came back with its full crew and its tech. No crew were ejected and the save holds no over-crewing reports.

## What is not proven yet

- Clan commands. The Clan echelon packs carriers differently, but the capability vehicles are the same two units and the seating code does not read faction.
- A medical section large enough to field all three MASH trucks. Medics generate as a pool rather than as people by default, so the staff ran out after one truck.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have verified the result
