### PR TITLE
Fix #6228, #7250, #8336, #8638, #9413, #9952, #9959, #9960: Fixed a Multitude of PACAR bugs

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -984,6 +984,11 @@ optionDisplayUnitDeploymentLog.text=Unit Deployment Log
 optionDisplayUnitDeploymentLog.toolTipText=Start the unit deployment log expanded on the unit history.
 optionDisplayUnitRepairLog.text=Unit Repair Log
 optionDisplayUnitRepairLog.toolTipText=Start the unit repair log expanded on the unit history.
+optionEnableAbstractCombatAutoResolve.text=Enable Abstract Combat Auto Resolve (Developer Tool)
+optionEnableAbstractCombatAutoResolve.toolTipText=Developer tool. Abstract Combat Auto Resolve (ACAR) is a statistical \
+  approximation intended for development and testing, not normal play. When this is off (the default), Auto Resolve \
+  always uses PACAR (the Princess-driven resolution). Enable this only if you specifically want the ACAR method \
+  offered as a choice.
 optionHideUnitFluff.text=Only Use Unit Sprites in Hangar
 optionHideUnitFluff.toolTipText=Some units have images assigned, usually of their models. This option hides these \
   images while in the hangar. Units will always display their sprite instead.

--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -631,6 +631,8 @@ chkGM.toolTipText=This allows you to start a campaign as a GM, so that you don't
 ## Continuous Panel
 continuousCampaignPresetPanel.title=Continuous Options
 continuousCampaignPresetPanel.toolTipText=These are options that are applied when starting a new campaign and can be applied to a pre-existing campaign.
+startHost.serverStartFailed.title=Could Not Start Scenario Server
+startHost.serverStartFailed.message=MekHQ could not start the game server on port {0}. This usually means a previous scenario did not shut down cleanly and is still using that port. Please wait a moment and try again, or restart MekHQ if the problem continues.
 chkSpecifyGameOptions.text=Specify MegaMek Game Options
 chkSpecifyGameOptions.toolTipText=This allows you to specify the MegaMek game options. If this is left empty, the default options will be kept.
 btnGameOptions.text=View Game Options

--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -137,7 +137,10 @@ public class AtBGameThread extends GameThread {
             var acarGui = new CommanderGUI(client, controller);
             localBots = acarGui;
             swingGui = acarGui;
-            acarGui.start();
+            // Give the "Request Victory" button the server password so it authenticates on a passworded server, then
+            // build the window on the EDT. CommanderGUI is no longer a Thread. See issue #8891.
+            acarGui.setServerPassword(password);
+            acarGui.initialize();
         } else {
             var clientGui = new ClientGUI(client, controller);
             localBots = clientGui;
@@ -292,6 +295,7 @@ public class AtBGameThread extends GameThread {
                         copyDeploymentParameters(benchedEntity, entity);
                     }
                 }
+                logPlayerDeployment(entities);
                 client.sendAddEntity(entities);
 
                 // Run through the units again. This time add
@@ -336,6 +340,7 @@ public class AtBGameThread extends GameThread {
                     entity.setDeployRound(deploymentRound);
                     entities.add(entity);
                 }
+                logPlayerDeployment(entities);
                 client.sendAddEntity(entities);
                 client.sendPlayerInfo();
                 var botClients = new ArrayList<BotClient>();
@@ -700,6 +705,24 @@ public class AtBGameThread extends GameThread {
         }
         Unit towedUnit = campaign.getUnit(towedUnitIds.getFirst());
         return ((towedUnit == null) || (towedUnit.getEntity() == null)) ? null : towedUnit;
