### PR TITLE
Set the Command Generator's recommended defaults

### DIFF
--- a/MekHQ/resources/mekhq/resources/CommandGenerationDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CommandGenerationDialog.properties
@@ -54,7 +54,7 @@ lblAssistants.tooltip=The helpers behind the techs and doctors: six astechs per 
 lblTechAssignment.text=Tech Assignment
 lblTechAssignment.tooltip=Which tech looks after which unit. Units are put in order by the choices below and the best techs are handed out down the list, so the first choice decides who gets the best tech.
 lblOfficerSelection.text=Officer Selection
-lblOfficerSelection.tooltip=Who ends up in charge. Picks the company commander and the officers from the people generated, by skill or by combat record, and can seat the most skilled pilots in the leading lances.
+lblOfficerSelection.tooltip=Who ends up in charge. Picks the campaign commander and the officers from the people generated, by skill or by combat record, and can seat the most skilled pilots in the leading lances.
 lblNamingAndRanks.text=Naming & Ranks
 lblNamingAndRanks.tooltip=How the command is named and ranked: the alphabet its formations are named by, whether regiments are numbered, and whether the people generated get ranks, callsigns and founder status.
 lblRandomOrigin.text=Random Origin
@@ -62,7 +62,7 @@ lblRandomOrigin.tooltip=Where the people generated were born. Rolls a home plane
 
 # ---- Setup: Force Shape
 lblGenerateMercenaryCompanyCommandLance.text=Generate Company Command Lance
-lblGenerateMercenaryCompanyCommandLance.tooltip=Gives the company commander a separate command lance of their own. When off, the commander leads the first lance generated instead.
+lblGenerateMercenaryCompanyCommandLance.tooltip=Gives the campaign commander a separate command lance of their own. When off, the commander leads the first lance generated instead.
 lblForceNamingMethod.text=Formation Naming Method
 lblForceNamingMethod.tooltip=The alphabet used to name formations at every level of the command. A regiment's battalions are named Alpha, Beta, Gamma; each battalion's companies start again at Alpha, and so on down to the lances.
 lblAlwaysNumberRegiments.text=Always Number Regiments

--- a/MekHQ/resources/mekhq/resources/CommandGenerationDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CommandGenerationDialog.properties
@@ -107,10 +107,10 @@ lblTechAssignmentDirection.descending=Highest first
 lblTechAssignmentDirection.ascending=Lowest first
 
 # ---- Setup: Officer Selection
-lblAssignBestCompanyCommander.text=Assign Best Company Commander
+lblAssignBestCompanyCommander.text=Assign Best Campaign Commander
 lblAssignBestCompanyCommander.tooltip=The most skilled person leads the command, wherever the roll seated them. Tactical Genius counts first, then command skills, then combat skills. Off, the first pilot found in the top formation leads it.
 lblPrioritizeCompanyCommanderCombatSkills.text=Prioritize Commander Combat Skills Over Command Skills
-lblPrioritizeCompanyCommanderCombatSkills.tooltip=When choosing the company commander, gunnery and piloting count for more than Leadership, Strategy and Tactics. Tactical Genius still comes first.
+lblPrioritizeCompanyCommanderCombatSkills.tooltip=When choosing the campaign commander, gunnery and piloting count for more than Leadership, Strategy and Tactics. Tactical Genius still comes first.
 lblAssignBestOfficers.text=Assign Best Officers
 lblAssignBestOfficers.tooltip=Every battalion, company and lance is led by the most skilled person left in it, chosen from the top of the command down. Off, each is led by the first pilot found in it.
 lblPrioritizeOfficerCombatSkills.text=Prioritize Officer Combat Skills Over Command Skills

