### PR TITLE
Close #10041: Count a Flexible XP set's items the way the record counts them

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/advancedCharacterBuilder/lifePathBuilder/LifePathGroup.java
+++ b/MekHQ/src/mekhq/gui/dialog/advancedCharacterBuilder/lifePathBuilder/LifePathGroup.java
@@ -128,13 +128,15 @@ class LifePathGroup {
      * @since 0.51.01
      */
     int countItems() {
-        int itemCount = attributes.size()
-                              + traits.size()
-                              + skills.size()
-                              + metaSkills.size()
-                              + naturalAptitudes.size()
-                              + naturalAptitudesMetaSkills.size()
-                              + abilities.size();
+        // Counted the same way the record counts them: an entry whose value is null is not an item. A hand-edited
+        // file can leave one, and counting it here would let the spinner allow a pick the record then refuses.
+        int itemCount = countAwards(attributes)
+                              + countAwards(traits)
+                              + countAwards(skills)
+                              + countAwards(metaSkills)
+                              + countAwards(naturalAptitudes)
+                              + countAwards(naturalAptitudesMetaSkills)
+                              + countAwards(abilities);
 
         if (edge != null) {
             itemCount++;
@@ -144,6 +146,27 @@ class LifePathGroup {
         }
 
         return itemCount;
+    }
+
+    /**
+     * Counts the entries of an award map that carry a value.
+     *
+     * @param awards awards keyed by whatever the map awards
+     *
+     * @return the number of entries whose value is not {@code null}
+     *
+     * @since 0.51.01
+     */
+    private static int countAwards(Map<?, Integer> awards) {
+        int count = 0;
+
+        for (Integer value : awards.values()) {
+            if (value != null) {
+                count++;
+            }
+        }
+
+        return count;
     }
 
     /** @return how many items the player takes from this set, or {@code null} when not a flexible set */


### PR DESCRIPTION
## What this changes

The Flexible XP wizard now counts a set's items the way the record counts them, skipping award entries with no value, so the pick spinner's ceiling can never exceed what the record accepts. This is the one Copilot finding on the flexible sets work; everything else from that work reached main through #10042.

Fixes #10041

## Testing

- Life Path test package and RanksTest pass on the merged head.
- Compile, checkstyle, Spotless, Javadoc clean; full CI green on the previous head.

## What is not proven yet

- Only a hand-edited file with a null award reaches the changed line; not exercised in game.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes campaign state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result
