### PR TITLE
Fix campaign load NPE from the transport bay part

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/TransportBayPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/TransportBayPart.java
@@ -88,8 +88,12 @@ public class TransportBayPart extends Part {
 
     @Override
     public String getName() {
-        if (null != getBay()) {
-            return getBay().getTransporterType() + " Bay #" + bayNumber;
+        // Resolved once. getBay() reads through to the unit's entity, and the Warehouse tab refreshes on a Swing
+        // timer that can run while a campaign is still loading, so asking twice could return a bay and then null
+        // and throw between the two calls (issue #8925). Every other method here already caches it.
+        Bay bay = getBay();
+        if (null != bay) {
+            return bay.getTransporterType() + " Bay #" + bayNumber;
         }
         return super.getName();
     }


### PR DESCRIPTION
## What this changes

Loading a campaign no longer sometimes throws a NullPointerException from the Warehouse tab.

`TransportBayPart.getName()` already null-checked the bay, but it called `getBay()` twice: once for the check and again for the value. That method reads through to the unit's entity, and the Warehouse tab refreshes on a Swing timer that can fire while the campaign is still loading, so the second call could return null after the first returned a bay.

That is exactly why the reporter could only say it happens sometimes.

Resolved once into a local, which is what every other method in the class already does.

Fixes MegaMek/megamek#8925

## Testing

`compileJava` passes.

**Not tested, and no unit test.** Draft for that reason. Diagnosed from the reporter's stack trace, which names the line and the timer that drives it.

## What is not proven yet

- Their campaign has not been loaded against this build.
- Being a race, the only available evidence is absence of the crash over repeated loads, which nobody has done yet.
- Reported on the MegaMek tracker; the code is MekHQ's, so the issue is worth moving.

---
- [x] This PR is focused on one issue or RFE
- [x] Every file in the diff has a deliberate change
- [x] Tests added or updated - not yet, this is a draft; see What is not proven yet
- [x] Javadoc literals use {@code true} / {@code null} rather than bare or quoted text
- [x] Dev team only: AI tools used -> AI Assisted Development label applied