--- a/MekHQ/src/mekhq/campaign/universe/commandGeneration/CommandGenerationOptions.java
+++ b/MekHQ/src/mekhq/campaign/universe/commandGeneration/CommandGenerationOptions.java
@@ -66,6 +66,13 @@ import mekhq.campaign.universe.enums.TechAssignmentSortFactor;
 public class CommandGenerationOptions {
 
     /**
+     * Working capital the command is guaranteed to keep once the pay-for toggles have taken their
+     * cut, in C-bills. A command that starts broke cannot pay its first month's wages, so generation
+     * floors the float here and takes a loan for the shortfall when one is allowed.
+     */
+    private static final long DEFAULT_MINIMUM_STARTING_FLOAT = 10_000_000L;
+
+    /**
      * Support roles seeded with default coverage percentages and skill levels: the four tech roles,
      * doctor, and administrators - matches the SetupTab spinner/dropdown layout.
      */
@@ -172,7 +179,7 @@ public class CommandGenerationOptions {
     private int startingCashPercent;
     private boolean randomizeStartingCash;
     private int randomStartingCashDiceCount;
-    private int minimumStartingFloat;
+    private long minimumStartingFloat;
     private boolean startingLoan;
     private boolean payForSetup;
     private boolean payForPersonnel;
@@ -212,7 +219,7 @@ public class CommandGenerationOptions {
         setGenerateMedics(true);
         setMedicsAsPersonnel(false);
         setMedicSkillLevel(SkillLevel.NONE);
-        setGenerateMedicalReserve(false);
+        setGenerateMedicalReserve(true);
         setMedicalReservePercent(10);
 
         // Tech-to-unit assignment grid defaults: officers first, then heaviest, then best pilot.
@@ -225,14 +232,14 @@ public class CommandGenerationOptions {
         setTechAssignmentTertiaryDescending(true);
 
         // Officer assignment and personnel flags
-        setGenerateCaptains(false);
+        setGenerateCaptains(true);
         setAssignCompanyCommanderFlag(true);
         setApplyOfficerStatBonusToWorstSkill(false);
-        setAssignBestCompanyCommander(false);
+        setAssignBestCompanyCommander(true);
         setPrioritizeCompanyCommanderCombatSkills(false);
-        setAssignBestOfficers(false);
+        setAssignBestOfficers(true);
         setPrioritizeOfficerCombatSkills(false);
-        setAssignMostSkilledToPrimaryLances(false);
+        setAssignMostSkilledToPrimaryLances(true);
         setAutomaticallyAssignRanks(true);
         // Default ON so the target faction's rank system (Clan ranks for a Clan target, ComStar
         // ranks for a CS target, etc.) drives the generated commanders' rank names.
@@ -258,10 +265,10 @@ public class CommandGenerationOptions {
         setUseOriginNodeFormationIconLogo(false);
 
         // Starting simulation
-        setRunStartingSimulation(false);
+        setRunStartingSimulation(true);
         setSimulationDuration(10);
-        setSimulateRandomMarriages(false);
-        setSimulateRandomProcreation(false);
+        setSimulateRandomMarriages(true);
+        setSimulateRandomProcreation(true);
 
         // Contracts
         setSelectStartingContract(true);
@@ -270,12 +277,13 @@ public class CommandGenerationOptions {
         // Finances. Pay for Initial Setup defaults OFF: with the percentage-of-unit-value cash base,
         // paying for the units would always dwarf the base (10% cash vs 100% cost) and floor every
         // default build into a maximum loan. Out of the box the command is granted free with its
-        // working capital; players opt into the pay-for accounting.
+        // working capital; players opt into the pay-for accounting. The minimum float leaves the
+        // command able to pay its first month's wages rather than starting broke.
         setProcessFinances(true);
         setStartingCashPercent(10);
         setRandomizeStartingCash(false);
         setRandomStartingCashDiceCount(18);
-        setMinimumStartingFloat(0);
+        setMinimumStartingFloat(DEFAULT_MINIMUM_STARTING_FLOAT);
         setStartingLoan(true);
         setPayForSetup(false);
         setPayForPersonnel(true);
@@ -729,11 +737,11 @@ public class CommandGenerationOptions {
         this.randomStartingCashDiceCount = randomStartingCashDiceCount;
     }
 
-    public int getMinimumStartingFloat() {
+    public long getMinimumStartingFloat() {
         return minimumStartingFloat;
     }
 
-    public void setMinimumStartingFloat(final int minimumStartingFloat) {
+    public void setMinimumStartingFloat(final long minimumStartingFloat) {
         this.minimumStartingFloat = minimumStartingFloat;
     }
 

--- a/MekHQ/src/mekhq/gui/commandGeneration/contents/SparesAndFinancesTab.java
+++ b/MekHQ/src/mekhq/gui/commandGeneration/contents/SparesAndFinancesTab.java
@@ -264,7 +264,7 @@ public class SparesAndFinancesTab {
         spnRandomStartingCashDiceCount.setName("spnRandomStartingCashDiceCount");
         spnRandomStartingCashDiceCount.setToolTipText(diceCountLabel.getToolTipText());
         CommandGenerationLabel minimumFloatLabel = new CommandGenerationLabel("MinimumStartingFloat");
-        spnMinimumStartingFloat = new JSpinner(new SpinnerNumberModel(0, 0, 100_000_000, 100_000));
+        spnMinimumStartingFloat = new JSpinner(new SpinnerNumberModel(0L, 0L, 100_000_000L, 100_000L));
         spnMinimumStartingFloat.setName("spnMinimumStartingFloat");
         spnMinimumStartingFloat.setToolTipText(minimumFloatLabel.getToolTipText());
         chkStartingLoan = new CommandGenerationCheckBox("StartingLoan");
@@ -555,7 +555,7 @@ public class SparesAndFinancesTab {
         targetOptions.setStartingCashPercent((Integer) spnStartingCashPercent.getValue());
         targetOptions.setRandomizeStartingCash(chkRandomizeStartingCash.isSelected());
         targetOptions.setRandomStartingCashDiceCount((Integer) spnRandomStartingCashDiceCount.getValue());
-        targetOptions.setMinimumStartingFloat((Integer) spnMinimumStartingFloat.getValue());
+        targetOptions.setMinimumStartingFloat(((Number) spnMinimumStartingFloat.getValue()).longValue());
         targetOptions.setStartingLoan(chkStartingLoan.isSelected());
         targetOptions.setPayForSetup(payForToggles.get("PayForSetup").isSelected());
         targetOptions.setPayForPersonnel(payForToggles.get("PayForPersonnel").isSelected());

--- a/MekHQ/unittests/mekhq/campaign/universe/commandGeneration/CommandGenerationOptionsTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/commandGeneration/CommandGenerationOptionsTest.java
@@ -120,9 +120,33 @@ class CommandGenerationOptionsTest {
         assertFalse(options.isUseOriginNodeFormationIconLogo());
 
         // Finances: the command is granted free, with working capital defaulting to 10% of the
-        // generated units' purchase cost.
+        // generated units' purchase cost, floored so it can pay its first month's wages.
         assertTrue(options.isProcessFinances());
         assertEquals(10, options.getStartingCashPercent());
+        assertEquals(10_000_000L, options.getMinimumStartingFloat());
+    }
+
+    /**
+     * The recommended defaults from issue #9955. These are the values a player gets without touching
+     * the dialog, so they are pinned rather than left to drift.
+     */
+    @Test
+    void constructor_officerAndSimulationDefaults_matchTheRecommendedValues() {
+        CommandGenerationOptions options = new CommandGenerationOptions();
+
+        // The command is led by its best people rather than whoever the roll happened to seat first.
+        assertTrue(options.isAssignBestCompanyCommander());
+        assertTrue(options.isAssignBestOfficers());
+        assertTrue(options.isAssignMostSkilledToPrimaryLances());
+        assertTrue(options.isGenerateCaptains());
+
+        // A medical reserve so the command can absorb casualties from its first contract.
+        assertTrue(options.isGenerateMedicalReserve());
+
+        // The command arrives with a history: marriages and children from the years before play.
+        assertTrue(options.isRunStartingSimulation());
+        assertTrue(options.isSimulateRandomMarriages());
+        assertTrue(options.isSimulateRandomProcreation());
     }
 
     @Test

--- a/MekHQ/unittests/mekhq/campaign/universe/commandGeneration/StartingSimulationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/commandGeneration/StartingSimulationTest.java
@@ -97,8 +97,11 @@ class StartingSimulationTest {
         Campaign campaign = MHQTestUtilities.getTestCampaign();
         Person person = mekWarrior(campaign);
         CommandGenerationOptions off = new CommandGenerationOptions();
+        off.setRunStartingSimulation(false);
         CommandGenerationOptions nothingToDo = new CommandGenerationOptions();
         nothingToDo.setRunStartingSimulation(true);
+        nothingToDo.setSimulateRandomMarriages(false);
+        nothingToDo.setSimulateRandomProcreation(false);
         nothingToDo.setSimulationDuration(12);
 
         assertEquals(StartingSimulation.Result.none(), StartingSimulation.run(campaign, off, List.of(person), null));

--- a/MekHQ/unittests/mekhq/campaign/universe/commandGeneration/ratgen/CommandGeneratorStartingCashTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/commandGeneration/ratgen/CommandGeneratorStartingCashTest.java
@@ -72,6 +72,8 @@ class CommandGeneratorStartingCashTest {
         options.setStartingCashPercent(percent);
         options.setRandomizeStartingCash(false);
         options.setPayForSetup(false);
+        // These cases assert the percentage arithmetic itself, so the float must not floor it.
+        options.setMinimumStartingFloat(0);
         return options;
     }
 

--- a/MekHQ/unittests/mekhq/campaign/universe/commandGeneration/ratgen/OfficerSkillBoosterTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/commandGeneration/ratgen/OfficerSkillBoosterTest.java
@@ -125,7 +125,10 @@ class OfficerSkillBoosterTest {
         Person commandingOfficer = seatedMekWarrior(4, 4);
         RulesetRankAssigner.Result ranks = ranks(commandingOfficer, Map.of(commandingOfficer, FormationLevel.COMPANY));
 
-        int improved = OfficerSkillBooster.apply(new CommandGenerationOptions(), ranks, bound -> 0);
+        CommandGenerationOptions off = new CommandGenerationOptions();
+        off.setGenerateCaptains(false);
+
+        int improved = OfficerSkillBooster.apply(off, ranks, bound -> 0);
 
         assertEquals(0, improved);
         assertEquals(4, commandingOfficer.getSkill(SkillType.S_GUN_MEK).getLevel());

--- a/MekHQ/unittests/mekhq/campaign/universe/commandGeneration/ratgen/PilotSkillSorterTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/commandGeneration/ratgen/PilotSkillSorterTest.java
@@ -93,7 +93,10 @@ class PilotSkillSorterTest {
         Person green = pilot(campaign, firstSeat, 1);
         pilot(campaign, secondSeat, 5);
 
-        int moved = PilotSkillSorter.apply(campaign, new CommandGenerationOptions());
+        CommandGenerationOptions off = new CommandGenerationOptions();
+        off.setAssignMostSkilledToPrimaryLances(false);
+
+        int moved = PilotSkillSorter.apply(campaign, off);
 
         assertEquals(0, moved);
         assertSame(green, firstSeat.getCommander());

--- a/MekHQ/unittests/mekhq/campaign/universe/commandGeneration/ratgen/RulesetRankAssignerSelectionTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/commandGeneration/ratgen/RulesetRankAssignerSelectionTest.java
@@ -168,6 +168,9 @@ class RulesetRankAssignerSelectionTest {
     private static CommandGenerationOptions companyOptions() {
         CommandGenerationOptions options = new CommandGenerationOptions();
         options.setAutomaticallyAssignRanks(true);
+        // Each case turns on the selection option it is about; the baseline starts with none of them.
+        options.setAssignBestCompanyCommander(false);
+        options.setAssignBestOfficers(false);
         options.getForceDescriptorSnapshot().setEchelon(COMPANY_ECHELON);
         return options;
     }


### PR DESCRIPTION
## What this changes

The values a player gets from the Command Designer without touching anything, from @IllianiBird's review of the new generator.

Part of #9955. That issue asks for more than this, so it stays open.

**Officers and personnel**

- Assign Best Company Commander, Assign Best Officers, Assign Most Skilled to Primary Lances and Generate Captains now default on. A generated command is led by its best people instead of whoever the roll seated first.
- Generate Medical Reserve defaults on, so the command can absorb casualties from its first contract.

**Starting simulation**

- Run Starting Simulation, Simulate Random Marriages and Simulate Random Procreation default on. The command arrives with a history rather than as strangers who met that morning.

**Finances**

- Minimum Starting Float defaults to 10,000,000 C-bills, so a command can pay its first month's wages instead of starting broke.
- The field is widened from `int` to `long`, as the issue asks. Worth being clear that this is future-proofing, not a fix: the spinner caps at 100,000,000, well inside an `int`, so no overflow was reachable.

**Wording**

- "Assign Best Company Commander" now reads "Assign Best Campaign Commander", and the tooltip that said company commander says campaign commander. Labels only. The option and its accessors keep their names, so this stays a rename of what the player reads.

## Testing

- `./gradlew :MekHQ:test`, `:MekHQ:checkstyleMain` and `:MekHQ:javadoc` each run separately. 15,364 tests, 0 failures.
- New `constructor_officerAndSimulationDefaults_matchTheRecommendedValues` pins the values so they cannot drift back.
- Ten existing tests across five classes broke on this change and were fixed. Each asserted "nothing happens when this option is off" while leaning on the constructor default to supply the off. `StartingSimulationTest` ran a 522-week simulation where it expected none, and the four `CommandGeneratorStartingCashTest` cases had their percentage arithmetic floored by the new minimum. They now state the condition they test rather than inheriting it. No assertion was weakened.

## What is not proven yet

- Not run in game. Every change here is a default value or a label, and the behaviour behind each option already has its own tests.
- The `long` widening is compile-verified only. Nothing reads the value except `Money.of`, and the option is not serialized, so there was nothing else to check.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have verified the result
