### PR TITLE
Close #9955: show the augmentation panel only where it applies

### DIFF
--- a/MekHQ/resources/mekhq/resources/CommandGenerationDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CommandGenerationDialog.properties
@@ -234,13 +234,15 @@ warningDefaultsOnlyRuleset.title=Confirm Force Generation
 warningDefaultsOnlyRuleset.continue=Continue?
 
 # Augmentation (cybernetics). Both are off in a new campaign; they are repeated here because
-# they must be set before generating and cannot be applied to warriors afterwards.
+# they must be set before generating and cannot be applied to warriors afterwards. The section is
+# shown only for the factions an augmentation stage will act on - see
+# CommandGenerationPane.offersAugmentation.
 lblAugmentation.text=Augmentation
-lblAugmentation.tooltip=Cybernetic implants for the warriors generated. The campaign has to track implants first; the pilot implants rule is a MegaMek game option and is written to the campaign when the command is built.
+lblAugmentation.tooltip=Whether the warriors this build generates come out with cybernetic implants. Both settings below must be on before you press Accept and Build: implants are fitted while the command is generated and cannot be added to the warriors afterwards. With both on, a Word of Blake Shadow Division is fitted with Manei Domini implants, and Clan formations receive enhanced imaging. Warrior House Thuggee has implant tracking switched on for the campaign but its warriors are not fitted automatically. Turn either setting off and no warrior is augmented. Shown only for the factions that can be augmented.
 lblUseImplants.text=Track Cybernetic Implants
-lblUseImplants.tooltip=Lets the campaign record cybernetic implants. Needed before any augmentation can be generated, and saved with the campaign.
+lblUseImplants.tooltip=On: the campaign records cybernetic implants, and the generated warriors can be fitted with them. Off: no warrior is augmented, whatever the Pilot Implants setting says. Saved with the campaign, and it cannot be applied to warriors after they are generated.
 lblNeuralInterfaceMode.text=Pilot Implants
-lblNeuralInterfaceMode.tooltip=MegaMek's pilot implants option, covering Manei Domini implants and neural interfaces. Off means no implant of any kind is allowed, so a generated Shadow Division gets none. Pilot Abilities Only allows every implant and needs only the implant for its bonuses. Full Tracking also needs interface equipment fitted in the unit. Saved with the campaign's game options.
+lblNeuralInterfaceMode.tooltip=MegaMek's pilot implants rule, covering Manei Domini implants and neural interfaces. Off: no implant of any kind is allowed, so no warrior is augmented even with tracking on above, and a generated Shadow Division gets none. Pilot Abilities Only: implants are fitted and work on their own. Full Tracking: implants are fitted, but a warrior only gets the benefit in a unit carrying the matching interface equipment. Saved with the campaign's game options.
 
 # Force Generator bar
 btnClearRolls.text=Clear Rolls

--- a/MekHQ/src/mekhq/gui/commandGeneration/CommandGenerationPane.java
+++ b/MekHQ/src/mekhq/gui/commandGeneration/CommandGenerationPane.java
@@ -43,6 +43,8 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 
 import megamek.client.ratgenerator.FactionRecord;
+import megamek.client.ratgenerator.ManeiDominiCrewAugmentor;
+import megamek.common.annotations.Nullable;
 import megamek.common.ui.FastJScrollPane;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.universe.enums.ForceNamingMethod;
