### PR TITLE
Keep the Command Designer open when Accept builds nothing

### DIFF
--- a/MekHQ/src/mekhq/gui/commandGeneration/CommandGenerationDialog.java
+++ b/MekHQ/src/mekhq/gui/commandGeneration/CommandGenerationDialog.java
@@ -35,6 +35,7 @@ package mekhq.gui.commandGeneration;
 import java.awt.Component;
 import java.awt.Insets;
 import javax.swing.JButton;
+import megamek.client.ui.enums.DialogResult;
 import megamek.client.ui.util.UIUtil;
 import mekhq.campaign.campaignOptions.CampaignOption;
 import static megamek.client.ui.util.FlatLafStyleBuilder.setFontScaling;
@@ -118,6 +119,17 @@ public class CommandGenerationDialog extends AbstractMHQValidationButtonDialog {
      * command that differs from the one previewed.
      */
     private CommandGenerationOptions settingsAtLastGenerate;
+
+    /**
+     * Whether the last press of Accept &amp; Build actually started a build.
+     *
+     * <p>{@code okAction} gives up without building on three paths - the tab settings cannot be collected, no
+     * force has been previewed yet, or the player cancels at the build confirmation. None of those should close
+     * the designer or greet the player with a command they have not built, so the flag lets
+     * {@link #okButtonActionPerformed} and {@link #confirmationActionListener} tell a real commit from a
+     * change of mind.</p>
+     */
+    private boolean buildStarted;
 
     private Campaign campaign;
     private CommandGenerationOptions commandGenerationOptions;
@@ -259,8 +271,32 @@ public class CommandGenerationDialog extends AbstractMHQValidationButtonDialog {
         }
     }
 
