### PR TITLE
Fix #10005, #10007: Fixed Mole Hunt & Prisoner Liberation Not Spawning Crucial Units; Removed 'Intercept the Escapees' From Scenario Manifest

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/scenarios/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/scenarios/AtBDynamicScenarioFactory.java
@@ -362,7 +362,15 @@ public class AtBDynamicScenarioFactory {
                 LOGGER.info("++ Generating a force for the {} template ++",
                       forceTemplate.getForceName().toUpperCase());
 
-                if (forceTemplate.getGenerationMethod() == ForceGenerationMethod.FixedMUL.ordinal()) {
+                if (forceTemplate.getGenerationMethod() == ForceGenerationMethod.None.ordinal()) {
+                    if (scenario.getStratConScenarioType().isMoleHunt() &&
+                              forceTemplate.getForceName().contains("Mole")) {
+                        generatedLanceCount += generateMole(scenario, contract, campaign, forceTemplate);
+                    } else if (scenario.getStratConScenarioType().isPrisonerLiberation() &&
+                                     forceTemplate.getForceName().contains("Prisoners")) {
+                        generatedLanceCount += generateEscapees(scenario, contract, campaign, forceTemplate);
+                    }
+                } else if (forceTemplate.getGenerationMethod() == ForceGenerationMethod.FixedMUL.ordinal()) {
                     generatedLanceCount += generateFixedForce(scenario, contract, campaign, forceTemplate);
                 } else {
                     int weightClass = randomForceWeight();
@@ -379,6 +387,80 @@ public class AtBDynamicScenarioFactory {
         }
 
         return generatedLanceCount;
+    }
+
+    public static int generateEscapees(AtBDynamicScenario scenario, AbstractContract contract, Campaign campaign,
+          ScenarioForceTemplate forceTemplate) {
+        ForceAlignment forceAlignment = ForceAlignment.getForceAlignment(forceTemplate.getForceAlignment());
+
+        String factionCode = contract.getEnemyFactionCode();
+        Faction faction = Factions.getInstance().getFaction(factionCode);
+        MekSummary mekSummary = MekSummaryCache.getInstance().getMek("Mob (Small)");
+        if (mekSummary == null) {
+            LOGGER.error("Cannot find entry for Mob (Small)");
+            return 0;
+        }
+
+        Vector<Entity> generatedEntities = new Vector<>();
+        int mobCount = forceTemplate.getFixedUnitCount();
+        for (int i = 0; i < mobCount; i++) {
+            Entity escapee = createEntityWithCrew(faction, SkillLevel.ULTRA_GREEN, campaign, mekSummary, false);
+            if (escapee == null) {
+                LOGGER.error("Cannot create entity for Mob (Small)");
+                continue;
+            }
+
+            updateArmorKits(scenario, escapee);
+
+            generatedEntities.add(escapee);
+        }
+
+        BotForce generatedForce = new BotForce();
+        generatedForce.setFixedEntityList(generatedEntities);
+        setBotForceParameters(generatedForce, forceTemplate, forceAlignment, contract);
+        scenario.addBotForce(generatedForce, forceTemplate, campaign);
+
+        return (int) floor(generatedEntities.size() / 4.0);
+    }
+
+    public static int generateMole(AtBDynamicScenario scenario, AbstractContract contract, Campaign campaign,
+          ScenarioForceTemplate forceTemplate) {
+        ForceAlignment forceAlignment = ForceAlignment.getForceAlignment(forceTemplate.getForceAlignment());
+
+        String factionCode = contract.getEnemyFactionCode();
+        Faction faction = Factions.getInstance().getFaction(factionCode);
+        MekSummary mekSummary = MekSummaryCache.getInstance().getMek("VIP");
+        if (mekSummary == null) {
+            LOGGER.error("Cannot find entry for VIP");
+            return 0;
+        }
+
+        Entity vip = createEntityWithCrew(faction, SkillLevel.ULTRA_GREEN, campaign, mekSummary, false);
+        if (vip == null) {
+            LOGGER.error("Cannot create entity for VIP");
+            return 0;
+        }
+
+        updateArmorKits(scenario, vip);
+
+        Vector<Entity> generatedEntities = new Vector<>();
+        generatedEntities.add(vip);
+
+        BotForce generatedForce = new BotForce();
+        generatedForce.setFixedEntityList(generatedEntities);
+        setBotForceParameters(generatedForce, forceTemplate, forceAlignment, contract);
+        scenario.addBotForce(generatedForce, forceTemplate, campaign);
+
+        return (int) floor(generatedEntities.size() / 4.0);
+    }
+
+    private static void updateArmorKits(AtBDynamicScenario scenario, Entity entity) {
+        if (entity instanceof ConvInfantry infantry) {
+            boolean isLowPressure = scenario.getAtmosphere().isLighterThan(THIN);
+            boolean isPoisonous = !scenario.getAtmosphericTaint().isBreathable();
+            int temperature = scenario.getTemperature();
+            changeInfantryKit(infantry, isLowPressure, isPoisonous, temperature);
+        }
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/mission/scenarios/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/scenarios/AtBDynamicScenarioFactory.java
@@ -394,8 +394,16 @@ public class AtBDynamicScenarioFactory {
         ForceAlignment forceAlignment = ForceAlignment.getForceAlignment(forceTemplate.getForceAlignment());
 
         String factionCode = contract.getEnemyFactionCode();
+        if (factionCode.isBlank()) {
+            LOGGER.error("Enemy faction code is blank; using fallback faction code. This is indicative of a deeper problem and should be reported.");
+            factionCode = "IS";
+        }
+
         Faction faction = Factions.getInstance().getFaction(factionCode);
-        MekSummary mekSummary = MekSummaryCache.getInstance().getMek("Mob (Small)");
+        if (faction == null) {
+            LOGGER.error("Enemy faction {} does not exist; aborting escapee generation.", factionCode);
+            return 0;
+        }
         if (mekSummary == null) {
             LOGGER.error("Cannot find entry for Mob (Small)");
             return 0;

--- a/MekHQ/src/mekhq/campaign/mission/scenarios/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/scenarios/AtBDynamicScenarioFactory.java
@@ -404,6 +404,8 @@ public class AtBDynamicScenarioFactory {
             LOGGER.error("Enemy faction {} does not exist; aborting escapee generation.", factionCode);
             return 0;
         }
+
+        MekSummary mekSummary = MekSummaryCache.getInstance().getMek("Mob (Small)");
         if (mekSummary == null) {
             LOGGER.error("Cannot find entry for Mob (Small)");
             return 0;

--- a/MekHQ/src/mekhq/campaign/mission/scenarios/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/scenarios/AtBDynamicScenarioFactory.java
@@ -410,7 +410,9 @@ public class AtBDynamicScenarioFactory {
                 continue;
             }
 
-            updateArmorKits(scenario, escapee);
+            if (campaign.getCampaignOptions().get(CampaignOption.USE_PLANETARY_MODIFIERS)) {
+                updateArmorKits(scenario, escapee);
+            }
 
             generatedEntities.add(escapee);
         }
@@ -441,7 +443,9 @@ public class AtBDynamicScenarioFactory {
             return 0;
         }
 
-        updateArmorKits(scenario, vip);
+        if (campaign.getCampaignOptions().get(CampaignOption.USE_PLANETARY_MODIFIERS)) {
+            updateArmorKits(scenario, vip);
+        }
 
         Vector<Entity> generatedEntities = new Vector<>();
         generatedEntities.add(vip);

--- a/MekHQ/src/mekhq/campaign/mission/scenarios/ScenarioType.java
+++ b/MekHQ/src/mekhq/campaign/mission/scenarios/ScenarioType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2024-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -59,7 +59,9 @@ public enum ScenarioType {
     CONVOY,
     RIOT,
     OFFICIAL_CHALLENGE,
-    HOSTILE_FACILITY;
+    HOSTILE_FACILITY,
+    MOLE_HUNT,
+    PRISONER_LIBERATION;
 
     /**
      * @return {@code true} if the scenario is considered a LosTech scenario, {@code false} otherwise.
@@ -97,6 +99,14 @@ public enum ScenarioType {
      */
     public boolean isOfficialChallenge() {
         return this == OFFICIAL_CHALLENGE;
+    }
+
+    public boolean isPrisonerLiberation() {
+        return this == PRISONER_LIBERATION;
+    }
+
+    public boolean isMoleHunt() {
+        return this == MOLE_HUNT;
     }
 
     /**


### PR DESCRIPTION
# Requires https://github.com/MegaMek/mm-data/pull/555

Fix #10005
Fix #10007

## What this changes

Mole Hunt & Prisoner Liberation weren't consistently spawning prisoners or moles. I went in and added special handlers to ensure they do moving forward. They'll also update their armor kit based on environmental conditions.

'Intercept the Escapees' is a special scenario type that is only meant to be used during prison breaks. It was incorrectly added to the scenario manifest and has now been removed.

## Testing

- Manual testing

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result