### PR TITLE
Fix #10011: Enable MegaMek Armor Kit Option When Armor Kits Enabled in MekHQ Campaign Options

### DIFF
--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
@@ -57,6 +57,7 @@ import mekhq.campaign.personnel.enums.MergingSurnameStyle;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.enums.Phenotype;
 import mekhq.campaign.personnel.enums.SplittingSurnameStyle;
+import mekhq.campaign.personnel.quartermaster.ArmorKitCatalog;
 import mekhq.campaign.universe.PlanetarySystem.PlanetaryRating;
 import mekhq.campaign.universe.PlanetarySystem.PlanetarySophistication;
 import mekhq.service.mrms.MRMSOption;
@@ -710,8 +711,14 @@ public class CampaignOptions {
         gameOptions.getOption(ADVANCED_STRATOPS_QUIRKS).setValue(get(CampaignOption.USE_QUIRKS));
         gameOptions.getOption(ALLOWED_CANON_ONLY).setValue(get(CampaignOption.ALLOW_CANON_ONLY));
         gameOptions.getOption(ALLOWED_CANON_ONLY).setValue(get(CampaignOption.ALLOW_CANON_ONLY));
-
         gameOptions.getOption(ALLOWED_TECH_LEVEL)
               .setValue(TechConstants.T_SIMPLE_NAMES[get(CampaignOption.TECH_LEVEL)]);
+
+        boolean useNPCArmorKits = get(CampaignOption.NPC_FACTION_ARMOR_KITS);
+        boolean useMekWarriorArmorKit = !get(CampaignOption.MEKWARRIOR_DEFAULT_KIT).equals(ArmorKitCatalog.DEFAULT_ARMOR_KIT_NAME);
+        boolean useVehicleArmorKit = !get(CampaignOption.VEHICLE_CREW_DEFAULT_KIT).equals(ArmorKitCatalog.DEFAULT_ARMOR_KIT_NAME);
+        boolean useAeroArmorKit = !get(CampaignOption.AIRCRAFT_DEFAULT_KIT).equals(ArmorKitCatalog.DEFAULT_ARMOR_KIT_NAME);
+        gameOptions.getOption(RPG_COMBAT_SUITS)
+              .setValue(useNPCArmorKits || useMekWarriorArmorKit || useVehicleArmorKit || useAeroArmorKit);
     }
 }


### PR DESCRIPTION
Fix #10011

## What this changes

If the player has NPC armor kits enabled in campaign options, or has any of the armor kit options set to something other than the default (overalls), the corresponding MegaMek option will be enabled automatically.

## Testing

- Manual testing

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result