@@ -161,6 +163,7 @@ public class CommandGenerationPane extends AbstractMHQTabbedPane {
      */
     public void applyFactionDrivenDefaults() {
         FactionRecord factionRecord = lastFactionRecord;
+        setupTab.setAugmentationSectionVisible(offersAugmentation(factionRecord));
         if (factionRecord == null) {
             LOGGER.debug("[NamingMethod] no faction reported yet; leaving naming alone");
             return;
@@ -175,6 +178,51 @@ public class CommandGenerationPane extends AbstractMHQTabbedPane {
         if (namesFormationsInGreek) {
             setupTab.setSelectedForceNamingMethod(ForceNamingMethod.GREEK_ALPHABET);
         }
+    }
+
+    /**
+     * The sub-faction key for Warrior House Thuggee, the Capellan command whose warriors are augmented.
+     *
+     * <p>Kali Liao raised these Houses in secret from her Thuggee cult and the Manei Domini, so they answer to
+     * her rather than to the Warrior House Orders. The regular Warrior Houses ({@code CC.WHO}) are not
+     * augmented and are deliberately not included here.</p>
+     */
+    static final String WARRIOR_HOUSE_THUGGEE_FACTION_KEY = "CC.THG";
+
+    /**
+     * Whether the selected faction is one the player would want the augmentation controls for, which decides
+     * whether the Setup tab shows them at all.
+     *
+     * <p>Three cases, for two different reasons:</p>
+     * <ul>
+     *   <li><b>The Word of Blake Shadow Divisions</b>, keyed
+     *       {@value ManeiDominiCrewAugmentor#SHADOW_DIVISION_FACTION_KEY} - the only faction the Manei Domini
+     *       stage fits implants to.</li>
+     *   <li><b>Any Clan</b> - enhanced imaging is the Clans' alone, and its stage reads the same Use Implants
+     *       setting. Gating on the Shadow Divisions by themselves would leave a Clan player unable to switch
+     *       implants on from here, and enhanced imaging would then never be fitted.</li>
+     *   <li><b>Warrior House Thuggee</b>, keyed {@value #WARRIOR_HOUSE_THUGGEE_FACTION_KEY} - raised from the
+     *       Thuggee cult and the Manei Domini, so its warriors carry implants. No generation stage fits them
+     *       today, but the setting lets the campaign track implants for a command whose warriors have
+     *       them.</li>
+     * </ul>
+     *
+     * <p>For anyone else the two settings change nothing, so they are not offered.</p>
+     *
+     * @param factionRecord the selected faction, or {@code null} when none has been reported yet
+     *
+     * @return {@code true} if the augmentation controls should be shown for this faction
+     */
+    static boolean offersAugmentation(@Nullable FactionRecord factionRecord) {
+        if (factionRecord == null) {
+            return false;
+        }
+        if (factionRecord.isClan()) {
+            return true;
+        }
+        String key = factionRecord.getKey();
+        return ManeiDominiCrewAugmentor.SHADOW_DIVISION_FACTION_KEY.equalsIgnoreCase(key)
+                     || WARRIOR_HOUSE_THUGGEE_FACTION_KEY.equalsIgnoreCase(key);
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/commandGeneration/contents/SetupTab.java
+++ b/MekHQ/src/mekhq/gui/commandGeneration/contents/SetupTab.java
@@ -204,6 +204,8 @@ public class SetupTab {
     // who has not gone looking through two other options dialogs cannot generate an augmented command.
     private CommandGenerationCheckBox chkUseImplants;
     private MMComboBox<NeuralInterfaceMode> cmbNeuralInterfaceMode;
+    private JPanel augmentationSection;
+    private Component augmentationStrut;
 
     // Random origin
     private RandomOriginOptionsPanel randomOriginOptionsPanel;
@@ -258,10 +260,14 @@ public class SetupTab {
         rightColumn.setLayout(new BoxLayout(rightColumn, BoxLayout.Y_AXIS));
         rightColumn.add(buildRandomOriginSection());
         rightColumn.add(Box.createVerticalStrut(UIUtil.scaleForGUI(6)));
-        rightColumn.add(Box.createVerticalStrut(UIUtil.scaleForGUI(6)));
         rightColumn.add(buildTechAssignmentSection());
-        rightColumn.add(Box.createVerticalStrut(UIUtil.scaleForGUI(6)));
-        rightColumn.add(buildAugmentationSection());
+        // Held so the section and the gap above it can be hidden together; hiding the section alone
+        // would leave the gap behind and the column would look like it had lost something.
+        augmentationStrut = Box.createVerticalStrut(UIUtil.scaleForGUI(6));
+        rightColumn.add(augmentationStrut);
+        augmentationSection = buildAugmentationSection();
+        rightColumn.add(augmentationSection);
+        setAugmentationSectionVisible(false);
         constraints.gridx = 1;
         constraints.gridy = 0;
         constraints.gridwidth = 1;
@@ -725,6 +731,51 @@ public class SetupTab {
         return section;
     }
 
+    /**
+     * Shows or hides the augmentation section.
+     *
+     * <p>The two controls only reach a generation for the factions that can be augmented, so for every other
+     * faction they are two settings the player can change to no effect. Hidden rather than greyed out because a
+     * disabled control still reads as "this could apply to you".</p>
+     *
+     * @param visible whether the selected faction can be augmented
+     */
+    public void setAugmentationSectionVisible(boolean visible) {
+        if (augmentationSection == null) {
+            return;
+        }
+        augmentationSection.setVisible(visible);
+        if (augmentationStrut != null) {
+            augmentationStrut.setVisible(visible);
+        }
+    }
+
+
+    /**
+     * Writes the augmentation choices onto {@code targetOptions} and remembers them as the player's own answer.
+     *
+     * @param targetOptions the options to write to
+     */
+    private void writeAugmentationValues(CommandGenerationOptions targetOptions) {
+        targetOptions.setUseImplants(chkUseImplants.isSelected());
+        NeuralInterfaceMode mode = NeuralInterfaceMode.OFF;
+        if (cmbNeuralInterfaceMode.getSelectedItem() instanceof NeuralInterfaceMode selected) {
+            mode = selected;
+            targetOptions.setNeuralInterfaceMode(selected);
+        }
+
+        // Remembered as the player's own answer, so the next new campaign opens on it rather than
+        // asking again. The campaign still holds its own copy; this only decides what a campaign that
+        // has chosen nothing is shown.
+        MekHQ.getMHQOptions().setLastUseImplants(chkUseImplants.isSelected());
+        MekHQ.getMHQOptions().setLastNeuralInterfaceMode(mode);
+    }
+
+    /** @return whether the augmentation section is currently shown, which decides whether its values are written */
+    public boolean isAugmentationSectionVisible() {
+        return (augmentationSection != null) && augmentationSection.isVisible();
+    }
+
     /** Greys the rule out while the campaign is not tracking implants at all. */
     private void refreshAugmentationEnablement() {
         cmbNeuralInterfaceMode.setEnabled(chkUseImplants.isSelected());
@@ -1041,18 +1092,12 @@ public class SetupTab {
         targetOptions.setAssignMekWarriorsCallSigns(chkAssignMekWarriorsCallSigns.isSelected());
         targetOptions.setAssignFounderFlag(chkAssignFounderFlag.isSelected());
 
-        targetOptions.setUseImplants(chkUseImplants.isSelected());
-        NeuralInterfaceMode mode = NeuralInterfaceMode.OFF;
-        if (cmbNeuralInterfaceMode.getSelectedItem() instanceof NeuralInterfaceMode selected) {
-            mode = selected;
-            targetOptions.setNeuralInterfaceMode(selected);
+        // Only written when the section is on screen. A player who set implants for a Shadow Division and then
+        // switched to a faction that cannot be augmented would otherwise still have that choice written to the
+        // campaign from a panel they can no longer see.
+        if (isAugmentationSectionVisible()) {
+            writeAugmentationValues(targetOptions);
         }
-
-        // Remembered as the player's own answer, so the next new campaign opens on it rather than
-        // asking again. The campaign still holds its own copy; this only decides what a campaign that
-        // has chosen nothing is shown.
-        MekHQ.getMHQOptions().setLastUseImplants(chkUseImplants.isSelected());
-        MekHQ.getMHQOptions().setLastNeuralInterfaceMode(mode);
     }
 
     public RandomOriginOptionsPanel getRandomOriginOptionsPanel() {

--- a/MekHQ/unittests/mekhq/gui/commandGeneration/AugmentationFactionGateTest.java
+++ b/MekHQ/unittests/mekhq/gui/commandGeneration/AugmentationFactionGateTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.commandGeneration;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import megamek.client.ratgenerator.FactionRecord;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The Setup tab only offers the augmentation controls to factions they mean something for. The rule is easy to get
+ * subtly wrong in a way nobody notices: gate it on the Shadow Divisions alone and a Clan player quietly loses
+ * enhanced imaging, because its stage reads the same Use Implants setting and nothing tells them it is off.
+ */
+class AugmentationFactionGateTest {
+
+    private static FactionRecord faction(String key, boolean clan) {
+        FactionRecord record = new FactionRecord(key);
+        record.setClan(clan);
+        return record;
+    }
+
+    @Test
+    void theWordOfBlakeShadowDivisionsAreOffered() {
+        assertTrue(CommandGenerationPane.offersAugmentation(faction("WOB.SD", false)),
+              "the Shadow Divisions are the one faction the Manei Domini stage fits implants to");
+    }
+
+    @Test
+    void everyClanIsOffered() {
+        assertTrue(CommandGenerationPane.offersAugmentation(faction("CJF", true)),
+              "enhanced imaging is the Clans' own, and it reads the same Use Implants setting");
+    }
+
+    @Test
+    void warriorHouseThuggeeIsOffered() {
+        assertTrue(CommandGenerationPane.offersAugmentation(faction("CC.THG", false)),
+              "Thuggee's Houses were raised from the cult and the Manei Domini, so their warriors are augmented");
+    }
+
+    @Test
+    void theRegularWarriorHouseOrdersAreNotOffered() {
+        assertFalse(CommandGenerationPane.offersAugmentation(faction("CC.WHO", false)),
+              "Thuggee's Houses answer to Kali Liao rather than the Warrior House Orders, who are not augmented");
+    }
+
+    @Test
+    void theKeyIsMatchedWithoutRegardToCase() {
+        assertTrue(CommandGenerationPane.offersAugmentation(faction("wob.sd", false)));
+        assertTrue(CommandGenerationPane.offersAugmentation(faction("cc.thg", false)));
+    }
+
+    @Test
+    void anUnaugmentedInnerSphereFactionIsNotOffered() {
+        assertFalse(CommandGenerationPane.offersAugmentation(faction("FS", false)),
+              "the Federated Suns fits no augmentation, so the controls would change nothing");
+        assertFalse(CommandGenerationPane.offersAugmentation(faction("LA", false)));
+    }
+
+    @Test
+    void thePlainWordOfBlakeIsNotOffered() {
+        assertFalse(CommandGenerationPane.offersAugmentation(faction("WOB", false)),
+              "only the Shadow Divisions are Manei Domini, not the Word of Blake at large");
+    }
+
+    @Test
+    void thePlainCapellanConfederationIsNotOffered() {
+        assertFalse(CommandGenerationPane.offersAugmentation(faction("CC", false)),
+              "the Warrior Houses are augmented, the Confederation's regular forces are not");
+    }
+
+    @Test
+    void nothingSelectedIsNotOffered() {
+        assertFalse(CommandGenerationPane.offersAugmentation(null),
+              "before a faction is reported the controls stay hidden rather than flashing on");
+    }
+}


### PR DESCRIPTION
## What this changes

The Command Designer's Setup tab offered Track Cybernetic Implants and Pilot Implants to every faction, though only some can be augmented at all. For everyone else they were two settings a player could change to no effect.

The panel now appears only for the factions those settings do something for:

- **Word of Blake Shadow Divisions** (`WOB.SD`) - the only faction the Manei Domini stage fits implants to.
- **Any Clan** - enhanced imaging is theirs alone, and its stage reads the same Use Implants option.
- **Warrior House Thuggee** (`CC.THG`) - raised from the Thuggee cult and the Manei Domini, so its warriors carry implants.

The helper text now says what choosing the settings produces rather than describing the controls: with both on a Shadow Division is fitted with Manei Domini implants and Clan formations receive enhanced imaging; with either off no warrior is augmented, and it cannot be applied after generation.

The values are only written back while the panel is on screen, so a choice made for a Shadow Division is not written to the campaign from a panel the player can no longer see after switching faction.

Fixes #9955

## Testing

`./gradlew :MekHQ:test` - 15,393 tests, 0 failures, 0 errors, 14 skipped. `checkstyleMain` and `javadoc` run separately, both clean.

New `AugmentationFactionGateTest` pins the rule in eight cases, including the two easiest to get wrong: plain `WOB` and plain `CC` are not offered, and `CC.WHO` is not offered either. Verified by breaking it - removing the Clan branch fails `everyClanIsOffered` with the reason attached, which is the silent breakage the test exists to catch (gate on the Shadow Divisions alone and a Clan player loses enhanced imaging with nothing to tell them).

Not tested in game yet.

## What is not proven yet

No generation stage augments Capellans today, so for Warrior House Thuggee the panel switches implant tracking on for the campaign but no warrior is fitted during generation. The helper text says so rather than promising augmentation that does not arrive. A Thuggee augmentation stage would be separate work.

The panel's visibility has not been watched in game across a faction change.

## Note on scope

This PR previously removed the panel outright, which is what #9955 asked for. @HammerGS has since decided it should be conditional instead, so the same PR now gates it rather than deleting it. It is a different change from the one approved earlier and worth a fresh look.

---
- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have verified the result