+    /**
+     * Confirms and closes the designer only when {@link #okAction()} actually started a build.
+     *
+     * <p>The inherited behaviour marks the dialog confirmed and hides it unconditionally, because {@code okAction}
+     * returns {@code void} and cannot refuse. That turned every way of backing out - cancelling the build
+     * confirmation among them - into a confirmed close, so the designer vanished and the player was greeted for a
+     * command that was never built.</p>
+     *
+     * @param evt the button event
+     */
+    @Override
+    protected void okButtonActionPerformed(final ActionEvent evt) {
+        okAction();
+        if (!buildStarted) {
+            LOGGER.info("[CompanyGen] Accept pressed but no build started; leaving the designer open");
+            return;
+        }
+        setResult(DialogResult.CONFIRMED);
+        setVisible(false);
+    }
+
     private void confirmationActionListener(final ActionEvent evt) {
         okButtonActionPerformed(evt);
+        if (!buildStarted) {
+            return;
+        }
 
         Faction campaignFaction = campaign.getPlayerForce().getFaction();
         String campaignFactionCode = campaignFaction.getShortName();
@@ -387,6 +423,7 @@ public class CommandGenerationDialog extends AbstractMHQValidationButtonDialog {
 
     @Override
     protected void okAction() {
+        buildStarted = false;
         CommandGenerationOptions options = settingsToBuildWith(collectOptionsFromTabs("okAction"));
         if (options == null) {
             return;
@@ -422,6 +459,7 @@ public class CommandGenerationDialog extends AbstractMHQValidationButtonDialog {
         if (!confirmBuildCommand(options, chosenEchelon, combatUnitCount)) {
             return;
         }
+        buildStarted = true;
 
         // Build the command in two background phases behind a modal progress dialog (long
         // generations would otherwise look frozen). Phase one commits the model's combat force to

--- a/MekHQ/src/mekhq/gui/commandGeneration/CommandGenerationDialog.java
+++ b/MekHQ/src/mekhq/gui/commandGeneration/CommandGenerationDialog.java
@@ -123,11 +123,15 @@ public class CommandGenerationDialog extends AbstractMHQValidationButtonDialog {
     /**
      * Whether the last press of Accept &amp; Build actually started a build.
      *
-     * <p>{@code okAction} gives up without building on three paths - the tab settings cannot be collected, no
-     * force has been previewed yet, or the player cancels at the build confirmation. None of those should close
-     * the designer or greet the player with a command they have not built, so the flag lets
-     * {@link #okButtonActionPerformed} and {@link #confirmationActionListener} tell a real commit from a
-     * change of mind.</p>
+     * <p>Set once the combat phase has put a force in the TOE, which is the point the build becomes real. Every
+     * way of not getting there leaves it {@code false}: the tab settings cannot be collected, no force has been
+     * previewed yet, the player cancels at the build confirmation, the phase throws, or it returns no result.
+     * None of those should close the designer or greet the player with a command they have not built, so the
+     * flag lets {@link #okButtonActionPerformed} and {@link #confirmationActionListener} tell a real commit from
+     * everything else.</p>
+     *
+     * <p>A later phase failing does not clear it. By then the combat force is committed to the campaign, so the
+     * designer has nothing left to go back to.</p>
      */
     private boolean buildStarted;
 
@@ -459,7 +463,6 @@ public class CommandGenerationDialog extends AbstractMHQValidationButtonDialog {
         if (!confirmBuildCommand(options, chosenEchelon, combatUnitCount)) {
             return;
         }
-        buildStarted = true;
 
         // Build the command in two background phases behind a modal progress dialog (long
         // generations would otherwise look frozen). Phase one commits the model's combat force to
@@ -482,6 +485,10 @@ public class CommandGenerationDialog extends AbstractMHQValidationButtonDialog {
                 LOGGER.info("[CompanyGen][Worker] combat phase produced no result; skipping support");
                 return;
             }
+            // The commit point: the combat force is in the TOE, so this counts as a build even if a later
+            // phase falls over. A phase that threw never reaches here, because runGenerationPhase reports the
+            // failure and skips this consumer entirely.
+            buildStarted = true;
             List<Person> generatedPersons = new ArrayList<>(combatResult.generatedPersons());
             runGenerationPhase("Generating support forces...",
                   supportListener -> CommandGenerator.generateSupportFromToe(getCampaign(), options,


### PR DESCRIPTION
## What this changes

Cancelling at the build confirmation closed the Command Designer and greeted you for a command that was never built. It now leaves the designer open, exactly where you were.

- **Cancel means cancel.** The design stays on screen, nothing is committed, and no welcome dialog appears.
- **Two more ways of building nothing behaved the same way** and are fixed with it: pressing Accept before generating anything, and the tab settings failing to collect. Pressing Accept with no force previewed now shows its "generate a force first" message and leaves the designer open, rather than closing it and greeting you.

Root cause: `okAction()` returns `void`, so it cannot refuse the close. The inherited `okButtonActionPerformed` calls it, then marks the dialog confirmed and hides it whatever happened, and `confirmationActionListener` runs the post-accept welcome regardless. All three of `okAction`'s give-up paths ended the same way.

`okAction` now records whether a build actually started. The dialog confirms and hides only when it did, and the welcome is skipped otherwise.

Found by @HammerGS testing the Command Generator branches. Not caused by any of them - the flaw is on `main` and every path through it predates this work.

## Testing

- `./gradlew :MekHQ:test`, `:MekHQ:checkstyleMain` and `:MekHQ:javadoc` each run separately. 15,363 tests, 0 failures.

## What is not proven yet

- No unit test. The behaviour is a modal Swing dialog's close path, and the class has no test harness; adding one for a single boolean would cost more than it proves. It is a few seconds to check by hand: open the Command Designer, press Accept &amp; Build, cancel at the confirmation, and the designer should still be there.
- Not yet re-run in game. The three paths are reasoned from the code rather than exercised.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [ ] Tests added or updated, if this implements a rule or changes game state - see above, no harness for a modal dialog close path
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have verified the result
