### PR TITLE
Fix #9981: Fixed Resupply Size Under nuContract

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
@@ -439,7 +439,9 @@ public class Resupply {
         }
 
         // Next, we determine the tonnage cap. This is the maximum tonnage the employer is willing to support.
-        double dropSize = getDropSize(contract, unitTonnage);
+        boolean includeBSPInScale = campaign.getCampaignOptions()
+                                          .get(CampaignOption.USE_CHAOS_SCALE_SUPPORT_POINT_CONVERSION);
+        double dropSize = getDropSize(contract, unitTonnage, includeBSPInScale);
 
         if (campaign.getCampaignOptions().isUseFactionStandingResupplySafe()) {
             FactionStandings standings = campaign.getPlayerForce().getFactionStandings();
@@ -451,8 +453,8 @@ public class Resupply {
         return (int) max(CARGO_MINIMUM_WEIGHT, round(dropSize));
     }
 
-    private static double getDropSize(AbstractContract contract, double unitTonnage) {
-        final int INDIVIDUAL_TONNAGE_ALLOWANCE = 20; // Tons the employer will budget per contract scale point
+    private static double getDropSize(AbstractContract contract, double unitTonnage, boolean isIncludeBSP) {
+        final int INDIVIDUAL_TONNAGE_ALLOWANCE = isIncludeBSP ? 80 * 12 : 80 * 4;
         final int tonnageCap = contract.getScale() * INDIVIDUAL_TONNAGE_ALLOWANCE;
 
         // Then we determine the size of each individual 'drop'. This uses the lowest of

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/ResupplyUtilities.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/ResupplyUtilities.java
@@ -33,21 +33,18 @@
 package mekhq.campaign.mission.resupplyAndCaches;
 
 import static java.lang.Math.max;
-import static java.lang.Math.round;
 import static megamek.common.compute.Compute.randomInt;
 import static mekhq.campaign.force.FormationType.CONVOY;
 import static mekhq.campaign.mission.resupplyAndCaches.Resupply.CARGO_MULTIPLIER;
 import static mekhq.campaign.mission.resupplyAndCaches.Resupply.RESUPPLY_AMMO_TONNAGE;
 import static mekhq.campaign.mission.resupplyAndCaches.Resupply.RESUPPLY_ARMOR_TONNAGE;
 import static mekhq.campaign.mission.resupplyAndCaches.Resupply.calculateTargetCargoTonnage;
-import static mekhq.campaign.mission.resupplyAndCaches.Resupply.isProhibitedUnitType;
 import static mekhq.campaign.personnel.enums.PersonnelStatus.KIA;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 import java.util.UUID;
 
 import megamek.common.compute.Compute;
-import megamek.common.units.Entity;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Formation;
 import mekhq.campaign.mission.contract.AbstractContract;
@@ -186,51 +183,5 @@ public class ResupplyUtilities {
         // Armor and ammo are always delivered in blocks, so cargo will never be less than the sum
         // of those blocks
         return max(RESUPPLY_AMMO_TONNAGE + RESUPPLY_ARMOR_TONNAGE, (int) Math.ceil(targetTonnage));
-    }
-
-    public static int estimateAvailablePlayerCargo(Campaign campaign) {
-        double totalPlayerCargoCapacity = 0;
-
-        for (Formation formation : campaign.getPlayerForce().getAllFormations()) {
-            if (!formation.isFormationType(CONVOY)) {
-                continue;
-            }
-
-            if (formation.getParentFormation() != null && formation.getParentFormation().isFormationType(CONVOY)) {
-                continue;
-            }
-
-            double cargoCapacitySubTotal = 0;
-            boolean hasCargo = false;
-            for (UUID unitId : formation.getAllUnits(false)) {
-                try {
-                    Unit unit = campaign.getUnit(unitId);
-                    Entity entity = unit.getEntity();
-
-                    if (unit.isDamaged() || !unit.isFullyCrewed() || isProhibitedUnitType(entity, true, true)) {
-                        continue;
-                    }
-
-                    double individualCargo = unit.getCargoCapacityForConvoy();
-
-                    if (individualCargo > 0) {
-                        hasCargo = true;
-                    }
-
-                    cargoCapacitySubTotal += individualCargo;
-                } catch (Exception ignored) {
-                    // If we run into an exception, it's because we failed to get Unit or Entity.
-                    // In either case, we just ignore that unit.
-                }
-            }
-
-            if (hasCargo) {
-                if (cargoCapacitySubTotal > 0) {
-                    totalPlayerCargoCapacity += cargoCapacitySubTotal;
-                }
-            }
-        }
-
-        return (int) round(totalPlayerCargoCapacity);
     }
 }


### PR DESCRIPTION
Fix #9981

## What this changes

Resupply cargo size wasn't scaling properly for contract Scale, now it is.

## Testing

- Manual testing

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result