+    }
+
+    /**
+     * Logs each player entity's owner, start zone and deploy round at INFO before it is sent to the server. In
+     * Commander mode the lobby is skipped, so a misplaced unit (e.g. a reinforcement in the enemy's start zone) can
+     * only be diagnosed from mekhq.log; this makes that possible without a screenshot. See issue #9960.
+     *
+     * @param entities the player entities about to be sent to the server
+     */
+    private void logPlayerDeployment(List<Entity> entities) {
+        for (Entity entity : entities) {
+            Player owner = entity.getOwner();
+            LOGGER.info("[Deployment] {} owner={} startZone={} deployRound={}",
+                  entity.getShortName(),
+                  (owner == null) ? "none" : owner.getName(),
+                  entity.getStartingPos(),
+                  entity.getDeployRound());
+        }
     }
 
     private BotClient setupPlayerBotForAutoResolve(Player player) throws InterruptedException, PrincessException {

--- a/MekHQ/src/mekhq/GameThread.java
+++ b/MekHQ/src/mekhq/GameThread.java
@@ -38,6 +38,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.sentry.Sentry;
 import megamek.client.AbstractClient;
@@ -81,6 +82,9 @@ class GameThread extends Thread implements CloseClientListener {
     protected List<Unit> units;
 
     protected volatile boolean stop = false;
+
+    /** Ensures {@link #clientClosed()} triggers the host teardown at most once for this thread. */
+    private final AtomicBoolean closed = new AtomicBoolean(false);
 
     private final Scenario scenario;
     // endregion Variable Declarations
@@ -370,6 +374,13 @@ class GameThread extends Thread implements CloseClientListener {
      */
     @Override
     public void clientClosed() {
+        // Tear the host down at most once per game thread. A thread's client can be die()d twice - once when MekHQ
+        // tears the game down, and again from this thread's own run() finally block - and each die() fires this
+        // callback. Without this guard, a previous scenario's thread finishing after a new scenario has started could
+        // call app.stopHost() and tear down the new host/client/server. See issue #9959.
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
         requestStop();
         app.stopHost();
     }

--- a/MekHQ/src/mekhq/MHQConstants.java
+++ b/MekHQ/src/mekhq/MHQConstants.java
@@ -301,6 +301,7 @@ public final class MHQConstants extends SuiteConstants {
     public static final String START_GAME_CLIENT_RETRY_COUNT = "startGameClientRetryCount";
     public static final String START_GAME_BOT_CLIENT_DELAY = "startGameBotClientDelay";
     public static final String START_GAME_BOT_CLIENT_RETRY_COUNT = "startGameBotClientRetryCount";
+    public static final String ENABLE_ABSTRACT_COMBAT_AUTO_RESOLVE = "enableAbstractCombatAutoResolve";
 
     // The augmentation rules last chosen in the Command Generator, remembered so a new campaign
     // starts from the player's own answer rather than from the all-off defaults every time.

--- a/MekHQ/src/mekhq/MHQOptions.java
+++ b/MekHQ/src/mekhq/MHQOptions.java
@@ -1507,6 +1507,17 @@ public final class MHQOptions extends SuiteOptions {
     // endregion Nag Tab
 
     // region Miscellaneous Options
+
+    public boolean getEnableAbstractCombatAutoResolve() {
+        return userPreferences.node(MHQConstants.MISCELLANEOUS_NODE)
+                     .getBoolean(MHQConstants.ENABLE_ABSTRACT_COMBAT_AUTO_RESOLVE, false);
+    }
+
+    public void setEnableAbstractCombatAutoResolve(final boolean value) {
+        userPreferences.node(MHQConstants.MISCELLANEOUS_NODE)
+              .putBoolean(MHQConstants.ENABLE_ABSTRACT_COMBAT_AUTO_RESOLVE, value);
+    }
+
     public int getStartGameDelay() {
         return userPreferences.node(MHQConstants.MISCELLANEOUS_NODE).getInt(MHQConstants.START_GAME_DELAY, 1000);
     }

--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -34,6 +34,7 @@
 package mekhq;
 
 import static megamek.MMConstants.LOCALHOST_IP;
+import static mekhq.utilities.MHQInternationalization.getFormattedText;
 import static mekhq.utilities.MHQInternationalization.getText;
 
 import java.awt.Desktop;
@@ -476,6 +477,9 @@ public class MekHQ implements GameListener {
     }
 
     public void joinGame(Scenario scenario, List<Unit> meks) {
+        // Force down any game left over from a previous scenario
+        stopHost();
+
         ConnectDialog joinGameDialog = new ConnectDialog(campaignGUI.getFrame(), campaignGUI.getCampaign().getPlayerForce().getName());
         joinGameDialog.setVisible(true);
 
@@ -527,6 +531,9 @@ public class MekHQ implements GameListener {
      */
     public void startHost(Scenario scenario, boolean loadSaveGame, List<Unit> meks,
           @Nullable BehaviorSettings autoResolveBehaviorSettings) {
+        // Force down any game left over from a previous scenario whose hand-off never completed.
+        stopHost();
+
         HostDialog hostDialog = new HostDialog(campaignGUI.getFrame(), getCampaign().getPlayerForce().getName());
         hostDialog.setVisible(true);
 
@@ -567,6 +574,9 @@ public class MekHQ implements GameListener {
         } catch (Exception ex) {
             LOGGER.error(ex, "Failed to start up server");
             stopHost();
+            LOGGER.errorDialog(ex,
+                  getFormattedText("startHost.serverStartFailed.message", String.valueOf(port)),
+                  getText("startHost.serverStartFailed.title"));
             return;
         }
         // Refactor this into a factory
@@ -599,11 +609,41 @@ public class MekHQ implements GameListener {
 
     // Stop & send the close game event to the Server
     public synchronized void stopHost() {
-        if (getMyServer() != null) {
-            getMyServer().die();
-            myServer = null;
-        }
+        // Snapshot and immediately null the fields before we start tearing anything down. Client.die() synchronously
+        // fires CloseClientListener.clientClosed(), which calls back into stopHost() (see GameThread#clientClosed); by
+        // nulling first, that re-entrant call sees a clean state and becomes a no-op instead of recursing.
+        final GameThread stoppingThread = gameThread;
+        final Client stoppingClient = client;
+        final Server stoppingServer = myServer;
+
+        gameThread = null;
+        client = null;
+        myServer = null;
         currentScenario = null;
+
+        // Stop the game thread so its run loop exits and it releases the client GUI and bot clients.
+        if (stoppingThread != null) {
+            stoppingThread.requestStop();
+        }
+
+        // Deregister ourselves as a game listener and close the client connection so no stale listeners linger.
+        if (stoppingClient != null) {
+            try {
+                stoppingClient.getGame().removeGameListener(this);
+                stoppingClient.die();
+            } catch (Exception ex) {
+                LOGGER.error(ex, "Failed to tear down the game client while stopping the host.");
+            }
+        }
+
+        // Finally, kill the server so it releases its port; a lingering server is what blocks the next launch.
+        if (stoppingServer != null) {
+            try {
+                stoppingServer.die();
+            } catch (Exception ex) {
+                LOGGER.error(ex, "Failed to shut down the game server while stopping the host.");
+            }
+        }
     }
 
     @Override

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -78,6 +78,7 @@ import megamek.common.options.OptionsConstants;
 import megamek.common.ui.FastJScrollPane;
 import megamek.common.units.Entity;
 import megamek.common.units.EntityListFile;
+import megamek.common.units.UnitType;
 import megamek.common.util.sorter.NaturalOrderComparator;
 import megamek.logging.MMLogger;
 import megameklab.util.UnitPrintManager;
@@ -129,9 +130,9 @@ import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.randomEvents.prisoners.PrisonerMissionEndEvent;
 import mekhq.campaign.reputation.chaosReputation.ChaosReputation;
 import mekhq.campaign.unit.Unit;
-import mekhq.campaign.universe.commandGeneration.SupportCarrierDeployment;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Factions;
+import mekhq.campaign.universe.commandGeneration.SupportCarrierDeployment;
 import mekhq.campaign.universe.factionStanding.FactionStandings;
 import mekhq.gui.adapter.ScenarioTableMouseAdapter;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogNotification;
@@ -1896,6 +1897,30 @@ public final class BriefingTab extends CampaignGuiTab {
         return scenarioModel.getScenario(scenarioTable.convertRowIndexToModel(row));
     }
 
+    /**
+     * Determines whether a unit is a space-only craft being sent to a board it cannot operate on.
+     *
+     * <p>WarShips, JumpShips and space stations can only fight on a space map; on a ground or atmospheric map they
+     * have no legal deployment. Aerospace fighters, DropShips and small craft are not blocked here - they follow the
+     * scenario's own rules. The check uses the entity's unit type rather than matching on chassis names. See issue
+     * #9960 (#9952).</p>
+     *
+     * @param entity    the player entity being considered
+     * @param boardType the scenario board type ({@link Scenario#T_GROUND}, {@link Scenario#T_ATMOSPHERE} or
+     *                  {@link Scenario#T_SPACE})
+     *
+     * @return {@code true} if the entity is space-only and the board is not a space map
+     */
+    static boolean isSpaceOnlyUnitOnNonSpaceBoard(Entity entity, int boardType) {
+        if (boardType == Scenario.T_SPACE) {
+            return false;
+        }
+        int unitType = entity.getUnitType();
+        return (unitType == UnitType.WARSHIP)
+                     || (unitType == UnitType.JUMPSHIP)
+                     || (unitType == UnitType.SPACE_STATION);
+    }
+
     private void startScenario(Scenario scenario, BehaviorSettings autoResolveBehaviorSettings) {
         Vector<UUID> uids = scenario.getForces(getCampaign()).getAllUnits(false);
         if (uids.isEmpty()) {
@@ -1925,6 +1950,19 @@ public final class BriefingTab extends CampaignGuiTab {
 
             if (entity == null) {
                 logger.error("Skipping unit {} because it's entity is null", uid);
+                continue;
+            }
+
+            // A space-only unit (WarShip, JumpShip, space station) cannot fight on a ground or atmospheric map. In
+            // Commander mode there is no lobby to catch this, so it is refused here for both launch modes rather than
+            // deployed onto a map it cannot operate on. See issue #9960 (#9952).
+            if (isSpaceOnlyUnitOnNonSpaceBoard(entity, scenario.getBoardType())) {
+                unDeployed.append('\n')
+                      .append(unit.getName())
+                      .append(" (a space-only unit cannot deploy on a ")
+                      .append(Scenario.getBoardTypeName(scenario.getBoardType()).toLowerCase())
+                      .append(" map)");
+                unDeployedUnits.add(unit);
                 continue;
             }
 

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -1837,6 +1837,11 @@ public final class BriefingTab extends CampaignGuiTab {
     }
 
     private void promptAutoResolve(Scenario scenario) {
+        if (!MekHQ.getMHQOptions().getEnableAbstractCombatAutoResolve()) {
+            runPrincessAutoResolve();
+            return;
+        }
+
         // the options for the auto resolve method follow a predefined order, which is the same as the order in the enum,
         // and it uses that to preselect the option that is currently set in the campaign options
         Object[] options = new Object[] { getText("AutoResolveMethod.PRINCESS.text"),

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -1965,7 +1965,7 @@ public final class BriefingTab extends CampaignGuiTab {
                 unDeployed.append('\n')
                       .append(unit.getName())
                       .append(" (a space-only unit cannot deploy on a ")
-                      .append(Scenario.getBoardTypeName(scenario.getBoardType()).toLowerCase())
+                      .append(Scenario.getBoardTypeName(scenario.getBoardType()).toLowerCase(Locale.ROOT))
                       .append(" map)");
                 unDeployedUnits.add(unit);
                 continue;

--- a/MekHQ/src/mekhq/gui/clientOptions/MHQAdvancedPage.java
+++ b/MekHQ/src/mekhq/gui/clientOptions/MHQAdvancedPage.java
@@ -51,6 +51,7 @@ import javax.swing.JTextField;
 import megamek.client.ui.Messages;
 import megamek.client.ui.dialogs.buttonDialogs.CommonSettingsDialog;
 import megamek.client.ui.dialogs.helpDialogs.HelpDialog;
+import megamek.client.ui.settings.SettingsCheckBox;
 import megamek.client.ui.settings.SettingsFormPanel;
 import megamek.client.ui.settings.SettingsLabel;
 import megamek.client.ui.settings.SettingsSpinner;
@@ -75,6 +76,7 @@ class MHQAdvancedPage extends MHQOptionsPage {
     private SettingsSpinner spinnerStartGameClientRetryCount;
     private SettingsSpinner spinnerStartGameBotClientDelay;
     private SettingsSpinner spinnerStartGameBotClientRetryCount;
+    private SettingsCheckBox chkEnableAbstractCombatAutoResolve;
 
     MHQAdvancedPage(MHQOptionsModel model, JFrame frame) {
         super(model);
@@ -153,6 +155,9 @@ class MHQAdvancedPage extends MHQOptionsPage {
         spinnerStartGameBotClientRetryCount = advancedSpinner(panel, "lblStartGameBotClientRetryCount", 250, 100, 2500,
               50, model.startGameBotClientRetryCount);
 
+        chkEnableAbstractCombatAutoResolve = checkBox("optionEnableAbstractCombatAutoResolve",
+              model.enableAbstractCombatAutoResolve);
+        panel.addCheckBoxGrid(1, chkEnableAbstractCombatAutoResolve);
 
         Component page = buildMHQPage("MHQAdvancedPage", "lblMHQAdvancedSection.text", "lblMHQAdvancedSection.summary",
               panel);
@@ -185,5 +190,6 @@ class MHQAdvancedPage extends MHQOptionsPage {
         model.startGameClientRetryCount = (int) spinnerStartGameClientRetryCount.getValue();
         model.startGameBotClientDelay = (int) spinnerStartGameBotClientDelay.getValue();
         model.startGameBotClientRetryCount = (int) spinnerStartGameBotClientRetryCount.getValue();
+        model.enableAbstractCombatAutoResolve = chkEnableAbstractCombatAutoResolve.isSelected();
     }
 }

--- a/MekHQ/src/mekhq/gui/clientOptions/MHQOptionsModel.java
+++ b/MekHQ/src/mekhq/gui/clientOptions/MHQOptionsModel.java
@@ -206,6 +206,7 @@ class MHQOptionsModel {
     int startGameClientRetryCount;
     int startGameBotClientDelay;
     int startGameBotClientRetryCount;
+    boolean enableAbstractCombatAutoResolve;
     // endregion Advanced
 
     MHQOptionsModel(MHQOptions options) {
@@ -378,6 +379,7 @@ class MHQOptionsModel {
         startGameClientRetryCount = options.getStartGameClientRetryCount();
         startGameBotClientDelay = options.getStartGameBotClientDelay();
         startGameBotClientRetryCount = options.getStartGameBotClientRetryCount();
+        enableAbstractCombatAutoResolve = options.getEnableAbstractCombatAutoResolve();
     }
 
     /**
@@ -562,5 +564,6 @@ class MHQOptionsModel {
         options.setStartGameClientRetryCount(startGameClientRetryCount);
         options.setStartGameBotClientDelay(startGameBotClientDelay);
         options.setStartGameBotClientRetryCount(startGameBotClientRetryCount);
+        options.setEnableAbstractCombatAutoResolve(enableAbstractCombatAutoResolve);
     }
 }

--- a/MekHQ/unittests/mekhq/gui/BriefingTabDeploymentEligibilityTest.java
+++ b/MekHQ/unittests/mekhq/gui/BriefingTabDeploymentEligibilityTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import megamek.common.units.Entity;
+import megamek.common.units.UnitType;
+import mekhq.campaign.mission.scenarios.Scenario;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for issue #9960 (#9952): a space-only unit (WarShip, JumpShip, space station) must be refused on a
+ * ground or atmospheric map, since Commander mode has no lobby to catch it. Aerospace fighters and DropShips are not
+ * blocked here - they follow the scenario's own rules.
+ */
+class BriefingTabDeploymentEligibilityTest {
+
+    private static Entity entityOfType(int unitType) {
+        Entity entity = mock(Entity.class);
+        when(entity.getUnitType()).thenReturn(unitType);
+        return entity;
+    }
+
+    @Test
+    void warShipIsBlockedOnGround() {
+        assertTrue(BriefingTab.isSpaceOnlyUnitOnNonSpaceBoard(entityOfType(UnitType.WARSHIP), Scenario.T_GROUND));
+    }
+
+    @Test
+    void warShipIsBlockedInAtmosphere() {
+        assertTrue(BriefingTab.isSpaceOnlyUnitOnNonSpaceBoard(entityOfType(UnitType.WARSHIP), Scenario.T_ATMOSPHERE));
+    }
+
+    @Test
+    void warShipIsAllowedInSpace() {
+        assertFalse(BriefingTab.isSpaceOnlyUnitOnNonSpaceBoard(entityOfType(UnitType.WARSHIP), Scenario.T_SPACE));
+    }
+
+    @Test
+    void jumpShipAndSpaceStationAreBlockedOnGround() {
+        assertTrue(BriefingTab.isSpaceOnlyUnitOnNonSpaceBoard(entityOfType(UnitType.JUMPSHIP), Scenario.T_GROUND));
+        assertTrue(BriefingTab.isSpaceOnlyUnitOnNonSpaceBoard(entityOfType(UnitType.SPACE_STATION), Scenario.T_GROUND));
+    }
+
+    @Test
+    void mekIsAllowedOnGround() {
+        assertFalse(BriefingTab.isSpaceOnlyUnitOnNonSpaceBoard(entityOfType(UnitType.MEK), Scenario.T_GROUND));
+    }
+
+    @Test
+    void dropShipIsNotBlockedHere() {
+        // DropShips can make ground/atmospheric landfall, so they follow the scenario's own rules rather than being
+        // refused by this space-only guard.
+        assertFalse(BriefingTab.isSpaceOnlyUnitOnNonSpaceBoard(entityOfType(UnitType.DROPSHIP), Scenario.T_GROUND));
+    }
+
+    @Test
+    void aerospaceFighterIsNotBlockedHere() {
+        assertFalse(BriefingTab.isSpaceOnlyUnitOnNonSpaceBoard(entityOfType(UnitType.AEROSPACE_FIGHTER),
+              Scenario.T_GROUND));
+    }
+}


### PR DESCRIPTION
# Requires https://github.com/MegaMek/megamek/pull/8922

Fix #6228
Fix #7250
Fix #8336
Fix #8638
Fix #9413
Fix #9952
Fix #9959
Fix #9960

## What this changes

This PR fixes many PACAR bugs. Most largely resolving around the handing off process from PACAR to MekHQ (via MegaMek).

## Testing

- Manual testing
- AI unit tests

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result