### PR TITLE
Fixed Lakelands StratCon Sector Generation

### DIFF
--- a/MekHQ/src/mekhq/campaign/digitalGM/stratCon/sectorGeneration/StratConOceanPlacer.java
+++ b/MekHQ/src/mekhq/campaign/digitalGM/stratCon/sectorGeneration/StratConOceanPlacer.java
@@ -95,7 +95,7 @@ public final class StratConOceanPlacer {
         int landTarget = total - oceanTarget;
         Set<StratConCoords> ocean = switch (type) {
             case INLAND -> scatteredBlobs(track, oceanTarget, 1, 2, true);
-            case LAKELANDS -> scatteredBlobs(track, oceanTarget, 4, 8, false);
+            case LAKELANDS -> scatteredBlobs(track, oceanTarget, 4, 8, true);
             case MARSHLANDS -> scatteredBlobs(track, oceanTarget, 8, 16, false);
             case COASTAL -> singleBlob(track, oceanTarget, StratConHexGeometry.randomEdgeCoords(track));
             case INLAND_SEA -> singleBlob(track, oceanTarget, StratConHexGeometry.centerCoords(track));


### PR DESCRIPTION
## What this changes

Lakelands was incorrectly missing its' 'blob' generation, causing its associated test to periodically fail.

## Testing

- Manual testing

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result