### PR TITLE
Fixed ProtoMek Compatibility Handler

### DIFF
--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -2526,14 +2526,10 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                 campaign.addReport(GENERAL, report);
             }
 
-            // This resolves a bug squashed in 2025 (50.03) but lurked in our codebase
-            // potentially as far back as 2014. The next two handlers should never be removed.
-            if (!person.canPerformRole(today, person.getSecondaryRole(), false)) {
-                resolveRolePerformability(person, campaign);
-            }
-
-            if (!person.canPerformRole(today, person.getPrimaryRole(), true)) {
-            }
+            // This resolves a bug squashed in 2025 (50.03) but lurked in our codebase potentially as far back as
+            // 2014. The next two handlers should never be removed. It makes a good place to add missing skills, in
+            // the event we change the skill requirements for a role.
+            resolveRolePerformability(person, campaign);
         }
 
         campaign.getPlayerForce().getHangar().forEachUnit(unit -> {
@@ -2790,7 +2786,6 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
             reportInvalidProfession(person, campaign, "ineligibleForSecondaryRole");
         }
     }
-
 
     private static void reportInvalidProfession(Person person, Campaign campaign, String key) {
         campaign.addReport(GENERAL, getFormattedTextAt(RESOURCE_BUNDLE, key,


### PR DESCRIPTION
## What this changes

A fix to the compatibility handler failed to push correctly so was missed during the merge. This PR adds it back.

## Testing

- None Needed

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result