### PR TITLE
Fix #9998: Adjusted Enemy Negotiator Skill to Be Faction Based

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/AbstractContractDeterminationEmployer.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/AbstractContractDeterminationEmployer.java
@@ -133,7 +133,7 @@ public abstract class AbstractContractDeterminationEmployer {
         }
         HiringHallLevel hiringHall = currentPlanet.getHiringHallLevel(currentDate);
 
-        Person negotiator = EmployerNegotiator.generateNegotiator(campaign, searchType, employer, hiringHall);
+        Person negotiator = EmployerNegotiator.generateNegotiator(campaign, searchType, employer, hiringHall, type);
         Person liaison = EmployerLiaison.generateLiaison(campaign,
               searchType,
               employer.isClan(),

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/negotiationsAndNPCs/EmployerNegotiator.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/negotiationsAndNPCs/EmployerNegotiator.java
@@ -162,15 +162,20 @@ public class EmployerNegotiator {
 
         // Due to modifiers, the final skill level will usually be one step above
         SkillLevel targetSkillLevel = switch (chaosEmployerType) {
-            case ANY_PLANETARY_GOVERNMENT, ANY_SYSTEM_OWNER, LOCAL_SYSTEM_OWNER -> {
-                if (faction.isMajorOrSuperPower() || faction.isClan() || faction.isComStarOrWoB()) {
+            case ANY_SYSTEM_OWNER, LOCAL_SYSTEM_OWNER -> {
+                if (faction.isMajorOrSuperPower() || faction.isClan()) {
                     yield SkillLevel.VETERAN;
+                } else if (faction.isComStarOrWoB()) {
+                    yield SkillLevel.ELITE;
                 } else {
                     yield SkillLevel.REGULAR;
                 }
             }
             case NOBLE, MERCENARY_SUBCONTRACT, CORPORATION -> SkillLevel.REGULAR;
-            case CIVILIAN_ORGANIZATION_BUSINESS, CIVILIAN_ORGANIZATION_MILITIA, LOCAL_PLANETARY_GOVERNMENT ->
+            case CIVILIAN_ORGANIZATION_BUSINESS,
+                 CIVILIAN_ORGANIZATION_MILITIA,
+                 LOCAL_PLANETARY_GOVERNMENT,
+                 ANY_PLANETARY_GOVERNMENT ->
                   SkillLevel.GREEN;
             case CIVILIAN_ORGANIZATION_REBELS -> SkillLevel.ULTRA_GREEN;
         };

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/negotiationsAndNPCs/EmployerNegotiator.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/negotiationsAndNPCs/EmployerNegotiator.java
@@ -46,6 +46,7 @@ import java.util.List;
 import megamek.common.enums.Gender;
 import megamek.common.enums.SkillLevel;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.mission.contract.contractGeneration.ChaosEmployerType;
 import mekhq.campaign.mission.contract.contractGeneration.ContractSearchType;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonUtility;
@@ -90,8 +91,6 @@ public class EmployerNegotiator {
 
     private EmployerNegotiator() {}
 
-    // TODO have a way for the player to get intel on the opposing negotiator
-
     /**
      * Generates the employer's negotiator, choosing an appropriate role and raising the person to the CamOps negotiator
      * baseline.
@@ -104,14 +103,14 @@ public class EmployerNegotiator {
      * @return the generated negotiator
      */
     public static Person generateNegotiator(Campaign campaign, ContractSearchType searchType,
-          Faction employerFaction, HiringHallLevel hiringHallLevel) {
+          Faction employerFaction, HiringHallLevel hiringHallLevel, ChaosEmployerType chaosEmployerType) {
         PersonnelRole role = getNegotiatorRole(hiringHallLevel, searchType, employerFaction);
 
         Person negotiator = campaign.getPlayerForce()
                                   .getHumanResources()
                                   .newPerson(campaign, role, employerFaction.getShortName(), Gender.RANDOMIZE);
 
-        adjustExperienceLevel(campaign, negotiator, role, employerFaction.isClan());
+        adjustExperienceLevel(campaign, negotiator, role, employerFaction, chaosEmployerType);
         adjustCharisma(negotiator);
         adjustNegotiation(negotiator);
         giveSPA(campaign, negotiator);
@@ -153,14 +152,30 @@ public class EmployerNegotiator {
     }
 
     private static void adjustExperienceLevel(Campaign campaign, Person negotiator, PersonnelRole role,
-          boolean isClanForce) {
+          Faction faction, ChaosEmployerType chaosEmployerType) {
+        boolean isClan = faction.isClan();
         int experienceLevel = negotiator.getExperienceLevel(campaign.getCampaignOptions(),
-              isClanForce,
+              isClan,
               campaign.getLocalDate(),
               false,
               false);
 
-        if (experienceLevel <= SkillLevel.VETERAN.getExperienceLevel()) {
+        // Due to modifiers, the final skill level will usually be one step above
+        SkillLevel targetSkillLevel = switch (chaosEmployerType) {
+            case ANY_PLANETARY_GOVERNMENT, ANY_SYSTEM_OWNER, LOCAL_SYSTEM_OWNER -> {
+                if (faction.isMajorOrSuperPower() || faction.isClan() || faction.isComStarOrWoB()) {
+                    yield SkillLevel.VETERAN;
+                } else {
+                    yield SkillLevel.REGULAR;
+                }
+            }
+            case NOBLE, MERCENARY_SUBCONTRACT, CORPORATION -> SkillLevel.REGULAR;
+            case CIVILIAN_ORGANIZATION_BUSINESS, CIVILIAN_ORGANIZATION_MILITIA, LOCAL_PLANETARY_GOVERNMENT ->
+                  SkillLevel.GREEN;
+            case CIVILIAN_ORGANIZATION_REBELS -> SkillLevel.ULTRA_GREEN;
+        };
+
+        if (experienceLevel < targetSkillLevel.getExperienceLevel()) {
             PersonUtility.overrideSkills(campaign, negotiator, role, SkillLevel.VETERAN, true);
         }
     }

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/negotiationsAndNPCs/EmployerNegotiator.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/negotiationsAndNPCs/EmployerNegotiator.java
@@ -175,7 +175,7 @@ public class EmployerNegotiator {
             case CIVILIAN_ORGANIZATION_REBELS -> SkillLevel.ULTRA_GREEN;
         };
 
-        if (experienceLevel < targetSkillLevel.getExperienceLevel()) {
+        if (experienceLevel != targetSkillLevel.getExperienceLevel()) {
             PersonUtility.overrideSkills(campaign, negotiator, role, SkillLevel.VETERAN, true);
         }
     }

--- a/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/negotiationsAndNPCs/EmployerNegotiator.java
+++ b/MekHQ/src/mekhq/campaign/mission/contract/contractGeneration/negotiationsAndNPCs/EmployerNegotiator.java
@@ -175,8 +175,8 @@ public class EmployerNegotiator {
             case CIVILIAN_ORGANIZATION_REBELS -> SkillLevel.ULTRA_GREEN;
         };
 
-        if (experienceLevel != targetSkillLevel.getExperienceLevel()) {
-            PersonUtility.overrideSkills(campaign, negotiator, role, SkillLevel.VETERAN, true);
+        if (experienceLevel > targetSkillLevel.getExperienceLevel()) {
+            PersonUtility.overrideSkills(campaign, negotiator, role, targetSkillLevel, true);
         }
     }
 

--- a/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractEditorDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/contractMarket/ContractEditorDialog.java
@@ -1313,7 +1313,8 @@ public class ContractEditorDialog extends JDialog {
         Person liaison = null;
         if (employerFaction != null && currentSystem != null) {
             HiringHallLevel hiringHall = currentSystem.getHiringHallLevel(currentDate);
-            negotiator = EmployerNegotiator.generateNegotiator(campaign, bucket, employerFaction, hiringHall);
+            negotiator = EmployerNegotiator.generateNegotiator(campaign, bucket, employerFaction, hiringHall,
+                  enumValue(employerTypeCombo, contract.getEmployerType()));
             liaison = EmployerLiaison.generateLiaison(campaign, bucket, employerFaction.isClan(),
                   employerFaction.getShortName());
         }


### PR DESCRIPTION
Fix #9998

## What this changes

Enemy negotiator experience level will now depend on the type of employer for the contract:

Noble, Mercenary, Corporation: Regular
Business, Militia, Planetary Government: Green
Rebels: Ultra-Green

For system owners it will depend on the faction:

Major or Super Power: Veteran
Clan: Veteran
ComStar or Word of Blake: Veteran
Other: Regular

**Important**
This just determines the clamp experience level. Individual negotiators can still be higher, or lower than the target value.

## Testing

- Manual testing

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result