### PR TITLE
Keep a chosen sensor when readying a unit for a game

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5159,31 +5159,6 @@ public class Campaign implements ITechManager {
      *
      * @param entity the entity to clear the game data for
      */
-    /**
-     * Puts a unit's sensor back to the one it should start a battle on.
-     *
-     * <p>A sensor the player chose themselves is left alone. That means the sensor picked in the MegaMek lobby, and
-     * any sensor saved against this chassis and model, which the unit file parser applies as the unit loads. Without
-     * this check the campaign would hand every unit back its active probe, or radar when it has no probe, undoing
-     * the choice before the game even starts.</p>
-     *
-     * <p>Example: a player saves Infrared for the Marauder MAD-3R. Their MAD-3R deploys on Mek IR. A Griffin
-     * GRF-1N with nothing saved still deploys on Mek Radar exactly as it always did.</p>
-     *
-     * @param entity the unit being readied for a game
-     */
-    // Package-private rather than private so the rule can be tested without standing up a whole Campaign
-    static void resetSensorChoice(Entity entity) {
-        if (entity.getSensors().isEmpty() || entity.hasCustomSensorChoice()) {
-            return;
-        }
-        if (entity.hasBAP()) {
-            entity.setNextSensor(entity.getSensors().lastElement());
-        } else {
-            entity.setNextSensor(entity.getSensors().firstElement());
-        }
-    }
-
     public void clearGameData(Entity entity) {
         // First, lets remove any improvised clubs picked up during the combat
         entity.removeMisc(EquipmentTypeLookup.LIMB_CLUB);
@@ -5273,6 +5248,31 @@ public class Campaign implements ITechManager {
         // TODO: still a lot of stuff to do here, but oh well
         entity.setOwner(player);
         entity.setGame(game);
+    }
+
+    /**
+     * Puts a unit's sensor back to the one it should start a battle on.
+     *
+     * <p>A sensor the player chose themselves is left alone. That means the sensor picked in the MegaMek lobby, and
+     * any sensor saved against this chassis and model, which the unit file parser applies as the unit loads. Without
+     * this check the campaign would hand every unit back its active probe, or radar when it has no probe, undoing
+     * the choice before the game even starts.</p>
+     *
+     * <p>Example: a player saves Infrared for the Marauder MAD-3R. Their MAD-3R deploys on Mek IR. A Griffin
+     * GRF-1N with nothing saved still deploys on Mek Radar exactly as it always did.</p>
+     *
+     * @param entity the unit being readied for a game
+     */
+    // Package-private rather than private so the rule can be tested without standing up a whole Campaign
+    static void resetSensorChoice(Entity entity) {
+        if (entity.getSensors().isEmpty() || entity.hasCustomSensorChoice()) {
+            return;
+        }
+        if (entity.hasBAP()) {
+            entity.setNextSensor(entity.getSensors().lastElement());
+        } else {
+            entity.setNextSensor(entity.getSensors().firstElement());
+        }
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5159,6 +5159,31 @@ public class Campaign implements ITechManager {
      *
      * @param entity the entity to clear the game data for
      */
+    /**
+     * Puts a unit's sensor back to the one it should start a battle on.
+     *
+     * <p>A sensor the player chose themselves is left alone. That means the sensor picked in the MegaMek lobby, and
+     * any sensor saved against this chassis and model, which the unit file parser applies as the unit loads. Without
+     * this check the campaign would hand every unit back its active probe, or radar when it has no probe, undoing
+     * the choice before the game even starts.</p>
+     *
+     * <p>Example: a player saves Infrared for the Marauder MAD-3R. Their MAD-3R deploys on Mek IR. A Griffin
+     * GRF-1N with nothing saved still deploys on Mek Radar exactly as it always did.</p>
+     *
+     * @param entity the unit being readied for a game
+     */
+    // Package-private rather than private so the rule can be tested without standing up a whole Campaign
+    static void resetSensorChoice(Entity entity) {
+        if (entity.getSensors().isEmpty() || entity.hasCustomSensorChoice()) {
+            return;
+        }
+        if (entity.hasBAP()) {
+            entity.setNextSensor(entity.getSensors().lastElement());
+        } else {
+            entity.setNextSensor(entity.getSensors().firstElement());
+        }
+    }
+
     public void clearGameData(Entity entity) {
         // First, lets remove any improvised clubs picked up during the combat
         entity.removeMisc(EquipmentTypeLookup.LIMB_CLUB);
@@ -5204,13 +5229,7 @@ public class Campaign implements ITechManager {
         entity.setShutDown(false);
         entity.setSearchlightState(false);
 
-        if (!entity.getSensors().isEmpty()) {
-            if (entity.hasBAP()) {
-                entity.setNextSensor(entity.getSensors().lastElement());
-            } else {
-                entity.setNextSensor(entity.getSensors().firstElement());
-            }
-        }
+        resetSensorChoice(entity);
 
         if (entity instanceof IBomber bomber) {
             List<BombMounted> mountedBombs = bomber.getBombs();

--- a/MekHQ/unittests/mekhq/campaign/CampaignSensorResetTest.java
+++ b/MekHQ/unittests/mekhq/campaign/CampaignSensorResetTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import megamek.common.equipment.Sensor;
+import megamek.common.units.BipedMek;
+import megamek.common.units.Mek;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that readying a unit for a game no longer discards a sensor the player chose.
+ *
+ * <p>Before this, the campaign handed every unit back its active probe, or radar when it had no probe, every time a
+ * unit was refreshed. That undid anything set in the MegaMek lobby and anything saved against the chassis, so a
+ * sensor preference could never reach a campaign game.</p>
+ */
+class CampaignSensorResetTest {
+
+    private static final int MEK_RADAR_INDEX = 0;
+    private static final int MEK_SEISMIC_INDEX = 3;
+
+    /** Builds a Mek with the four sensors the unit file parser gives every Mek, starting on radar. */
+    private static Mek mekWithStandardSensors() {
+        Mek mek = new BipedMek();
+        mek.getSensors().add(new Sensor(Sensor.TYPE_MEK_RADAR));
+        mek.getSensors().add(new Sensor(Sensor.TYPE_MEK_IR));
+        mek.getSensors().add(new Sensor(Sensor.TYPE_MEK_MAG_SCAN));
+        mek.getSensors().add(new Sensor(Sensor.TYPE_MEK_SEISMIC));
+        mek.setNextSensor(mek.getSensors().firstElement());
+        return mek;
+    }
+
+    @Test
+    @DisplayName("A unit with no chosen sensor is still reset the way it always was")
+    void aUnitWithNoChosenSensorIsStillReset() {
+        Mek mek = mekWithStandardSensors();
+        mek.setNextSensor(mek.getSensors().elementAt(MEK_SEISMIC_INDEX));
+
+        Campaign.resetSensorChoice(mek);
+
+        assertNotNull(mek.getNextSensor());
+        assertEquals(Sensor.TYPE_MEK_RADAR, mek.getNextSensor().type(),
+              "A unit nobody configured must go back to radar, exactly as it did before this change");
+    }
+
+    @Test
+    @DisplayName("A sensor the player chose survives being readied for a game")
+    void aChosenSensorSurvives() {
+        Mek mek = mekWithStandardSensors();
+        mek.setNextSensor(mek.getSensors().elementAt(MEK_SEISMIC_INDEX));
+        mek.setCustomSensorChoice(true);
+
+        Campaign.resetSensorChoice(mek);
+
+        assertEquals(Sensor.TYPE_MEK_SEISMIC, mek.getNextSensor().type(),
+              "The campaign must not discard a sensor chosen in the lobby or saved against the chassis");
+    }
+
+    @Test
+    @DisplayName("A unit with no sensors is left alone")
+    void aUnitWithNoSensorsIsLeftAlone() {
+        Mek mek = new BipedMek();
+
+        Campaign.resetSensorChoice(mek);
+
+        assertEquals(null, mek.getNextSensor(), "A unit carrying no sensors has nothing to reset");
+    }
+
+    @Test
+    @DisplayName("Resetting twice changes nothing further")
+    void resettingTwiceChangesNothingFurther() {
+        Mek mek = mekWithStandardSensors();
+
+        Campaign.resetSensorChoice(mek);
+        Campaign.resetSensorChoice(mek);
+
+        assertEquals(mek.getSensors().elementAt(MEK_RADAR_INDEX).type(), mek.getNextSensor().type(),
+              "Readying a unit repeatedly, which the campaign does, must stay stable");
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/CampaignSensorResetTest.java
+++ b/MekHQ/unittests/mekhq/campaign/CampaignSensorResetTest.java
@@ -34,6 +34,7 @@ package mekhq.campaign;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import megamek.common.equipment.Sensor;
 import megamek.common.units.BipedMek;
@@ -97,7 +98,7 @@ class CampaignSensorResetTest {
 
         Campaign.resetSensorChoice(mek);
 
-        assertEquals(null, mek.getNextSensor(), "A unit carrying no sensors has nothing to reset");
+        assertNull(mek.getNextSensor(), "A unit carrying no sensors has nothing to reset");
     }
 
     @Test


### PR DESCRIPTION
## What this changes

A sensor you chose now survives into a campaign game.

Readying a unit used to hand it back its active probe, or radar when it had no probe, every single time. That ran on every unit refresh, not just at launch, so anything set in the MegaMek lobby or saved against the chassis was wiped before the game started.

Units you have not configured reset exactly as they always did.

Example: save Infrared for the Marauder MAD-3R and your MAD-3R deploys on Mek IR. A Griffin GRF-1N with nothing saved still deploys on Mek Radar.

Companion to MegaMek/megamek#5868, which is what actually closes that RFE. This PR is the MekHQ half and closes nothing on its own.

## Testing

`compileJava` passes against the matching MegaMek branch. Full suite: 15,644 tests, 0 failures.

New `CampaignSensorResetTest` (4 tests) covers the rule: an unconfigured unit still resets to radar, a chosen sensor survives, a unit with no sensors is left alone, and resetting twice is stable.

**Verified by breaking the fix.** With the `hasCustomSensorChoice` guard removed, exactly one test fails, the one asserting a chosen sensor survives. The other three still pass, which shows the old behaviour is genuinely preserved for unconfigured units.

## What is not proven yet

- Not tested in a live campaign. No campaign was loaded, launched into a scenario, and checked for the sensor the unit deployed with.
- The MegaMek side that writes the per-design file is a separate PR and has not been round-tripped in game either.
- Per-unit sensor memory is not implemented. This is per chassis and model, so two MAD-3Rs in one campaign cannot differ. That is #4044.

---
- [x] This PR is focused on one issue or RFE
- [x] Every file in the diff has a deliberate change
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use {@code true} / {@code null} rather than bare or quoted text
- [x] Dev team only: AI tools used -> AI Assisted Development label applied

Depends on MegaMek/megamek#8950, which adds the `Entity.hasCustomSensorChoice()` this uses.
