### PR TITLE
Disabled Support Teams by Default

### DIFF
--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOption.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOption.java
@@ -374,7 +374,7 @@ public final class CampaignOption<T> {
     public static final CampaignOption<Integer> MASH_THEATRE_CAPACITY =
           of(Integer.class, 25, "mashTheatreCapacity");
     public static final CampaignOption<Boolean> USE_SUPPORT_TEAMS =
-          of(Boolean.class, true, "useSupportTeams");
+          of(Boolean.class, false, "useSupportTeams");
     public static final CampaignOption<Boolean> USE_BLOB_INFANTRY =
           of(Boolean.class, false, "useBlobInfantry");
     public static final CampaignOption<Boolean> USE_BLOB_BATTLE_ARMOR =


### PR DESCRIPTION
## What this changes

Players get really grumpy when we enable new features by default

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result