### PR TITLE
Fix #10000: Temp Pools Refresh Went Automated Unmothballing Occurs

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -107,7 +107,6 @@ import megamek.common.options.OptionsConstants;
 import megamek.logging.MMLogger;
 import mekhq.MHQOptions;
 import mekhq.MekHQ;
-
 import mekhq.campaign.campaignOptions.CampaignOption;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.digitalGM.stratCon.StratConCampaignState;

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -372,138 +372,7 @@ public class CampaignNewDayManager {
 
         campaign.getPlayerForce().getHumanResources().getPersonnelWhoAdvancedInXP().clear();
 
-        // Refill automated personnel pools now that the new day has begun and its report header exists, so any
-        // hiring/firing these post lands in today's log under the date line (rather than being wiped by the
-        // clear above, as happened when this ran before the day was started).
-        // When "no release" is also set, only hire to cover shortfalls (skip firing surplus).
-        final MHQOptions mhqOptions = MekHQ.getMHQOptions();
-        if (mhqOptions.getNewDayAsTechPoolFill()) {
-            if (mhqOptions.getNewDayAsTechPoolNoRelease()) {
-                campaign.fillAsTechPool();
-            } else {
-                campaign.resetAsTechPool();
-            }
-        }
-
-        if (mhqOptions.getNewDayMedicPoolFill()) {
-            if (mhqOptions.getNewDayMedicPoolNoRelease()) {
-                campaign.fillMedicPool();
-            } else {
-                campaign.resetMedicPool();
-            }
-        }
-
-        if (mhqOptions.getNewDaySoldierPoolFill()) {
-            if (!mhqOptions.getNewDaySoldierPoolNoRelease()) {
-                campaign.emptyTempCrewPoolForRole(PersonnelRole.SOLDIER);
-            }
-            campaign.getPlayerForce()
-                  .getHumanResources()
-                  .fillTempCrewPoolForRole(campaign, campaign.getCampaignOptions(),
-                        PersonnelRole.SOLDIER);
-            campaign.getPlayerForce()
-                  .getHumanResources()
-                  .distributeTempCrewPoolToUnits(campaign, campaign.getCampaignOptions(),
-                        PersonnelRole.SOLDIER);
-        }
-
-        if (mhqOptions.getNewDayBattleArmorPoolFill()) {
-            if (!mhqOptions.getNewDayBattleArmorPoolNoRelease()) {
-                campaign.emptyTempCrewPoolForRole(PersonnelRole.BATTLE_ARMOUR);
-            }
-            campaign.getPlayerForce()
-                  .getHumanResources()
-                  .fillTempCrewPoolForRole(campaign, campaign.getCampaignOptions(),
-                        PersonnelRole.BATTLE_ARMOUR);
-            campaign.getPlayerForce()
-                  .getHumanResources()
-                  .distributeTempCrewPoolToUnits(campaign, campaign.getCampaignOptions(),
-                        PersonnelRole.BATTLE_ARMOUR);
-        }
-
-        if (mhqOptions.getNewDayVehicleCrewGroundPoolFill()) {
-            if (!mhqOptions.getNewDayVehicleCrewGroundPoolNoRelease()) {
-                campaign.emptyTempCrewPoolForRole(PersonnelRole.VEHICLE_CREW_GROUND);
-            }
-            campaign.getPlayerForce()
-                  .getHumanResources()
-                  .fillTempCrewPoolForRole(campaign, campaign.getCampaignOptions(),
-                        PersonnelRole.VEHICLE_CREW_GROUND);
-            campaign.getPlayerForce()
-                  .getHumanResources()
-                  .distributeTempCrewPoolToUnits(campaign, campaign.getCampaignOptions(),
-                        PersonnelRole.VEHICLE_CREW_GROUND);
-        }
-
-        if (mhqOptions.getNewDayVehicleCrewVTOLPoolFill()) {
-            if (!mhqOptions.getNewDayVehicleCrewVTOLPoolNoRelease()) {
-                campaign.emptyTempCrewPoolForRole(PersonnelRole.VEHICLE_CREW_VTOL);
-            }
-            campaign.getPlayerForce()
-                  .getHumanResources()
-                  .fillTempCrewPoolForRole(campaign, campaign.getCampaignOptions(),
-                        PersonnelRole.VEHICLE_CREW_VTOL);
-            campaign.getPlayerForce()
-                  .getHumanResources()
-                  .distributeTempCrewPoolToUnits(campaign, campaign.getCampaignOptions(),
-                        PersonnelRole.VEHICLE_CREW_VTOL);
-        }
-
-        if (mhqOptions.getNewDayVehicleCrewNavalPoolFill()) {
-            if (!mhqOptions.getNewDayVehicleCrewNavalPoolNoRelease()) {
-                campaign.emptyTempCrewPoolForRole(PersonnelRole.VEHICLE_CREW_NAVAL);
-            }
-            campaign.getPlayerForce()
-                  .getHumanResources()
-                  .fillTempCrewPoolForRole(campaign, campaign.getCampaignOptions(),
-                        PersonnelRole.VEHICLE_CREW_NAVAL);
-            campaign.getPlayerForce()
-                  .getHumanResources()
-                  .distributeTempCrewPoolToUnits(campaign, campaign.getCampaignOptions(),
-                        PersonnelRole.VEHICLE_CREW_NAVAL);
-        }
-
-        if (mhqOptions.getNewDayVesselPilotPoolFill()) {
-            if (!mhqOptions.getNewDayVesselPilotPoolNoRelease()) {
-                campaign.emptyTempCrewPoolForRole(PersonnelRole.VESSEL_PILOT);
-            }
-            campaign.getPlayerForce()
-                  .getHumanResources()
-                  .fillTempCrewPoolForRole(campaign, campaign.getCampaignOptions(),
-                        PersonnelRole.VESSEL_PILOT);
-            campaign.getPlayerForce()
-                  .getHumanResources()
-                  .distributeTempCrewPoolToUnits(campaign, campaign.getCampaignOptions(),
-                        PersonnelRole.VESSEL_PILOT);
-        }
-
-        if (mhqOptions.getNewDayVesselGunnerPoolFill()) {
-            if (!mhqOptions.getNewDayVesselGunnerPoolNoRelease()) {
-                campaign.emptyTempCrewPoolForRole(PersonnelRole.VESSEL_GUNNER);
-            }
-            campaign.getPlayerForce()
-                  .getHumanResources()
-                  .fillTempCrewPoolForRole(campaign, campaign.getCampaignOptions(),
-                        PersonnelRole.VESSEL_GUNNER);
-            campaign.getPlayerForce()
-                  .getHumanResources()
-                  .distributeTempCrewPoolToUnits(campaign, campaign.getCampaignOptions(),
-                        PersonnelRole.VESSEL_GUNNER);
-        }
-
-        if (mhqOptions.getNewDayVesselCrewPoolFill()) {
-            if (!mhqOptions.getNewDayVesselCrewPoolNoRelease()) {
-                campaign.emptyTempCrewPoolForRole(PersonnelRole.VESSEL_CREW);
-            }
-            campaign.getPlayerForce()
-                  .getHumanResources()
-                  .fillTempCrewPoolForRole(campaign, campaign.getCampaignOptions(),
-                        PersonnelRole.VESSEL_CREW);
-            campaign.getPlayerForce()
-                  .getHumanResources()
-                  .distributeTempCrewPoolToUnits(campaign, campaign.getCampaignOptions(),
-                        PersonnelRole.VESSEL_CREW);
-        }
+        fillTempPools();
 
         // New Year Changes
         if (isNewYear) {
@@ -703,6 +572,141 @@ public class CampaignNewDayManager {
         }
 
         return startDayWithNoInterruptions;
+    }
+
+    private void fillTempPools() {
+        // Refill automated personnel pools now that the new day has begun and its report header exists, so any
+        // hiring/firing these post lands in today's log under the date line (rather than being wiped by the
+        // clear above, as happened when this ran before the day was started).
+        // When "no release" is also set, only hire to cover shortfalls (skip firing surplus).
+        final MHQOptions mhqOptions = MekHQ.getMHQOptions();
+        if (mhqOptions.getNewDayAsTechPoolFill()) {
+            if (mhqOptions.getNewDayAsTechPoolNoRelease()) {
+                campaign.fillAsTechPool();
+            } else {
+                campaign.resetAsTechPool();
+            }
+        }
+
+        if (mhqOptions.getNewDayMedicPoolFill()) {
+            if (mhqOptions.getNewDayMedicPoolNoRelease()) {
+                campaign.fillMedicPool();
+            } else {
+                campaign.resetMedicPool();
+            }
+        }
+
+        if (mhqOptions.getNewDaySoldierPoolFill()) {
+            if (!mhqOptions.getNewDaySoldierPoolNoRelease()) {
+                campaign.emptyTempCrewPoolForRole(PersonnelRole.SOLDIER);
+            }
+            campaign.getPlayerForce()
+                  .getHumanResources()
+                  .fillTempCrewPoolForRole(campaign, campaign.getCampaignOptions(),
+                        PersonnelRole.SOLDIER);
+            campaign.getPlayerForce()
+                  .getHumanResources()
+                  .distributeTempCrewPoolToUnits(campaign, campaign.getCampaignOptions(),
+                        PersonnelRole.SOLDIER);
+        }
+
+        if (mhqOptions.getNewDayBattleArmorPoolFill()) {
+            if (!mhqOptions.getNewDayBattleArmorPoolNoRelease()) {
+                campaign.emptyTempCrewPoolForRole(PersonnelRole.BATTLE_ARMOUR);
+            }
+            campaign.getPlayerForce()
+                  .getHumanResources()
+                  .fillTempCrewPoolForRole(campaign, campaign.getCampaignOptions(),
+                        PersonnelRole.BATTLE_ARMOUR);
+            campaign.getPlayerForce()
+                  .getHumanResources()
+                  .distributeTempCrewPoolToUnits(campaign, campaign.getCampaignOptions(),
+                        PersonnelRole.BATTLE_ARMOUR);
+        }
+
+        if (mhqOptions.getNewDayVehicleCrewGroundPoolFill()) {
+            if (!mhqOptions.getNewDayVehicleCrewGroundPoolNoRelease()) {
+                campaign.emptyTempCrewPoolForRole(PersonnelRole.VEHICLE_CREW_GROUND);
+            }
+            campaign.getPlayerForce()
+                  .getHumanResources()
+                  .fillTempCrewPoolForRole(campaign, campaign.getCampaignOptions(),
+                        PersonnelRole.VEHICLE_CREW_GROUND);
+            campaign.getPlayerForce()
+                  .getHumanResources()
+                  .distributeTempCrewPoolToUnits(campaign, campaign.getCampaignOptions(),
+                        PersonnelRole.VEHICLE_CREW_GROUND);
+        }
+
+        if (mhqOptions.getNewDayVehicleCrewVTOLPoolFill()) {
+            if (!mhqOptions.getNewDayVehicleCrewVTOLPoolNoRelease()) {
+                campaign.emptyTempCrewPoolForRole(PersonnelRole.VEHICLE_CREW_VTOL);
+            }
+            campaign.getPlayerForce()
+                  .getHumanResources()
+                  .fillTempCrewPoolForRole(campaign, campaign.getCampaignOptions(),
+                        PersonnelRole.VEHICLE_CREW_VTOL);
+            campaign.getPlayerForce()
+                  .getHumanResources()
+                  .distributeTempCrewPoolToUnits(campaign, campaign.getCampaignOptions(),
+                        PersonnelRole.VEHICLE_CREW_VTOL);
+        }
+
+        if (mhqOptions.getNewDayVehicleCrewNavalPoolFill()) {
+            if (!mhqOptions.getNewDayVehicleCrewNavalPoolNoRelease()) {
+                campaign.emptyTempCrewPoolForRole(PersonnelRole.VEHICLE_CREW_NAVAL);
+            }
+            campaign.getPlayerForce()
+                  .getHumanResources()
+                  .fillTempCrewPoolForRole(campaign, campaign.getCampaignOptions(),
+                        PersonnelRole.VEHICLE_CREW_NAVAL);
+            campaign.getPlayerForce()
+                  .getHumanResources()
+                  .distributeTempCrewPoolToUnits(campaign, campaign.getCampaignOptions(),
+                        PersonnelRole.VEHICLE_CREW_NAVAL);
+        }
+
+        if (mhqOptions.getNewDayVesselPilotPoolFill()) {
+            if (!mhqOptions.getNewDayVesselPilotPoolNoRelease()) {
+                campaign.emptyTempCrewPoolForRole(PersonnelRole.VESSEL_PILOT);
+            }
+            campaign.getPlayerForce()
+                  .getHumanResources()
+                  .fillTempCrewPoolForRole(campaign, campaign.getCampaignOptions(),
+                        PersonnelRole.VESSEL_PILOT);
+            campaign.getPlayerForce()
+                  .getHumanResources()
+                  .distributeTempCrewPoolToUnits(campaign, campaign.getCampaignOptions(),
+                        PersonnelRole.VESSEL_PILOT);
+        }
+
+        if (mhqOptions.getNewDayVesselGunnerPoolFill()) {
+            if (!mhqOptions.getNewDayVesselGunnerPoolNoRelease()) {
+                campaign.emptyTempCrewPoolForRole(PersonnelRole.VESSEL_GUNNER);
+            }
+            campaign.getPlayerForce()
+                  .getHumanResources()
+                  .fillTempCrewPoolForRole(campaign, campaign.getCampaignOptions(),
+                        PersonnelRole.VESSEL_GUNNER);
+            campaign.getPlayerForce()
+                  .getHumanResources()
+                  .distributeTempCrewPoolToUnits(campaign, campaign.getCampaignOptions(),
+                        PersonnelRole.VESSEL_GUNNER);
+        }
+
+        if (mhqOptions.getNewDayVesselCrewPoolFill()) {
+            if (!mhqOptions.getNewDayVesselCrewPoolNoRelease()) {
+                campaign.emptyTempCrewPoolForRole(PersonnelRole.VESSEL_CREW);
+            }
+            campaign.getPlayerForce()
+                  .getHumanResources()
+                  .fillTempCrewPoolForRole(campaign, campaign.getCampaignOptions(),
+                        PersonnelRole.VESSEL_CREW);
+            campaign.getPlayerForce()
+                  .getHumanResources()
+                  .distributeTempCrewPoolToUnits(campaign, campaign.getCampaignOptions(),
+                        PersonnelRole.VESSEL_CREW);
+        }
     }
 
     private void checkForBioweaponAttacksOrNewVaccines(String systemName, String systemId) {

--- a/MekHQ/src/mekhq/campaign/mission/contract/utilities/ContractAutomation.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/utilities/ContractAutomation.java
@@ -260,6 +260,10 @@ public class ContractAutomation {
 
     private static void fillTempPools(Campaign campaign) {
         final MHQOptions mhqOptions = MekHQ.getMHQOptions();
+        if (mhqOptions == null) { // This makes unit testing easier
+            return;
+        }
+
         ForceHumanResources humanResources = campaign.getPlayerForce().getHumanResources();
 
         if (mhqOptions.getNewDaySoldierPoolFill()) {

--- a/MekHQ/src/mekhq/campaign/mission/contract/utilities/ContractAutomation.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/utilities/ContractAutomation.java
@@ -46,9 +46,11 @@ import java.util.stream.Collectors;
 
 import megamek.common.units.Entity;
 import megamek.logging.MMLogger;
+import mekhq.MHQOptions;
 import mekhq.MekHQ;
 import mekhq.campaign.AbstractLocation;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.ForceHumanResources;
 import mekhq.campaign.JumpPath;
 import mekhq.campaign.events.units.UnitChangedEvent;
 import mekhq.campaign.finances.Money;
@@ -59,6 +61,7 @@ import mekhq.campaign.mission.contract.AbstractContract;
 import mekhq.campaign.mission.utilities.ContractUtilities;
 import mekhq.campaign.mission.utilities.TransportCostCalculations;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.actions.ActivateUnitAction;
 import mekhq.campaign.unit.actions.MothballUnitAction;
@@ -249,8 +252,81 @@ public class ContractAutomation {
             }
         }
 
+        fillTempPools(campaign);
+
         // We still want to clear out any units
-        detachment.setAutomatedMothballUnits(new ArrayList<UUID>());
+        detachment.setAutomatedMothballUnits(new ArrayList<>());
+    }
+
+    private static void fillTempPools(Campaign campaign) {
+        final MHQOptions mhqOptions = MekHQ.getMHQOptions();
+        ForceHumanResources humanResources = campaign.getPlayerForce().getHumanResources();
+
+        if (mhqOptions.getNewDaySoldierPoolFill()) {
+            humanResources.fillTempCrewPoolForRole(campaign, campaign.getCampaignOptions(), PersonnelRole.SOLDIER);
+            humanResources.distributeTempCrewPoolToUnits(campaign,
+                  campaign.getCampaignOptions(),
+                  PersonnelRole.SOLDIER);
+        }
+
+        if (mhqOptions.getNewDayBattleArmorPoolFill()) {
+            humanResources.fillTempCrewPoolForRole(campaign,
+                  campaign.getCampaignOptions(),
+                  PersonnelRole.BATTLE_ARMOUR);
+            humanResources.distributeTempCrewPoolToUnits(campaign,
+                  campaign.getCampaignOptions(),
+                  PersonnelRole.BATTLE_ARMOUR);
+        }
+
+        if (mhqOptions.getNewDayVehicleCrewGroundPoolFill()) {
+            humanResources.fillTempCrewPoolForRole(campaign,
+                  campaign.getCampaignOptions(),
+                  PersonnelRole.VEHICLE_CREW_GROUND);
+            humanResources.distributeTempCrewPoolToUnits(campaign,
+                  campaign.getCampaignOptions(),
+                  PersonnelRole.VEHICLE_CREW_GROUND);
+        }
+
+        if (mhqOptions.getNewDayVehicleCrewVTOLPoolFill()) {
+            humanResources.fillTempCrewPoolForRole(campaign,
+                  campaign.getCampaignOptions(),
+                  PersonnelRole.VEHICLE_CREW_VTOL);
+            humanResources.distributeTempCrewPoolToUnits(campaign,
+                  campaign.getCampaignOptions(),
+                  PersonnelRole.VEHICLE_CREW_VTOL);
+        }
+
+        if (mhqOptions.getNewDayVehicleCrewNavalPoolFill()) {
+            humanResources.fillTempCrewPoolForRole(campaign,
+                  campaign.getCampaignOptions(),
+                  PersonnelRole.VEHICLE_CREW_NAVAL);
+            humanResources.distributeTempCrewPoolToUnits(campaign,
+                  campaign.getCampaignOptions(),
+                  PersonnelRole.VEHICLE_CREW_NAVAL);
+        }
+
+        if (mhqOptions.getNewDayVesselPilotPoolFill()) {
+            humanResources.fillTempCrewPoolForRole(campaign, campaign.getCampaignOptions(), PersonnelRole.VESSEL_PILOT);
+            humanResources.distributeTempCrewPoolToUnits(campaign,
+                  campaign.getCampaignOptions(),
+                  PersonnelRole.VESSEL_PILOT);
+        }
+
+        if (mhqOptions.getNewDayVesselGunnerPoolFill()) {
+            humanResources.fillTempCrewPoolForRole(campaign,
+                  campaign.getCampaignOptions(),
+                  PersonnelRole.VESSEL_GUNNER);
+            humanResources.distributeTempCrewPoolToUnits(campaign,
+                  campaign.getCampaignOptions(),
+                  PersonnelRole.VESSEL_GUNNER);
+        }
+
+        if (mhqOptions.getNewDayVesselCrewPoolFill()) {
+            humanResources.fillTempCrewPoolForRole(campaign, campaign.getCampaignOptions(), PersonnelRole.VESSEL_CREW);
+            humanResources.distributeTempCrewPoolToUnits(campaign,
+                  campaign.getCampaignOptions(),
+                  PersonnelRole.VESSEL_CREW);
+        }
     }
 
     public static void outOfContractMothballAutomation(Campaign campaign) {

--- a/MekHQ/unittests/mekhq/campaign/mission/contract/utilities/ContractAutomationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/contract/utilities/ContractAutomationTest.java
@@ -55,6 +55,7 @@ import megamek.common.units.Entity;
 import mekhq.MekHQ;
 import mekhq.campaign.AbstractLocation;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.ForceHumanResources;
 import mekhq.campaign.LocalHangar;
 import mekhq.campaign.force.Detachment;
 import mekhq.campaign.force.Formation;
@@ -177,6 +178,12 @@ class ContractAutomationTest {
             Campaign campaign = mock(Campaign.class);
             when(campaign.getUnit(idA)).thenReturn(unitA);
 
+            PlayerForce playerForce = mock(PlayerForce.class);
+            when(campaign.getPlayerForce()).thenReturn(playerForce);
+
+            ForceHumanResources forceHumanResources = mock(ForceHumanResources.class);
+            when(playerForce.getHumanResources()).thenReturn(forceHumanResources);
+
             Detachment detachmentA = new Detachment();
             detachmentA.setAutomatedMothballUnits(new ArrayList<>(List.of(idA)));
             Detachment detachmentB = new Detachment();
@@ -201,6 +208,12 @@ class ContractAutomationTest {
 
             Campaign campaign = mock(Campaign.class);
             when(campaign.getUnit(id)).thenReturn(alreadyActive);
+
+            PlayerForce playerForce = mock(PlayerForce.class);
+            when(campaign.getPlayerForce()).thenReturn(playerForce);
+
+            ForceHumanResources forceHumanResources = mock(ForceHumanResources.class);
+            when(playerForce.getHumanResources()).thenReturn(forceHumanResources);
 
             Detachment detachment = new Detachment();
             detachment.setAutomatedMothballUnits(new ArrayList<>(List.of(id)));


### PR DESCRIPTION
Fix #10000

## What this changes

As per title

## Testing

- Manual testing

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result