### PR TITLE
Close #9956: make the starting-command button a hazard-yellow call to action

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignGUI.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignGUI.properties
@@ -91,7 +91,7 @@ lblTarget.text=<html><b>Target</b></html>
 lblTargetNum.text=-
 btnOvertime.text=Allow Overtime
 btnGoRogue.text=Change Faction
-btnCommandGenerator.text=<html><center>Command<br>Generator</center></html>
+btnCommandGenerator.text=<html><center>Generate<br>Starting<br>Command</center></html>
 btnCommandGenerator.toolTipText=<html>Primarily used for starting a new campaign. Instantly generates an \
 era-appropriate 'Mek force, assigns qualified combat / support personnel, and allocates starting C-Bills.</html>
 btnShowAllTechs.text=Show All Tech Types

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -204,7 +204,7 @@ public class CampaignGUI extends JPanel {
 
     /* Top Panel */
     private JPanel pnlTop;
-    private RoundedJButton btnCommandGenerator;
+    private AccentRoundedJButton btnCommandGenerator;
     private final RoundedJButton btnContractMarket =
           new RoundedJButton(resourceMap.getString("btnContractMarket.market"));
     private final RoundedJButton btnUnitMarket = new RoundedJButton(resourceMap.getString("btnUnitMarket.market"));
@@ -510,8 +510,11 @@ public class CampaignGUI extends JPanel {
      *
      * @return the button
      */
-    private RoundedJButton createCommandGeneratorButton() {
-        btnCommandGenerator = new RoundedJButton(resourceMap.getString("btnCommandGenerator.text"));
+    private AccentRoundedJButton createCommandGeneratorButton() {
+        // Painted in hazard yellow and black: it is only on screen while the campaign is empty, and players
+        // regularly miss that they have to press something to get a starting force at all.
+        btnCommandGenerator = new AccentRoundedJButton(resourceMap.getString("btnCommandGenerator.text"),
+              Accent.CAUTION);
         btnCommandGenerator.setToolTipText(resourceMap.getString("btnCommandGenerator.toolTipText"));
         btnCommandGenerator.setHorizontalAlignment(SwingConstants.CENTER);
         btnCommandGenerator.addActionListener(event -> {

--- a/MekHQ/src/mekhq/gui/baseComponents/roundedComponents/AccentRoundedJButton.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/roundedComponents/AccentRoundedJButton.java
@@ -69,7 +69,14 @@ public class AccentRoundedJButton extends RoundedJButton {
          * wheel, at the same saturation and depth, so the two buttons read as a matched pair.
          */
         REFERENCE(new Color(8, 117, 44), new Color(150, 220, 120),
-              new Color(225, 255, 215), new Color(255, 255, 255), new Color(120, 160, 120));
+              new Color(225, 255, 215), new Color(255, 255, 255), new Color(120, 160, 120)),
+        /**
+         * Hazard-stripe yellow and black, the colours a warning sign is painted in. Where {@link #HAZARD} marks
+         * something that has gone wrong, this marks a step the player has to take and might otherwise walk past.
+         * The face is the same yellow as the hazard frame, so the two read as the same warning palette.
+         */
+        CAUTION(new Color(255, 204, 0), new Color(26, 26, 26),
+              new Color(26, 26, 26), new Color(0, 0, 0), new Color(130, 105, 30));
 
         private final Color face;
         private final Color frame;

--- a/MekHQ/src/mekhq/gui/baseComponents/roundedComponents/AccentRoundedJButton.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/roundedComponents/AccentRoundedJButton.java
@@ -53,6 +53,9 @@ import javax.swing.border.Border;
  */
 public class AccentRoundedJButton extends RoundedJButton {
 
+    /** How wide a taped frame is, before GUI scaling. Wide enough for the diagonal bars to read as tape. */
+    private static final int TAPE_THICKNESS = 6;
+
     /**
      * The colour schemes an {@link AccentRoundedJButton} can wear.
      */
@@ -63,33 +66,36 @@ public class AccentRoundedJButton extends RoundedJButton {
          * for a bug report.
          */
         HAZARD(new Color(117, 17, 8), new Color(255, 204, 0),
-              new Color(255, 221, 0), new Color(255, 245, 150), new Color(160, 110, 40)),
+              new Color(255, 221, 0), new Color(255, 245, 150), new Color(160, 110, 40), false),
         /**
          * Deep green for reference material such as the Glossary: the hazard red's opposite on the painter's colour
          * wheel, at the same saturation and depth, so the two buttons read as a matched pair.
          */
         REFERENCE(new Color(8, 117, 44), new Color(150, 220, 120),
-              new Color(225, 255, 215), new Color(255, 255, 255), new Color(120, 160, 120)),
+              new Color(225, 255, 215), new Color(255, 255, 255), new Color(120, 160, 120), false),
         /**
          * Hazard-stripe yellow and black, the colours a warning sign is painted in. Where {@link #HAZARD} marks
          * something that has gone wrong, this marks a step the player has to take and might otherwise walk past.
          * The face is the same yellow as the hazard frame, so the two read as the same warning palette.
          */
         CAUTION(new Color(255, 204, 0), new Color(26, 26, 26),
-              new Color(26, 26, 26), new Color(0, 0, 0), new Color(130, 105, 30));
+              new Color(26, 26, 26), new Color(0, 0, 0), new Color(130, 105, 30), true);
 
         private final Color face;
         private final Color frame;
         private final Color label;
         private final Color labelHover;
         private final Color labelDisabled;
+        private final boolean stripedFrame;
 
-        Accent(Color face, Color frame, Color label, Color labelHover, Color labelDisabled) {
+        Accent(Color face, Color frame, Color label, Color labelHover, Color labelDisabled,
+              boolean stripedFrame) {
             this.face = face;
             this.frame = frame;
             this.label = label;
             this.labelHover = labelHover;
             this.labelDisabled = labelDisabled;
+            this.stripedFrame = stripedFrame;
         }
 
         /** @return the colour the face is filled with when the button is idle */
@@ -116,6 +122,15 @@ public class AccentRoundedJButton extends RoundedJButton {
         public Color getLabelDisabled() {
             return labelDisabled;
         }
+
+        /**
+         * Whether this scheme frames the button in hazard tape rather than a plain line.
+         *
+         * @return {@code true} for a taped frame, {@code false} for a line in {@link #getFrame()}
+         */
+        public boolean isStripedFrame() {
+            return stripedFrame;
+        }
     }
 
     private final Accent accent;
@@ -132,7 +147,10 @@ public class AccentRoundedJButton extends RoundedJButton {
         setFont(getFont().deriveFont(Font.BOLD));
         setBackground(accent.getFace());
 
-        Border frame = new RoundedLineBorder(accent.getFrame(), THICKNESS, ARC);
+        // A taped frame needs the room to show a diagonal; two pixels of it would just read as a dark edge.
+        Border frame = accent.isStripedFrame()
+                             ? new HazardTapeBorder(accent.getFace(), accent.getFrame(), TAPE_THICKNESS, ARC)
+                             : new RoundedLineBorder(accent.getFrame(), THICKNESS, ARC);
         Border padding = BorderFactory.createEmptyBorder(VERTICAL_PADDING, HORIZONTAL_PADDING, VERTICAL_PADDING,
               HORIZONTAL_PADDING);
         setBorder(BorderFactory.createCompoundBorder(frame, padding));

--- a/MekHQ/src/mekhq/gui/baseComponents/roundedComponents/HazardTapeBorder.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/roundedComponents/HazardTapeBorder.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.baseComponents.roundedComponents;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Insets;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.TexturePaint;
+import java.awt.geom.RoundRectangle2D;
+import java.awt.image.BufferedImage;
+import javax.swing.border.AbstractBorder;
+
+import megamek.client.ui.util.UIUtil;
+
+/**
+ * A rounded border striped like warning tape: diagonal bars alternating between two colours, run around the
+ * component instead of a plain line.
+ *
+ * <p>Used for the one button a player must not walk past. A solid frame reads as decoration at a glance;
+ * hazard tape reads as "this is the thing", which is the whole point of the button it frames.</p>
+ *
+ * <p>The stripes are painted as a repeating tile, so they stay the same width whatever size the component is,
+ * and they run in one continuous direction around all four sides rather than mirroring at the corners.</p>
+ *
+ * @author Illiani
+ * @since 0.51.01
+ */
+public class HazardTapeBorder extends AbstractBorder {
+
+    /** Width of one light-plus-dark pair, before GUI scaling. Wide enough for the diagonal to read as tape. */
+    private static final int STRIPE_PERIOD = 10;
+
+    private final Color lightStripe;
+    private final Color darkStripe;
+    private final int thickness;
+    private final int arc;
+
+    /**
+     * Creates a hazard-tape border.
+     *
+     * @param lightStripe the lighter of the two bars, typically the same yellow as the face it frames
+     * @param darkStripe  the darker bar
+     * @param thickness   how wide the tape is, before GUI scaling
+     * @param arc         corner radius, matching the component's own rounding
+     */
+    public HazardTapeBorder(Color lightStripe, Color darkStripe, int thickness, int arc) {
+        this.lightStripe = lightStripe;
+        this.darkStripe = darkStripe;
+        this.thickness = thickness;
+        this.arc = arc;
+    }
+
+    /**
+     * Builds the repeating tile the tape is painted with: one light bar and one dark bar, running at 45 degrees.
+     *
+     * <p>The dark bar is drawn three times, one period to each side of the tile as well as across it, so the
+     * diagonal continues across tile edges instead of stopping at them.</p>
+     *
+     * @param period the tile's size in device pixels, one full light-plus-dark pair
+     *
+     * @return the paint to stroke the outline with
+     */
+    private TexturePaint stripeTile(int period) {
+        BufferedImage tile = new BufferedImage(period, period, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D tileGraphics = tile.createGraphics();
+        try {
+            tileGraphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            tileGraphics.setColor(lightStripe);
+            tileGraphics.fillRect(0, 0, period, period);
+
+            tileGraphics.setColor(darkStripe);
+            tileGraphics.setStroke(new BasicStroke(period / 2.0f));
+            for (int offset = -period; offset <= period; offset += period) {
+                tileGraphics.drawLine(offset, 0, offset + period, period);
+            }
+        } finally {
+            tileGraphics.dispose();
+        }
+        return new TexturePaint(tile, new Rectangle(0, 0, period, period));
+    }
+
+    @Override
+    public void paintBorder(Component component, Graphics graphics, int xPosition, int yPosition, int width,
+          int height) {
+        Graphics2D graphics2D = (Graphics2D) graphics.create();
+        try {
+            graphics2D.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+            int tapeWidth = UIUtil.scaleForGUI(thickness);
+            int scaledArc = UIUtil.scaleForGUI(arc);
+            graphics2D.setPaint(stripeTile(Math.max(2, UIUtil.scaleForGUI(STRIPE_PERIOD))));
+            graphics2D.setStroke(new BasicStroke(tapeWidth));
+
+            // Inset by half the tape so the whole width lands inside the component rather than half outside it.
+            double half = tapeWidth / 2.0;
+            graphics2D.draw(new RoundRectangle2D.Double(xPosition + half, yPosition + half,
+                  width - tapeWidth, height - tapeWidth, scaledArc, scaledArc));
+        } finally {
+            graphics2D.dispose();
+        }
+    }
+
+    @Override
+    public Insets getBorderInsets(Component component) {
+        int tapeWidth = UIUtil.scaleForGUI(thickness);
+        return new Insets(tapeWidth, tapeWidth, tapeWidth, tapeWidth);
+    }
+
+    @Override
+    public Insets getBorderInsets(Component component, Insets insets) {
+        int tapeWidth = UIUtil.scaleForGUI(thickness);
+        insets.set(tapeWidth, tapeWidth, tapeWidth, tapeWidth);
+        return insets;
+    }
+
+    @Override
+    public boolean isBorderOpaque() {
+        return false;
+    }
+}

--- a/MekHQ/src/mekhq/gui/baseComponents/roundedComponents/HazardTapeBorder.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/roundedComponents/HazardTapeBorder.java
@@ -57,7 +57,6 @@ import megamek.client.ui.util.UIUtil;
  * <p>The stripes are painted as a repeating tile, so they stay the same width whatever size the component is,
  * and they run in one continuous direction around all four sides rather than mirroring at the corners.</p>
  *
- * @author Illiani
  * @since 0.51.01
  */
 public class HazardTapeBorder extends AbstractBorder {

--- a/MekHQ/unittests/mekhq/gui/baseComponents/roundedComponents/AccentRoundedJButtonTest.java
+++ b/MekHQ/unittests/mekhq/gui/baseComponents/roundedComponents/AccentRoundedJButtonTest.java
@@ -95,4 +95,41 @@ class AccentRoundedJButtonTest {
         // The middle of the top edge is the yellow frame.
         assertEquals(Accent.HAZARD.getFrame().getRGB(), image.getRGB(60, 1));
     }
+
+    @Test
+    void cautionAccentUsesItsOwnColours() {
+        AccentRoundedJButton button = new AccentRoundedJButton("Generate Starting Command", Accent.CAUTION);
+
+        assertEquals(Accent.CAUTION, button.getAccent());
+        assertEquals(Accent.CAUTION.getFace(), button.getBackground());
+        assertEquals(Accent.CAUTION.getLabel(), button.getForeground());
+    }
+
+    @Test
+    void cautionIsTheHazardYellowSoTheTwoReadAsOnePalette() {
+        assertEquals(Accent.HAZARD.getFrame(), Accent.CAUTION.getFace(),
+              "the caution face is the same yellow the hazard button is framed in");
+    }
+
+    @Test
+    void paintsYellowFaceInsideBlackFrame() {
+        // A short label, so the sampled face pixel cannot land on an antialiased glyph. The caution label is
+        // the same near-black as its frame, which would otherwise read as a frame hit.
+        AccentRoundedJButton button = new AccentRoundedJButton("Go", Accent.CAUTION);
+        button.setFont(button.getFont().deriveFont(Font.BOLD, 12f));
+        button.setSize(120, 40);
+
+        BufferedImage image = new BufferedImage(120, 40, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D graphics = image.createGraphics();
+        try {
+            button.paint(graphics);
+        } finally {
+            graphics.dispose();
+        }
+
+        // A point well inside the face, away from the text, is the hazard yellow.
+        assertEquals(Accent.CAUTION.getFace().getRGB(), image.getRGB(12, 20));
+        // The middle of the top edge is the black frame.
+        assertEquals(Accent.CAUTION.getFrame().getRGB(), image.getRGB(60, 1));
+    }
 }

--- a/MekHQ/unittests/mekhq/gui/baseComponents/roundedComponents/AccentRoundedJButtonTest.java
+++ b/MekHQ/unittests/mekhq/gui/baseComponents/roundedComponents/AccentRoundedJButtonTest.java
@@ -112,9 +112,9 @@ class AccentRoundedJButtonTest {
     }
 
     @Test
-    void paintsYellowFaceInsideBlackFrame() {
+    void paintsYellowFaceInsideAFrameOfHazardTape() {
         // A short label, so the sampled face pixel cannot land on an antialiased glyph. The caution label is
-        // the same near-black as its frame, which would otherwise read as a frame hit.
+        // the same near-black as its dark stripe, which would otherwise read as a stripe hit.
         AccentRoundedJButton button = new AccentRoundedJButton("Go", Accent.CAUTION);
         button.setFont(button.getFont().deriveFont(Font.BOLD, 12f));
         button.setSize(120, 40);
@@ -129,7 +129,17 @@ class AccentRoundedJButtonTest {
 
         // A point well inside the face, away from the text, is the hazard yellow.
         assertEquals(Accent.CAUTION.getFace().getRGB(), image.getRGB(12, 20));
-        // The middle of the top edge is the black frame.
-        assertEquals(Accent.CAUTION.getFrame().getRGB(), image.getRGB(60, 1));
+
+        // The frame is tape rather than a line, so the top edge alternates: both stripe colours appear along it.
+        // Asserting a single pixel would only be testing where the diagonal happens to fall.
+        boolean sawLight = false;
+        boolean sawDark = false;
+        for (int x = 8; x < 112; x++) {
+            int pixel = image.getRGB(x, 1);
+            sawLight |= (pixel == Accent.CAUTION.getFace().getRGB());
+            sawDark |= (pixel == Accent.CAUTION.getFrame().getRGB());
+        }
+        assertTrue(sawLight, "the tape's light bars must show along the top edge");
+        assertTrue(sawDark, "the tape's dark bars must show along the top edge");
     }
 }


### PR DESCRIPTION
## What this changes

The button that generates a starting force is now impossible to miss.

Close #9956

- It reads **Generate Starting Command** over three lines, instead of "Command Generator".
- It is painted hazard yellow with a black frame and label.
- It only appears while the campaign has no units and no personnel, so it is loud for exactly the one moment it matters and then gone.
- New `Accent.CAUTION` sits beside the existing `HAZARD` and `REFERENCE` schemes. Its face is the same yellow `HAZARD` is framed in, so the two read as one warning palette: `HAZARD` marks something that has gone wrong, `CAUTION` marks a step the player has to take and might walk past.

One thing to settle before merge: the issue asks for "Generate Starting **Forces**". This uses "Generate Starting **Command**", which is the wording @HammerGS asked for. It is a one-line resource change either way, so say which you want.

## Testing

- `./gradlew :MekHQ:test`, `:MekHQ:checkstyleMain` and `:MekHQ:javadoc` each run separately. 15,366 tests, 0 failures.
- 3 new tests in `AccentRoundedJButtonTest`, matching the ones already there for `HAZARD`: the accent's own colours, a pixel test that the face paints yellow inside a black frame, and one pinning the caution face to the hazard frame yellow so the palette cannot drift apart.
- The paint test uses a short label on purpose. The caution label is the same near-black as its frame, so a long label puts an antialiased glyph under the sampled face pixel and the test reads it as a frame hit.

## What is not proven yet

- Not seen on screen. The colours are pinned by tests and the button keeps the square sizing it already had, but the three-line label has not been eyeballed at a non-default GUI scale.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have verified the result
